### PR TITLE
add an .analysis_options file

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,6 @@
+# Analyzer options file.
+
+analyzer:
+  exclude:
+    - test_package_bad/
+    - doc/api/


### PR DESCRIPTION
Add an .analysis_options file. This will cut down on false positives (`test_package_bad/`) and on unnecessary analysis (`doc/api/`).

@sethladd @johnmccutchan 