### PR TITLE
improve failure message on windows

### DIFF
--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -64,10 +64,9 @@ void main() {
           Process.runSync('dart', args, workingDirectory: _testPackagePath);
 
       if (result.exitCode != 0) {
-        print(result.exitCode);
         print(result.stdout);
         print(result.stderr);
-        fail('dartdoc failed');
+        fail('dartdoc failed: ${result.exitCode}');
       }
 
       var gitPath = await _gitBinPath();
@@ -133,16 +132,13 @@ void main() {
           Process.runSync('dart', args, workingDirectory: _testPackagePath);
 
       if (result.exitCode != 0) {
-        print(result.exitCode);
         print(result.stdout);
         print(result.stderr);
-        fail('dartdoc failed');
+        fail('dartdoc failed: ${result.exitCode}');
       }
 
-      if (!result.stdout
-          .contains('core/pipes/ts/slice_pipe/slice_pipe_example.ts')) {
-        fail('Did not process @example in comments');
-      }
+      expect(result.stdout,
+          contains('core/pipes/ts/slice_pipe/slice_pipe_example.ts'));
     });
   }, onPlatform: {'windows': new Skip('Avoiding parsing git output')});
 }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -413,7 +413,8 @@ void main() {
     test('single ref to class', () {
       expect(
           B.documentationAsHtml.contains(
-              '<p>Extends class <a href="ex/Apple-class.html">Apple</a>, use <a href="ex/Apple/Apple.html">new Apple</a> or <a href="ex/Apple/Apple.fromString.html">new Apple.fromString</a></p>'),
+              '<p>Extends class <a href="ex/Apple-class.html">Apple</a>, use <a href="ex/Apple/Apple.html">new Apple</a> '
+              'or <a href="ex/Apple/Apple.fromString.html">new Apple.fromString</a></p>'),
           isTrue);
     });
 


### PR DESCRIPTION
trying to track down a windows failure (https://ci.appveyor.com/project/devoncarew/dartdoc/build/1.0.1405) - fail w/ an expect message for an `@example` test