### PR TITLE
remove duplicated func

### DIFF
--- a/lib/src/html_utils.dart
+++ b/lib/src/html_utils.dart
@@ -8,12 +8,6 @@ import 'dart:convert';
 
 String htmlEscape(String text) => HTML_ESCAPE.convert(text);
 
-String getHtmlFileNameFor(String name) {
-  // dart.dartdoc => dart_dartdoc
-  // dart:core => dart_core
-  return '${name.replaceAll('.', '_').replaceAll(':', '_')}.html';
-}
-
 String escapeBrackets(String text) {
   return text.replaceAll('>', '_').replaceAll('<', '_');
 }


### PR DESCRIPTION
This one doesn't seem to be used, whereas 

https://github.com/dart-lang/dartdoc/blob/master/lib/src/io_utils.dart#L112

is used somewhere else.

It may make more sense to keep this one because of the more exact name, though.