### PR TITLE
regen test docs

### DIFF
--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -4,15 +4,15 @@
 
 library dartdoc.model_utils;
 
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source_io.dart';
-import 'package:path/path.dart' as p;
+
 import 'config.dart';
 
 final Map<String, String> _fileContents = <String, String>{};

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -939,7 +939,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       new File(p.join(Directory.current.path, "crossdart.json"))
           .writeAsStringSync("""
               {"testing/test_package/lib/fake.dart":
-                {"references":[{"offset":5806,"end":5809,"remotePath":"http://www.example.com/fake.dart"}]}}
+                {"references":[{"offset":1069,"end":1072,"remotePath":"http://www.example.com/fake.dart"}]}}
       """);
 
       initializeConfig(addCrossdart: true, inputDir: Directory.current);

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -50,6 +50,19 @@ import 'css.dart' as css;
 
 import 'two_exports.dart' show BaseClass;
 
+class HasGenerics<X, Y, Z> {
+  HasGenerics(X x, Y y, Z z) {}
+
+  X returnX() => null;
+
+  Z returnZ() => null;
+
+  Z doStuff(String s, X x) => null;
+
+  /// Converts itself to a map.
+  Map<X, Y> convertToMap() => null;
+}
+
 Map<dynamic, String> mapWithDynamicKeys = {};
 
 /// Useful for annotations.
@@ -255,19 +268,6 @@ class Foo2 {
 
   static const Foo2 BAR = const Foo2(0);
   static const Foo2 BAZ = const Foo2(1);
-}
-
-class HasGenerics<X, Y, Z> {
-  HasGenerics(X x, Y y, Z z) {}
-
-  X returnX() => null;
-
-  Z returnZ() => null;
-
-  Z doStuff(String s, X x) => null;
-
-  /// Converts itself to a map.
-  Map<X, Y> convertToMap() => null;
 }
 
 class OtherGenericsThing<A> {

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -134,7 +134,8 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="desc markdown">
-      <p>implements <a href="ex/Cat-class.html">Cat</a>, <a href="ex/E-class.html">E</a></p>
+      <p>implements <a href="ex/Cat-class.html">Cat</a>, <a href="ex/E-class.html">E</a>
+{@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_list'}</p>
     </section>
     
     <section>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -335,7 +335,8 @@
           <span class="name "><a href="ex/Dog-class.html">Dog</a></span>
         </dt>
         <dd>
-          <p>implements <a href="ex/Cat-class.html">Cat</a>, <a href="ex/E-class.html">E</a></p>
+          <p>implements <a href="ex/Cat-class.html">Cat</a>, <a href="ex/E-class.html">E</a>
+{@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_list'}</p>
         </dd>
         <dt id="E">
           <span class="name "><a href="ex/E-class.html">E</a></span>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -678,7 +678,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          <p>Returns an Iterable that provides all but the first <code>count</code> elements.<a href="fake/ExtraSpecialList/skip.html">&hellip;</a>
+          <p>Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.<a href="fake/ExtraSpecialList/skip.html">&hellip;</a>
 </p>
           <div class="features">inherited</div>
         </dd>
@@ -688,7 +688,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          <p>Returns an Iterable that skips leading elements while <code>test</code> is satisfied.<a href="fake/ExtraSpecialList/skipWhile.html">&hellip;</a>
+          <p>Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.<a href="fake/ExtraSpecialList/skipWhile.html">&hellip;</a>
 </p>
           <div class="features">inherited</div>
         </dd>

--- a/testing/test_package_docs/fake/ExtraSpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/firstWhere.html
@@ -154,7 +154,7 @@
     </section>
     <section class="desc markdown">
       <p>Returns the first element that satisfies the given predicate <code>test</code>.</p>
-<p>Iterates through elements and returns the first to satsify <code>test</code>.</p>
+<p>Iterates through elements and returns the first to satisfy <code>test</code>.</p>
 <p>If no element satisfies <code>test</code>, the result of invoking the <code>orElse</code>
 function is returned.
 If <code>orElse</code> is omitted, it defaults to throwing a <code>StateError</code>.</p>

--- a/testing/test_package_docs/fake/ExtraSpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/lastWhere.html
@@ -160,7 +160,7 @@ last element and then moves towards the start of the list).
 The default implementation iterates elements in iteration order,
 checks <code>test(element)</code> for each,
 and finally returns that last one that matched.</p>
-<p>If no element satsfies <code>test</code>, the result of invoking the <code>orElse</code>
+<p>If no element satisfies <code>test</code>, the result of invoking the <code>orElse</code>
 function is returned.
 If <code>orElse</code> is omitted, it defaults to throwing a <code>StateError</code>.</p>
     </section>

--- a/testing/test_package_docs/fake/ExtraSpecialList/map.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/map.html
@@ -158,7 +158,7 @@ calling <code>f</code> on each element of this <code>Iterable</code> in iteratio
 <p>This method returns a view of the mapped elements. As long as the
 returned <code>Iterable</code> is not iterated over, the supplied function <code>f</code> will
 not be invoked. The transformed elements will not be cached. Iterating
-multiple times over the the returned <code>Iterable</code> will invoke the supplied
+multiple times over the returned <code>Iterable</code> will invoke the supplied
 function <code>f</code> multiple times on the same element.</p>
 <p>Methods on the returned iterable are allowed to omit calling <code>f</code>
 on any element where the result isn't needed.

--- a/testing/test_package_docs/fake/ExtraSpecialList/skip.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/skip.html
@@ -153,13 +153,16 @@
       <span class="name ">skip</span>(<wbr><span class="parameter" id="skip-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
     </section>
     <section class="desc markdown">
-      <p>Returns an Iterable that provides all but the first <code>count</code> elements.</p>
+      <p>Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.</p>
 <p>When the returned iterable is iterated, it starts iterating over <code>this</code>,
 first skipping past the initial <code>count</code> elements.
 If <code>this</code> has fewer than <code>count</code> elements, then the resulting Iterable is
 empty.
 After that, the remaining elements are iterated in the same order as
 in this iterable.</p>
+<p>Some iterables may be able to find later elements without first iterating
+through earlier elements, for example when iterating a <code>List</code>.
+Such iterables are allowed to ignore the initial skipped elements.</p>
 <p>The <code>count</code> must not be negative.</p>
     </section>
     

--- a/testing/test_package_docs/fake/ExtraSpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/skipWhile.html
@@ -153,14 +153,14 @@
       <span class="name ">skipWhile</span>(<wbr><span class="parameter" id="skipWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
     <section class="desc markdown">
-      <p>Returns an Iterable that skips leading elements while <code>test</code> is satisfied.</p>
-<p>The filtering happens lazily. Every new Iterator of the returned
-Iterable iterates over all elements of <code>this</code>.</p>
+      <p>Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.</p>
+<p>The filtering happens lazily. Every new <code>Iterator</code> of the returned
+iterable iterates over all elements of <code>this</code>.</p>
 <p>The returned iterable provides elements by iterating this iterable,
 but skipping over all initial elements where <code>test(element)</code> returns
 true. If all elements satisfy <code>test</code> the resulting iterable is empty,
 otherwise it iterates the remaining elements in their original order,
-starting with the first element for which <code>test(element)</code> returns false,</p>
+starting with the first element for which <code>test(element)</code> returns <code>false</code>.</p>
     </section>
     
     

--- a/testing/test_package_docs/fake/ExtraSpecialList/where.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/where.html
@@ -157,10 +157,11 @@
 predicate <code>test</code>.</p>
 <p>The matching elements have the same order in the returned iterable
 as they have in <code>iterator</code>.</p>
-<p>This method returns a view of the mapped elements. As long as the
-returned <code>Iterable</code> is not iterated over, the supplied function <code>test</code> will
-not be invoked. Iterating will not cache results, and thus iterating
-multiple times over the returned <code>Iterable</code> will invoke the supplied
+<p>This method returns a view of the mapped elements.
+As long as the returned <code>Iterable</code> is not iterated over,
+the supplied function <code>test</code> will not be invoked.
+Iterating will not cache results, and thus iterating multiple times over
+the returned <code>Iterable</code> may invoke the supplied
 function <code>test</code> multiple times on the same element.</p>
     </section>
     

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -680,7 +680,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          <p>Returns an Iterable that provides all but the first <code>count</code> elements.<a href="fake/SpecialList/skip.html">&hellip;</a>
+          <p>Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.<a href="fake/SpecialList/skip.html">&hellip;</a>
 </p>
           <div class="features">inherited</div>
         </dd>
@@ -690,7 +690,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          <p>Returns an Iterable that skips leading elements while <code>test</code> is satisfied.<a href="fake/SpecialList/skipWhile.html">&hellip;</a>
+          <p>Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.<a href="fake/SpecialList/skipWhile.html">&hellip;</a>
 </p>
           <div class="features">inherited</div>
         </dd>

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -154,7 +154,7 @@
     </section>
     <section class="desc markdown">
       <p>Returns the first element that satisfies the given predicate <code>test</code>.</p>
-<p>Iterates through elements and returns the first to satsify <code>test</code>.</p>
+<p>Iterates through elements and returns the first to satisfy <code>test</code>.</p>
 <p>If no element satisfies <code>test</code>, the result of invoking the <code>orElse</code>
 function is returned.
 If <code>orElse</code> is omitted, it defaults to throwing a <code>StateError</code>.</p>

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -160,7 +160,7 @@ last element and then moves towards the start of the list).
 The default implementation iterates elements in iteration order,
 checks <code>test(element)</code> for each,
 and finally returns that last one that matched.</p>
-<p>If no element satsfies <code>test</code>, the result of invoking the <code>orElse</code>
+<p>If no element satisfies <code>test</code>, the result of invoking the <code>orElse</code>
 function is returned.
 If <code>orElse</code> is omitted, it defaults to throwing a <code>StateError</code>.</p>
     </section>

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -158,7 +158,7 @@ calling <code>f</code> on each element of this <code>Iterable</code> in iteratio
 <p>This method returns a view of the mapped elements. As long as the
 returned <code>Iterable</code> is not iterated over, the supplied function <code>f</code> will
 not be invoked. The transformed elements will not be cached. Iterating
-multiple times over the the returned <code>Iterable</code> will invoke the supplied
+multiple times over the returned <code>Iterable</code> will invoke the supplied
 function <code>f</code> multiple times on the same element.</p>
 <p>Methods on the returned iterable are allowed to omit calling <code>f</code>
 on any element where the result isn't needed.

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -153,13 +153,16 @@
       <span class="name ">skip</span>(<wbr><span class="parameter" id="skip-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
     </section>
     <section class="desc markdown">
-      <p>Returns an Iterable that provides all but the first <code>count</code> elements.</p>
+      <p>Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.</p>
 <p>When the returned iterable is iterated, it starts iterating over <code>this</code>,
 first skipping past the initial <code>count</code> elements.
 If <code>this</code> has fewer than <code>count</code> elements, then the resulting Iterable is
 empty.
 After that, the remaining elements are iterated in the same order as
 in this iterable.</p>
+<p>Some iterables may be able to find later elements without first iterating
+through earlier elements, for example when iterating a <code>List</code>.
+Such iterables are allowed to ignore the initial skipped elements.</p>
 <p>The <code>count</code> must not be negative.</p>
     </section>
     

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -153,14 +153,14 @@
       <span class="name ">skipWhile</span>(<wbr><span class="parameter" id="skipWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
     <section class="desc markdown">
-      <p>Returns an Iterable that skips leading elements while <code>test</code> is satisfied.</p>
-<p>The filtering happens lazily. Every new Iterator of the returned
-Iterable iterates over all elements of <code>this</code>.</p>
+      <p>Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.</p>
+<p>The filtering happens lazily. Every new <code>Iterator</code> of the returned
+iterable iterates over all elements of <code>this</code>.</p>
 <p>The returned iterable provides elements by iterating this iterable,
 but skipping over all initial elements where <code>test(element)</code> returns
 true. If all elements satisfy <code>test</code> the resulting iterable is empty,
 otherwise it iterates the remaining elements in their original order,
-starting with the first element for which <code>test(element)</code> returns false,</p>
+starting with the first element for which <code>test(element)</code> returns <code>false</code>.</p>
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -157,10 +157,11 @@
 predicate <code>test</code>.</p>
 <p>The matching elements have the same order in the returned iterable
 as they have in <code>iterator</code>.</p>
-<p>This method returns a view of the mapped elements. As long as the
-returned <code>Iterable</code> is not iterated over, the supplied function <code>test</code> will
-not be invoked. Iterating will not cache results, and thus iterating
-multiple times over the returned <code>Iterable</code> will invoke the supplied
+<p>This method returns a view of the mapped elements.
+As long as the returned <code>Iterable</code> is not iterated over,
+the supplied function <code>test</code> will not be invoked.
+Iterating will not cache results, and thus iterating multiple times over
+the returned <code>Iterable</code> may invoke the supplied
 function <code>test</code> multiple times on the same element.</p>
     </section>
     

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.9.4">
+  <meta name="generator" content="made with love by dartdoc 0.9.5">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -178,6 +178,16 @@ h2 .crossdart {
   margin-top: 1em;
 }
 
+.crossdart-link {
+  border-bottom: 1px solid #dfdfdf;
+  text-decoration: none;
+}
+
+.crossdart-link:hover {
+  border-bottom: 1px solid #aaa;
+  text-decoration: none;
+}
+
 @media(max-width: 768px) {
   nav .container {
     width: 100%


### PR DESCRIPTION
- fix one analysis warning
- regen the test docs
- make a crossdoc test more maintainable (it depends on the precise char position of a symbol in `testing/test_package/lib/fake.dart`)

@keertip 