### PR TITLE
Oneliner: Skip Over Code Blocks

### DIFF
--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -241,6 +241,8 @@ String renderMarkdown(String markdown, {nestedContext}) {
   return doc.body.innerHtml;
 }
 
+const List<String> _oneLinerSkipTags = const ["code", "pre"];
+
 String oneLiner(String text, {nestedContext}) {
   String mustached = render(text.trim(), nestedContext,
           assumeNullNonExistingProperty: false, errorOnMissingProperty: true)
@@ -251,6 +253,14 @@ String oneLiner(String text, {nestedContext}) {
   var document = new md.Document();
   document.parseRefLinks(lines);
   var blocks = document.parseLines(lines);
+
+  while (blocks.isNotEmpty && (blocks.first is md.Element && _oneLinerSkipTags.contains(blocks.first.tag))) {
+    blocks.removeAt(0);
+  }
+
+  if (blocks.isEmpty) {
+    return '';
+  }
 
   var firstPara = new PlainTextRenderer().render([blocks.first]);
   if (firstPara.length > 200) {


### PR DESCRIPTION
This PR makes sure that the oneliner function skips over code-blocks. This is to ensure that if a code block is above the initial documentation comment (which it should pretty much never be), that the documentation will still look clean by not displaying code blocks are HTML Escaped (thus having &lt; etc sequences in the oneliner).