### PR TITLE
generate docs when the output dir already exists

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -67,7 +67,8 @@ void main(List<String> arguments) {
     exit(1);
   }
 
-  var outputDir = new Directory(path.join(Directory.current.path, defaultOutDir));
+  var outputDir =
+      new Directory(path.join(Directory.current.path, defaultOutDir));
   if (args['output'] != null) {
     outputDir = new Directory(_resolveTildePath(args['output']));
   }

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -107,7 +107,7 @@ ArgParser _createArgsParser() {
   parser.addOption('input',
       help: 'Path to source directory', defaultsTo: Directory.current.path);
   parser.addOption('output',
-      help: 'Path to output directory.', defaultsTo: 'docs');
+      help: 'Path to output directory.', defaultsTo: defaultOutDir);
   parser.addOption('header',
       help: 'path to file containing HTML text, inserted into the header of every page.');
   parser.addOption('footer',

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -63,17 +63,13 @@ void main(List<String> arguments) {
   String headerFilePath = _resolveTildePath(args['header']);
   if (headerFilePath != null && !new File(headerFilePath).existsSync()) {
     print(
-        "Warning: unable to locate the file with footer at ${headerFilePath}.");
+        "Warning: unable to locate the file with header at ${headerFilePath}.");
     exit(1);
   }
 
-  var outputDir = new Directory(path.join(Directory.current.path, 'docs'));
+  var outputDir = new Directory(path.join(Directory.current.path, defaultOutDir));
   if (args['output'] != null) {
     outputDir = new Directory(_resolveTildePath(args['output']));
-  }
-  if (outputDir.existsSync()) {
-    print("Warning: output directory exists: ${args['output']}");
-    exit(1);
   }
 
   String packageName = getPackageName(inputDir.path);

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -22,9 +22,10 @@ import 'src/model.dart';
 import 'src/model_utils.dart';
 
 const String NAME = 'dartdoc';
-
 // Update when pubspec version changes.
 const String VERSION = '0.0.1+10';
+
+const String defaultOutDir = 'docs';
 
 /// Initialize and setup the generators.
 List<Generator> initGenerators(
@@ -65,13 +66,11 @@ class DartDoc {
     libs.removeWhere((library) => _excludes.contains(library.name));
     libraries.addAll(libs);
 
-    // create the out directory
-    if (!outputDir.existsSync()) {
-      outputDir.createSync(recursive: true);
-    }
-
     Package package = new Package(libraries, _rootDir.path,
         sdkVersion: _getSdkVersion(), isSdk: sdkDocs, readmeLoc: sdkReadmePath);
+
+    // Create the out directory.
+    if (!outputDir.existsSync()) outputDir.createSync(recursive: true);
 
     for (var generator in _generators) {
       await generator.generate(package, outputDir);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -5,6 +5,7 @@
 import 'dart:async' show Future;
 import 'dart:io';
 
+import 'package:dartdoc/dartdoc.dart' show defaultOutDir;
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:den_api/den_api.dart';
 import 'package:grinder/grinder.dart';
@@ -12,7 +13,7 @@ import 'package:librato/librato.dart';
 import 'package:path/path.dart' as path;
 
 final Directory docsDir =
-    new Directory(path.join('${Directory.systemTemp.path}', 'docs'));
+    new Directory(path.join('${Directory.systemTemp.path}', defaultOutDir));
 
 main([List<String> args]) => grind(args);
 


### PR DESCRIPTION
- address #472, generate the docs even in the presence of an existing `docs/` directory
- added a constant (`defaultOutDir`) for the `docs/` dir name