### PR TITLE
css tweaks

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -5,3 +5,4 @@ analyzer:
     - test_package/doc/api
     - test_package_bad/
     - doc/api/
+    - pub.dartlang.org/

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -475,6 +475,11 @@ ol#sidebar {
   list-style: none;
   padding: 0;
   font-size: 14px;
+  line-height: 24px;
+}
+
+ol#sidebar li {
+  text-overflow: ellipsis;
   overflow: hidden;
 }
 
@@ -490,8 +495,8 @@ ol#sidebar li.section-title {
 }
 
 ol#sidebar li:first-child {
-  padding-top: 0px;
-  margin-top: 0px;
+  padding-top: 0;
+  margin-top: 0;
 }
 
 #sidenav-toggle {

--- a/lib/templates/_documentation.html
+++ b/lib/templates/_documentation.html
@@ -1,7 +1,7 @@
 <section class="desc markdown">
 
     {{^hasDocumentation}}
-    <p class="no-docs">(Not documented.)</p>
+    <p class="no-docs">Not documented.</p>
     {{/hasDocumentation}}
 
     {{{ documentationAsHtml }}}

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -8,8 +8,11 @@
                 <span class="copyright no-break">{{package.name}} {{package.version}}</span>
                 &bull;
                 <span class="copyright no-break">
-                <a href="https://www.dartlang.org"><img src="static-assets/favicon.png" alt="Dart" title="Dart"
-                  width="24" height="24"></a> API Docs
+                  apis
+                  <a href="https://www.dartlang.org">
+                    <img src="static-assets/favicon.png" alt="Dart" title="Dart"width="16" height="16">
+                  </a>
+                  docs
                 </span>
                 &bull;
                 <span class="copyright no-break">

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -4,19 +4,18 @@
     <div class="container-fluid">
         <div class="container">
             <p class="text-center">
-
-                <span class="copyright no-break">{{package.name}} {{package.version}}</span>
-                &bull;
-                <span class="copyright no-break">
-                  apis
-                  <a href="https://www.dartlang.org">
-                    <img src="static-assets/favicon.png" alt="Dart" title="Dart"width="16" height="16">
-                  </a>
-                  docs
+                <span class="no-break">
+                  {{package.name}} {{package.version}} api docs
                 </span>
                 &bull;
                 <span class="copyright no-break">
-                    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+                  <a href="https://www.dartlang.org">
+                    <img src="static-assets/favicon.png" alt="Dart" title="Dart"width="16" height="16">
+                  </a>
+                </span>
+                &bull;
+                <span class="copyright no-break">
+                  <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
                 </span>
             </p>
         </div>


### PR DESCRIPTION
- increase the line-height for the left nav (it looked too compressed as is)
- make the footer more symmetrical

<img width="315" alt="screen shot 2015-07-21 at 6 00 30 pm" src="https://cloud.githubusercontent.com/assets/1269969/8815777/ab2be05a-2fd2-11e5-861e-e3cb9ec20331.png">

<img width="180" alt="screen shot 2015-07-21 at 6 00 22 pm" src="https://cloud.githubusercontent.com/assets/1269969/8815783/b430751c-2fd2-11e5-9a4b-1afde2c1c61a.png">

<img width="194" alt="screen shot 2015-07-21 at 6 00 44 pm" src="https://cloud.githubusercontent.com/assets/1269969/8815787/bb5f6316-2fd2-11e5-9c0e-801ec1c72f5b.png">

Also, thoughts on the section headers? Should they be all-caps, a bit smaller, and have their underlined slightly closer to the text?
<img width="185" alt="screen shot 2015-07-21 at 6 01 00 pm" src="https://cloud.githubusercontent.com/assets/1269969/8815790/dbc4ca06-2fd2-11e5-9017-b507a4caac50.png">

@sethladd 