### PR TITLE
show the entire text for the first line of dartdoc

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -255,7 +255,6 @@ dd.callable, dd.constant, dd.property {
 }
 
 dd p {
-  white-space: nowrap;
   overflow-x: hidden;
   text-overflow: ellipsis;
   margin-bottom: 0;

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -10,8 +10,6 @@ import 'resource_loader.dart' as loader;
 typedef String TemplateRenderer(context,
     {bool assumeNullNonExistingProperty, bool errorOnMissingProperty});
 
-// TODO: if we can ever enumerate the contents of a package, we
-// won't need this.
 const _partials = const <String>[
   'callable',
   'callable_multiline',
@@ -26,7 +24,6 @@ const _partials = const <String>[
   'sidebar_for_class',
   'source_code',
   'sidebar_for_library',
-  'has_more_docs',
   'accessor_getter',
   'accessor_setter'
 ];

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -163,7 +163,6 @@ class Documentation {
   final String raw;
   final String asHtml;
   final String asOneLiner;
-  final bool hasMoreThanOneLineDocs;
 
   factory Documentation(String markdown) {
     String tempHtml = _renderMarkdownToHtml(markdown);
@@ -175,8 +174,7 @@ class Documentation {
     return new Documentation._internal(element.documentation, tempHtml);
   }
 
-  Documentation._(
-      this.raw, this.asHtml, this.hasMoreThanOneLineDocs, this.asOneLiner);
+  Documentation._(this.raw, this.asHtml, this.asOneLiner);
 
   factory Documentation._internal(String markdown, String rawHtml) {
     var asHtmlDocument = parse(rawHtml);
@@ -206,18 +204,14 @@ class Documentation {
     }
     var asHtml = asHtmlDocument.body.innerHtml;
 
-    // Fixes issue with line ending differences between mac and windows, affecting tests
+    // Fixes issue with line ending differences between mac and windows.
     if (asHtml != null) asHtml = asHtml.trim();
 
-    var asOneLiner = '';
-    var moreThanOneLineDoc = asHtmlDocument.body.children.length > 1;
+    var asOneLiner = asHtmlDocument.body.children.isEmpty
+        ? ''
+        : asHtmlDocument.body.children.first.innerHtml;
 
-    if (asHtmlDocument.body.children.isNotEmpty) {
-      asOneLiner = asHtmlDocument.body.children.first.innerHtml;
-    }
-
-    return new Documentation._(
-        markdown, asHtml, moreThanOneLineDoc, asOneLiner);
+    return new Documentation._(markdown, asHtml, asOneLiner);
   }
 }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -659,7 +659,6 @@ abstract class Documentable {
   String get documentation;
   String get documentationAsHtml;
   bool get hasDocumentation;
-  bool get hasMoreThanOneLineDocs;
   String get oneLineDoc;
 }
 
@@ -1363,9 +1362,6 @@ abstract class ModelElement implements Comparable, Nameable, Documentable {
   bool get hasDocumentation =>
       documentation != null && documentation.isNotEmpty;
 
-  @override
-  bool get hasMoreThanOneLineDocs => _documentation.hasMoreThanOneLineDocs;
-
   bool get hasParameters => parameters.isNotEmpty;
 
   String get href;
@@ -1787,8 +1783,6 @@ class Package implements Nameable, Documentable {
   // TODO: Clients should use [documentationFile] so they can act differently on
   // plain text or markdown.
   bool get hasDocumentationFile => documentationFile != null;
-
-  bool get hasMoreThanOneLineDocs => true;
 
   // TODO: make this work
   String get href => 'index.html';

--- a/lib/templates/_callable.html
+++ b/lib/templates/_callable.html
@@ -4,7 +4,7 @@
   </span>
 </dt>
 <dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
-  <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+  <p>{{{ oneLineDoc }}}</p>
   {{#isInherited}}
   <div class="features">inherited</div>
   {{/isInherited}}

--- a/lib/templates/_constant.html
+++ b/lib/templates/_constant.html
@@ -3,7 +3,7 @@
   <span class="signature">&#8594; {{{ linkedReturnType }}}</span>
 </dt>
 <dd>
-  <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+  <p>{{{ oneLineDoc }}}</p>
   <div>
     <span class="signature"><code>{{{ constantValue }}}</code></span>
   </div>

--- a/lib/templates/_has_more_docs.html
+++ b/lib/templates/_has_more_docs.html
@@ -1,3 +1,0 @@
-{{#hasMoreThanOneLineDocs}}
-<a href="{{href}}">&hellip;</a>
-{{/hasMoreThanOneLineDocs}}

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -3,6 +3,6 @@
   <span class="signature">&#8594; {{{ linkedReturnType }}}</span>
 </dt>
 <dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
-  <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+  <p>{{{ oneLineDoc }}}</p>
   {{>readable_writable}}
 </dd>

--- a/lib/templates/class.html
+++ b/lib/templates/class.html
@@ -114,7 +114,7 @@
           <span class="name">{{{linkedName}}}</span><span class="signature">({{{ linkedParams }}})</span>
         </dt>
         <dd>
-          <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+          <p>{{{ oneLineDoc }}}</p>
           {{#isConst}}
           <div class="constructor-modifier features">const</div>
           {{/isConst}}

--- a/lib/templates/library.html
+++ b/lib/templates/library.html
@@ -91,7 +91,7 @@
           {{{linkedName}}}
         </dt>
         <dd>
-          <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+          <p>{{{ oneLineDoc }}}</p>
         </dd>
         {{/library.enums}}
       </dl>
@@ -108,7 +108,7 @@
           <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{linkedName}}}</span>
         </dt>
         <dd>
-          <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+          <p>{{{ oneLineDoc }}}</p>
         </dd>
         {{/library.classes}}
       </dl>
@@ -125,7 +125,7 @@
           <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{linkedName}}}</span>
         </dt>
         <dd>
-          <p>{{{ oneLineDoc }}}{{>has_more_docs}}</p>
+          <p>{{{ oneLineDoc }}}</p>
         </dd>
         {{/library.exceptions}}
       </dl>

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -165,11 +165,6 @@ void main() {
               'WOW FAKE PACKAGE IS <strong>BEST</strong> <a href="http://example.org">PACKAGE</a>'));
     });
 
-    test('has more than one line docs (or not)', () {
-      expect(fakeLibrary.hasMoreThanOneLineDocs, true);
-      expect(exLibrary.hasMoreThanOneLineDocs, false);
-    });
-
     test('has properties', () {
       expect(exLibrary.hasProperties, isTrue);
     });


### PR DESCRIPTION
Show the full text for the first line of dartdoc. This gives doc writers more control over what the summary of an item is, and gives more context for each item on the summary pages.

<img width="754" alt="screen shot 2016-06-18 at 10 10 33 pm" src="https://cloud.githubusercontent.com/assets/1269969/16175446/017bcfbc-35a2-11e6-857f-63971f101793.png">

