### PR TITLE
don't show method sigs for methods with source code

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -194,8 +194,9 @@ ArgParser _createArgsParser() {
       help:
           'URL where the docs will be hosted (used to generate the sitemap).');
   parser.addOption('rel-canonical-prefix',
-      help:
-          'If provided, add a rel="canonical" prefixed with provided value. Consider using if building many versions of the docs for public SEO. Learn more at https://goo.gl/gktN6F');
+      help: 'If provided, add a rel="canonical" prefixed with provided value. '
+          'Consider using if building many versions of the docs for public SEO. '
+          'Learn more at https://goo.gl/gktN6F');
   return parser;
 }
 

--- a/lib/templates/constructor.html
+++ b/lib/templates/constructor.html
@@ -12,17 +12,21 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-        {{#constructor}}
-        {{#isConst}}const{{/isConst}}
-        {{>name_summary}}({{#hasParameters}}
-        <br>
-        <div class="parameters">
+    {{#constructor}}
+      {{^hasSourceCode}}
+        <section class="multi-line-signature">
+          {{#constructor}}
+          {{#isConst}}const{{/isConst}}
+          {{>name_summary}}({{#hasParameters}}
+          <br>
+          <div class="parameters">
             {{{linkedParamsLines}}}
-        </div>
-        {{/hasParameters}})
-        {{/constructor}}
-    </section>
+          </div>
+          {{/hasParameters}})
+          {{/constructor}}
+        </section>
+      {{/hasSourceCode}}
+    {{/constructor}}
 
     {{#constructor}}
     {{>documentation}}

--- a/lib/templates/function.html
+++ b/lib/templates/function.html
@@ -9,12 +9,6 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-        {{#function}}
-            {{>callable_multiline}}
-        {{/function}}
-    </section>
-
     {{#function}}
     {{>documentation}}
     {{/function}}

--- a/lib/templates/method.html
+++ b/lib/templates/method.html
@@ -11,12 +11,6 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-        {{#method}}
-            {{>callable_multiline}}
-        {{/method}}
-    </section>
-
     {{#method}}
     {{>documentation}}
     {{/method}}


### PR DESCRIPTION
For methods with any associated source (everything but no-body constructors), don't show a method sig at the top of a file. Lead with the method's dartdoc, and let the `Source` section show the method and params. With the source section, we already have the method name on the page 3 times.

<img width="838" alt="screen shot 2015-09-22 at 11 50 10 am" src="https://cloud.githubusercontent.com/assets/1269969/10030166/21702954-612b-11e5-8b2e-78b5f4d57ea4.png">
