### PR TITLE
show source for ctors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ HTML files.
 You can view the generated docs directly from the file system, but if you want
 to use the search function, you must load them with an HTTP server.
 
-An easy way to run an HTTP server locally is to use the `simple_http_server`
-package. For example:
+An easy way to run an HTTP server locally is to use the `dhttpd` package. For
+example:
 
 ```
-$ pub global activate simple_http_server
+$ pub global activate dhttpd
 $ dhttpd --path doc/api
 ```
 
-Navigate to `localhost:8080` in your browser. The search function should now
-work.
+Navigate to `http://localhost:8080` in your browser; the search function should
+now work.
 
 ## Options
 

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -149,17 +149,23 @@ pre.prettyprint {
   word-wrap: normal;
   line-height: 1.4;
   background: #f7f7f7;
-  border: 1px solid #f0f0f0;
+  border: 1px solid #ddd;
   margin: 16px 0 16px 0;
   padding: 8px;
 }
 
 pre code {
   white-space: pre;
+  word-wrap: initial;
 }
 
 .fixed {
   white-space: pre;
+}
+
+pre {
+  border: 1px solid #ddd;
+  background-color: #f7f7f7;
 }
 
 code {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// The models used to represent Dart code
+/// The models used to represent Dart code.
 library dartdoc.models;
 
 import 'package:analyzer/src/generated/ast.dart' show AnnotatedNode, Annotation;
@@ -1285,8 +1285,10 @@ class Enum extends Class {
 abstract class SourceCodeMixin {
   String get sourceCode {
     String contents = element.source.contents.data;
-    var node = element.computeNode(); // TODO: computeNode once we go to 0.25.2
-    // find the start of the line, so that we can line up all the indents
+    var node = element.computeNode();
+    if (node == null) return '';
+
+    // Find the start of the line, so that we can line up all the indents.
     int i = node.offset;
     while (i > 0) {
       i -= 1;
@@ -1489,7 +1491,9 @@ class EnumField extends Field {
   String get linkedName => name;
 }
 
-class Constructor extends ModelElement implements EnclosedElement {
+class Constructor extends ModelElement
+    with SourceCodeMixin
+    implements EnclosedElement {
   ConstructorElement get _constructor => (element as ConstructorElement);
 
   Constructor(ConstructorElement element, Library library)

--- a/lib/src/resources.g.dart
+++ b/lib/src/resources.g.dart
@@ -1,4 +1,4 @@
-// WARNING: This file is auto-generated.
+// WARNING: This file is auto-generated. Do not taunt.
 
 library resources;
 


### PR DESCRIPTION
- show source code for constructors
- minor updates to the readme
- make the style of the source box more consistent with source code boxes in dartdoc
- make long source code scroll instead of word-wrap; reading word-wrapped, indented source code is pretty hard