### PR TITLE
remove --package-root, use --input for the analysis root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+* Removed the `--package-root` option. Dartdoc now uses the `--input` flag as
+  the place to start looking for an analysis root. This better supports the
+  `.packages` file and use cases where dartdoc is invoked from locations other
+  than the project directory.
+
 ## 0.6.0+1
 * [bug] fix for getting uri for sources in lib folder
 

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -74,11 +74,6 @@ main(List<String> arguments) async {
     outputDir = new Directory(_resolveTildePath(args['output']));
   }
 
-  Directory packageRootDir;
-  if (args['package-root'] != null) {
-    packageRootDir = new Directory(_resolveTildePath(args['package-root']));
-  }
-
   Map<String, String> urlMappings;
   if (args['url-mapping'] != null) {
     urlMappings = new Map<String, String>();
@@ -117,7 +112,7 @@ main(List<String> arguments) async {
   var generators = initGenerators(url, headerFilePath, footerFilePath);
 
   var dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
-      outputDir, packageRootDir, packageMeta, urlMappings, includeLibraries);
+      outputDir, packageMeta, urlMappings, includeLibraries);
 
   try {
     DartDocResults results = await dartdoc.generateDocs();
@@ -165,7 +160,6 @@ ArgParser _createArgsParser() {
       help: 'path to file containing HTML text, inserted into the header of every page.');
   parser.addOption('footer',
       help: 'path to file containing HTML text, inserted into the footer of every page.');
-  parser.addOption('package-root', help: 'The path to the package root.');
   parser.addOption('url-mapping',
       help: '--url-mapping=libraryUri,/path/to/library.dart directs dartdoc to '
       'use "library.dart" as the source for an import of "libraryUri"',

--- a/lib/resource_loader.dart
+++ b/lib/resource_loader.dart
@@ -18,9 +18,6 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:pub_cache/pub_cache.dart';
 
-/// Optional package root path.
-String packageRootPath;
-
 /// Loads a `package:` resource as a String.
 Future<String> loadAsString(String path) {
   if (!path.startsWith('package:')) {
@@ -29,10 +26,10 @@ Future<String> loadAsString(String path) {
 
   // TODO: Remove once https://github.com/dart-lang/pub/issues/22 is fixed.
   return _doLoad(path)
-    .then((bytes) => new String.fromCharCodes(bytes))
-    .catchError((_) {
-      return new Resource(path).readAsString();
-    });
+      .then((bytes) => new String.fromCharCodes(bytes))
+      .catchError((_) {
+    return new Resource(path).readAsString();
+  });
 }
 
 /// Loads a `package:` resource as an [List<int>].
@@ -52,8 +49,6 @@ Future<Uint8List> _doLoad(final String path) {
     return _doLoadOverHttp(path);
   } else if (scriptUri.toString().endsWith('.snapshot')) {
     return _doLoadWhenSnapshot(path);
-  } else if (packageRootPath != null) {
-    return _doLoadFromPackageRoot(path);
   } else {
     return _doLoadFromFileFromPackagesDir(path);
   }
@@ -130,12 +125,6 @@ Future<Uint8List> _doLoadFromFileFromPackagesDir(final String resourcePath) {
   }
 
   var fullPath = p.join(baseDir, convertedPath);
-  return _readFile(resourcePath, fullPath);
-}
-
-Future<Uint8List> _doLoadFromPackageRoot(final String resourcePath) {
-  var withoutScheme = _removePackageScheme(resourcePath);
-  var fullPath = p.join(packageRootPath, withoutScheme);
   return _readFile(resourcePath, fullPath);
 }
 

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -31,7 +31,7 @@ void main() {
         () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageDir);
       DartDoc dartdoc = new DartDoc(
-          testPackageDir, [], getSdkDir(), [], tempDir, null, meta, null, []);
+          testPackageDir, [], getSdkDir(), [], tempDir, meta, null, []);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);
@@ -45,8 +45,8 @@ void main() {
     test('generate docs for ${path.basename(testPackageBadDir.path)} fails',
         () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageBadDir);
-      DartDoc dartdoc = new DartDoc(testPackageBadDir, [], getSdkDir(), [],
-          tempDir, null, meta, null, []);
+      DartDoc dartdoc = new DartDoc(
+          testPackageBadDir, [], getSdkDir(), [], tempDir, meta, null, []);
 
       try {
         await dartdoc.generateDocs();
@@ -59,7 +59,7 @@ void main() {
     test('generate docs for a package that does not have a readme', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageWithNoReadme);
       DartDoc dartdoc = new DartDoc(testPackageWithNoReadme, [], getSdkDir(),
-          [], tempDir, null, meta, null, []);
+          [], tempDir, meta, null, []);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);
@@ -72,8 +72,8 @@ void main() {
 
     test('generate docs including a single library', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageDir);
-      DartDoc dartdoc = new DartDoc(testPackageDir, [], getSdkDir(), [],
-          tempDir, null, meta, null, ['fake']);
+      DartDoc dartdoc = new DartDoc(
+          testPackageDir, [], getSdkDir(), [], tempDir, meta, null, ['fake']);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);
@@ -87,8 +87,8 @@ void main() {
 
     test('generate docs excluding a single library', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageDir);
-      DartDoc dartdoc = new DartDoc(testPackageDir, ['fake'], getSdkDir(), [],
-          tempDir, null, meta, null, []);
+      DartDoc dartdoc = new DartDoc(
+          testPackageDir, ['fake'], getSdkDir(), [], tempDir, meta, null, []);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);

--- a/test/resource_loader_test.dart
+++ b/test/resource_loader_test.dart
@@ -4,29 +4,12 @@
 
 library dartdoc.resource_loader_test;
 
-import 'dart:io';
-
-import 'package:path/path.dart';
 import 'package:dartdoc/resource_loader.dart' as loader;
 import 'package:test/test.dart';
 
 void main() {
   group('Resource Loader', () {
     test('load from packages', () async {
-      var contents =
-          await loader.loadAsString('package:dartdoc/templates/index.html');
-      expect(contents, isNotNull);
-    });
-
-    test('package root setting', () {
-      var root = Directory.current;
-      loader.packageRootPath = root.path;
-      expect(loader.packageRootPath, equals(root.path));
-    });
-
-    test('load from packages with package root setting', () async {
-      var root = Directory.current;
-      loader.packageRootPath = join(root.path, 'packages');
       var contents =
           await loader.loadAsString('package:dartdoc/templates/index.html');
       expect(contents, isNotNull);


### PR DESCRIPTION
- Removed the `--package-root` option

This was implemented from the pov of the dartdoc tool (where to I load my code from?), rather than from the pov of the user (where are the packages by libraries needs to analyze correctly?). Even re-purposed, the --package-root would not have handled cases like libraries using sdk extensions.

I removed it in favor of using the existing `--input` option to help us locate an analysis context. dartdoc can now generate docs for sky, when driven by their skydoc.py script, which runs from a different cwd than the `sky` package.