### PR TITLE
Change callable metadata to be the same as class's

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -309,9 +309,9 @@ abstract class ModelElement implements Comparable, Nameable, Documentable {
       StringBuffer buf = new StringBuffer();
       buf.write('<span class="parameter" id="${p.htmlId}">');
       if (showMetadata && p.hasAnnotations) {
-        buf.write('<ol class="comma-separated metadata-annotations">');
+        buf.write('<ol class="annotation-list">');
         p.annotations.forEach((String annotation) {
-          buf.write('<li class="metadata-annotation">@$annotation</li>');
+          buf.write('<li>$annotation</li>');
         });
         buf.write('</ol> ');
       }

--- a/lib/templates/_callable_multiline.html
+++ b/lib/templates/_callable_multiline.html
@@ -1,8 +1,8 @@
 {{#hasAnnotations}}
 <div>
-    <ol class="comma-separated metadata-annotations">
+    <ol class="annotation-list">
         {{#annotations}}
-        <li class="metadata-annotation">@{{.}}</li>
+        <li>{{.}}</li>
         {{/annotations}}
     </ol>
 </div>


### PR DESCRIPTION
Very related to #780, but it's not 100% the same.

Currently the metadata of "callables" are listed out inline, and with commas. [Example](https://api.dartlang.org/1.12.1/dart-html/DatabaseCallback.html).

This changes the latter, and adds the `annotation-list` class, so that #899 fixes the former.

Of note, I don't understand why I found this code 2 times, in `lib/src/`, and `lib/templates/`. I fixed it in both places. *shrugs*

Example:

![DatabaseCallback](https://cloud.githubusercontent.com/assets/103167/9835086/fc16dd42-598c-11e5-981c-beb2e98a9c2b.png)
