### PR TITLE
add visualization for deprecated

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -174,6 +174,10 @@ dl dt.callable .signature {
   font-style: italic;
 }
 
+.deprecated {
+  text-decoration: line-through;
+}
+
 p.firstline {
   font-weight: bold;
 }

--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -70,7 +70,8 @@ class Templates {
       'property',
       'styles_and_scripts',
       'readable_writable',
-      'documentation'
+      'documentation',
+      'name_summary'
     ];
     for (var partial in partials) {
       _partialTemplates[partial] = await _loadPartial('_$partial.html');

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -289,6 +289,8 @@ abstract class ModelElement {
 
   bool get isConst => false;
 
+  bool get isDeprecated => element.metadata.any((a) => a.isDeprecated);
+
   ElementType get modelType => _modelType;
 
   /// Returns the [ModelElement] that encloses this.

--- a/lib/templates/_callable.html
+++ b/lib/templates/_callable.html
@@ -1,5 +1,6 @@
 <dt id="{{htmlId}}" class="callable">
-    <span class="name"><a href="{{href}}">{{ name }}</a>
+    <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">
+    <a href="{{href}}">{{ name }}</a>
     {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
     </span>
     <span class="signature">({{{ linkedParamsNoMetadata }}})

--- a/lib/templates/_callable.html
+++ b/lib/templates/_callable.html
@@ -1,8 +1,6 @@
 <dt id="{{htmlId}}" class="callable">
-    <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">
-    <a href="{{href}}">{{ name }}</a>
+    <a href="{{href}}">{{>name_summary}}</a>
     {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
-    </span>
     <span class="signature">({{{ linkedParamsNoMetadata }}})
         &#8594;
         <span class="returntype">{{{ linkedReturnType }}}</span>

--- a/lib/templates/_callable_multiline.html
+++ b/lib/templates/_callable_multiline.html
@@ -8,7 +8,7 @@
 </div>
 {{/hasAnnotations}}
 <span class="returntype">{{{ linkedReturnType }}}</span>
-<span class="name">{{ name }}</span>(
+{{>name_summary}}(
 {{#hasParameters}}
 <br>
 <div class="parameters">

--- a/lib/templates/_constant.html
+++ b/lib/templates/_constant.html
@@ -1,5 +1,5 @@
 <dt id="{{htmlId}}" class="constant">
-    <span class="name">{{{ linkedName }}}</span>
+    <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{ linkedName }}}</span>
     =
     <span class="constant-value">{{{ constantValue }}}</span>
 </dt>

--- a/lib/templates/_name_summary.html
+++ b/lib/templates/_name_summary.html
@@ -1,0 +1,1 @@
+<span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{name}}</span>

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,9 +1,7 @@
 <dt id="{{htmlId}}" class="property">
-    <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">
-      <a href="{{href}}">{{ name }}</a>
-    </span>
+    <a href="{{href}}">{{>name_summary}}</a>
     <span class="returntype">{{{ linkedReturnType }}}</span>
-     {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
+    {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
 </dt>
 <dd>
     {{>readable_writable}}

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,5 +1,7 @@
 <dt id="{{htmlId}}" class="property">
-    <span class="name"><a href="{{href}}">{{ name }}</a></span>
+    <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">
+      <a href="{{href}}">{{ name }}</a>
+    </span>
     <span class="returntype">{{{ linkedReturnType }}}</span>
      {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
 </dt>

--- a/lib/templates/constant.html
+++ b/lib/templates/constant.html
@@ -3,7 +3,7 @@
   <section class="multi-line-signature">
         {{#property}}
             <span class="returntype">{{{ linkedReturnType }}}</span>
-            <span class="name">{{ name }}</span>
+            {{>name_summary}}
             =
             <span class="constant-value">{{{ constantValue }}}</span>
         {{/property}}

--- a/lib/templates/constructor.html
+++ b/lib/templates/constructor.html
@@ -3,7 +3,7 @@
     <section class="multi-line-signature">
         {{#constructor}}
         {{#isConst}}const{{/isConst}}
-        <span class="name">{{ name }}</span>({{#hasParameters}}
+        {{>name_summary}}({{#hasParameters}}
         <br>
         <div class="parameters">
             {{{linkedParamsLines}}}

--- a/lib/templates/library.html
+++ b/lib/templates/library.html
@@ -12,7 +12,7 @@
         <dl>
             {{#library.classes}}
             <dt id="{{htmlId}}">
-                <span class="name">{{{linkedName}}}</span>
+                <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{linkedName}}}</span>
             </dt>
             <dd>
                 {{#oneLiner}}{{ documentation }}{{/oneLiner}}
@@ -95,7 +95,7 @@
         <dl>
             {{#library.exceptions}}
             <dt id="{{htmlId}}">
-                <span class="name">{{{linkedName}}}</span>
+                <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{linkedName}}}</span>
             </dt>
             <dd>
                 {{#oneLiner}}{{ documentation }}{{/oneLiner}}

--- a/lib/templates/property.html
+++ b/lib/templates/property.html
@@ -3,7 +3,7 @@
   <section class="multi-line-signature">
     {{#property}}
       <span class="returntype">{{{ linkedReturnType }}}</span>
-      <span class="name">{{ name }}</span>
+      {{>name_summary}}
 
       {{>readable_writable}}
     {{/property}}

--- a/lib/templates/top_level_constant.html
+++ b/lib/templates/top_level_constant.html
@@ -2,7 +2,7 @@
 
   <section class="multi-line-signature">
     {{#property}}
-        <span class="name">{{ name }}</span>
+        {{>name_summary}}
         =
         <span class="constant-value">{{{ constantValue }}}</span>
     {{/property}}

--- a/lib/templates/top_level_property.html
+++ b/lib/templates/top_level_property.html
@@ -3,7 +3,7 @@
   <section class="multi-line-signature">
     {{#property}}
       <span class="returntype">{{{ linkedReturnType }}}</span>
-      <span class="name">{{ name }}</span>
+      {{>name_summary}}
 
       {{>readable_writable}}
     {{/property}}

--- a/test_package/lib/fake.dart
+++ b/test_package/lib/fake.dart
@@ -79,6 +79,7 @@ const ConstantClass CUSTOM_CLASS = const ConstantClass('custom');
 const String UP = 'up';
 
 /// Dynamic-typed down.
+@deprecated
 const DOWN = 'down';
 
 /// A constant integer value,
@@ -86,6 +87,7 @@ const DOWN = 'down';
 const int ZERO = 0;
 
 /// Takes input, returns output.
+@deprecated
 typedef String FakeProcesses(String input);
 
 /// A typedef with a type parameter.
@@ -108,6 +110,7 @@ abstract class Interface {}
 abstract class AnotherInterface {}
 
 /// A super class, with many powers.
+@deprecated
 class SuperAwesomeClass {
 
   /// In the super class.
@@ -138,6 +141,7 @@ class LongFirstLine extends SuperAwesomeClass with MixMeIn
   static int meaningOfLife = 42;
 
   /// The default constructor.
+  @deprecated
   LongFirstLine();
 
   /// Named constructors are awesome.
@@ -148,6 +152,7 @@ class LongFirstLine extends SuperAwesomeClass with MixMeIn
   LongFirstLine.fromHasGenerics(HasGenerics hg);
 
   /// No params.
+  @deprecated
   void noParams() {}
 
   /// Returns a single string.
@@ -195,6 +200,7 @@ class Oops implements Exception {
 }
 
 /// Also, my bad.
+@deprecated
 class Doh extends Error {}
 
 /// ROYGBIV
@@ -239,6 +245,7 @@ class OtherGenericsThing<A> {
 const double PI = 3.14159;
 
 /// Final property.
+@deprecated
 final int meaningOfLife = 42;
 
 /// Simple property
@@ -271,6 +278,7 @@ get dynamicGetter => 'i could be anything';
 ///     var thing = topLevelFunction(1, true, 3.4);
 ///
 /// Thanks for using this function!
+@deprecated
 String topLevelFunction(int param1, bool param2, Cool coolBeans,
     [double optionalPositional = 0.0]) {
   return null;


### PR DESCRIPTION
Some work towards #355.

![screen shot 2015-05-14 at 4 06 41 pm](https://cloud.githubusercontent.com/assets/1269969/7643980/77a6af80-fa53-11e4-84a3-e0aedd2087b0.png)

![screen shot 2015-05-14 at 4 06 51 pm](https://cloud.githubusercontent.com/assets/1269969/7643979/77a6489c-fa53-11e4-9940-9a504b91eb29.png)

Would love some guidance on this PR. I have added the `{{#isDeprecated}}deprecated{{/isDeprecated}}` template fragment in many of the places where a deprecated style would be appropriate, but am missing it in many more places. Is there a less brute force approach to this?

