### PR TITLE
Add support for --url-mapping to dartdoc

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -76,6 +76,21 @@ main(List<String> arguments) async {
     packageRootDir = new Directory(_resolveTildePath(args['package-root']));
   }
 
+  Map<String, String> urlMappings;
+  if (args['url-mapping'] != null) {
+    urlMappings = new Map<String, String>();
+    for (String mapping in args['url-mapping']) {
+      int commaIndex = mapping.indexOf(',');
+      if (commaIndex == -1) {
+        print('Error: URL mapping "$mapping" does not contain a comma.');
+        exit(1);
+      }
+      String url = mapping.substring(0, commaIndex);
+      String path = mapping.substring(commaIndex + 1);
+      urlMappings[url] = path;
+    }
+  }
+
   if (args.rest.isNotEmpty) {
     var unknownArgs = args.rest.join(' ');
     print('Error: detected unknown command-line argument(s): $unknownArgs');
@@ -93,7 +108,7 @@ main(List<String> arguments) async {
   var generators = initGenerators(url, headerFilePath, footerFilePath);
 
   var dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
-      outputDir, packageRootDir, packageMeta);
+      outputDir, packageRootDir, packageMeta, urlMappings);
 
   try {
     DartDocResults results = await dartdoc.generateDocs();
@@ -142,6 +157,11 @@ ArgParser _createArgsParser() {
   parser.addOption('footer',
       help: 'path to file containing HTML text, inserted into the footer of every page.');
   parser.addOption('package-root', help: 'The path to the package root.');
+  parser.addOption('url-mapping',
+      help: '--url-mapping=libraryUri,/path/to/library.dart directs dartdoc to '
+      'use "library.dart" as the source for an import of "libraryUri"',
+      allowMultiple: true,
+      splitCommas: false);
   parser.addOption('exclude',
       help: 'Comma-separated list of library names to ignore.');
   parser.addOption('hosted-url',

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -13,6 +13,7 @@ import 'package:analyzer/src/generated/error.dart';
 import 'package:analyzer/src/generated/java_io.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/sdk_io.dart';
+import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
 
 import 'generator.dart';
@@ -47,13 +48,14 @@ class DartDoc {
   final Directory outputDir;
   final Directory packageRootDir;
   final PackageMeta packageMeta;
+  final Map<String, String> urlMappings;
 
   final Set<LibraryElement> libraries = new Set();
 
   Stopwatch _stopwatch;
 
   DartDoc(this.rootDir, this.excludes, this.sdkDir, this.generators,
-      this.outputDir, this.packageRootDir, this.packageMeta);
+      this.outputDir, this.packageRootDir, this.packageMeta, this.urlMappings);
 
   /// Generate the documentation. [DartDocResults] is returned if dartdoc
   /// succeeds. [DartDocFailure] is thrown if dartdoc fails in an expected way,
@@ -98,6 +100,8 @@ class DartDoc {
       new DartUriResolver(sdk),
       new FileUriResolver()
     ];
+    if (urlMappings != null) resolvers.insert(
+        0, new CustomUriResolver(urlMappings));
     JavaFile packagesDir = packageRootDir == null
         ? new JavaFile.relative(new JavaFile(rootDir.path), 'packages')
         : new JavaFile(packageRootDir.path);

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -29,8 +29,8 @@ void main() {
 
     test('generateDocs ${path.basename(testPackageDir.path)}', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageDir);
-      DartDoc dartdoc =
-          new DartDoc(testPackageDir, [], getSdkDir(), [], tempDir, null, meta);
+      DartDoc dartdoc = new DartDoc(
+          testPackageDir, [], getSdkDir(), [], tempDir, null, meta, null);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);
@@ -44,7 +44,7 @@ void main() {
     test('generateDocs ${path.basename(testPackageBadDir.path)}', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageBadDir);
       DartDoc dartdoc = new DartDoc(
-          testPackageBadDir, [], getSdkDir(), [], tempDir, null, meta);
+          testPackageBadDir, [], getSdkDir(), [], tempDir, null, meta, null);
 
       try {
         await dartdoc.generateDocs();


### PR DESCRIPTION
This option is useful for clients who embed the DartVM and define their own
built-in libraries, such as Sky.

Fixes #599