### PR TITLE
add an option to inject examples

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -14,8 +14,6 @@ import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 
-bool _showProgress = false;
-
 /// Analyzes Dart files and generates a representation of included libraries,
 /// classes, and members. Uses the current directory to look for libraries.
 main(List<String> arguments) async {
@@ -145,21 +143,7 @@ main(List<String> arguments) async {
   });
 }
 
-void _onProgress(File file) {
-  if (_showProgress) stdout.write('.');
-}
-
-/// Print help if we are passed the help option.
-void _printHelp(ArgParser parser, {int exitCode: 0}) {
-  print('Generate HTML documentation for Dart libraries.\n');
-  _printUsageAndExit(parser, exitCode: exitCode);
-}
-
-void _printUsageAndExit(ArgParser parser, {int exitCode: 0}) {
-  print('Usage: dartdoc [OPTIONS]\n');
-  print(parser.usage);
-  exit(exitCode);
-}
+bool _showProgress = false;
 
 ArgParser _createArgsParser() {
   var parser = new ArgParser();
@@ -212,6 +196,22 @@ ArgParser _createArgsParser() {
       negatable: false,
       defaultsTo: false);
   return parser;
+}
+
+void _onProgress(File file) {
+  if (_showProgress) stdout.write('.');
+}
+
+/// Print help if we are passed the help option.
+void _printHelp(ArgParser parser, {int exitCode: 0}) {
+  print('Generate HTML documentation for Dart libraries.\n');
+  _printUsageAndExit(parser, exitCode: exitCode);
+}
+
+void _printUsageAndExit(ArgParser parser, {int exitCode: 0}) {
+  print('Usage: dartdoc [OPTIONS]\n');
+  print(parser.usage);
+  exit(exitCode);
 }
 
 String _resolveTildePath(String originalPath) {

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -8,6 +8,7 @@ library dartdoc;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart' as fileSystem;
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/source/embedder.dart';
@@ -15,7 +16,6 @@ import 'package:analyzer/source/package_map_provider.dart';
 import 'package:analyzer/source/package_map_resolver.dart';
 import 'package:analyzer/source/pub_package_map_provider.dart';
 import 'package:analyzer/source/sdk_ext.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/error.dart';
 import 'package:analyzer/src/generated/java_io.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.9.4
+version: 0.9.5-dev
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -162,6 +162,7 @@ class ConstantCat implements Cat {
 }
 
 /// implements [Cat], [E]
+/// {@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_list'}
 class Dog implements Cat, E {
   String name;
 


### PR DESCRIPTION
This adds a flag `--include-examples` which for now looks for `@example` tag in the comments and looks for the file associated with the sample code.

#1105 