### PR TITLE
Implement Property Pages

### DIFF
--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -40,6 +40,14 @@ class HtmlGenerator extends Generator {
       _loadTemplate('templates/method.html');
   static final String constructorTemplate =
       _loadTemplate('templates/constructor.html');
+  static final String propertyTemplate =
+      _loadTemplate('templates/property.html');
+  static final String constantTemplate =
+      _loadTemplate('templates/constant.html');
+  static final String topLevelConstantTemplate =
+    _loadTemplate('templates/top_level_constant.html');
+  static final String topLevelPropertyTemplate =
+      _loadTemplate('templates/top_level_property.html');
 
   static final Map<String, String> _partialTemplates = {};
 
@@ -56,7 +64,7 @@ class HtmlGenerator extends Generator {
     if (!_out.existsSync()) _out.createSync();
     generatePackage();
     _copyResources();
-    package.libraries.forEach((lib) {
+    package.libraries.forEach((Library lib) {
       generateLibrary(package, lib);
 
       lib.getClasses().forEach((Class clazz) {
@@ -64,6 +72,18 @@ class HtmlGenerator extends Generator {
 
         clazz.constructors.forEach((constructor) {
           generateConstructor(package, lib, clazz, constructor);
+        });
+
+        clazz.constants.forEach((constant) {
+          generateConstant(package, lib, clazz, constant);
+        });
+
+        clazz.staticProperties.forEach((property) {
+          generateProperty(package, lib, clazz, property);
+        });
+
+        clazz.instanceProperties.forEach((property) {
+          generateProperty(package, lib, clazz, property);
         });
 
         clazz.instanceMethods.forEach((method) {
@@ -81,6 +101,14 @@ class HtmlGenerator extends Generator {
 
       lib.getEnums().forEach((eNum) {
         generateEnum(package, lib, eNum);
+      });
+
+      lib.getConstants().forEach((constant) {
+        generateTopLevelConstant(package, lib, constant);
+      });
+
+      lib.getProperties().forEach((property) {
+        generateTopLevelProperty(package, lib, property);
       });
 
       lib.getFunctions().forEach((function) {
@@ -203,6 +231,64 @@ class HtmlGenerator extends Generator {
     };
 
     _build(path.joinAll(method.href.split('/')), methodTemplate, data);
+  }
+
+  void generateConstant(
+    Package package, Library lib, Class clazz, Field property) {
+    Map data = {
+      'package': package,
+      'generatedOn': generatedOn,
+      'markdown': renderMarkdown,
+      'oneLiner': oneLiner,
+      'library': lib,
+      'class': clazz,
+      'property': property
+    };
+
+    _build(path.joinAll(property.href.split('/')), constantTemplate, data);
+  }
+
+  void generateProperty(
+    Package package, Library lib, Class clazz, Field property) {
+    Map data = {
+      'package': package,
+      'generatedOn': generatedOn,
+      'markdown': renderMarkdown,
+      'oneLiner': oneLiner,
+      'library': lib,
+      'class': clazz,
+      'property': property
+    };
+
+    _build(path.joinAll(property.href.split('/')), propertyTemplate, data);
+  }
+
+  void generateTopLevelProperty(
+    Package package, Library lib, TopLevelVariable property) {
+    Map data = {
+      'package': package,
+      'generatedOn': generatedOn,
+      'markdown': renderMarkdown,
+      'oneLiner': oneLiner,
+      'library': lib,
+      'property': property
+    };
+
+    _build(path.joinAll(property.href.split('/')), topLevelPropertyTemplate, data);
+  }
+
+  void generateTopLevelConstant(
+    Package package, Library lib, TopLevelVariable property) {
+    Map data = {
+      'package': package,
+      'generatedOn': generatedOn,
+      'markdown': renderMarkdown,
+      'oneLiner': oneLiner,
+      'library': lib,
+      'property': property
+    };
+
+    _build(path.joinAll(property.href.split('/')), topLevelConstantTemplate, data);
   }
 
   void _copyResources() {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -971,11 +971,26 @@ class Field extends ModelElement {
 
   bool get hasSetter => _field.setter != null;
 
+  String get typeName => "property";
+
+  String get ownerHref {
+    if (element.enclosingElement is ClassElement) {
+      return "${library.getClassByName(_field.enclosingElement.name).href}#${htmlId}";
+    } else if (element.enclosingElement is LibraryElement) {
+      return "${library.fileName}.html#$name";
+    } else {
+      throw new StateError(
+        '$name is not in a class or library, instead a ${element.enclosingElement}');
+    }
+  }
+
+  String get linkedOwner => '<a href="${ownerHref}">${name}</a>';
+
   String get _href {
     if (element.enclosingElement is ClassElement) {
-      return '/${library.fileName}/${element.enclosingElement.name}.html#$name';
+      return '${library.fileName}/${element.enclosingElement.name}/$name.html';
     } else if (element.enclosingElement is LibraryElement) {
-      return '/${library.fileName}.html#$name';
+      return '${library.fileName}/$name.html';
     } else {
       throw new StateError(
           '$name is not in a class or library, instead a ${element.enclosingElement}');
@@ -1138,13 +1153,15 @@ class TopLevelVariable extends ModelElement {
     return v.substring(v.indexOf('= ') + 2, v.length);
   }
 
+  String get ownerHref => "${library.href}#${htmlId}";
+  String get linkedOwner => '<a href="${ownerHref}">${name}</a>';
+
   bool get hasGetter => _variable.getter != null;
 
   bool get hasSetter => _variable.setter != null;
 
-  // TODO: check if this works for libraries and classes
   @override
-  String get _href => throw 'Not implemented yet';
+  String get _href => '${library.fileName}/${name}.html';
 }
 
 class Parameter extends ModelElement {

--- a/templates/class.html
+++ b/templates/class.html
@@ -147,7 +147,7 @@
             <dt id="{{htmlId}}">
                 <code>
                     <span class="returntype">{{{ linkedReturnType }}}</span>
-                    <span class="name">{{ name }}</span>
+                    <span class="name"><a href="{{href}}">{{ name }}</a></span>
                 </code>
             </dt>
             <dd>
@@ -188,7 +188,7 @@
             <dt id="{{htmlId}}">
                 <code>
                     <span class="returntype">{{{ linkedReturnType }}}</span>
-                    <span class="name">{{ name }}</span>
+                    <span class="name"><a href="{{href}}">{{ name }}</a></span>
                 </code>
             </dt>
             <dd>
@@ -208,7 +208,7 @@
         <h2 class="text-display-1">Static Methods</h2>
         <dl class="withreturntypes">
             {{#class.staticMethods}}
-            <dt>
+            <dt id="{{htmlId}}">
                 <code>
                     <span class="returntype">{{{ linkedReturnType }}}</span>
                     <span class="name-and-params">

--- a/templates/constant.html
+++ b/templates/constant.html
@@ -1,0 +1,58 @@
+{{>head}}
+<title>{{property.name}} constant - {{class.name}} class - {{ library.name }} library - Dart API</title>
+
+<!-- required because all the links are pseudo-absolute -->
+<base href="../..">
+
+{{>styles_and_scripts}}
+
+<meta name="description" content="API docs for the {{property.name}} constant from the {{class.name}} class {{ library.name }} library, for the Dart programming language.">
+
+</head>
+
+<body>
+
+<header class="container-fluid" id="title">
+  <!-- TODO: align this -->
+  <div class="container">
+    <ul class="breadcrumbs gt-separated">
+      <li><a href="{{package.href}}">{{package.name}} package</a></li>
+      <li><a href="{{library.href}}">{{library.name}} library</a></li>
+      <li><a href="{{class.href}}">{{class.name}} class</a></li>
+    </ul>
+    <h1 class="title">
+        {{ property.name }}
+      <span class="type">
+                {{#property.isStatic}}static {{/property.isStatic}}constant
+        on <span class="classname"><a href="{{class.href}}">{{class.name}}</a></span>
+            </span>
+    </h1>
+  </div>
+</header>
+
+<div class="container">
+
+  <section class="multi-line-signature">
+    <code>
+        {{#property}}
+          <code>
+            <span class="returntype">{{{ linkedReturnType }}}</span>
+            <span class="name">{{{ linkedOwner }}}</span>
+            =
+            <span class="constant-value">{{ constantValue }}</span>
+          </code>
+        {{/property}}
+    </code>
+  </section>
+
+  <section class="desc markdown">
+
+      {{#markdown}}
+          {{{ property.documentation }}}
+      {{/markdown}}
+
+  </section>
+
+</div>
+
+{{>footer}}

--- a/templates/library.html
+++ b/templates/library.html
@@ -79,7 +79,7 @@
             <dt id="{{htmlId}}">
                 <code>
                     <span class="returntype">{{{ linkedReturnType }}}</span>
-                    <span class="name">{{ name }}</span>
+                    <span class="name"><a href="{{href}}">{{ name }}</a></span>
                 </code>
             </dt>
             <dd>
@@ -103,7 +103,7 @@
             <dt id="{{htmlId}}">
                 <code>
                     <span class="returntype">{{{ linkedReturnType }}}</span>
-                    <span class="name">{{ name }}</span>
+                    <span class="name">{{{ linkedName }}}</span>
                     =
                     <span class="constant-value">{{ constantValue }}</span>
                 </code>

--- a/templates/property.html
+++ b/templates/property.html
@@ -1,0 +1,59 @@
+{{>head}}
+<title>{{property.name}} {{property.typeName}} - {{class.name}} class - {{ library.name }} library - Dart API</title>
+
+<!-- required because all the links are pseudo-absolute -->
+<base href="../..">
+
+{{>styles_and_scripts}}
+
+<meta name="description" content="API docs for the {{property.name}} property from the {{class.name}} class {{ library.name }} library, for the Dart programming language.">
+
+</head>
+
+<body>
+
+<header class="container-fluid" id="title">
+  <!-- TODO: align this -->
+  <div class="container">
+    <ul class="breadcrumbs gt-separated">
+      <li><a href="{{package.href}}">{{package.name}} package</a></li>
+      <li><a href="{{library.href}}">{{library.name}} library</a></li>
+      <li><a href="{{class.href}}">{{class.name}} class</a></li>
+    </ul>
+    <h1 class="title">
+        {{ property.name }}
+      <span class="type">
+                {{#property.isStatic}}static {{/property.isStatic}}{{property.typeName}}
+        on <span class="classname"><a href="{{class.href}}">{{class.name}}</a></span>
+            </span>
+    </h1>
+  </div>
+</header>
+
+<div class="container">
+
+  <section class="multi-line-signature">
+    <code>
+        {{#property}}
+          <span class="returntype">{{{ linkedReturnType }}}</span>
+          <span class="name">{{{ linkedOwner }}}</span>
+        {{/property}}
+    </code>
+  </section>
+
+  <div>
+    <span class="{{#property.hasGetter}}has-it{{/property.hasGetter}} getter">read</span>
+    <span class="{{#property.hasSetter}}has-it{{/property.hasSetter}} setter">write</span>
+  </div>
+
+  <section class="desc markdown">
+
+      {{#markdown}}
+          {{{ property.documentation }}}
+      {{/markdown}}
+
+  </section>
+
+</div>
+
+{{>footer}}

--- a/templates/top_level_constant.html
+++ b/templates/top_level_constant.html
@@ -1,0 +1,54 @@
+{{>head}}
+<title>{{property.name}} constant - {{ library.name }} library - Dart API</title>
+
+<!-- required because all the links are pseudo-absolute -->
+<base href="..">
+
+{{>styles_and_scripts}}
+
+<meta name="description" content="API docs for the {{property.name}} constant from the {{ library.name }} library, for the Dart programming language.">
+
+</head>
+
+<body>
+
+<header class="container-fluid" id="title">
+  <!-- TODO: align this -->
+  <div class="container">
+    <ul class="breadcrumbs gt-separated">
+      <li><a href="{{package.href}}">{{package.name}} package</a></li>
+      <li><a href="{{library.href}}">{{library.name}} library</a></li>
+    </ul>
+    <h1 class="title">
+        {{ property.name }}
+      <span class="type">constant</span>
+    </h1>
+  </div>
+</header>
+
+<div class="container">
+
+  <section class="multi-line-signature">
+    <code>
+        {{#property}}
+          <code>
+            <span class="returntype">{{{ linkedReturnType }}}</span>
+            <span class="name">{{{ linkedOwner }}}</span>
+            =
+            <span class="constant-value">{{ constantValue }}</span>
+          </code>
+        {{/property}}
+    </code>
+  </section>
+
+  <section class="desc markdown">
+
+      {{#markdown}}
+          {{{ property.documentation }}}
+      {{/markdown}}
+
+  </section>
+
+</div>
+
+{{>footer}}

--- a/templates/top_level_property.html
+++ b/templates/top_level_property.html
@@ -1,0 +1,55 @@
+{{>head}}
+<title>{{property.name}} {{property.typeName}} - {{ library.name }} library - Dart API</title>
+
+<!-- required because all the links are pseudo-absolute -->
+<base href="..">
+
+{{>styles_and_scripts}}
+
+<meta name="description" content="API docs for the {{property.name}} property from the {{ library.name }} library, for the Dart programming language.">
+
+</head>
+
+<body>
+
+<header class="container-fluid" id="title">
+  <!-- TODO: align this -->
+  <div class="container">
+    <ul class="breadcrumbs gt-separated">
+      <li><a href="{{package.href}}">{{package.name}} package</a></li>
+      <li><a href="{{library.href}}">{{library.name}} library</a></li>
+    </ul>
+    <h1 class="title">
+        {{ property.name }}
+      <span class="type">property</span>
+    </h1>
+  </div>
+</header>
+
+<div class="container">
+
+  <section class="multi-line-signature">
+    <code>
+        {{#property}}
+          <span class="returntype">{{{ linkedReturnType }}}</span>
+          <span class="name">{{{ linkedOwner }}}</span>
+        {{/property}}
+    </code>
+  </section>
+
+  <div>
+    <span class="{{#property.hasGetter}}has-it{{/property.hasGetter}} getter">read</span>
+    <span class="{{#property.hasSetter}}has-it{{/property.hasSetter}} setter">write</span>
+  </div>
+
+  <section class="desc markdown">
+
+      {{#markdown}}
+          {{{ property.documentation }}}
+      {{/markdown}}
+
+  </section>
+
+</div>
+
+{{>footer}}


### PR DESCRIPTION
This implements properties pages.

- Generates pages for static properties on classes
- Generates pages for instance properties on classes
- Generates pages for constant properties on classes.
- Generates pages for constant properties on libraries.
- Generates pages for top level properties on libraries.

This also links everything on the index pages.

cc @sethladd