### PR TITLE
fix upload to firebase

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -227,7 +227,8 @@ firebase() {
   Map env = Platform.environment;
 
   if (env['FIREBASE_USER'] == null) return;
-  if (env['TRAVIS_DART_VERSION'] != 'stable') return;
+  // TODO: Change this check back to 'stable' once #827 is addressed.
+  if (env['TRAVIS_DART_VERSION'] != 'dev') return;
 
   // Build the docs.
   Dart.run('bin/dartdoc.dart');


### PR DESCRIPTION
Fix https://github.com/dart-lang/dartdoc/issues/824 - upload the built docs to firebase during the build, when building on the dev channel bot.