### PR TITLE
work-around issues in coveralls until they taken the latest pull request

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -34,10 +34,11 @@ grind test
 
 # Gather and send coverage data.
 if [ "$REPO_TOKEN" ]; then
-  pub global activate dart_coveralls
+  pub global activate --source git https://github.com/kevmoo/dart_coveralls_hacking.git
   pub global run dart_coveralls report \
     --token $REPO_TOKEN \
     --retry 2 \
     --exclude-test-files \
+    --debug \
     test/all.dart
 fi


### PR DESCRIPTION
I have a pull request out w/ these fixes.

But in the mean time, it does a good job of reporting correctly – or at least giving clear errors when upload to coveralls fails

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dart-lang/dartdoc/514)
<!-- Reviewable:end -->
