### PR TITLE
html escape unresolved references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 doc/api/
+doc/sdk/
 testing/test_package/doc
 testing/test_package_small/doc
 packages

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -144,7 +144,7 @@ String _linkDocReference(String reference, ModelElement element,
     if (_emitWarning) {
       print("  warning: unresolved doc reference '$reference' (in $element)");
     }
-    return '<code>$reference</code>';
+    return '<code>${HTML_ESCAPE.convert(reference)}</code>';
   }
 }
 
@@ -195,7 +195,7 @@ class Documentation {
       bool specifiesLanguage = pre.classes.isNotEmpty;
       pre.classes.add('prettyprint');
       // Assume the user intended Dart if there are no other classes present.
-      if (!specifiesLanguage) pre.classes.add('language-dart');      
+      if (!specifiesLanguage) pre.classes.add('language-dart');
     }
 
     // `trim` fixes issue with line ending differences between mac and windows.

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -274,7 +274,7 @@ class PublicClassImplementsPrivateInterface implements _PrivateInterface {
 /// 3. All references should be hyperlinks. [MyError] and
 ///    [ShapeType] and [MyError] and [MyException] and
 ///    [MyError] and [MyException] and
-///    [ShapeType] foo bar.
+///    [List<int>] foo bar.
 class ShapeType extends _RetainedEnum {
   static const ShapeType rect = const ShapeType._internal("Rect");
   static const ShapeType ellipse = const ShapeType._internal("Ellipse");

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -136,7 +136,7 @@
 <p>All references should be hyperlinks. <a href="ex/MyError-class.html">MyError</a> and
    <code>ShapeType</code> and <a href="ex/MyError-class.html">MyError</a> and <code>MyException</code> and
    <a href="ex/MyError-class.html">MyError</a> and <code>MyException</code> and
-   <code>ShapeType</code> foo bar.</p></li></ol>
+   <code>List&lt;int&gt;</code> foo bar.</p></li></ol>
     </section>
     
 


### PR DESCRIPTION
- html escape unresolved square bracket references, so things like unresolved generics aren't converted into inline html

@pq @keertip 