### PR TITLE
warn when we encounter an undocumented library

### DIFF
--- a/lib/markdown_processor.dart
+++ b/lib/markdown_processor.dart
@@ -172,7 +172,7 @@ String _replaceAllLinks(ModelElement element, String str,
         if (link != null) {
           buf.write('<a href="$link">$codeRef</a>');
         } else {
-          print("WARNING: $element contains unknown doc reference [$codeRef]");
+          print("  warning: unresolved doc reference '$codeRef' (in $element)");
           buf.write(codeRef);
         }
       }

--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -222,8 +222,13 @@ class HtmlGeneratorInstance {
   void generateLibrary(Package package, Library lib) {
     print('generating docs for library ${lib.path}...');
 
-    // TODO should we add _this_ to the context and avoid putting stuff
-    // in the map?
+    if (!lib.hasDocumentation) {
+      print(
+          "  warning: library '${lib.name}' has no documentation; consider adding some");
+    }
+
+    // TODO: Should we add _this_ to the context and avoid putting stuff in the
+    // map?
     Map data = {
       'package': package,
       'library': lib,


### PR DESCRIPTION
Warn when we encounter an undocumented library.

```
generating docs for library dartdoc.dart...
generating docs for library generator.dart...
  warning: library 'dartdoc.generator' has no documentation; consider adding some
generating docs for library markdown_processor.dart...
generating docs for library resource_loader.dart...
  warning: unresolved doc reference 'Uint8List' (in ModelFunction loadAsBytes)
  warning: unresolved doc reference 'Uint8List' (in ModelFunction loadAsBytes)
Documented 4 libraries in 11.4 seconds.
```

@keertip 