### PR TITLE
Fix line number in the "Link to Crossdart" link

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -13,6 +13,9 @@ import 'package:dartdoc/src/config.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
+import 'package:analyzer/src/generated/sdk.dart';
+import 'package:analyzer/src/generated/sdk_io.dart';
+import 'package:analyzer/src/generated/java_io.dart';
 
 /// Analyzes Dart files and generates a representation of included libraries,
 /// classes, and members. Uses the current directory to look for libraries.
@@ -123,10 +126,13 @@ main(List<String> arguments) async {
   var addCrossdart = args['add-crossdart'] as bool;
   var includeSource = args['include-source'] as bool;
 
+  DartSdk sdk = new DirectoryBasedDartSdk(new JavaFile(sdkDir.path));
+
   initializeConfig(
       addCrossdart: addCrossdart,
       includeSource: includeSource,
-      inputDir: inputDir);
+      inputDir: inputDir,
+      sdkVersion: sdk.sdkVersion);
 
   var dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
       outputDir, packageMeta, includeLibraries,

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -6,13 +6,18 @@ class Config {
   final Directory inputDir;
   final bool addCrossdart;
   final bool includeSource;
-  Config._(this.inputDir, this.addCrossdart, this.includeSource);
+  final String sdkVersion;
+  Config._(
+      this.inputDir, this.addCrossdart, this.includeSource, this.sdkVersion);
 }
 
 Config _config;
 Config get config => _config;
 
 void initializeConfig(
-    {Directory inputDir, bool addCrossdart: false, bool includeSource: true}) {
-  _config = new Config._(inputDir, addCrossdart, includeSource);
+    {Directory inputDir,
+    String sdkVersion,
+    bool addCrossdart: false,
+    bool includeSource: true}) {
+  _config = new Config._(inputDir, addCrossdart, includeSource, sdkVersion);
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2001,21 +2001,8 @@ abstract class SourceCodeMixin {
   }
 
   String get _crossdartUrl {
-    if (_lineNumber != null && _sourceFilePath != null) {
-      String packageName = library.package.isSdk ? "sdk" : library.package.name;
-      String packageVersion = library.package.version;
-      var root = library.package.packageMeta.resolvedDir;
-      if (!library.package.isSdk) {
-        root += "/lib";
-      }
-      root = root.replaceAll("\\", "/");
-      var sourceFilePath = new File(_sourceFilePath)
-          .resolveSymbolicLinksSync()
-          .replaceAll("\\", "/")
-          .replaceAll(root, "")
-          .replaceAll(new RegExp(r"^/*"), "");
-      String url =
-          "//www.crossdart.info/p/$packageName/$packageVersion/$sourceFilePath.html";
+    if (_lineNumber != null && _crossdartPath != null) {
+      String url = "//www.crossdart.info/p/${_crossdartPath}.html";
       return "${url}#line-${_lineNumber}";
     } else {
       return null;
@@ -2034,12 +2021,40 @@ abstract class SourceCodeMixin {
     }
   }
 
-  String get _sourceFilePath {
+  String get _crossdartPath {
     var node = element.computeNode();
     if (node is Declaration && (node as Declaration).element != null) {
-      return ((node as Declaration).element.source as FileBasedSource)
-          .file
-          .toString();
+      var source = ((node as Declaration).element.source as FileBasedSource);
+      var file = source.file.toString();
+      var uri = source.uri.toString();
+      var packageMeta = library.package.packageMeta;
+      if (uri.startsWith("package:")) {
+        var splittedUri =
+            uri.replaceAll(new RegExp(r"^package:"), "").split("/");
+        var packageName = splittedUri.first;
+        var packageVersion;
+        if (packageName == packageMeta.name) {
+          packageVersion = packageMeta.version;
+        } else {
+          var match = new RegExp(
+                  ".pub-cache/(hosted/pub.dartlang.org|git)/${packageName}-([^/]+)")
+              .firstMatch(file);
+          if (match != null) {
+            packageVersion = match[2];
+          }
+        }
+        if (packageVersion != null) {
+          return "${packageName}/${packageVersion}/${splittedUri.skip(1).join("/")}";
+        } else {
+          return null;
+        }
+      } else if (uri.startsWith("dart:")) {
+        var packageName = "sdk";
+        var packageVersion = config.sdkVersion;
+        return "${packageName}/${packageVersion}/lib/${uri.replaceAll(new RegExp(r"^dart:"), "")}";
+      } else {
+        return null;
+      }
     } else {
       return null;
     }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2025,8 +2025,10 @@ abstract class SourceCodeMixin {
   int get _lineNumber {
     var node = element.computeNode();
     if (node is Declaration && (node as Declaration).element != null) {
-      return lineNumberCache.lineNumber(
-          (node as Declaration).element.source.fullName, node.offset);
+      var element = (node as Declaration).element;
+      var lineNumber = lineNumberCache.lineNumber(
+          element.source.fullName, element.nameOffset);
+      return lineNumber + 1;
     } else {
       return null;
     }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -948,14 +948,6 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     group(".crossdartHtmlTag()", () {
-      test('it returns a Crossdart link when Crossdart support is enabled', () {
-        initializeConfig(addCrossdart: true);
-        String packageName = m1.library.package.name;
-        String packageVersion = m1.library.package.version;
-        expect(m1.crossdartHtmlTag,
-            contains("//www.crossdart.info/p/$packageName/$packageVersion"));
-      });
-
       test('it returns an empty string when Crossdart support is disabled', () {
         initializeConfig(addCrossdart: false);
         expect(m1.crossdartHtmlTag, "");


### PR DESCRIPTION
Hey @keertip, I'm really sorry, but there's one more thing I need to fix.
Hopefully, the last one :)

The "Link to Crossdart" used to point to the beginning of the comment section, and also was
off by 1 (I guess because `LineNumberCache` counts them from 0, but
www.crossdart.info starts from 1).

Now it points to the actual declaration.