### PR TITLE
fix some style issues; remove an analysis warning

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -182,11 +182,11 @@ dt {
 
 dd {
   margin-bottom: 16px;
-  color: hsl(0, 0%, 46%);
+  color: #727272;
 }
 
 section.summary h2 {
-  color: hsl(0, 0%, 46%);
+  color: #727272;
   margin-bottom: 16px;
   border-bottom: 1px solid #B6B6B6;
 }
@@ -310,7 +310,7 @@ footer .container-fluid {
 }
 
 .gt-separated.dark li:after {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='#000000' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='#727272' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
 }
 
 .gt-separated li:last-child:after {
@@ -318,6 +318,7 @@ footer .container-fluid {
 }
 
 .is-inherited {
+  color: #727272;
   font-style: italic;
 }
 
@@ -388,15 +389,15 @@ section.multi-line-signature div.parameters {
 }
 
 span.top-level-variable-type {
-  opacity: 0.6;
+  color: #727272;
 }
 
 @media(max-width: 768px) {
-  span.top-level-variable-type {
-    display:block;
+  dl.properties span.top-level-variable-type {
+    display: block;
   }
 
-  section.summary dt {
+  section.summary dl.properties dt {
     margin-left: 0;
     text-indent: inherit;
   }

--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -135,7 +135,7 @@ class HtmlGenerator extends Generator {
 }
 
 class HtmlGeneratorInstance {
-  final String _url;
+  final String url;
   final Templates _templates;
 
   final Package package;
@@ -143,7 +143,7 @@ class HtmlGeneratorInstance {
 
   final List<String> _htmlFiles = [];
 
-  HtmlGeneratorInstance(this._url, this._templates, this.package, this.out);
+  HtmlGeneratorInstance(this.url, this._templates, this.package, this.out);
 
   Future generate() async {
     var previousTag = _HTML_GENERATE.makeCurrent();
@@ -207,7 +207,7 @@ class HtmlGeneratorInstance {
       });
     });
 
-    //if (_url != null) generateSiteMap();
+    //if (url != null) generateSiteMap();
 
     await _copyResources();
 

--- a/lib/templates/_callable.html
+++ b/lib/templates/_callable.html
@@ -3,7 +3,7 @@
         &#8594;
         <span class="returntype">{{{ linkedReturnType }}}</span>
     </span>
-    {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
+    {{#isInherited}}<span class="is-inherited">inherited</span>{{/isInherited}}
 </dt>
 <dd>
     {{{ oneLineDoc }}}

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,7 +1,7 @@
 <dt id="{{htmlId}}" class="property">
     <span class="top-level-variable-type">{{{ linkedReturnType }}}</span>
     <a href="{{href}}">{{>name_summary}}</a>
-    {{#isInherited}}<span class="is-inherited">Inherited</span>{{/isInherited}}
+    {{#isInherited}}<span class="is-inherited">inherited</span>{{/isInherited}}
 </dt>
 <dd>
     {{>readable_writable}}


### PR DESCRIPTION
- restore some wrapping behavior with method params - the 2nd line and following lines are indented
<img width="189" alt="screen shot 2015-07-10 at 9 05 00 pm" src="https://cloud.githubusercontent.com/assets/1269969/8632240/075754e2-2748-11e5-8312-ac980a169a1e.png">
- normalize our colors a bit - there were a few colors that were very similar but had slightly different values (colors to represent non-primary things)
- fixed an analysis warning
- made the `inherited ` marker look more like the `read-only` et all markers
<img width="280" alt="screen shot 2015-07-10 at 9 03 17 pm" src="https://cloud.githubusercontent.com/assets/1269969/8632258/5e787210-2748-11e5-8394-f13799a6d2cb.png">
