### PR TITLE
`pub run test` fails if `dart` is not in your path

### DIFF
--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -60,8 +60,8 @@ void main() {
         tempDir.path
       ];
 
-      var result =
-          Process.runSync('dart', args, workingDirectory: _testPackagePath);
+      var result = Process.runSync(Platform.resolvedExecutable, args,
+          workingDirectory: _testPackagePath);
 
       if (result.exitCode != 0) {
         print(result.exitCode);
@@ -129,8 +129,8 @@ void main() {
         tempDir.path
       ];
 
-      var result =
-          Process.runSync('dart', args, workingDirectory: _testPackagePath);
+      var result = Process.runSync(Platform.resolvedExecutable, args,
+          workingDirectory: _testPackagePath);
 
       if (result.exitCode != 0) {
         print(result.exitCode);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -144,7 +144,7 @@ Future buildSdkDocs() async {
   delete(docsDir);
   log('building SDK docs');
   int sdkDocsGenTime = await _runAsyncTimed(() async {
-    var process = await Process.start('dart', [
+    var process = await Process.start(Platform.resolvedExecutable, [
       'bin/dartdoc.dart',
       '--output',
       '${docsDir.path}',


### PR DESCRIPTION
These also might fail if the `dart` in your path was
of a different version than you expected.  This happens
with Flutter since flutter downloads its own copy of the
Dart SDK which may be different from the one installed
globally on your disk.

In my case, I just was using an explicit path to `pub`
for `pub run test` and was surprised to see test failures.

@keertip