### PR TITLE
Clean up unnecessary braces in string interpolation.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -17,7 +17,7 @@ String stripComments(String str) {
       } else if (line.startsWith('///')) {
         buf.write('${line.substring(3)}\n');
       } else {
-        buf.write('${line}\n');
+        buf.write('$line\n');
       }
     }
   } else {

--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -169,11 +169,11 @@ Map<String, String> _parseOutput(
 
     if (type == 'A') {
       expect(p.isWithin(tempPath, path), isTrue,
-          reason: '`${path}` should be within ${tempPath}');
+          reason: '`$path` should be within $tempPath');
       path = p.relative(path, from: tempPath);
     } else {
       expect(p.isWithin(sourcePath, path), isTrue,
-          reason: '`${path}` should be within ${sourcePath}');
+          reason: '`$path` should be within $sourcePath');
       path = p.relative(path, from: sourcePath);
     }
 


### PR DESCRIPTION
Sniffed out by the `unnecessary_brace_in_string_interp` lint.