### PR TITLE
Don't include "Library not documented." statement on docs index page

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -133,10 +133,6 @@ p {
   margin-bottom: 1em;
 }
 
-p.no-docs {
-  font-style: italic;
-}
-
 a, a:hover {
   color: rgb(0, 102, 152);
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -634,7 +634,7 @@ class Library extends ModelElement {
 
   bool get isInSdk => _library.isInSdk;
 
-  bool get isNotDocumented => oneLineDoc.isEmpty;
+  bool get isDocumented => oneLineDoc.isNotEmpty;
 
   List<TopLevelVariable> _getVariables() {
     if (_variables != null) return _variables;

--- a/lib/templates/_documentation.html
+++ b/lib/templates/_documentation.html
@@ -1,10 +1,5 @@
+{{#hasDocumentation}}
 <section class="desc markdown">
-
-  {{^hasDocumentation}}
-    <p class="no-docs">Not documented.</p>
-  {{/hasDocumentation}}
-  {{#hasDocumentation}}
-    {{{ documentationAsHtml }}}
-  {{/hasDocumentation}}
-
+  {{{ documentationAsHtml }}}
 </section>
+{{/hasDocumentation}}

--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -25,11 +25,12 @@
             <span class="name">{{{ linkedName }}}</span>
           </dt>
           <dd>
-            {{#isNotDocumented}}<span class="undocumented">Library not documented.</span>{{/isNotDocumented}}
+            {{#isDocumented}}
             <p>
               {{{ oneLineDoc }}}
               {{>has_more_docs}}
             </p>
+            {{/isDocumented}}
           </dd>
         {{/package.libraries}}
       </dl>


### PR DESCRIPTION
Also remove the "Not documented." message for members without doc comments

Closes https://github.com/dart-lang/dartdoc/issues/998
Closes https://github.com/dart-lang/dartdoc/issues/1003

CC @kwalrath @nex3 @devoncarew

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dart-lang/dartdoc/1017)
<!-- Reviewable:end -->
