### PR TITLE
reduce fonts and styles on page

### DIFF
--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -8,7 +8,7 @@ function initScroller() {
     var position = window.pageYOffset || document.documentElement.scrollTop;
 
     if (header) {
-      if (position >= 110) { // TODO: where did this num come from?
+      if (position >= 122) {
         header.classList.add("header-fixed");
       } else if (header.classList.contains("header-fixed")) {
         header.classList.remove("header-fixed");
@@ -16,7 +16,7 @@ function initScroller() {
     }
 
     if (selfName) {
-      if (position >= 80) { // TODO: is this too brittle ?
+      if (position >= 122) {
         selfName.classList.add('visible-xs-inline');
       } else {
         selfName.classList.remove('visible-xs-inline');

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -199,7 +199,7 @@ code {
   }
 
   ul.subnav li {
-    font-size: 110%;
+    font-size: 17px;
   }
 }
 
@@ -216,9 +216,15 @@ header li {
 }
 
 header h1 .kind {
-  color: #DDDDDD;
+  color: #ddd;
   text-transform: uppercase;
-  font-size: 13px;
+  font-size: 15px;
+}
+
+@media screen and (max-width: 768px) {
+  header h1 .kind {
+    font-size: 14px;
+  }
 }
 
 dt {
@@ -227,6 +233,7 @@ dt {
 
 dd {
   color: #212121;
+  margin-bottom: 1em;
 }
 
 dd.callable, dd.constant, dd.property {
@@ -234,17 +241,17 @@ dd.callable, dd.constant, dd.property {
 }
 
 dd p {
-  margin-top: 4px;
   white-space: nowrap;
   overflow-x: hidden;
   text-overflow: ellipsis;
+  margin-bottom: 0;
 }
 
 section.summary h2 {
   color: #727272;
   margin-bottom: 16px;
   padding-bottom: 4px;
-  border-bottom: 1px solid #DDDDDD;
+  border-bottom: 1px solid #ddd;
 }
 
 /* indents wrapped lines */
@@ -264,7 +271,6 @@ dl.dl-horizontal dt::after {
 }
 
 dt .name {
-  font-size: 17px;
   font-weight: 500;
 }
 
@@ -385,10 +391,8 @@ footer .container-fluid {
   margin: 0;
 }
 
-/* The little slug line under a declaration for things like "const",
-   "read-only", etc. */
+/* The slug line under a declaration for things like "const", "read-only", etc. */
 .features {
-  font-size: 14px;
   font-style: italic;
   color: #727272;
 }
@@ -414,15 +418,16 @@ footer .container-fluid {
 @media screen and (max-width: 768px) {
   .breadcrumbs {
     margin: 0 0 24px 0;
+    overflow-x: hidden;
   }
 }
 
 .self-crumb {
-  color: #DDDDDD;
+  color: #ddd;
 }
 
 nav .self-name {
-  color: #DDDDDD;
+  color: #ddd;
   display: none;
 }
 
@@ -623,7 +628,7 @@ button {
 }
 
 .sidebar-offcanvas-left h5 {
-  border-bottom: 1px solid #dddddd;
+  border-bottom: 1px solid #ddd;
   padding: 16px;
 }
 
@@ -737,6 +742,6 @@ form.search {
 }
 
 section#setter {
-  border-top: 1px solid #dddddd;
+  border-top: 1px solid #ddd;
   padding-top: 36px;
 }

--- a/lib/templates/_callable.html
+++ b/lib/templates/_callable.html
@@ -1,12 +1,11 @@
 <dt id="{{htmlId}}" class="callable">
     <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{linkedName}}}</span><span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})
-        &#8594;
-        <span class="returntype">{{{ linkedReturnType }}}</span>
+        <span class="returntype parameter">&#8594; {{{ linkedReturnType }}}</span>
     </span>
 </dt>
 <dd>
+    <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
     {{#isInherited}}
     <div class="features">inherited</div>
     {{/isInherited}}
-    <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
 </dd>

--- a/lib/templates/_constant.html
+++ b/lib/templates/_constant.html
@@ -4,6 +4,6 @@
     <span class="signature">= {{{ constantValue }}}</span>
 </dt>
 <dd>
-    <div class="features">const</div>
     <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+    <div class="features">const</div>
 </dd>

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -3,6 +3,6 @@
     <span class="signature">&#8594; {{{ linkedReturnType }}}</span>
 </dt>
 <dd>
-    {{>readable_writable}}
     <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+    {{>readable_writable}}
 </dd>


### PR DESCRIPTION
Some work to reduce the number of fonts and styles on the page.

- fix a regression where the shadow on the scrolling header would show up too soon
- _slightly_ fewer fonts in the header
- use the same font size in-line in a summary page

<img width="459" alt="screen shot 2015-09-22 at 2 30 26 pm" src="https://cloud.githubusercontent.com/assets/1269969/10032273/ebf2f516-6136-11e5-95c5-86e44c3dd422.png">

<img width="589" alt="screen shot 2015-09-22 at 2 30 36 pm" src="https://cloud.githubusercontent.com/assets/1269969/10032274/ec114c14-6136-11e5-8792-0213410e0e64.png">
