### PR TITLE
fix a bug generating windows element links

### DIFF
--- a/lib/markdown_processor.dart
+++ b/lib/markdown_processor.dart
@@ -253,21 +253,18 @@ String _getMatchingLink(
       }
     }
   }
-  if (refElement == null) {
-    return null;
-  }
+
+  if (refElement == null) return null;
+
   var refLibrary;
-  try {
-    var e = refElement is ClassMemberElement ||
-            refElement is PropertyAccessorElement
-        ? refElement.enclosingElement
-        : refElement;
-    refLibrary =
-        element.package.libraries.firstWhere((lib) => lib.hasInNamespace(e));
-  } on StateError {}
+  var e = refElement is ClassMemberElement ||
+          refElement is PropertyAccessorElement
+      ? refElement.enclosingElement
+      : refElement;
+  refLibrary = element.package.libraries.firstWhere(
+      (lib) => lib.hasInNamespace(e), orElse: () => null);
   if (refLibrary != null) {
-    var e = new ModelElement.from(refElement, refLibrary);
-    return e.href;
+    return new ModelElement.from(refElement, refLibrary).href;
   }
   return null;
 }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -222,22 +222,16 @@ void main() {
           '<a href="ex/Apple/Apple.fromString.html">new Apple.fromString</a>'));
     });
 
-    // On Windows, this test fails due to not being able to find the library that
-    // contains class Apple, checking in namespace does not work.
-    // TODO(keertip): figure out why the element returned from namespace is not
-    // the same as the one we are checking for.
-    if (!Platform.isWindows) {
-      test('reference to class from another library', () {
-        String comment = superAwesomeClass.documentationAsHtml;
-        expect(comment, contains('<a href="ex/Apple-class.html">Apple</a>'));
-      });
+    test('reference to class from another library', () {
+      String comment = superAwesomeClass.documentationAsHtml;
+      expect(comment, contains('<a href="ex/Apple-class.html">Apple</a>'));
+    });
 
-      test('reference to method', () {
-        String comment = foo2.documentationAsHtml;
-        expect(comment, equals(
-            '<p>link to method from class <a href="ex/Apple/m.html">Apple.m</a></p>'));
-      });
-    }
+    test('reference to method', () {
+      String comment = foo2.documentationAsHtml;
+      expect(comment, equals(
+          '<p>link to method from class <a href="ex/Apple/m.html">Apple.m</a></p>'));
+    });
 
     test('legacy code blocks render correctly', () {
       expect(testingCodeSyntaxInOneLiners.oneLineDoc,

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -63,8 +63,7 @@ void main() {
     });
 
     test('getReadmeContents()', () {
-      // TODO: This is null for SDK 1.10.
-      //expect(p.getReadmeContents(), isNotNull);
+      expect(p.getReadmeContents(), isNotNull);
     });
 
     test('getLicenseContents()', () {

--- a/test/template_test.dart
+++ b/test/template_test.dart
@@ -25,7 +25,7 @@ void main() {
       });
 
       test('render', () {
-        expect(sitemap({'links': [{'name': 'somefile.html'}]}), '''
+        expect(_normalize(sitemap({'links': [{'name': 'somefile.html'}]})), '''
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
@@ -36,9 +36,9 @@ void main() {
       });
 
       test('substitute multiple links', () {
-        expect(sitemap({
+        expect(_normalize(sitemap({
           'links': [{'name': 'somefile.html'}, {'name': 'asecondfile.html'}]
-        }), '''
+        })), '''
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
@@ -52,10 +52,10 @@ void main() {
       });
 
       test('url and file name', () {
-        expect(sitemap({
+        expect(_normalize(sitemap({
           'url': 'http://mydoc.com',
           'links': [{'name': 'somefile.html'}]
-        }), '''
+        })), '''
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
@@ -67,3 +67,5 @@ void main() {
     });
   });
 }
+
+String _normalize(String str) => str.replaceAll('\r\n', '\n');

--- a/test_package/lib/example.dart
+++ b/test_package/lib/example.dart
@@ -51,6 +51,7 @@ class Apple {
 
   void paramFromExportLib(Helper helper) {}
 }
+
 /// Extends class [Apple], use [new Apple] or [new Apple.fromString]
 class B extends Apple with Cat {
   List<String> list;


### PR DESCRIPTION
Fix https://github.com/dart-lang/dartdoc/issues/587 - a bug with a windows test and an issue generating links to elements in dartdoc on windows.

- re-enable two windows tests and one general test
- fix an issue with some tests on windows and `\r\n` line endings
- fix a regression where the docs for many properties were "`null`"
