### PR TITLE
add a nav section for packages

### DIFF
--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -545,9 +545,7 @@ class Subnav {
 }
 
 List<Subnav> _gatherSubnavForPackage(Package package) {
-  return [
-    new Subnav('Libraries', '${package.href}#libraries')
-  ];
+  return [new Subnav('Libraries', '${package.href}#libraries')];
 }
 
 List<Subnav> _gatherSubnavForLibrary(Library lib) {

--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -226,6 +226,7 @@ class HtmlGeneratorInstance {
       'metaDescription':
           '${package.name} API docs, for the Dart programming language.',
       'navLinks': [package],
+      'subnavItems': _gatherSubnavForPackage(package),
       'htmlBase': '.'
     };
 
@@ -541,6 +542,12 @@ class Subnav {
   Subnav(this.name, this.href);
 
   String toString() => name;
+}
+
+List<Subnav> _gatherSubnavForPackage(Package package) {
+  return [
+    new Subnav('Libraries', '${package.href}#libraries')
+  ];
 }
 
 List<Subnav> _gatherSubnavForLibrary(Library lib) {


### PR DESCRIPTION
Follow up to the nav PR, add a nav section to the package page, to jump to the `Libraries` section.

<img width="171" alt="screen shot 2015-07-13 at 10 09 06 am" src="https://cloud.githubusercontent.com/assets/1269969/8655638/5f36faf4-2947-11e5-9322-3f1025266c12.png">
