### PR TITLE
improve the display of constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 * [health] remove --url-mappings option, the analyzer picks up sdk extensions
   from the package
+* [style] changed how we display constant values
 
 ## 0.6.6
 * [style] reduce number of fonts and styles used on a page
@@ -22,7 +23,7 @@
 * [enhancement] print annotations on separate lines
 
 ## 0.6.3
-* [bug] remove duplicate property enteries 
+* [bug] remove duplicate property enteries
 * [enhancement] better distinction between getters and setters for properties
 * [enchancement] link inherited elements to superclass pages if available
 * [bug] fix README.md not rendering correctly on pub.dartlang

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -511,21 +511,6 @@ ul.subnav li:last-of-type {
   }
 }
 
-span.top-level-variable-type {
-  color: #727272;
-}
-
-@media (max-width: 768px) {
-  dl.properties span.top-level-variable-type {
-    display: block;
-  }
-
-  section.summary dl.properties dt {
-    margin-left: 0;
-    text-indent: inherit;
-  }
-}
-
 /* sidebar styles */
 
 .sidebar-offcanvas-left {

--- a/lib/templates/_constant.html
+++ b/lib/templates/_constant.html
@@ -1,9 +1,11 @@
 <dt id="{{htmlId}}" class="constant">
-    <span class="top-level-variable-type">{{{ linkedReturnType }}}</span>
     <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{ linkedName }}}</span>
-    <span class="signature">= {{{ constantValue }}}</span>
+    <span class="signature">&#8594; {{{ linkedReturnType }}}</span>
 </dt>
 <dd>
     <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
-    <div class="features">const</div>
+    <div>
+      <!-- span class="features">const</span -->
+      <span class="signature"><code>{{{ constantValue }}}</code><span>
+    </div>
 </dd>

--- a/lib/templates/_constant.html
+++ b/lib/templates/_constant.html
@@ -5,7 +5,7 @@
 <dd>
     <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
     <div>
-      <!-- span class="features">const</span -->
+      <span class="features">const</span>
       <span class="signature"><code>{{{ constantValue }}}</code><span>
     </div>
 </dd>

--- a/lib/templates/class.html
+++ b/lib/templates/class.html
@@ -126,12 +126,10 @@
                 <span class="name">{{{linkedName}}}</span><span class="signature">({{{ linkedParams }}})</span>
             </dt>
             <dd>
-                {{#isConst}}
-                <div class="constructor-modifier">
-                    const
-                </div>
-                {{/isConst}}
                 <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+                {{#isConst}}
+                <div class="constructor-modifier features">const</div>
+                {{/isConst}}
             </dd>
             {{/clazz.constructors}}
         </dl>


### PR DESCRIPTION
address https://github.com/dart-lang/dartdoc/issues/813

Improve the display of constants:

<img width="344" alt="screen shot 2015-09-26 at 9 19 51 pm" src="https://cloud.githubusercontent.com/assets/1269969/10123749/693ee7f6-64f6-11e5-90fc-af5a13f97ffe.png">

- change to use the name on the left, type on the right notation for constants
- include the constant value on a separate line, after the `const` keyword

I played with a few other looks - this one seemed like the best result. The single line ones didn't read well (`name -> type, value`, `name -> type: value`, `name -> type (value)`).