### PR TITLE
cleanup bin/dartdoc to use public dartdoc API

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -9,8 +9,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/config.dart';
-import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 import 'package:analyzer/src/generated/sdk.dart';

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -32,6 +32,7 @@ import 'src/model.dart';
 import 'src/model_utils.dart';
 import 'src/package_meta.dart';
 
+import 'src/config.dart';
 export 'src/element_type.dart';
 export 'src/generator.dart';
 export 'src/model.dart';
@@ -42,6 +43,19 @@ const String name = 'dartdoc';
 const String version = '0.9.6+2';
 
 final String defaultOutDir = p.join('doc', 'api');
+
+/// Configure the dartdoc generation process
+void initializeConfig(
+    {Directory inputDir,
+    String sdkVersion,
+    bool addCrossdart: false,
+    bool includeSource: true}) {
+  setConfig(
+      inputDir: inputDir,
+      sdkVersion: sdkVersion,
+      addCrossdart: addCrossdart,
+      includeSource: includeSource);
+}
 
 /// Initialize and setup the generators.
 Future<List<Generator>> initGenerators(String url, List<String> headerFilePaths,

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -14,7 +14,7 @@ class Config {
 Config _config;
 Config get config => _config;
 
-void initializeConfig(
+void setConfig(
     {Directory inputDir,
     String sdkVersion,
     bool addCrossdart: false,

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -7,7 +7,7 @@ library dartdoc.model_test;
 import 'dart:io';
 
 import 'package:cli_util/cli_util.dart' as cli_util;
-import 'package:dartdoc/src/config.dart';
+import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_meta.dart';


### PR DESCRIPTION
This makes dartdoc initialization part of the public API
and updates bin/dartdoc to use it.
Needed by dartinodoc.

@keertip 