### PR TITLE
style tweaks to the footer

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -310,6 +310,7 @@ footer {
 
 footer p {
   margin: 0;
+  color: #555;
 }
 
 footer .no-break {
@@ -323,7 +324,7 @@ footer .container-fluid {
 }
 
 .copyright a {
-  color: #212121;
+  color: #555;
 }
 
 .markdown h1 {

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -6,10 +6,10 @@
         <div class="container">
             <p class="text-center">
                 <span class="no-break">
-                  {{package.name}} {{package.version}} api docs
+                  {{package.name}} {{package.version}}
                 </span>
                 &bull;
-                <span class="copyright no-break">
+                <span class="no-break">
                   <a href="https://www.dartlang.org">
                     <img src="static-assets/favicon.png" alt="Dart" title="Dart"width="16" height="16">
                   </a>


### PR DESCRIPTION
De-emphasize the footer slightly and make it more symmetrical around the dart icon.

<img width="255" alt="screen shot 2015-09-21 at 9 25 07 am" src="https://cloud.githubusercontent.com/assets/1269969/9998029/2edf3af4-6044-11e5-9a6a-49334b3bfc3e.png">

@sethladd, I can't remember whether you had SEO concerns around removing `api docs`.