### PR TITLE
add caching for file contents

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1380,7 +1380,7 @@ abstract class SourceCodeMixin {
 
   String get sourceCode {
     if (_sourceCodeCache == null) {
-      String contents = element.source.contents.data;
+      String contents = getFileContentsFor(element);
       var node = element.computeNode();
       if (node != null) {
         // Find the start of the line, so that we can line up all the indents.

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -4,10 +4,46 @@
 
 library dartdoc.model_utils;
 
+import 'dart:io';
+
 import 'package:analyzer/src/generated/element.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source_io.dart';
+
+final Map<String, String> _fileContents = <String, String>{};
+
+List<InterfaceType> getAllSupertypes(ClassElement c) => c.allSupertypes;
+
+String getFileContentsFor(Element e) {
+  var location = e.source.fullName;
+  if (!_fileContents.containsKey(location)) {
+    var contents = new File(location).readAsStringSync();
+    _fileContents.putIfAbsent(location, () => contents);
+  }
+  return _fileContents[location];
+}
+
+Iterable<LibraryElement> getSdkLibrariesToDocument(
+    DartSdk sdk, AnalysisContext context) sync* {
+  var sdkApiLibs = sdk.sdkLibraries
+      .where((SdkLibrary sdkLib) => !sdkLib.isInternal && sdkLib.isDocumented)
+      .toList();
+  sdkApiLibs.sort((lib1, lib2) => lib1.shortName.compareTo(lib2.shortName));
+
+  for (var sdkLib in sdkApiLibs) {
+    Source source = sdk.mapDartUri(sdkLib.shortName);
+    LibraryElement library = context.computeLibraryElement(source);
+    yield library;
+    yield* library.exportedLibraries;
+  }
+}
+
+bool isInExportedLibraries(
+    List<LibraryElement> libraries, LibraryElement library) {
+  return libraries
+      .any((lib) => lib == library || lib.exportedLibraries.contains(library));
+}
 
 bool isPrivate(Element e) => e.name.startsWith('_');
 
@@ -33,39 +69,6 @@ bool isPublic(Element e) {
   return true;
 }
 
-Iterable<LibraryElement> getSdkLibrariesToDocument(
-    DartSdk sdk, AnalysisContext context) sync* {
-  var sdkApiLibs = sdk.sdkLibraries
-      .where((SdkLibrary sdkLib) => !sdkLib.isInternal && sdkLib.isDocumented)
-      .toList();
-  sdkApiLibs.sort((lib1, lib2) => lib1.shortName.compareTo(lib2.shortName));
-
-  for (var sdkLib in sdkApiLibs) {
-    Source source = sdk.mapDartUri(sdkLib.shortName);
-    LibraryElement library = context.computeLibraryElement(source);
-    yield library;
-    yield* library.exportedLibraries;
-  }
-}
-
-List<InterfaceType> getAllSupertypes(ClassElement c) => c.allSupertypes;
-
-bool isInExportedLibraries(
-    List<LibraryElement> libraries, LibraryElement library) {
-  return libraries
-      .any((lib) => lib == library || lib.exportedLibraries.contains(library));
-}
-
-/// Strip the common indent from the given source fragment.
-String stripIndentFromSource(String source) {
-  String remainer = source.trimLeft();
-  String indent = source.substring(0, source.length - remainer.length);
-  return source.split('\n').map((line) {
-    line = line.trimRight();
-    return line.startsWith(indent) ? line.substring(indent.length) : line;
-  }).join('\n');
-}
-
 /// Strip leading dartdoc comments from the given source code.
 String stripDartdocCommentsFromSource(String source) {
   String remainer = source.trimLeft();
@@ -87,5 +90,15 @@ String stripDartdocCommentsFromSource(String source) {
     }
 
     return true;
+  }).join('\n');
+}
+
+/// Strip the common indent from the given source fragment.
+String stripIndentFromSource(String source) {
+  String remainer = source.trimLeft();
+  String indent = source.substring(0, source.length - remainer.length);
+  return source.split('\n').map((line) {
+    line = line.trimRight();
+    return line.startsWith(indent) ? line.substring(indent.length) : line;
   }).join('\n');
 }


### PR DESCRIPTION
Cache the file contents and use it when getting the source for methods etc. This speeds up dartdoc. 

for #1061 