### PR TITLE
fix the dartdoc build against the dev sdk

### DIFF
--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -125,7 +125,7 @@ class _FilePackageMeta extends PackageMeta {
 }
 
 File _locate(Directory dir, List<String> fileNames) {
-  List<File> files = dir.listSync().where((f) => f is File).toList();
+  List<File> files = new List<File>.from(dir.listSync().where((f) => f is File));
 
   for (String name in fileNames) {
     for (File f in files) {

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -125,7 +125,8 @@ class _FilePackageMeta extends PackageMeta {
 }
 
 File _locate(Directory dir, List<String> fileNames) {
-  List<File> files = new List<File>.from(dir.listSync().where((f) => f is File));
+  List<File> files =
+      new List<File>.from(dir.listSync().where((f) => f is File));
 
   for (String name in fileNames) {
     for (File f in files) {


### PR DESCRIPTION
The current dartdoc build is failing due to a checked mode issue against the dev sdk (https://travis-ci.org/dart-lang/dartdoc).

@keertip 