### PR TITLE
Bump analyzer dependency.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.3-alpha.7"
+    version: "0.27.4-alpha.18"
   ansicolor:
     description:
       name: ansicolor
@@ -66,7 +66,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.2+1"
+    version: "2.0.1"
   csslib:
     description:
       name: csslib
@@ -109,6 +109,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  isolate:
+    description:
+      name: isolate
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
   logging:
     description:
       name: logging
@@ -162,7 +168,7 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   pool:
     description:
       name: pool

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=1.14.0 <2.0.0'
 dependencies:
-  analyzer: 0.27.3-alpha.7
+  analyzer: 0.27.4-alpha.18
   args: ^0.13.0
   cli_util: ^0.0.1
   collection: ^1.2.0


### PR DESCRIPTION
Pulls in support for references to operators in doc comments (#26929).