### PR TITLE
fix an npe

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -421,10 +421,7 @@ class HtmlGenerator {
   String _resolveCodeReference(ModelElement e, String reference) {
     ModelElement element = e.getChild(reference);
 
-    if (element.isLocalElement) {
-      element = null;
-    }
-    if (element != null) {
+    if (element != null && !element.isLocalElement) {
       return helper.createLinkedName(element, true);
     } else {
       //return "<a>$reference</a>";


### PR DESCRIPTION
Fix an NPE - it's possible for the referenced `element` to not resolve, and be null. @keertip 