### PR TITLE
Fix spans in _accessor_setter template

### DIFF
--- a/lib/templates/_accessor_setter.html
+++ b/lib/templates/_accessor_setter.html
@@ -2,7 +2,7 @@
 
 <section class="multi-line-signature">
   <span class="returntype">void</span>
-  {{>name_summary}}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})
+  {{>name_summary}}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
 </section>
 
 {{>documentation}}


### PR DESCRIPTION
Added a missing close span

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dart-lang/dartdoc/963)
<!-- Reviewable:end -->
