### PR TITLE
show a source link in the subnav

### DIFF
--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -323,6 +323,7 @@ class HtmlGeneratorInstance {
       'layoutTitle': _layoutTitle(
           constructor.name, 'constructor', constructor.isDeprecated),
       'navLinks': [package, lib, clazz],
+      'subnavItems': _gatherSubnavForInvokable(constructor),
       'htmlBase': '../..',
       'self': constructor
     };
@@ -362,6 +363,7 @@ class HtmlGeneratorInstance {
       'metaDescription':
           'API docs for the ${function.name} function from the ${lib.name} library, for the Dart programming language.',
       'navLinks': [package, lib],
+      'subnavItems': _gatherSubnavForInvokable(function),
       'htmlBase': '..',
       'self': function
     };
@@ -386,6 +388,7 @@ class HtmlGeneratorInstance {
       'metaDescription':
           'API docs for the ${method.name} method from the ${clazz.name} class, for the Dart programming language.',
       'navLinks': [package, lib, clazz],
+      'subnavItems': _gatherSubnavForInvokable(method),
       'htmlBase': '../..',
       'self': method
     };
@@ -599,6 +602,15 @@ List<Subnav> _gatherSubnavForClass(Class clazz) {
       .add(new Subnav('Methods', '${clazz.href}#instance-methods'));
 
   return navs;
+}
+
+List<Subnav> _gatherSubnavForInvokable(ModelElement element) {
+  if (element is SourceCodeMixin &&
+      (element as SourceCodeMixin).hasSourceCode) {
+    return [new Subnav('Source', '${element.href}#source')];
+  } else {
+    return [];
+  }
 }
 
 String _layoutTitle(String name, String kind, bool isDeprecated) {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1126,9 +1126,12 @@ abstract class SourceCodeMixin {
     String remainer = source.trimLeft();
     String indent = source.substring(0, source.length - remainer.length);
     return source.split('\n').map((line) {
+      line = line.trimRight();
       return line.startsWith(indent) ? line.substring(indent.length) : line;
     }).join('\n');
   }
+
+  bool get hasSourceCode => sourceCode.trim().isNotEmpty;
 
   Element get element;
 }

--- a/lib/templates/_source_code.html
+++ b/lib/templates/_source_code.html
@@ -1,4 +1,4 @@
-<section class="summary source-code">
+<section class="summary source-code" id="source">
   <h2>Source</h2>
   <pre><code class="prettyprint lang-dart">{{ sourceCode }}</code></pre>
 </section>

--- a/lib/templates/constant.html
+++ b/lib/templates/constant.html
@@ -1,16 +1,31 @@
 {{>head}}
+<div class="row row-offcanvas row-offcanvas-left">
 
-  <section class="multi-line-signature">
-        {{#property}}
-            <span class="returntype">{{{ linkedReturnType }}}</span>
-            {{>name_summary}}
-            =
-            <span class="constant-value">{{{ constantValue }}}</span>
-        {{/property}}
-  </section>
+  <div class="col-xs-6 col-sm-3 sidebar-offcanvas">
 
-  {{#property}}
-  {{>documentation}}
-  {{/property}}
+    <h5>{{{class.linkedName}}}</h5>
+
+    {{>sidebar_for_class}}
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9">
+
+    <section class="multi-line-signature">
+          {{#property}}
+              <span class="returntype">{{{ linkedReturnType }}}</span>
+              {{>name_summary}}
+              =
+              <span class="constant-value">{{{ constantValue }}}</span>
+          {{/property}}
+    </section>
+
+    {{#property}}
+    {{>documentation}}
+    {{/property}}
+
+  </div> <!-- /.col-xs-12.col-sm-9 -->
+
+</div> <!-- /.row-offcanvas -->
 
 {{>footer}}

--- a/lib/templates/constructor.html
+++ b/lib/templates/constructor.html
@@ -28,6 +28,12 @@
     {{>documentation}}
     {{/constructor}}
 
+    {{#constructor}}
+      {{#hasSourceCode}}
+      {{>source_code}}
+      {{/hasSourceCode}}
+    {{/constructor}}
+
   </div> <!-- /.col-xs-12.col-sm-9 -->
 
 </div> <!-- /.row-offcanvas -->

--- a/lib/templates/function.html
+++ b/lib/templates/function.html
@@ -3,8 +3,6 @@
 <div class="row row-offcanvas row-offcanvas-left">
 
   <div class="col-xs-6 col-sm-3 sidebar-offcanvas">
-    <h5>{{{library.linkedName}}}</h5>
-
     <ol id="sidebar">
       {{#library.hasConstants}}
       <li class="section-title"><a href="{{library.href}}#constants">Constants</a></li>

--- a/lib/templates/top_level_constant.html
+++ b/lib/templates/top_level_constant.html
@@ -3,8 +3,6 @@
 <div class="row row-offcanvas row-offcanvas-left">
 
   <div class="col-xs-6 col-sm-3 sidebar-offcanvas">
-    <h5>{{{library.linkedName}}}</h5>
-
     <ol id="sidebar">
       {{#library.hasConstants}}
       <li class="section-title"><a href="{{library.href}}#constants">Constants</a></li>

--- a/lib/templates/top_level_property.html
+++ b/lib/templates/top_level_property.html
@@ -3,8 +3,6 @@
 <div class="row row-offcanvas row-offcanvas-left">
 
   <div class="col-xs-6 col-sm-3 sidebar-offcanvas">
-    <h5>{{{library.linkedName}}}</h5>
-
     <ol id="sidebar">
       {{#library.hasConstants}}
       <li class="section-title"><a href="{{library.href}}#constants">Constants</a></li>

--- a/lib/templates/typedef.html
+++ b/lib/templates/typedef.html
@@ -3,8 +3,6 @@
 <div class="row row-offcanvas row-offcanvas-left">
 
   <div class="col-xs-6 col-sm-3 sidebar-offcanvas">
-    <h5>{{{library.linkedName}}}</h5>
-
     <ol id="sidebar">
       {{#library.hasConstants}}
       <li class="section-title"><a href="{{library.href}}#constants">Constants</a></li>


### PR DESCRIPTION
- show a left nav for constants
- show the source code for constructors (fix https://github.com/dart-lang/dartdoc/issues/708)
- show a top nav link for `Source`. This gives us some visual consistency with the other pages
- remove the h5 link on the top of left navs. Navigating between parent and child pages, the left nav was very slightly different; this normalizes them.

@sethladd 