### PR TITLE
display the method sig at the top of method/ctor/function pages

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -145,7 +145,7 @@ pre.prettyprint {
   font-family: 'Source Code Pro', monospace;
   color: black;
   border-radius: 4px;
-  font-size: 13px;
+  font-size: 14px;
   word-wrap: normal;
   line-height: 1.4;
   background: #f7f7f7;
@@ -166,6 +166,7 @@ pre code {
 pre {
   border: 1px solid #ddd;
   background-color: #f7f7f7;
+  font-size: 14px;
 }
 
 code {
@@ -405,6 +406,9 @@ footer .container-fluid {
 
 .multi-line-signature {
   font-size: 17px;
+  color: #727272;
+  margin-left: 24px;
+  text-indent: -24px;
 }
 
 .breadcrumbs {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -384,10 +384,7 @@ abstract class ModelElement implements Comparable, Nameable, Documentable {
 
   String get linkedParamsNoMetadata => linkedParams(showMetadata: false);
 
-  /// End each parameter with `<br>`
-  String get linkedParamsLines {
-    return linkedParams(separator: ',<br>');
-  }
+  String get linkedParamsLines => linkedParams().trim();
 }
 
 // TODO: how do we get rid of this class?

--- a/lib/templates/_callable_multiline.html
+++ b/lib/templates/_callable_multiline.html
@@ -8,11 +8,4 @@
 </div>
 {{/hasAnnotations}}
 <span class="returntype">{{{ linkedReturnType }}}</span>
-{{>name_summary}}(
-{{#hasParameters}}
-<br>
-<div class="parameters">
-    {{{linkedParamsLines}}}
-</div>
-{{/hasParameters}}
-)
+{{>name_summary}}(<wbr>{{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}})

--- a/lib/templates/constructor.html
+++ b/lib/templates/constructor.html
@@ -13,19 +13,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     {{#constructor}}
-      {{^hasSourceCode}}
-        <section class="multi-line-signature">
-          {{#constructor}}
-          {{#isConst}}const{{/isConst}}
-          {{>name_summary}}({{#hasParameters}}
-          <br>
-          <div class="parameters">
-            {{{linkedParamsLines}}}
-          </div>
-          {{/hasParameters}})
-          {{/constructor}}
-        </section>
-      {{/hasSourceCode}}
+      <section class="multi-line-signature">
+        {{#constructor}}
+        {{#isConst}}const{{/isConst}}
+        {{>name_summary}}(<wbr>{{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}})
+        {{/constructor}}
+      </section>
     {{/constructor}}
 
     {{#constructor}}

--- a/lib/templates/function.html
+++ b/lib/templates/function.html
@@ -9,6 +9,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      {{#function}}
+        {{>callable_multiline}}
+      {{/function}}
+    </section>
+
     {{#function}}
     {{>documentation}}
     {{/function}}

--- a/lib/templates/method.html
+++ b/lib/templates/method.html
@@ -11,6 +11,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      {{#method}}
+        {{>callable_multiline}}
+      {{/method}}
+    </section>
+
     {{#method}}
     {{>documentation}}
     {{/method}}


### PR DESCRIPTION
fix https://github.com/dart-lang/dartdoc/issues/946

- restore the method sig at the top of method/ctor/function/operator pages
- style the method sig so that it's similar (but not quite as much emphasis) as the h2 section headers, like `Source`
- display using one line, similar to how it would look in a dart file. when wrapping, indent; ensure we only wrap between params, not between a param type and name

@sethladd 

<img width="405" alt="screen shot 2015-10-10 at 7 20 11 pm" src="https://cloud.githubusercontent.com/assets/1269969/10414344/cd9c6582-6f84-11e5-8e22-50ffbabe87d4.png">

<img width="404" alt="screen shot 2015-10-10 at 7 20 33 pm" src="https://cloud.githubusercontent.com/assets/1269969/10414345/cd9cfd8a-6f84-11e5-8530-7a0249b508ae.png">

<img width="402" alt="screen shot 2015-10-10 at 7 20 48 pm" src="https://cloud.githubusercontent.com/assets/1269969/10414346/cd9d175c-6f84-11e5-8239-4152d43787c0.png">

<img width="416" alt="screen shot 2015-10-10 at 7 21 03 pm" src="https://cloud.githubusercontent.com/assets/1269969/10414347/cd9d619e-6f84-11e5-9eca-b665202f34b9.png">

<img width="686" alt="screen shot 2015-10-10 at 7 21 17 pm" src="https://cloud.githubusercontent.com/assets/1269969/10414343/cd9af896-6f84-11e5-8d74-67d5034e5187.png">
