### PR TITLE
Make section titles lighter (and a bit bigger).

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -324,7 +324,7 @@ footer .container-fluid {
 }
 
 .gt-separated li:before {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='#FFFFFF' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='#DDDDDD' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
   background-position: center;
   content: "\00a0";
   margin: 0 6px 0 4px;
@@ -504,7 +504,8 @@ span.top-level-variable-type {
 }
 
 .sidebar ol li.section-title {
-  font-size: 12px;
+  font-size: 13px;
+  color: #B6B6B6;
   text-transform: uppercase;
   line-height: 20px;
   margin-top: 24px;


### PR DESCRIPTION
Since they don't contain real content, they don't need to stand out
that much. Lightening does that, and making the font a bit bigger makes
it a bit easier to read when you do want to.

Also, darkened the ">" in the breadcrumbs to show that it's not part
of the link.