### PR TITLE
Add ability to "Crossdartify" the source code

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -123,7 +123,10 @@ main(List<String> arguments) async {
   var addCrossdart = args['add-crossdart'] as bool;
   var includeSource = args['include-source'] as bool;
 
-  initializeConfig(addCrossdart: addCrossdart, includeSource: includeSource);
+  initializeConfig(
+      addCrossdart: addCrossdart,
+      includeSource: includeSource,
+      inputDir: inputDir);
 
   var dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
       outputDir, packageMeta, includeLibraries,

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -178,6 +178,16 @@ h2 .crossdart {
   margin-top: 1em;
 }
 
+.crossdart-link {
+  border-bottom: 1px solid #dfdfdf;
+  text-decoration: none;
+}
+
+.crossdart-link:hover {
+  border-bottom: 1px solid #aaa;
+  text-decoration: none;
+}
+
 @media(max-width: 768px) {
   nav .container {
     width: 100%

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -1,14 +1,18 @@
 library dartdoc.config;
 
+import 'dart:io';
+
 class Config {
+  final Directory inputDir;
   final bool addCrossdart;
   final bool includeSource;
-  Config._(this.addCrossdart, this.includeSource);
+  Config._(this.inputDir, this.addCrossdart, this.includeSource);
 }
 
 Config _config;
 Config get config => _config;
 
-void initializeConfig({bool addCrossdart: false, bool includeSource: true}) {
-  _config = new Config._(addCrossdart, includeSource);
+void initializeConfig(
+    {Directory inputDir, bool addCrossdart: false, bool includeSource: true}) {
+  _config = new Config._(inputDir, addCrossdart, includeSource);
 }

--- a/lib/templates/_source_code.html
+++ b/lib/templates/_source_code.html
@@ -1,5 +1,5 @@
 {{#hasSourceCode}}
 <section class="summary source-code" id="source">
   <h2><span>Source</span> {{{crossdartHtmlTag}}}</h2>
-  <pre><code class="prettyprint lang-dart">{{ sourceCode }}</code></pre>
+  <pre class="prettyprint lang-dart">{{{ sourceCode }}}</pre>
 </section>{{/hasSourceCode}}


### PR DESCRIPTION
If there's a crossdart.json file in the input dir (which can be generated by Crossdart), it will use that file to add links to crossdart.info in the source code block.

Since now we should support links in the source code section, I removed `<code>` wrapping tags from it, and also now I HTML escape the source code, and use triple mustache curly braces (`{{{sourceCode}}}`) to insert it to the page.

Hopefully, that will simplify developer's life, when they want to look into the method's implementation.

Example: https://www.dartdocs.org/documentation/hop/0.30.4+2/hop/runHop.html

/cc @sethladd 