### PR TITLE
Add redirector script from the old dartdocs.org path schema

### DIFF
--- a/lib/resources/redirector.js
+++ b/lib/resources/redirector.js
@@ -1,0 +1,85 @@
+(function () {
+    function getFromHash(hash, regexp, body) {
+        var match = hash.match(regexp);
+        var result;
+        if (match) {
+            result = body ? body(match[1]) : match[1];
+        }
+        return [result, hash.replace(regexp, "")];
+    }
+
+    function getPackage(hash) {
+        return getFromHash(hash, /^([^\/]+)\//, function (m) { return m.replace("-", "."); });
+    }
+
+    function getLibrary(hash) {
+        return getFromHash(hash, /^([^@\.]+)/, function (m) { return m.replace("-", "."); });
+    }
+
+    function getClass(hash) {
+        return getFromHash(hash, /^\.([^@]+)/);
+    }
+
+    function getFunction(hash) {
+        return getFromHash(hash, /^@id_(.+)$/);
+    }
+
+    function getMethod(hash) {
+        return getFromHash(hash, /^@id_(.+)$/, function (m) {
+            // if it contains ',', we should discard everything after that,
+            // that was probably named parameter arguments
+            // if it ends with '-', it may be a constructor
+            return m.replace(/,.*/, "").replace("-", "");
+        });
+    }
+
+    var hash = location.hash.replace(/^#/, "");
+
+    var packageResult = getPackage(hash);
+    var packageName = packageResult[0];
+    hash = packageResult[1];
+
+    if (packageName && location.pathname.indexOf(packageName) !== -1) {
+        var libraryResult = getLibrary(hash);
+        var library = libraryResult[0];
+        hash = libraryResult[1];
+
+        if (library) {
+            var classResult = getClass(hash);
+            var className = classResult[0];
+            hash = classResult[1];
+
+            var method;
+            var func;
+            if (className) {
+                method = getMethod(hash)[0];
+            } else {
+                func = getFunction(hash)[0];
+            }
+
+            var newPath;
+            if (className) {
+                if (method) {
+                    newPath = "/" + library + "/" + className + "/" + method + ".html";
+                } else {
+                    newPath = "/" + library + "/" + className + "-class.html";
+                }
+            } else if (func) {
+                newPath = "/" + library + "/" + func + ".html";
+            } else {
+                newPath = "/" + library + "/" + library + "-library.html";
+            }
+
+            var newLocation = location.href.replace(/\/index.html.*/, newPath);
+
+            var http = new XMLHttpRequest();
+            http.open('HEAD', newLocation);
+            http.onreadystatechange = function () {
+                if (this.readyState === this.DONE && this.status === 200) {
+                    location.href = newLocation;
+                }
+            };
+            http.send();
+        }
+    }
+}());

--- a/lib/src/resources.g.dart
+++ b/lib/src/resources.g.dart
@@ -1,4 +1,4 @@
-// WARNING: This file is auto-generated. Do not taunt.
+// WARNING: This file is auto-generated.
 
 library resources;
 
@@ -6,6 +6,7 @@ const List<String> resource_names = const [
   'package:dartdoc/resources/favicon.png',
   'package:dartdoc/resources/prettify.css',
   'package:dartdoc/resources/prettify.js',
+  'package:dartdoc/resources/redirector.js',
   'package:dartdoc/resources/script.js',
   'package:dartdoc/resources/styles.css',
   'package:dartdoc/resources/typeahead.bundle.min.js',

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -27,6 +27,7 @@
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/script.js"></script>
+<script src="static-assets/redirector.js"></script>
 <!-- Do not remove placeholder -->
 <!-- Footer Placeholder -->
 


### PR DESCRIPTION
The old schema was something like
`index.html#package/library.Class@id_method`. So, we parse it and try to
redirect to the new dartdoc's path. For that, we first make a HEAD
request to check if that location actually exists, and if yes - change
`location.href` to that new location

It doesn't always work, because there are some changes between the old
schema and the new schema, so sometimes the redirect would lead to 404.
Known cases:

* Operators. Old dartdocs.org doesn't make a distinction between
  an operator and e.g. a method, but the new dartdoc does. So, there is
  no way to know if this is an operator or not, so the redirect won't
  work.

* Inherited methods. If class B extends A, and B has inherited methods
  from A, then dartdocs.org will show them as `#package/lib.B@id_foo`, and
  dartdoc will consider it as `lib/A/foo.html`, so the redirect won't work
  either.

There may be other cases, but most of the time it should work fine.