### PR TITLE
enable parse function bodies

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -103,9 +103,7 @@ class DartDoc {
     SourceFactory sourceFactory =
         new SourceFactory(/*contentCache,*/ resolvers);
 
-    var options = new AnalysisOptionsImpl()
-      ..analyzeFunctionBodies = false
-      ..cacheSize = 512;
+    var options = new AnalysisOptionsImpl()..cacheSize = 512;
 
     AnalysisContext context = AnalysisEngine.instance.createAnalysisContext()
       ..analysisOptions = options

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -245,7 +245,7 @@ void main() {
     });
 
     test('correctly finds classes', () {
-      expect(classes, hasLength(13));
+      expect(classes, hasLength(14));
     });
 
     test('abstract', () {
@@ -380,15 +380,18 @@ void main() {
   });
 
   group('Method', () {
-    Class classB;
-    Method m, m3, m4;
+    Class classB, klass;
+    Method m, m3, m4, m5, m6;
 
     setUp(() {
+      klass = exLibrary.classes.singleWhere((c) => c.name == 'Klass');
       classB = exLibrary.classes.singleWhere((c) => c.name == 'B');
       m = classB.instanceMethods.first;
       m3 = exLibrary.classes
           .singleWhere((c) => c.name == 'Apple').instanceMethods.first;
       m4 = classB.instanceMethods[1];
+      m5 = klass.instanceMethods.singleWhere((m) => m.name == 'another');
+      m6 = klass.instanceMethods.singleWhere((m) => m.name == 'toString');
     });
 
     test('overriden method', () {
@@ -414,6 +417,13 @@ void main() {
     test('parameter is a function', () {
       var element = m4.parameters[1].modelType.element as Typedef;
       expect(element.linkedReturnType, 'String');
+    });
+
+    test('doc for method with no return type', () {
+      var comment = m5.documentation;
+      var comment2 = m6.documentation;
+      expect(comment, equals('Another method'));
+      expect(comment2, equals('A shadowed method'));
     });
   });
 

--- a/test_package/lib/example.dart
+++ b/test_package/lib/example.dart
@@ -63,9 +63,6 @@ class B extends Apple with Cat {
   void writeMsg(String msg, [String transformMsg(String origMsg, bool flag)]) {
     // do nothing
   }
-
-  /// method has no return type
-  noReturnType() {}
 }
 
 // Do NOT add a doc comment to C. Testing blank comments.

--- a/test_package/lib/example.dart
+++ b/test_package/lib/example.dart
@@ -63,6 +63,9 @@ class B extends Apple with Cat {
   void writeMsg(String msg, [String transformMsg(String origMsg, bool flag)]) {
     // do nothing
   }
+
+  /// method has no return type
+  noReturnType() {}
 }
 
 // Do NOT add a doc comment to C. Testing blank comments.
@@ -142,3 +145,15 @@ class ConstantCat implements Cat {
 }
 
 enum Animal { CAT, DOG, HORSE }
+
+/// A class
+class Klass {
+/// A method
+  method() {}
+
+/// Another method
+  another() {}
+
+/// A shadowed method
+  toString() {}
+}


### PR DESCRIPTION
 @sethladd  By not parsing the body, dartdoc looses the information on whether to query a method as being async. We had turned it off to save time. Running it on the sdk, see that there is about 2 sec difference for parsing and not parsing function bodies. So turning it back on.

closes #568 