### PR TITLE
Print annotations on separate lines

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -425,10 +425,6 @@ nav .self-name {
   display: inline;
 }
 
-.annotation-list li {
-  display: inline;
-}
-
 .annotation-list li:before {
   content: "@";
 }


### PR DESCRIPTION
Fixes #780 

I think this looks pretty good. Two examples:

---

![Element annotations](https://cloud.githubusercontent.com/assets/103167/9834915/34d99582-5985-11e5-918e-748e903edda6.png)

---

![CDataSection](https://cloud.githubusercontent.com/assets/103167/9834924/7e77e630-5985-11e5-9164-7af67320c66d.png)

