### PR TITLE
Update dartdoc to use new EmbedderSdk API.

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -24,6 +24,7 @@ import 'package:analyzer/src/generated/sdk_io.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
 import 'package:path/path.dart' as p;
+import 'package:yaml/src/yaml_node.dart';
 
 import 'src/generator.dart';
 import 'src/html/html_generator.dart';
@@ -155,8 +156,10 @@ class DartDoc {
       resolvers.add(new PackageMapUriResolver(
           PhysicalResourceProvider.INSTANCE, packageMap));
 
-      embedderUriResolver = new EmbedderUriResolver(
-          new EmbedderYamlLocator(packageMap).embedderYamls);
+      Map<fileSystem.Folder, YamlMap> embedderMap =
+          new EmbedderYamlLocator(packageMap).embedderYamls;
+      embedderUriResolver =
+          new EmbedderUriResolver(new EmbedderSdk(embedderMap));
       if (embedderUriResolver.length == 0) {
         // The embedder uri resolver has no mappings. Use the default Dart SDK
         // uri resolver.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.3-alpha.7"
+    version: "0.27.4-alpha.8"
   ansicolor:
     description:
       name: ansicolor
@@ -18,19 +18,19 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.4+2"
   async:
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.11.0"
   barback:
     description:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+7"
+    version: "0.15.2+8"
   boolean_selector:
     description:
       name: boolean_selector
@@ -54,7 +54,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.8.0"
   contrast:
     description:
       name: contrast
@@ -66,7 +66,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   crypto:
     description:
       name: crypto
@@ -78,7 +78,7 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.2"
   den_api:
     description:
       name: den_api
@@ -108,13 +108,13 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.2+2"
   http:
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+3"
+    version: "0.11.3+7"
   http_multi_server:
     description:
       name: http_multi_server
@@ -126,7 +126,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.1"
   librato:
     description:
       name: librato
@@ -138,7 +138,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.2"
+    version: "0.11.3"
   markdown:
     description:
       name: markdown
@@ -186,19 +186,19 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.3"
   plugin:
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   pub_package_data:
     description:
       name: pub_package_data
@@ -228,19 +228,19 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.5+2"
   shelf_static:
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3+3"
+    version: "0.2.3+4"
   shelf_web_socket:
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -264,13 +264,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.6.5"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   string_scanner:
     description:
       name: string_scanner
@@ -288,13 +288,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.13+4"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   unscripted:
     description:
       name: unscripted
@@ -312,13 +312,13 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
+    version: "0.9.7+2"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   when:
     description:
       name: when
@@ -336,11 +336,11 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
-sdk: ">=1.14.0 <1.17.0"
+    version: "2.1.9"
+sdk: ">=1.16.0 <1.18.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=1.14.0 <2.0.0'
 dependencies:
-  analyzer: 0.27.3-alpha.7
+  analyzer: 0.27.4-alpha.8
   args: ^0.13.0
   cli_util: ^0.0.1
   collection: ^1.2.0


### PR DESCRIPTION
Addresses https://github.com/dart-lang/sdk/issues/26562.