### PR TITLE
implement a --use-categories option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## unreleased
 * [enhancement] added a `--favicon` option to specify a favicon to use for the
   generated docs
+* [enhancement] added a `--use-categories` flag to groups libraries into source
+  packages in the overview page and the left-hand side navigation panel
 
 ## 0.9.3+1
 * [bug] fix an issue with including duplicated libraries

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -116,7 +116,7 @@ main(List<String> arguments) async {
 
   var generators = await initGenerators(
       url, headerFilePaths, footerFilePaths, args['rel-canonical-prefix'],
-      faviconPath: args['favicon']);
+      faviconPath: args['favicon'], useCategories: args['use-categories']);
 
   for (var generator in generators) {
     generator.onFileCreated.listen(_onProgress);
@@ -207,6 +207,10 @@ ArgParser _createArgsParser() {
       help: 'Show source code blocks', negatable: true, defaultsTo: true);
   parser.addOption('favicon',
       help: 'A path to a favicon for the generated docs');
+  parser.addFlag('use-categories',
+      help: 'Group libraries from the same package into categories',
+      negatable: false,
+      defaultsTo: false);
   return parser;
 }
 

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -46,7 +46,7 @@ final String defaultOutDir = p.join('doc', 'api');
 /// Initialize and setup the generators.
 Future<List<Generator>> initGenerators(String url, List<String> headerFilePaths,
     List<String> footerFilePaths, String relCanonicalPrefix,
-    {String faviconPath}) async {
+    {String faviconPath, bool useCategories: false}) async {
   return [
     await HtmlGenerator.create(
         url: url,
@@ -54,7 +54,8 @@ Future<List<Generator>> initGenerators(String url, List<String> headerFilePaths,
         footers: footerFilePaths,
         relCanonicalPrefix: relCanonicalPrefix,
         toolVersion: version,
-        faviconPath: faviconPath)
+        faviconPath: faviconPath,
+        useCategories: useCategories)
   ];
 }
 

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -40,6 +40,7 @@ class HtmlGenerator extends Generator {
   final Templates _templates;
   final String _toolVersion;
   final String faviconPath;
+  final bool useCategories;
 
   final StreamController<File> _onFileCreated =
       new StreamController(sync: true);
@@ -53,7 +54,8 @@ class HtmlGenerator extends Generator {
       List<String> footers,
       String relCanonicalPrefix,
       String toolVersion,
-      String faviconPath}) async {
+      String faviconPath,
+      bool useCategories: false}) async {
     var templates =
         await Templates.create(headerPaths: headers, footerPaths: footers);
 
@@ -62,17 +64,17 @@ class HtmlGenerator extends Generator {
     }
 
     return new HtmlGenerator._(url, relCanonicalPrefix, templates, toolVersion,
-        faviconPath: faviconPath);
+        faviconPath: faviconPath, useCategories: useCategories);
   }
 
   HtmlGenerator._(
       this._url, this._relCanonicalPrefix, this._templates, this._toolVersion,
-      {this.faviconPath});
+      {this.faviconPath, this.useCategories});
 
   Future generate(Package package, Directory out) {
     return new HtmlGeneratorInstance(_toolVersion, _url, _templates, package,
             out, _onFileCreated, _relCanonicalPrefix,
-            faviconPath: faviconPath)
+            faviconPath: faviconPath, useCategories: useCategories)
         .generate();
   }
 }

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -25,10 +25,11 @@ class HtmlGeneratorInstance implements HtmlOptions {
   final String relCanonicalPrefix;
   final String toolVersion;
   final String faviconPath;
+  final bool useCategories;
 
   HtmlGeneratorInstance(this.toolVersion, this.url, this._templates,
       this.package, this.out, this._onFileCreated, this.relCanonicalPrefix,
-      {this.faviconPath});
+      {this.faviconPath, this.useCategories});
 
   Future generate() async {
     if (!out.existsSync()) out.createSync();
@@ -134,7 +135,7 @@ class HtmlGeneratorInstance implements HtmlOptions {
   void generatePackage() {
     stdout.write('documenting ${package.name}');
 
-    TemplateData data = new PackageTemplateData(this, package);
+    TemplateData data = new PackageTemplateData(this, package, useCategories);
 
     _build('index.html', _templates.indexTemplate, data);
   }
@@ -148,7 +149,8 @@ class HtmlGeneratorInstance implements HtmlOptions {
           "documentation comments");
     }
 
-    TemplateData data = new LibraryTemplateData(this, package, lib);
+    TemplateData data =
+        new LibraryTemplateData(this, package, lib, useCategories);
 
     _build(path.join(lib.dirName, '${lib.fileName}'),
         _templates.libraryTemplate, data);

--- a/lib/src/html/template_data.dart
+++ b/lib/src/html/template_data.dart
@@ -68,10 +68,12 @@ abstract class TemplateData<T extends Documentable> {
 }
 
 class PackageTemplateData extends TemplateData<Package> {
-  PackageTemplateData(HtmlOptions htmlOptions, Package package)
+  PackageTemplateData(
+      HtmlOptions htmlOptions, Package package, this.useCategories)
       : super(htmlOptions, package);
 
   bool get includeVersion => true;
+  final bool useCategories;
   List get navLinks => [];
   String get title => '${package.name} - Dart API docs';
   Package get self => package;
@@ -90,11 +92,13 @@ class PackageTemplateData extends TemplateData<Package> {
 class LibraryTemplateData extends TemplateData<Library> {
   final Library library;
 
-  LibraryTemplateData(HtmlOptions htmlOptions, Package package, this.library)
+  LibraryTemplateData(HtmlOptions htmlOptions, Package package, this.library,
+      this.useCategories)
       : super(htmlOptions, package);
 
   String get title => '${library.name} library - Dart API';
   String get documentation => library.documentation;
+  final bool useCategories;
   String get htmlBase => '..';
   String get metaDescription =>
       '${library.name} library API docs, for the Dart programming language.';

--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -3,38 +3,67 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5>{{self.name}}</h5>
 
+    {{#useCategories}}
+    <ol>
+      {{#package.categories}}
+        <li class="section-title">{{name}}</li>
+        {{#libraries}}
+        <li>{{{linkedName}}}</li>
+        {{/libraries}}
+      {{/package.categories}}
+
+    </ol>
+    {{/useCategories}}
+
+    {{^useCategories}}
     <ol>
       <li class="section-title"><a href="{{package.href}}#libraries">Libraries</a></li>
       {{#package.libraries}}
       <li>{{{linkedName}}}</li>
       {{/package.libraries}}
     </ol>
+    {{/useCategories}}
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     {{#package}}
       {{>documentation}}
     {{/package}}
 
-    <section class="summary" id="libraries">
-      <h2>Libraries</h2>
-      <dl>
-        {{#package.libraries}}
-          <dt id="{{htmlId}}">
-            <span class="name">{{{ linkedName }}}</span>
-          </dt>
-          <dd>
-            {{#isDocumented}}
-            <p>
-              {{{ oneLineDoc }}}
-              {{>has_more_docs}}
-            </p>
-            {{/isDocumented}}
-          </dd>
-        {{/package.libraries}}
-      </dl>
-    </section>
+    {{#useCategories}}
+      {{#package.categories}}
+        <section class="summary">
+          <h2>{{name}}</h2>
+          <dl>
+            {{#libraries}}
+              <dt id="{{htmlId}}">
+                <span class="name">{{{ linkedName }}}</span>
+              </dt>
+              <dd>
+                {{#isDocumented}}<p>{{{ oneLineDoc }}}</p>{{/isDocumented}}
+              </dd>
+            {{/libraries}}
+          </dl>
+        </section>
+      {{/package.categories}}
+
+    {{/useCategories}}
+
+    {{^useCategories}}
+      <section class="summary" id="libraries">
+        <h2>Libraries</h2>
+        <dl>
+          {{#package.libraries}}
+            <dt id="{{htmlId}}">
+              <span class="name">{{{ linkedName }}}</span>
+            </dt>
+            <dd>
+              {{#isDocumented}}<p>{{{ oneLineDoc }}}</p>{{/isDocumented}}
+            </dd>
+          {{/package.libraries}}
+        </dl>
+      </section>
+    {{/useCategories}}
 
   </div> <!-- /.main-content -->
 

--- a/lib/templates/library.html
+++ b/lib/templates/library.html
@@ -5,12 +5,26 @@
     <h5><a href="{{href}}">{{name}}</a></h5>
     {{/navLinks}}
 
+    {{#useCategories}}
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      {{#package.categories}}
+        <li class="section-title">{{name}}</li>
+        {{#libraries}}
+        <li>{{{linkedName}}}</li>
+        {{/libraries}}
+      {{/package.categories}}
+
+    </ol>
+    {{/useCategories}}
+
+    {{^useCategories}}
+    <ol>
+      <li class="section-title"><a href="{{package.href}}#libraries">Libraries</a></li>
       {{#package.libraries}}
       <li>{{{linkedName}}}</li>
       {{/package.libraries}}
     </ol>
+    {{/useCategories}}
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -47,6 +47,14 @@ void main() {
         expect(package.libraries, hasLength(6));
       });
 
+      test('categories', () {
+        expect(package.categories, hasLength(1));
+
+        PackageCategory category = package.categories.first;
+        expect(category.name, 'test_package');
+        expect(category.libraries, hasLength(6));
+      });
+
       test('is documented in library', () {
         expect(package.isDocumented(exLibrary.element), isTrue);
       });
@@ -119,6 +127,10 @@ void main() {
 
     test('has a name', () {
       expect(exLibrary.name, 'ex');
+    });
+
+    test('packageName', () {
+      expect(exLibrary.packageName, 'test_package');
     });
 
     test('has a fully qualified name', () {

--- a/testing/test_package_docs/anonymous_library/anonymous_library-library.html
+++ b/testing/test_package_docs/anonymous_library/anonymous_library-library.html
@@ -69,8 +69,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/another_anonymous_lib/another_anonymous_lib-library.html
+++ b/testing/test_package_docs/another_anonymous_lib/another_anonymous_lib-library.html
@@ -69,8 +69,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/code_in_comments/code_in_comments-library.html
+++ b/testing/test_package_docs/code_in_comments/code_in_comments-library.html
@@ -66,8 +66,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/css/css-library.html
+++ b/testing/test_package_docs/css/css-library.html
@@ -69,8 +69,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -75,8 +75,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -75,8 +75,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -64,6 +64,7 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5>test_package</h5>
 
+
     <ol>
       <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
@@ -78,7 +79,6 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
       <section class="desc markdown">
         <h1>Best Package</h1>
 <p>This is an amazing package.</p>
@@ -96,72 +96,64 @@
 <p>Be sure to check out other awesome packages on <a href="https://pub.dartlang.org">pub</a>.</p>
       </section>
       
-    <section class="summary" id="libraries">
-      <h2>Libraries</h2>
-      <dl>
-          <dt id="anonymous_library">
-            <span class="name"><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></span>
-          </dt>
-          <dd>
-          </dd>
-          <dt id="another_anonymous_lib">
-            <span class="name"><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></span>
-          </dt>
-          <dd>
-          </dd>
-          <dt id="code_in_comments">
-            <span class="name"><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></span>
-          </dt>
-          <dd>
-            <p>
-              <code>void main() {
+
+      <section class="summary" id="libraries">
+        <h2>Libraries</h2>
+        <dl>
+            <dt id="anonymous_library">
+              <span class="name"><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></span>
+            </dt>
+            <dd>
+              
+            </dd>
+            <dt id="another_anonymous_lib">
+              <span class="name"><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></span>
+            </dt>
+            <dd>
+              
+            </dd>
+            <dt id="code_in_comments">
+              <span class="name"><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></span>
+            </dt>
+            <dd>
+              <p><code>void main() {
   // in Dart!
 }
-</code>
-              <a href="code_in_comments/code_in_comments-library.html">&hellip;</a>
-                          </p>
-          </dd>
-          <dt id="css">
-            <span class="name"><a href="css/css-library.html">css</a></span>
-          </dt>
-          <dd>
-            <p>
-              Testing that a library name doesn't conflict
-with directories created by dartdoc.
-                          </p>
-          </dd>
-          <dt id="ex">
-            <span class="name"><a href="ex/ex-library.html">ex</a></span>
-          </dt>
-          <dd>
-            <p>
-              a library. testing string escaping: <code>var s = 'a string'</code> &lt;cool&gt;
-                          </p>
-          </dd>
-          <dt id="fake">
-            <span class="name"><a href="fake/fake-library.html">fake</a></span>
-          </dt>
-          <dd>
-            <p>
-              WOW FAKE PACKAGE IS <strong>BEST</strong> <a href="http://example.org">PACKAGE</a>
-              <a href="fake/fake-library.html">&hellip;</a>
-                          </p>
-          </dd>
-          <dt id="is_deprecated">
-            <span class="name"><a class="deprecated" href="is_deprecated/is_deprecated-library.html">is_deprecated</a></span>
-          </dt>
-          <dd>
-            <p>
-              This lib is deprecated. It never had a chance
-                          </p>
-          </dd>
-          <dt id="two_exports">
-            <span class="name"><a href="two_exports/two_exports-library.html">two_exports</a></span>
-          </dt>
-          <dd>
-          </dd>
-      </dl>
-    </section>
+</code></p>
+            </dd>
+            <dt id="css">
+              <span class="name"><a href="css/css-library.html">css</a></span>
+            </dt>
+            <dd>
+              <p>Testing that a library name doesn't conflict
+with directories created by dartdoc.</p>
+            </dd>
+            <dt id="ex">
+              <span class="name"><a href="ex/ex-library.html">ex</a></span>
+            </dt>
+            <dd>
+              <p>a library. testing string escaping: <code>var s = 'a string'</code> &lt;cool&gt;</p>
+            </dd>
+            <dt id="fake">
+              <span class="name"><a href="fake/fake-library.html">fake</a></span>
+            </dt>
+            <dd>
+              <p>WOW FAKE PACKAGE IS <strong>BEST</strong> <a href="http://example.org">PACKAGE</a></p>
+            </dd>
+            <dt id="is_deprecated">
+              <span class="name"><a class="deprecated" href="is_deprecated/is_deprecated-library.html">is_deprecated</a></span>
+            </dt>
+            <dd>
+              <p>This lib is deprecated. It never had a chance</p>
+            </dd>
+            <dt id="two_exports">
+              <span class="name"><a href="two_exports/two_exports-library.html">two_exports</a></span>
+            </dt>
+            <dd>
+              
+            </dd>
+        </dl>
+      </section>
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/is_deprecated/is_deprecated-library.html
+++ b/testing/test_package_docs/is_deprecated/is_deprecated-library.html
@@ -66,8 +66,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>

--- a/testing/test_package_docs/two_exports/two_exports-library.html
+++ b/testing/test_package_docs/two_exports/two_exports-library.html
@@ -70,8 +70,9 @@
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
     <h5><a href="index.html">test_package</a></h5>
 
+
     <ol>
-      <li class="section-title"><a href="index.html">Libraries</a></li>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
       <li><a href="anonymous_library/anonymous_library-library.html">anonymous_library</a></li>
       <li><a href="another_anonymous_lib/another_anonymous_lib-library.html">another_anonymous_lib</a></li>
       <li><a href="code_in_comments/code_in_comments-library.html">code_in_comments</a></li>


### PR DESCRIPTION
- implement a `--use-categories` option. This groups libraries into sections based on their source package. It's helpful when you have a lot of libraries (Flutter has 39).
- add tests
- update the generated test docs

<img width="382" alt="screen shot 2016-04-12 at 7 23 01 am" src="https://cloud.githubusercontent.com/assets/1269969/14463324/6f81f20a-007f-11e6-8129-f2c7c99bf467.png">

@keertip 