### PR TITLE
tweak stdout message; fix html entity ref

### DIFF
--- a/lib/src/html_generator.dart
+++ b/lib/src/html_generator.dart
@@ -299,8 +299,8 @@ class _HtmlGeneratorInstance implements HtmlOptions {
         .write('\ngenerating docs for library ${lib.name} from ${lib.path}...');
 
     if (!lib.isAnonymous && !lib.hasDocumentation) {
-      print(
-          "\n  warning: library '${lib.name}' itself has no documentation comments");
+      stdout.write(
+          "\n  warning: '${lib.name}' has no library level documentation comments");
     }
 
     TemplateData data = new LibraryTemplateData(this, package, lib);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -857,7 +857,7 @@ class Class extends ModelElement implements EnclosedElement {
 
   String get nameWithGenerics {
     if (!modelType.isParameterizedType) return name;
-    return '$name&lt${_typeParameters.map((t) => t.name).join(', ')}&gt';
+    return '$name&lt;${_typeParameters.map((t) => t.name).join(', ')}&gt;';
   }
 
   List<TypeParameter> get _typeParameters => _cls.typeParameters.map((f) {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -516,7 +516,7 @@ void main() {
     });
 
     test('class name with generics', () {
-      expect(F.nameWithGenerics, equals('F&ltT extends String&gt'));
+      expect(F.nameWithGenerics, equals('F&lt;T extends String&gt;'));
     });
 
     test('correctly finds all the classes', () {


### PR DESCRIPTION
- tweak the message when we don't find library level docs; it was printing out one too many newlines
- fix an issue with an html entity

@keertip 