### PR TITLE
extend --include and --header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# Don’t commit the following directories created by pub.
 build/
 doc/api/
 test_package/doc
@@ -6,7 +5,10 @@ test_package_small/doc
 packages
 .buildlog
 .pub
+
 .idea
+.atom/
+
 .packages
 .settings/
 .DS_Store
@@ -14,7 +16,6 @@ packages
 
 pub.dartlang.org/
 
-# Or the files created by dart2js.
 *.dart.js
 *.js.deps
 *.js.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 ## 0.9.3
-* [enhancement] Added support for URL-based search. If a query parameter named
+* [enhancement] added support for URL-based search. If a query parameter named
   "search" is passed, the page navigates to the first search result for its
   value.
+* [enhancement] added support for passing more than one `--header` or `--footer`
+* [enhancement] added the ability to `--include` libraries referenced by (but
+  not directly inside) the project
+* [bug] rev the analyzer version used to fix an issue generating docs for
+  Flutter
 
 ## 0.9.2
 * [bug] do not generate docs for `dart:_internal` and `dart:nativewrappers`, when defined
-  in the `_embedder.yaml` file. 
+  in the `_embedder.yaml` file.
 * [enhancement] print message to run pub if dartdoc does not find any libraries to
   document.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
   "search" is passed, the page navigates to the first search result for its
   value.
 * [enhancement] added support for passing more than one `--header` or `--footer`
-* [enhancement] added the ability to `--include` libraries referenced by (but
-  not directly inside) the project
+* [enhancement] added the ability to include libraries referenced by (but not
+  directly inside) the project (`--include-external`)
 * [bug] rev the analyzer version used to fix an issue generating docs for
   Flutter
 

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/config.dart';
+import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 
@@ -68,14 +68,11 @@ main(List<String> arguments) async {
     exit(1);
   }
 
-  List<String> excludeLibraries =
-      args['exclude'] == null ? [] : args['exclude'].split(',');
-  List<String> includeLibraries =
-      args['include'] == null ? [] : args['include'].split(',');
+  List<String> excludeLibraries = args['exclude'];
+  List<String> includeLibraries = args['include'];
 
   String url = args['hosted-url'];
   List<String> footerFilePaths = args['footer'].map(_resolveTildePath).toList();
-  print(footerFilePaths);
   for (String footerFilePath in footerFilePaths) {
     if (!new File(footerFilePath).existsSync()) {
       print("Error: unable to locate footer file: ${footerFilePath}.");
@@ -83,7 +80,6 @@ main(List<String> arguments) async {
     }
   }
   List<String> headerFilePaths = args['header'].map(_resolveTildePath).toList();
-  print(headerFilePaths);
   for (String headerFilePath in footerFilePaths) {
     if (!new File(headerFilePath).existsSync()) {
       print("Error: unable to locate header file: ${headerFilePath}.");
@@ -187,26 +183,23 @@ ArgParser _createArgsParser() {
   parser.addOption('output',
       help: 'Path to output directory.', defaultsTo: defaultOutDir);
   parser.addOption('header',
-      allowMultiple: true,
-      help: 'path to file containing HTML text.');
+      allowMultiple: true, help: 'path to file containing HTML text.');
   parser.addOption('footer',
-      allowMultiple: true,
-      help: 'path to file containing HTML text.');
+      allowMultiple: true, help: 'path to file containing HTML text.');
   parser.addOption('exclude',
-      help: 'Comma-separated list of library names to ignore.');
+      allowMultiple: true, help: 'library names to ignore');
   parser.addOption('include',
-      help: 'Comma-separated list of library names to generate docs for.');
+      allowMultiple: true, help: 'library names to generate docs for');
   parser.addOption('hosted-url',
       help:
           'URL where the docs will be hosted (used to generate the sitemap).');
   parser.addOption('rel-canonical-prefix',
-      help: 'If provided, add a rel="canonical" prefixed with provided value. \n'
+      help:
+          'If provided, add a rel="canonical" prefixed with provided value. \n'
           'Consider using if building many versions of the docs for public SEO. '
           'Learn more at https://goo.gl/gktN6F.');
   parser.addFlag('include-source',
-      help: 'If source code blocks should be shown, if they exist.',
-      negatable: true,
-      defaultsTo: true);
+      help: 'Show source code blocks', negatable: true, defaultsTo: true);
   return parser;
 }
 

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -70,6 +70,7 @@ main(List<String> arguments) async {
 
   List<String> excludeLibraries = args['exclude'];
   List<String> includeLibraries = args['include'];
+  List<String> includeExternals = args['include-external'];
 
   String url = args['hosted-url'];
   List<String> footerFilePaths = args['footer'].map(_resolveTildePath).toList();
@@ -126,7 +127,8 @@ main(List<String> arguments) async {
   initializeConfig(addCrossdart: addCrossdart, includeSource: includeSource);
 
   var dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
-      outputDir, packageMeta, includeLibraries);
+      outputDir, packageMeta, includeLibraries,
+      includeExternals: includeExternals);
 
   Chain.capture(() async {
     DartDocResults results = await dartdoc.generateDocs();
@@ -190,6 +192,8 @@ ArgParser _createArgsParser() {
       allowMultiple: true, help: 'library names to ignore');
   parser.addOption('include',
       allowMultiple: true, help: 'library names to generate docs for');
+  parser.addOption('include-external',
+      allowMultiple: true, help: 'additional (external) libraries to include');
   parser.addOption('hosted-url',
       help:
           'URL where the docs will be hosted (used to generate the sitemap).');

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -74,15 +74,21 @@ main(List<String> arguments) async {
       args['include'] == null ? [] : args['include'].split(',');
 
   String url = args['hosted-url'];
-  String footerFilePath = _resolveTildePath(args['footer']);
-  if (footerFilePath != null && !new File(footerFilePath).existsSync()) {
-    print("Error: unable to locate the file with footer at ${footerFilePath}.");
-    exit(1);
+  List<String> footerFilePaths = args['footer'].map(_resolveTildePath).toList();
+  print(footerFilePaths);
+  for (String footerFilePath in footerFilePaths) {
+    if (!new File(footerFilePath).existsSync()) {
+      print("Error: unable to locate footer file: ${footerFilePath}.");
+      exit(1);
+    }
   }
-  String headerFilePath = _resolveTildePath(args['header']);
-  if (headerFilePath != null && !new File(headerFilePath).existsSync()) {
-    print("Error: unable to locate the file with header at ${headerFilePath}.");
-    exit(1);
+  List<String> headerFilePaths = args['header'].map(_resolveTildePath).toList();
+  print(headerFilePaths);
+  for (String headerFilePath in footerFilePaths) {
+    if (!new File(headerFilePath).existsSync()) {
+      print("Error: unable to locate header file: ${headerFilePath}.");
+      exit(1);
+    }
   }
 
   Directory outputDir =
@@ -112,7 +118,7 @@ main(List<String> arguments) async {
   print('');
 
   var generators = await initGenerators(
-      url, headerFilePath, footerFilePath, args['rel-canonical-prefix']);
+      url, headerFilePaths, footerFilePaths, args['rel-canonical-prefix']);
 
   for (var generator in generators) {
     generator.onFileCreated.listen(_onProgress);
@@ -163,7 +169,7 @@ ArgParser _createArgsParser() {
   parser.addFlag('version',
       help: 'Display the version for $name.', negatable: false);
   parser.addFlag('add-crossdart',
-      help: 'Add Crossdart links to the source code pieces',
+      help: 'Add Crossdart links to the source code pieces.',
       negatable: false,
       defaultsTo: false);
   parser.addOption('dart-sdk',
@@ -181,11 +187,11 @@ ArgParser _createArgsParser() {
   parser.addOption('output',
       help: 'Path to output directory.', defaultsTo: defaultOutDir);
   parser.addOption('header',
-      help:
-          'path to file containing HTML text, inserted into the header of every page.');
+      allowMultiple: true,
+      help: 'path to file containing HTML text.');
   parser.addOption('footer',
-      help:
-          'path to file containing HTML text, inserted into the footer of every page.');
+      allowMultiple: true,
+      help: 'path to file containing HTML text.');
   parser.addOption('exclude',
       help: 'Comma-separated list of library names to ignore.');
   parser.addOption('include',
@@ -194,9 +200,9 @@ ArgParser _createArgsParser() {
       help:
           'URL where the docs will be hosted (used to generate the sitemap).');
   parser.addOption('rel-canonical-prefix',
-      help: 'If provided, add a rel="canonical" prefixed with provided value. '
+      help: 'If provided, add a rel="canonical" prefixed with provided value. \n'
           'Consider using if building many versions of the docs for public SEO. '
-          'Learn more at https://goo.gl/gktN6F');
+          'Learn more at https://goo.gl/gktN6F.');
   parser.addFlag('include-source',
       help: 'If source code blocks should be shown, if they exist.',
       negatable: true,

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -44,13 +44,13 @@ const String version = '0.9.2';
 final String defaultOutDir = p.join('doc', 'api');
 
 /// Initialize and setup the generators.
-Future<List<Generator>> initGenerators(String url, String headerFilePath,
-    String footerFilePath, String relCanonicalPrefix) async {
+Future<List<Generator>> initGenerators(String url, List<String> headerFilePaths,
+    List<String> footerFilePaths, String relCanonicalPrefix) async {
   return [
     await HtmlGenerator.create(
         url: url,
-        header: headerFilePath,
-        footer: footerFilePath,
+        headers: headerFilePaths,
+        footers: footerFilePaths,
         relCanonicalPrefix: relCanonicalPrefix,
         toolVersion: version)
   ];

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -5,6 +5,7 @@
 /// The models used to represent Dart code.
 library dartdoc.element_type;
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/element.dart';
 
 import 'model.dart';

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -48,12 +48,12 @@ class HtmlGenerator extends Generator {
   /// [url] - optional URL for where the docs will be hosted.
   static Future<HtmlGenerator> create(
       {String url,
-      String header,
-      String footer,
+      List<String> headers,
+      List<String> footers,
       String relCanonicalPrefix,
       String toolVersion}) async {
     var templates =
-        await Templates.create(headerPath: header, footerPath: footer);
+        await Templates.create(headerPaths: headers, footerPaths: footers);
 
     if (toolVersion == null) {
       toolVersion = 'unknown';

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -41,16 +41,23 @@ Future<Map<String, String>> _loadPartials(
   Future<String> _loadPartial(String templatePath) async {
     String template = await _getTemplateFile(templatePath);
     if (templatePath.contains('_head') && headerPaths.isNotEmpty) {
-      String headerValue = headerPaths.map((path) => new File(path).readAsStringSync()).join('\n');
+      String headerValue = headerPaths
+          .map((path) => new File(path).readAsStringSync())
+          .join('\n');
       template =
           template.replaceAll('<!-- Header Placeholder -->', headerValue);
+      template =
+          template.replaceAll('  <!-- Do not remove placeholder -->\n', '');
     }
     if (templatePath.contains('_footer') && footerPaths.isNotEmpty) {
-      String footerValue = footerPaths.map((path) => new File(path).readAsStringSync()).join('\n');
+      String footerValue = footerPaths
+          .map((path) => new File(path).readAsStringSync())
+          .join('\n');
       template =
           template.replaceAll('<!-- Footer Placeholder -->', footerValue);
+      template =
+          template.replaceAll('  <!-- Do not remove placeholder -->\n', '');
     }
-    template = template.replaceAll('  <!-- Do not remove placeholder -->\n', '');
     return template;
   }
 

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -32,22 +32,25 @@ const _partials = const <String>[
 ];
 
 Future<Map<String, String>> _loadPartials(
-    String headerPath, String footerPath) async {
+    List<String> headerPaths, List<String> footerPaths) async {
+  headerPaths ??= [];
+  footerPaths ??= [];
+
   var partials = <String, String>{};
 
   Future<String> _loadPartial(String templatePath) async {
     String template = await _getTemplateFile(templatePath);
-    // TODO: revisit, not sure this is the right place for this logic
-    if (templatePath.contains('_footer') && footerPath != null) {
-      String footerValue = await new File(footerPath).readAsString();
-      template =
-          template.replaceAll('<!-- Footer Placeholder -->', footerValue);
-    }
-    if (templatePath.contains('_head') && headerPath != null) {
-      String headerValue = await new File(headerPath).readAsString();
+    if (templatePath.contains('_head') && headerPaths.isNotEmpty) {
+      String headerValue = headerPaths.map((path) => new File(path).readAsStringSync()).join('\n');
       template =
           template.replaceAll('<!-- Header Placeholder -->', headerValue);
     }
+    if (templatePath.contains('_footer') && footerPaths.isNotEmpty) {
+      String footerValue = footerPaths.map((path) => new File(path).readAsStringSync()).join('\n');
+      template =
+          template.replaceAll('<!-- Footer Placeholder -->', footerValue);
+    }
+    template = template.replaceAll('  <!-- Do not remove placeholder -->\n', '');
     return template;
   }
 
@@ -75,8 +78,8 @@ class Templates {
   final TemplateRenderer typeDefTemplate;
 
   static Future<Templates> create(
-      {String headerPath, String footerPath}) async {
-    var partials = await _loadPartials(headerPath, footerPath);
+      {List<String> headerPaths, List<String> footerPaths}) async {
+    var partials = await _loadPartials(headerPaths, footerPaths);
 
     String _partial(String name) {
       String partial = partials[name];

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -8,7 +8,7 @@ library dartdoc.markdown_processor;
 
 import 'dart:convert';
 
-import 'package:analyzer/src/generated/ast.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/src/generated/element.dart'
     show
         LibraryElement,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -7,7 +7,7 @@ library dartdoc.models;
 
 import 'dart:convert';
 
-import 'package:analyzer/src/generated/ast.dart'
+import 'package:analyzer/dart/ast/ast.dart'
     show AnnotatedNode, Annotation, Declaration;
 import 'package:analyzer/src/generated/element.dart';
 import 'package:analyzer/src/generated/resolver.dart'
@@ -901,6 +901,17 @@ abstract class GetterSetterCombo {
 
 class Library extends ModelElement {
   static final Map<String, Library> _libraryMap = <String, Library>{};
+
+  static String getLibraryName(LibraryElement element) {
+    String name = element.name;
+
+    if (name == null || name.isEmpty) {
+      name = element.definingCompilationUnit.name;
+      name = name.substring(0, name.length - '.dart'.length);
+    }
+
+    return name;
+  }
 
   final Package package;
   List<Class> _classes;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,217 +6,341 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.2"
+    version: "0.27.3-alpha.7"
   ansicolor:
-    description: ansicolor
+    description:
+      name: ansicolor
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.9"
   args:
-    description: args
+    description:
+      name: args
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+1"
+    version: "0.13.4"
   async:
-    description: async
+    description:
+      name: async
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   barback:
-    description: barback
+    description:
+      name: barback
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.2+7"
+  boolean_selector:
+    description:
+      name: boolean_selector
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   charcode:
-    description: charcode
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   cli_util:
-    description: cli_util
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.1+2"
   collection:
-    description: collection
+    description:
+      name: collection
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.1"
   contrast:
-    description: contrast
+    description:
+      name: contrast
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1"
-  crypto:
-    description: crypto
+  convert:
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "1.0.1"
+  crypto:
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.2+1"
   csslib:
-    description: csslib
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.2"
   den_api:
-    description: den_api
+    description:
+      name: den_api
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
   github:
-    description: github
+    description:
+      name: github
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1+1"
   glob:
-    description: glob
+    description:
+      name: glob
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   grinder:
-    description: grinder
+    description:
+      name: grinder
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.8.0+2"
   html:
-    description: html
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.2+1"
   http:
-    description: http
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+3"
   http_multi_server:
-    description: http_multi_server
+    description:
+      name: http_multi_server
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   http_parser:
-    description: http_parser
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.1"
   librato:
-    description: librato
+    description:
+      name: librato
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.3"
   logging:
-    description: logging
+    description:
+      name: logging
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.2"
   markdown:
-    description: markdown
+    description:
+      name: markdown
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.8.0"
   matcher:
-    description: matcher
+    description:
+      name: matcher
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+1"
+    version: "0.12.0+2"
   mime:
-    description: mime
+    description:
+      name: mime
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.3"
   mockable_filesystem:
-    description: mockable_filesystem
+    description:
+      name: mockable_filesystem
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.3"
   mustache4dart:
-    description: mustache4dart
+    description:
+      name: mustache4dart
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.10"
   package_config:
-    description: package_config
+    description:
+      name: package_config
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
   path:
-    description: path
+    description:
+      name: path
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.9"
   petitparser:
-    description: petitparser
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
   plugin:
-    description: plugin
+    description:
+      name: plugin
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
   pool:
-    description: pool
+    description:
+      name: pool
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.3"
   pub_package_data:
-    description: pub_package_data
+    description:
+      name: pub_package_data
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.1"
   pub_semver:
-    description: pub_semver
+    description:
+      name: pub_semver
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   quiver:
-    description: quiver
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.21.4"
   resource:
-    description: resource
+    description:
+      name: resource
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   shelf:
-    description: shelf
+    description:
+      name: shelf
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.5"
   shelf_static:
-    description: shelf_static
+    description:
+      name: shelf_static
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3+2"
+    version: "0.2.3+3"
   shelf_web_socket:
-    description: shelf_web_socket
+    description:
+      name: shelf_web_socket
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+5"
+    version: "0.2.0"
   source_map_stack_trace:
-    description: source_map_stack_trace
+    description:
+      name: source_map_stack_trace
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
   source_maps:
-    description: source_maps
+    description:
+      name: source_maps
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.1"
+    version: "0.10.1+1"
   source_span:
-    description: source_span
+    description:
+      name: source_span
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   stack_trace:
-    description: stack_trace
+    description:
+      name: stack_trace
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.4"
   stream_channel:
-    description: stream_channel
+    description:
+      name: stream_channel
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.3.1"
   string_scanner:
-    description: string_scanner
+    description:
+      name: string_scanner
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.4+1"
   supports_color:
-    description: supports_color
+    description:
+      name: supports_color
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1"
   test:
-    description: test
+    description:
+      name: test
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.13"
   typed_data:
-    description: typed_data
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   unscripted:
-    description: unscripted
+    description:
+      name: unscripted
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.2"
   utf:
-    description: utf
+    description:
+      name: utf
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+2"
+    version: "0.9.0+3"
   watcher:
-    description: watcher
+    description:
+      name: watcher
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.7"
+  web_socket_channel:
+    description:
+      name: web_socket_channel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   when:
-    description: when
+    description:
+      name: when
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
   which:
-    description: which
+    description:
+      name: which
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
   xml:
-    description: xml
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   yaml:
-    description: yaml
+    description:
+      name: yaml
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.8"
-sdk: ">=1.14.0 <1.16.0"
+sdk: ">=1.14.0 <1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=1.14.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.27.2 <0.28.0'
+  analyzer: 0.27.3-alpha.7
   args: ^0.13.0
   cli_util: ^0.0.1
   collection: ^1.2.0

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -73,7 +73,7 @@ void main() {
     test('generate docs including a single library', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageDir);
       DartDoc dartdoc = new DartDoc(
-          testPackageDir, [], getSdkDir(), [], tempDir, meta, ['fake']);
+          testPackageDir, [], getSdkDir(), [], tempDir, meta, ['dart.core']);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);
@@ -81,7 +81,7 @@ void main() {
       Package p = results.package;
       expect(p.name, 'test_package');
       expect(p.hasDocumentationFile, isTrue);
-      expect(p.libraries, hasLength(1));
+      expect(p.libraries.map((lib) => lib.name), contains('dart:core'));
       expect(p.libraries.map((lib) => lib.name), contains('fake'));
     });
 

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -73,7 +73,7 @@ void main() {
     test('generate docs including a single library', () async {
       PackageMeta meta = new PackageMeta.fromDir(testPackageDir);
       DartDoc dartdoc = new DartDoc(
-          testPackageDir, [], getSdkDir(), [], tempDir, meta, ['dart.core']);
+          testPackageDir, [], getSdkDir(), [], tempDir, meta, ['fake']);
 
       DartDocResults results = await dartdoc.generateDocs();
       expect(results.package, isNotNull);
@@ -81,7 +81,7 @@ void main() {
       Package p = results.package;
       expect(p.name, 'test_package');
       expect(p.hasDocumentationFile, isTrue);
-      expect(p.libraries.map((lib) => lib.name), contains('dart:core'));
+      expect(p.libraries, hasLength(1));
       expect(p.libraries.map((lib) => lib.name), contains('fake'));
     });
 

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -6,7 +6,7 @@ library test_utils;
 
 import 'dart:io';
 
-import 'package:analyzer/src/generated/element.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/java_io.dart';
 import 'package:analyzer/src/generated/sdk.dart';


### PR DESCRIPTION
Better support the use case of generating docs for multiple projects in one repo; this will allow Flutter to improve their hosted docs.

- added support for passing more than one `--header` or `--footer`
- added the ability to `--include` libraries referenced by (but not directly inside) the project
- rev the analyzer version used to fix an issue generating docs for Flutter

@keertip 