### PR TITLE
use the new Resource api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: dart
 sudo: false
-dart: 
+dart:
   - dev
-  - stable
+#  - stable
 env:
   - GEN_SDK_DOCS=true
   - GEN_SDK_DOCS=false

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -151,7 +151,7 @@ class DartDoc {
         if (name.startsWith(Platform.pathSeparator)) name = name.substring(1);
       }
       print('parsing ${name}...');
-      Source source = new FileBasedSource.con1(new JavaFile(filePath));
+      Source source = new FileBasedSource(new JavaFile(filePath));
       sources.add(source);
       if (context.computeKindOf(source) == SourceKind.LIBRARY) {
         LibraryElement library = context.computeLibraryElement(source);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -11,7 +11,6 @@ import 'package:analyzer/src/generated/resolver.dart';
 import 'package:analyzer/src/generated/utilities_dart.dart' show ParameterKind;
 import 'package:quiver/core.dart';
 
-import 'debug.dart';
 import 'html_utils.dart';
 import 'model_utils.dart';
 import 'package_meta.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,9 +5,9 @@ author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
-  sdk: '>=1.9.0 <2.0.0' # when we go to 1.12, bump analyzer version
+  sdk: '>=1.12.0-dev.5.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.25.0 <0.27.0'
+  analyzer: '>=0.26.0 <0.27.0'
   args: ^0.13.0
   cli_util: ^0.0.1
   html: ^0.12.1

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -65,7 +65,7 @@ class AnalyzerHelper {
   }
 
   Source addSource(String filePath) {
-    Source source = new FileBasedSource.con1(new JavaFile(filePath));
+    Source source = new FileBasedSource(new JavaFile(filePath));
     ChangeSet changeSet = new ChangeSet();
     changeSet.addedSource(source);
     context.applyChanges(changeSet);


### PR DESCRIPTION
- redux of https://github.com/dart-lang/dartdoc/pull/769 - keep the old resource loading as a backup, until pub global activate generates .packages files
- use the new Resource API
- only support SDK 1.12.0 and newer