### PR TITLE
don't show package label for sdk docs

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -508,7 +508,7 @@ ul.subnav {
   overflow: auto;
   white-space: nowrap;
   padding-left: 0;
-  min-height: 24px;
+  min-height: 25px;
 }
 
 ul.subnav::-webkit-scrollbar {

--- a/lib/src/html/template_data.dart
+++ b/lib/src/html/template_data.dart
@@ -49,21 +49,21 @@ abstract class TemplateData<T extends Documentable> {
   String get version => htmlOptions.toolVersion;
   String get relCanonicalPrefix => htmlOptions.relCanonicalPrefix;
 
-  Iterable<Subnav> getSubNavItems() => const Iterable<Subnav>.empty();
+  Iterable<Subnav> getSubNavItems() => <Subnav>[];
 
   String _layoutTitle(String name, String kind, bool isDeprecated) {
-    if (kind.isEmpty)
-      kind =
-          '&nbsp;'; // Ugly. fixes https://github.com/dart-lang/dartdoc/issues/695
+    if (kind.isEmpty) kind = '&nbsp;';
     String str = '<span class="kind">$kind</span>';
     if (!isDeprecated) return '${str} ${name}';
     return '${str} <span class="deprecated">$name</span>';
   }
 
-  Iterable<Subnav> _gatherSubnavForInvokable(ModelElement element) sync* {
+  Iterable<Subnav> _gatherSubnavForInvokable(ModelElement element) {
     if (element is SourceCodeMixin &&
         (element as SourceCodeMixin).hasSourceCode) {
-      yield new Subnav('Source', '${element.href}#source');
+      return [new Subnav('Source', '${element.href}#source')];
+    } else {
+      return <Subnav>[];
     }
   }
 }
@@ -83,14 +83,14 @@ class PackageTemplateData extends TemplateData<Package> {
   @override
   Package get self => package;
   @override
-  String get layoutTitle =>
-      _layoutTitle(package.name, package.isSdk ? '' : 'package', false);
+  String get layoutTitle => _layoutTitle(
+      package.name, (useCategories || package.isSdk) ? '' : 'package', false);
   @override
   String get metaDescription =>
       '${package.name} API docs, for the Dart programming language.';
   @override
-  Iterable<Subnav> getSubNavItems() sync* {
-    yield new Subnav('Libraries', '${package.href}#libraries');
+  Iterable<Subnav> getSubNavItems() {
+    return [new Subnav('Libraries', '${package.href}#libraries')];
   }
 
   /// `null` for packages because they are at the root – not needed
@@ -177,13 +177,13 @@ class ClassTemplateData extends TemplateData<Class> {
       yield new Subnav('Static Properties', '${clazz.href}#static-properties');
     if (clazz.hasStaticMethods)
       yield new Subnav('Static Methods', '${clazz.href}#static-methods');
-    if (clazz.hasInstanceProperties)
+    if (clazz.hasProperties)
       yield new Subnav('Properties', '${clazz.href}#instance-properties');
     if (clazz.hasConstructors)
       yield new Subnav('Constructors', '${clazz.href}#constructors');
     if (clazz.hasOperators)
       yield new Subnav('Operators', '${clazz.href}#operators');
-    if (clazz.hasInstanceMethods)
+    if (clazz.hasMethods)
       yield new Subnav('Methods', '${clazz.href}#instance-methods');
   }
 
@@ -383,6 +383,8 @@ class TypedefTemplateData extends TemplateData<Typedef> {
   List get navLinks => [package, library];
   @override
   String get htmlBase => '..';
+  @override
+  Iterable<Subnav> getSubNavItems() => _gatherSubnavForInvokable(typeDef);
 }
 
 class TopLevelPropertyTemplateData extends TemplateData<TopLevelVariable> {

--- a/testing/test_package_docs/ex/CatString-class.html
+++ b/testing/test_package_docs/ex/CatString-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/CatString-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/CatString-class.html#constructors">Constructors</a></li>
           <li><a href="ex/CatString-class.html#operators">Operators</a></li>
+          <li><a href="ex/CatString-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/Cool-class.html
+++ b/testing/test_package_docs/ex/Cool-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/Cool-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/Cool-class.html#constructors">Constructors</a></li>
           <li><a href="ex/Cool-class.html#operators">Operators</a></li>
           <li><a href="ex/Cool-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/ex/E-class.html
+++ b/testing/test_package_docs/ex/E-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/E-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/E-class.html#constructors">Constructors</a></li>
           <li><a href="ex/E-class.html#operators">Operators</a></li>
+          <li><a href="ex/E-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/F-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/F-class.html#constructors">Constructors</a></li>
           <li><a href="ex/F-class.html#operators">Operators</a></li>
           <li><a href="ex/F-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -60,6 +60,7 @@
           <li><a href="ex/ForAnnotation-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/ForAnnotation-class.html#constructors">Constructors</a></li>
           <li><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
+          <li><a href="ex/ForAnnotation-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs/ex/HasAnnotation-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/HasAnnotation-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/HasAnnotation-class.html#constructors">Constructors</a></li>
           <li><a href="ex/HasAnnotation-class.html#operators">Operators</a></li>
+          <li><a href="ex/HasAnnotation-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/Helper-class.html
+++ b/testing/test_package_docs/ex/Helper-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/Helper-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/Helper-class.html#constructors">Constructors</a></li>
           <li><a href="ex/Helper-class.html#operators">Operators</a></li>
           <li><a href="ex/Helper-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/Klass-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/Klass-class.html#constructors">Constructors</a></li>
           <li><a href="ex/Klass-class.html#operators">Operators</a></li>
           <li><a href="ex/Klass-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/ex/MyError-class.html
+++ b/testing/test_package_docs/ex/MyError-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/MyError-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/MyError-class.html#constructors">Constructors</a></li>
           <li><a href="ex/MyError-class.html#operators">Operators</a></li>
+          <li><a href="ex/MyError-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -60,6 +60,7 @@
           <li><a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/MyErrorImplements-class.html#constructors">Constructors</a></li>
           <li><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
+          <li><a href="ex/MyErrorImplements-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/MyException-class.html
+++ b/testing/test_package_docs/ex/MyException-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/MyException-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/MyException-class.html#constructors">Constructors</a></li>
           <li><a href="ex/MyException-class.html#operators">Operators</a></li>
+          <li><a href="ex/MyException-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/MyExceptionImplements-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/MyExceptionImplements-class.html#constructors">Constructors</a></li>
           <li><a href="ex/MyExceptionImplements-class.html#operators">Operators</a></li>
+          <li><a href="ex/MyExceptionImplements-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/PublicClassExtendsPrivateClass-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/PublicClassExtendsPrivateClass-class.html#constructors">Constructors</a></li>
           <li><a href="ex/PublicClassExtendsPrivateClass-class.html#operators">Operators</a></li>
+          <li><a href="ex/PublicClassExtendsPrivateClass-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/PublicClassImplementsPrivateInterface-class.html#constructors">Constructors</a></li>
           <li><a href="ex/PublicClassImplementsPrivateInterface-class.html#operators">Operators</a></li>
           <li><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -58,7 +58,9 @@
         </div>
         <ul class="subnav">
           <li><a href="ex/ShapeType-class.html#constants">Constants</a></li>
+          <li><a href="ex/ShapeType-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/ShapeType-class.html#operators">Operators</a></li>
+          <li><a href="ex/ShapeType-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs/ex/SpecializedDuration-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="ex/SpecializedDuration-class.html#instance-properties">Properties</a></li>
           <li><a href="ex/SpecializedDuration-class.html#constructors">Constructors</a></li>
           <li><a href="ex/SpecializedDuration-class.html#operators">Operators</a></li>
+          <li><a href="ex/SpecializedDuration-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -60,6 +60,7 @@
           <li><a href="fake/Annotation-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/Annotation-class.html#constructors">Constructors</a></li>
           <li><a href="fake/Annotation-class.html#operators">Operators</a></li>
+          <li><a href="fake/Annotation-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/AnotherInterface-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/AnotherInterface-class.html#constructors">Constructors</a></li>
           <li><a href="fake/AnotherInterface-class.html#operators">Operators</a></li>
+          <li><a href="fake/AnotherInterface-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/BaseForDocComments-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/BaseForDocComments-class.html#constructors">Constructors</a></li>
           <li><a href="fake/BaseForDocComments-class.html#operators">Operators</a></li>
           <li><a href="fake/BaseForDocComments-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -60,6 +60,7 @@
           <li><a href="fake/ConstantClass-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/ConstantClass-class.html#constructors">Constructors</a></li>
           <li><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
+          <li><a href="fake/ConstantClass-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/Cool-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/Cool-class.html#constructors">Constructors</a></li>
           <li><a href="fake/Cool-class.html#operators">Operators</a></li>
           <li><a href="fake/Cool-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/Doh-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/Doh-class.html#constructors">Constructors</a></li>
           <li><a href="fake/Doh-class.html#operators">Operators</a></li>
+          <li><a href="fake/Doh-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/ExtraSpecialList-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/ExtraSpecialList-class.html#constructors">Constructors</a></li>
           <li><a href="fake/ExtraSpecialList-class.html#operators">Operators</a></li>
+          <li><a href="fake/ExtraSpecialList-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -61,6 +61,7 @@
           <li><a href="fake/Foo2-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/Foo2-class.html#constructors">Constructors</a></li>
           <li><a href="fake/Foo2-class.html#operators">Operators</a></li>
+          <li><a href="fake/Foo2-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/HasGenericWithExtends-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/HasGenericWithExtends-class.html#constructors">Constructors</a></li>
           <li><a href="fake/HasGenericWithExtends-class.html#operators">Operators</a></li>
+          <li><a href="fake/HasGenericWithExtends-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/HasGenerics-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/HasGenerics-class.html#constructors">Constructors</a></li>
           <li><a href="fake/HasGenerics-class.html#operators">Operators</a></li>
           <li><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/Interface-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/Interface-class.html#constructors">Constructors</a></li>
           <li><a href="fake/Interface-class.html#operators">Operators</a></li>
+          <li><a href="fake/Interface-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/MixMeIn-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/MixMeIn-class.html#constructors">Constructors</a></li>
           <li><a href="fake/MixMeIn-class.html#operators">Operators</a></li>
+          <li><a href="fake/MixMeIn-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -60,6 +60,7 @@
           <li><a href="fake/Oops-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/Oops-class.html#constructors">Constructors</a></li>
           <li><a href="fake/Oops-class.html#operators">Operators</a></li>
+          <li><a href="fake/Oops-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/OperatorReferenceClass-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/OperatorReferenceClass-class.html#constructors">Constructors</a></li>
           <li><a href="fake/OperatorReferenceClass-class.html#operators">Operators</a></li>
+          <li><a href="fake/OperatorReferenceClass-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/OtherGenericsThing-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/OtherGenericsThing-class.html#constructors">Constructors</a></li>
           <li><a href="fake/OtherGenericsThing-class.html#operators">Operators</a></li>
           <li><a href="fake/OtherGenericsThing-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -60,6 +60,7 @@
           <li><a href="fake/SpecialList-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/SpecialList-class.html#constructors">Constructors</a></li>
           <li><a href="fake/SpecialList-class.html#operators">Operators</a></li>
+          <li><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -57,6 +57,7 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="fake/SubForDocComments-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/SubForDocComments-class.html#constructors">Constructors</a></li>
           <li><a href="fake/SubForDocComments-class.html#operators">Operators</a></li>
           <li><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -60,6 +60,7 @@
           <li><a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a></li>
           <li><a href="fake/WithGetterAndSetter-class.html#constructors">Constructors</a></li>
           <li><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>
+          <li><a href="fake/WithGetterAndSetter-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -508,7 +508,7 @@ ul.subnav {
   overflow: auto;
   white-space: nowrap;
   padding-left: 0;
-  min-height: 24px;
+  min-height: 25px;
 }
 
 ul.subnav::-webkit-scrollbar {

--- a/testing/test_package_docs/two_exports/BaseClass-class.html
+++ b/testing/test_package_docs/two_exports/BaseClass-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="two_exports/BaseClass-class.html#instance-properties">Properties</a></li>
           <li><a href="two_exports/BaseClass-class.html#constructors">Constructors</a></li>
           <li><a href="two_exports/BaseClass-class.html#operators">Operators</a></li>
+          <li><a href="two_exports/BaseClass-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->

--- a/testing/test_package_docs/two_exports/ExtendingClass-class.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass-class.html
@@ -57,8 +57,10 @@
           </h1>
         </div>
         <ul class="subnav">
+          <li><a href="two_exports/ExtendingClass-class.html#instance-properties">Properties</a></li>
           <li><a href="two_exports/ExtendingClass-class.html#constructors">Constructors</a></li>
           <li><a href="two_exports/ExtendingClass-class.html#operators">Operators</a></li>
+          <li><a href="two_exports/ExtendingClass-class.html#instance-methods">Methods</a></li>
         </ul>
       </div> <!-- /col -->
     </div> <!-- /row -->


### PR DESCRIPTION
- if we're generating docs that use categories, don't show the 'package' label for the top-most index.html (https://github.com/dart-lang/dartdoc/issues/1146)
- fix an issue where the subnav headers wouldn't show all relevant options

<img width="431" alt="screen shot 2016-07-22 at 10 02 47 pm" src="https://cloud.githubusercontent.com/assets/1269969/17075908/2d6f9cae-5058-11e6-8e1b-304be2b19c86.png">

@keertip 