### PR TITLE
Document property types on the right like methods.

### DIFF
--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,6 +1,6 @@
 <dt id="{{htmlId}}" class="property">
-    <span class="top-level-variable-type">{{{ linkedReturnType }}}</span>
     {{#isInherited}}{{>name_summary}}{{/isInherited}}{{^isInherited}}{{{linkedName}}}{{/isInherited}}
+    <span class="signature">&#8594; {{{ linkedReturnType }}}</span>
 </dt>
 <dd>
     {{>readable_writable}}


### PR DESCRIPTION
This keeps the property name nice and flush left so it's easy to find.