### PR TITLE
0.9.3+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.3+1
+* [bug] fix an issue with including duplicated libraries
+
 ## 0.9.3
 * [enhancement] added support for URL-based search. If a query parameter named
   "search" is passed, the page navigates to the first search result for its

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -39,7 +39,7 @@ export 'src/package_meta.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String version = '0.9.3';
+const String version = '0.9.3+1';
 
 final String defaultOutDir = p.join('doc', 'api');
 
@@ -135,7 +135,7 @@ class DartDoc {
 
   List<LibraryElement> _parseLibraries(
       List<String> files, List<String> includeExternals) {
-    Set<LibraryElement> libraries = new Set();
+    List<LibraryElement> libraries = [];
     DartSdk sdk = new DirectoryBasedDartSdk(new JavaFile(sdkDir.path));
     List<UriResolver> resolvers = [];
 
@@ -222,7 +222,11 @@ class DartDoc {
     // Use the includeExternals.
     for (Source source in context.librarySources) {
       LibraryElement library = context.computeLibraryElement(source);
-      if (includeExternals.contains(Library.getLibraryName(library))) {
+      String libraryName = Library.getLibraryName(library);
+      if (includeExternals.contains(libraryName)) {
+        if (libraries.map(Library.getLibraryName).contains(libraryName)) {
+          continue;
+        }
         libraries.add(library);
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.9.3
+version: 0.9.3+1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/test_package_docs/index.html
+++ b/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.9.3">
+  <meta name="generator" content="made with love by dartdoc 0.9.3+1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
@keertip, a bug fix release. We can document libraries twice in some cases. Changed from using a Set (the object's don't implement `==` or hashcode) to a List, and manually de-duping the items.