### PR TITLE
fix the display of long constants

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -305,6 +305,14 @@ dl dt.callable .name {
   color: #4674a2;
 }
 
+/* make sure constant values don't overflow */
+.signature code {
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
 .optional {
   font-style: italic;
 }

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -180,33 +180,29 @@ class Documentation {
     for (var s in asHtmlDocument.querySelectorAll('script')) {
       s.remove();
     }
-    for (var e in asHtmlDocument.querySelectorAll('pre')) {
-      if (e.children.isNotEmpty &&
-          e.children.length != 1 &&
-          e.children.first.localName != 'code') {
+    for (var pre in asHtmlDocument.querySelectorAll('pre')) {
+      if (pre.children.isNotEmpty &&
+          pre.children.length != 1 &&
+          pre.children.first.localName != 'code') {
         continue;
       }
 
-      // TODO(kevmoo): This should be applied to <code>, not <pre>
-      //   Waiting on pkg/markdown v0.10
-      //   See https://github.com/dart-lang/markdown/commit/a7bf3dd
-      e.classes.add('prettyprint');
-
-      // Only "assume" the user intended dart if there are no other classes
-      // present.
-      if (e.classes.length == 1) {
-        e.classes.add('language-dart');
+      if (pre.children.isNotEmpty && pre.children.first.localName == 'code') {
+        var code = pre.children.first;
+        pre.classes.addAll(code.classes.where((name) => name.startsWith('language-')));
       }
+
+      bool specifiesLanguage = pre.classes.isNotEmpty;
+      pre.classes.add('prettyprint');
+      // Assume the user intended Dart if there are no other classes present.
+      if (!specifiesLanguage) pre.classes.add('language-dart');      
     }
-    var asHtml = asHtmlDocument.body.innerHtml;
 
-    // Fixes issue with line ending differences between mac and windows.
-    if (asHtml != null) asHtml = asHtml.trim();
-
+    // `trim` fixes issue with line ending differences between mac and windows.
+    var asHtml = asHtmlDocument.body.innerHtml?.trim();
     var asOneLiner = asHtmlDocument.body.children.isEmpty
         ? ''
         : asHtmlDocument.body.children.first.innerHtml;
-
     return new Documentation._(markdown, asHtml, asOneLiner);
   }
 }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -105,7 +105,7 @@ const String UP = 'up';
 
 const String NAME_SINGLEUNDERSCORE = 'yay bug hunting';
 
-const String NAME_WITH_TWO_UNDERSCORES = 'episode seven better be good';
+const String NAME_WITH_TWO_UNDERSCORES = 'episode seven better be good; episode seven better be good; episode seven better be good; episode seven better be good';
 
 /// Testing [NAME_WITH_TWO_UNDERSCORES] should not be italicized.
 ///

--- a/testing/test_package_docs/code_in_comments/code_in_comments-library.html
+++ b/testing/test_package_docs/code_in_comments/code_in_comments-library.html
@@ -83,11 +83,11 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="desc markdown">
-      <pre class="prettyprint language-dart"><code class="language-dart">void main() {
+      <pre class="language-dart prettyprint"><code class="language-dart">void main() {
   // in Dart!
 }
 </code></pre>
-<pre class="prettyprint language-dart"><code class="language-yaml">and_yaml:
+<pre class="language-yaml prettyprint"><code class="language-yaml">and_yaml:
   - value
   - "value"
   - 3.14

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -146,7 +146,7 @@
 
     <section class="multi-line-signature">
         <span class="name ">NAME_WITH_TWO_UNDERSCORES</span>        =
-        <span class="constant-value">&#39;episode seven better be good&#39;</span>
+        <span class="constant-value">&#39;episode seven better be good; episode seven better be good; episode seven better be good; episode seven better be good&#39;</span>
     </section>
 
             

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -184,7 +184,7 @@ Don't ask questions.</p>
         <dd>
           
           <div>
-            <span class="signature"><code>&#39;episode seven better be good&#39;</code></span>
+            <span class="signature"><code>&#39;episode seven better be good; episode seven better be good; episode seven better be good; episode seven better be good&#39;</code></span>
           </div>
         </dd>
         <dt id="PI" class="constant">

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -84,11 +84,11 @@
 <p>This is an amazing package.</p>
 <p>For example, it:</p><ul><li>Is very fast</li><li>Has zero bugs</li><li>Is free</li></ul>
 <p>It also has some awesome code</p>
-<pre class="prettyprint language-dart"><code class="language-dart">void main() {
+<pre class="language-dart prettyprint"><code class="language-dart">void main() {
   // in Dart!
 }
 </code></pre>
-<pre class="prettyprint language-dart"><code class="language-yaml">and_yaml:
+<pre class="language-yaml prettyprint"><code class="language-yaml">and_yaml:
   - value
   - "value"
   - 3.14

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -305,6 +305,14 @@ dl dt.callable .name {
   color: #4674a2;
 }
 
+/* make sure constant values don't overflow */
+.signature code {
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
 .optional {
   font-style: italic;
 }

--- a/testing/test_package_embedder_yaml/.analysis_options
+++ b/testing/test_package_embedder_yaml/.analysis_options
@@ -1,0 +1,1 @@
+{ analyzer: { exclude: ['**'] } }


### PR DESCRIPTION
On the summary page, one display one line of text for constants (fix https://github.com/dart-lang/dartdoc/issues/1077).

Also, update how we style in-line code (to adjust to the markdown library rev).

@pq @keertip 