### PR TITLE
Better warning message when library lacks documentation comments

### DIFF
--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -292,7 +292,7 @@ class _HtmlGeneratorInstance implements HtmlOptions {
         .write('\ngenerating docs for library ${lib.name} from ${lib.path}...');
 
     if (!lib.isAnonymous && !lib.hasDocumentation) {
-      print("\n  warning: library '${lib.name}' has no documentation");
+      print("\n  warning: library '${lib.name}' itself has no documentation comments");
     }
 
     TemplateData data = new LibraryTemplateData(this, package, lib);


### PR DESCRIPTION
Tweaked message makes it clearer that the library itself lacks documentation comments as this warning is emitted even if classes or functions in the library are documented.

As discussed here: #949