### PR TITLE
access bootstrap files from web

### DIFF
--- a/lib/src/css.dart
+++ b/lib/src/css.dart
@@ -12,6 +12,15 @@ class CSS {
   // The bootstrap css file
   final String cssFilePath = '/packages/bootstrap/css/bootstrap.css';
 
+  final String cssHeader =
+      'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css';
+
+  final String theme =
+      'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css';
+
+  final String jsScript =
+      'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js';
+
   String getCssName() => 'bootstrap.css';
 
   String getCssContent() {
@@ -20,4 +29,5 @@ class CSS {
     String text = cssFile.readAsStringSync(encoding: ASCII);
     return text;
   }
+
 }

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -61,7 +61,6 @@ body {
           title: 'Package ${packageName}',
           cssRef: css.cssHeader,
           theme: css.theme,
-          jsScript: css.jsScript,
           inlineStyle: bootstrapOverrides);
       html.generateHeader();
       html.startTag('div', attributes: "class='container'", newLine: false);
@@ -106,7 +105,6 @@ body {
         title: 'Library ${library.name}',
         cssRef: css.cssHeader,
         theme: css.theme,
-        jsScript: css.jsScript,
         inlineStyle: bootstrapOverrides);
 
     html.generateHeader();

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -40,8 +40,8 @@ body {
     generatePackage();
     package.libraries.forEach((lib) => generateLibrary(lib));
     // copy the css resource into 'out'
-    File f = joinFile(new Directory(out.path), [css.getCssName()]);
-    f.writeAsStringSync(css.getCssContent());
+//    File f = joinFile(new Directory(out.path), [css.getCssName()]);
+//    f.writeAsStringSync(css.getCssContent());
     if (url != null) {
       generateSiteMap();
     }
@@ -59,7 +59,9 @@ body {
 
       html.start(
           title: 'Package ${packageName}',
-          cssRef: css.getCssName(),
+          cssRef: css.cssHeader,
+          theme: css.theme,
+          jsScript: css.jsScript,
           inlineStyle: bootstrapOverrides);
       html.generateHeader();
       html.startTag('div', attributes: "class='container'", newLine: false);
@@ -102,7 +104,9 @@ body {
     html = new HtmlHelper();
     html.start(
         title: 'Library ${library.name}',
-        cssRef: css.getCssName(),
+        cssRef: css.cssHeader,
+        theme: css.theme,
+        jsScript: css.jsScript,
         inlineStyle: bootstrapOverrides);
 
     html.generateHeader();

--- a/lib/src/html_gen.dart
+++ b/lib/src/html_gen.dart
@@ -30,7 +30,7 @@ class HtmlHelper {
     endTag();
   }
 
-  void start({String title, String cssRef, String inlineStyle}) {
+  void start({String title, String cssRef, String theme, String jsScript, String inlineStyle}) {
     startTag('html', newLine: false);
     writeln();
     startTag('head');
@@ -42,6 +42,12 @@ class HtmlHelper {
     }
     if (cssRef != null) {
       writeln('<link href="${cssRef}" rel="stylesheet" media="screen">');
+    }
+    if (theme != null) {
+      writeln('<link href="${theme}" rel="stylesheet">');
+    }
+    if (jsScript != null) {
+      writeln('<script src="${jsScript}"></script>');
     }
     if (inlineStyle != null) {
       startTag('style');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   yaml: any
 
 dev_dependencies:
+  http: any
   unittest: any
 
 executables:

--- a/test/all.dart
+++ b/test/all.dart
@@ -4,8 +4,11 @@
 
 library dartdoc.all_tests;
 
+import 'css_test.dart' as css_tests;
 import 'template_test.dart' as template_tests;
 
+
 main() {
+  css_tests.tests();
   template_tests.tests();
 }

--- a/test/css_test.dart
+++ b/test/css_test.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartdoc.css_test;
+
+import 'package:http/http.dart' as http;
+import 'package:unittest/unittest.dart';
+
+import '../lib/src/css.dart';
+
+tests() {
+  group('check bootstrap', () {
+    CSS css = new CSS();
+
+    test('css stylesheet url exists', () {
+      var url = css.cssHeader;
+      http.get(url).then((response) {
+        expect(response.statusCode, 200);
+      });
+    });
+
+    test('theme stylesheet url exists', () {
+      var url = css.theme;
+      http.get(url).then((response) {
+        expect(response.statusCode, 200);
+      });
+    });
+
+    test('js script exists', () {
+      var url = css.jsScript;
+      http.get(url).then((response) {
+        expect(response.statusCode, 200);
+      });
+    });
+
+  });
+}


### PR DESCRIPTION
@sethladd 

Access the bootstrap files from the web, instead of copying it from the package. This gets us around to running dartdoc using pub run.