### PR TITLE
fix refs for parameters

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1367,8 +1367,15 @@ class Parameter extends ModelElement {
   Parameter(ParameterElement element, Library library)
       : super(element, library) {
     var t = _parameter.type;
-    _modelType = new ElementType(t, new ModelElement.from(
-        t.element, new Library(t.element.library, library.package)));
+    var lib;
+    try {
+      lib = library.package.libraries
+          .firstWhere((l) => l.hasInNamespace(t.element));
+    } on StateError {}
+    if (lib == null) {
+      lib = new Library(t.element.library, library.package);
+    }
+    _modelType = new ElementType(t, new ModelElement.from(t.element, lib));
   }
 
   ParameterElement get _parameter => element as ParameterElement;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1368,10 +1368,8 @@ class Parameter extends ModelElement {
       : super(element, library) {
     var t = _parameter.type;
     var lib;
-    try {
-      lib = library.package.libraries
-          .firstWhere((l) => l.hasInNamespace(t.element));
-    } on StateError {}
+    lib = library.package.libraries.firstWhere(
+        (l) => l.hasInNamespace(t.element), orElse: () => null);
     if (lib == null) {
       lib = new Library(t.element.library, library.package);
     }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -327,7 +327,7 @@ void main() {
     });
 
     test('inherited methods', () {
-      expect(B.inheritedMethods, hasLength(2));
+      expect(B.inheritedMethods, hasLength(3));
       expect(B.hasInheritedMethods, isTrue);
     });
 
@@ -576,12 +576,13 @@ void main() {
 
   group('Parameter', () {
     Class c, f;
-    Method isGreaterThan, asyncM, methodWithGenericParam;
+    Method isGreaterThan, asyncM, methodWithGenericParam, paramFromExportLib;
     Parameter p1;
 
     setUp(() {
       c = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
       isGreaterThan = c.instanceMethods[2]; // isGreaterThan
+      paramFromExportLib = c.instanceMethods[3];
       asyncM = exLibrary.classes
               .firstWhere((c) => c.name == 'Dog').instanceMethods
           .firstWhere((m) => m.name == 'foo');
@@ -613,6 +614,11 @@ void main() {
     test('param with generics', () {
       var params = methodWithGenericParam.linkedParams();
       expect(params.contains('List') && params.contains('Apple'), isTrue);
+    });
+
+    test('param exported in library', () {
+      var param = paramFromExportLib.parameters[0];
+      expect(param.library.name, equals('ex'));
     });
   });
 

--- a/test_package/lib/example.dart
+++ b/test_package/lib/example.dart
@@ -1,6 +1,7 @@
 /// a library. testing string escaping: `var s = 'a string'` <cool>
 library ex;
 
+import 'src/mylib.dart' show Helper;
 export 'src/mylib.dart' show Helper;
 export 'dart:core' show DateTime;
 
@@ -47,6 +48,8 @@ class Apple {
   bool isGreaterThan(int number, {int check: 5}) {
     return number > check;
   }
+
+  void paramFromExportLib(Helper helper) {}
 }
 /// Extends class [Apple], use [new Apple] or [new Apple.fromString]
 class B extends Apple with Cat {


### PR DESCRIPTION
fixes the broken link in #609. We can address the bigger issue of how/where the exported libraries are generated later.

@devoncarew 