### PR TITLE
display descriptions with ellipses

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -210,6 +210,9 @@ dd.callable, dd.constant, dd.property {
 
 dd p {
   margin-top: 4px;
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 section.summary h2 {
@@ -503,6 +506,7 @@ span.top-level-variable-type {
   padding: 16px;
 }
 
+.sidebar h5,
 .sidebar ol li {
   text-overflow: ellipsis;
   overflow: hidden;
@@ -553,7 +557,7 @@ button {
   }
 
   #overlay-under-drawer.active {
-    opacity: 0.7;
+    opacity: 0.4;
     height: 100%;
     z-index: 1999;
     position: fixed;

--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -1,5 +1,16 @@
 {{>head}}
 
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>{{self.name}}</h5>
+
+    <ol>
+      <li class="section-title"><a href="{{package.href}}#libraries">Libraries</a></li>
+      {{#package.libraries}}
+      <li><a href="{{href}}">{{name}}</a></li>
+      {{/package.libraries}}
+    </ol>
+  </div>
+
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     {{#package}}
@@ -24,15 +35,6 @@
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-
-    <h5>{{self.name}}</h5>
-
-    <ol>
-      <li class="section-title"><a href="{{package.href}}#libraries">Libraries</a></li>
-      {{#package.libraries}}
-      <li><a href="{{href}}">{{name}}</a></li>
-      {{/package.libraries}}
-    </ol>
 
   </div><!--/.sidebar-offcanvas-right-->
 


### PR DESCRIPTION
- fix #808; display one line of a description summary - use ellipses if it doesn't fit. This had been our behavior; not sure if this regressed or it was a conscious choice to move away from it.
- display the glass pane w/ slightly less opacity
- the columns on the index page now add up to 12
- move the nav from right to left on the index page. This way the libraries nav is in a consistent place when it's visible on the page.

<img width="416" alt="screen shot 2015-08-11 at 1 02 48 am" src="https://cloud.githubusercontent.com/assets/1269969/9194007/f90d9c96-3fcc-11e5-98c2-eb207e5b9e4c.png">

