### PR TITLE
always show source for methods

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -532,34 +532,8 @@ ol#sidebar li:first-child {
   .sidebar-offcanvas{position:absolute;top:0;width:50%;}
 }
 
-/* toggling source code */
+/* source code method bodies */
 
 .source-code pre {
   margin: 16px 0 16px 0;
-}
-
-.source-code h4 {
-  color: #455A64;
-  text-transform: uppercase;
-  font-size: 14px;
-}
-
-.source-code h4:hover {
-  cursor: pointer;
-}
-
-.source-code-toggle {
-  font-size: 80%;
-  float: left;
-  width: 1.2em;
-  padding-top: 2px; /* how to avoid this? how to vertically align? */
-  opacity: 0.7;
-}
-
-.source-code-toggle.closed::before {
-  content: '\25B6';
-}
-
-.source-code-toggle.open::before {
-  content: '\25BC';
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1119,7 +1119,15 @@ abstract class SourceCodeMixin {
         break;
       }
     }
-    return contents.substring(node.offset - (node.offset - i), node.end);
+
+    // Trim the common indent from the source snippet.
+    String source =
+        contents.substring(node.offset - (node.offset - i), node.end);
+    String remainer = source.trimLeft();
+    String indent = source.substring(0, source.length - remainer.length);
+    return source.split('\n').map((line) {
+      return line.startsWith(indent) ? line.substring(indent.length) : line;
+    }).join('\n');
   }
 
   Element get element;

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -58,26 +58,10 @@ function shiftWindow() {
   scrollBy(0, -68);
 }
 
-function initSourceToggle() {
-  var toggle = document.querySelector('.source-code h4');
-  var toggleArrow = document.querySelector('.source-code-toggle');
-  var code = document.querySelector('.source-code pre');
-
-  if (toggle && toggleArrow && code) {
-    toggle.addEventListener('click', function(e) {
-      var closed = toggleArrow.classList.contains('closed');
-      toggleArrow.classList.toggle('closed', !closed);
-      toggleArrow.classList.toggle('open', closed);
-      code.style.display = closed ? 'block' : 'none';
-    });
-  }
-}
-
 document.addEventListener("DOMContentLoaded", function() {
   prettyPrint();
   initScroller();
   initSideNav();
-  initSourceToggle();
 
   // Make sure the anchors scroll past the fixed page header (#648).
   if (location.hash) shiftWindow();

--- a/lib/templates/_readable_writable.html
+++ b/lib/templates/_readable_writable.html
@@ -1,6 +1,3 @@
 <div class="readable-writable">
-    {{#readOnly}}read-only{{/readOnly}}
-    {{#writeOnly}}write-only{{/writeOnly}}
-    {{#readWrite}}read / write{{/readWrite}}
-    {{#isInherited}}, <span class="is-inherited">inherited</span>{{/isInherited}}
+    {{#readOnly}}read-only{{/readOnly}}{{#writeOnly}}write-only{{/writeOnly}}{{#readWrite}}read / write{{/readWrite}}{{#isInherited}}, <span class="is-inherited">inherited</span>{{/isInherited}}
 </div>

--- a/lib/templates/_source_code.html
+++ b/lib/templates/_source_code.html
@@ -1,4 +1,4 @@
-<section class="source-code">
-  <h4><span class="source-code-toggle closed"></span> Source</h4>
-  <pre style="display:none"><code class="prettyprint lang-dart">{{ sourceCode }}</code></pre>
+<section class="summary source-code">
+  <h2>Source</h2>
+  <pre><code class="prettyprint lang-dart">{{ sourceCode }}</code></pre>
 </section>

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -473,8 +473,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('method source code indents correctly', () {
-      expect(convertToMap.sourceCode,
-          startsWith('  /// Converts itself to a map.'));
+      expect(
+          convertToMap.sourceCode, startsWith('/// Converts itself to a map.'));
     });
   });
 


### PR DESCRIPTION
- fixed a minor UI item where field properties would should as `read-only , inherited` rather than `read-only, inherited`
- always show source code; remove the disclosure toggle; use the section h2 instead of an h4
- strip the common indent off the displayed source