### PR TITLE
change sidebars to 2 cols and center to 8 cols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ packages
 .packages
 .settings/
 .DS_Store
+*.iml
 
 pub.dartlang.org/
 

--- a/lib/templates/class.html
+++ b/lib/templates/class.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 col-md-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
@@ -8,7 +8,7 @@
     {{>sidebar_for_library}}
   </div>
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     {{#clazz}}
     {{>documentation}}
@@ -162,7 +162,7 @@
 
     </div> <!-- /.main-content -->
 
-  <div class="col-xs-6 col-sm-6 col-md-3 sidebar sidebar-offcanvas-right">
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>{{self.name}}</h5>
     {{>sidebar_for_class}}
   </div><!--/.sidebar-offcanvas-->

--- a/lib/templates/constant.html
+++ b/lib/templates/constant.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
 
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
@@ -10,7 +10,7 @@
 
   </div><!--/.sidebar-offcanvas-left-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
           {{#property}}

--- a/lib/templates/constructor.html
+++ b/lib/templates/constructor.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
 
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
@@ -10,7 +10,7 @@
 
   </div><!--/.sidebar-offcanvas-left-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
         {{#constructor}}

--- a/lib/templates/function.html
+++ b/lib/templates/function.html
@@ -1,13 +1,13 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
     {{>sidebar_for_library}}
   </div><!--/.sidebar-offcanvas-left-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
         {{#function}}

--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-12 col-sm-9 col-md-9 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     {{#package}}
       {{>documentation}}
@@ -23,7 +23,7 @@
 
   </div> <!-- /.main-content -->
 
-  <div class="col-xs-6 col-sm-6 col-md-3 sidebar sidebar-offcanvas-right">
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
 
     <h5>{{self.name}}</h5>
 

--- a/lib/templates/library.html
+++ b/lib/templates/library.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 col-md-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
@@ -13,7 +13,7 @@
     </ol>
   </div>
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     {{#library}}
     {{>documentation}}
@@ -120,7 +120,7 @@
 
   </div> <!-- /.main-content -->
 
-  <div class="col-xs-6 col-sm-6 col-md-3 sidebar sidebar-offcanvas-right">
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>{{self.name}}</h5>
     {{>sidebar_for_library}}
   </div><!--/sidebar-offcanvas-right-->

--- a/lib/templates/method.html
+++ b/lib/templates/method.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
@@ -9,7 +9,7 @@
 
   </div><!--/.sidebar-offcanvas-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
         {{#method}}

--- a/lib/templates/property.html
+++ b/lib/templates/property.html
@@ -1,6 +1,6 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
@@ -9,7 +9,7 @@
 
   </div><!--/.sidebar-offcanvas-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
       {{#property}}

--- a/lib/templates/top_level_constant.html
+++ b/lib/templates/top_level_constant.html
@@ -1,13 +1,13 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
     {{>sidebar_for_library}}
   </div><!--/.sidebar-offcanvas-left-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
       {{#property}}

--- a/lib/templates/top_level_property.html
+++ b/lib/templates/top_level_property.html
@@ -1,13 +1,13 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
     {{>sidebar_for_library}}
   </div><!--/.sidebar-offcanvas-left-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
       {{#property}}

--- a/lib/templates/typedef.html
+++ b/lib/templates/typedef.html
@@ -1,13 +1,13 @@
 {{>head}}
 
-  <div class="col-xs-6 col-sm-3 sidebar sidebar-offcanvas-left">
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     {{#navLinks}}
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
     {{>sidebar_for_library}}
   </div><!--/.sidebar-offcanvas-left-->
 
-  <div class="col-xs-12 col-sm-9 col-md-6 main-content">
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
         {{#typeDef}}


### PR DESCRIPTION
Just floating this as an option, I don't think the sidebars need to be as large as they currently are, but I am sure others might disagree :).

This just applies to larger screens, and resolves https://github.com/dart-lang/dartdoc/issues/775, at least in the case of a full sized browser window.