### PR TITLE
Widen constraint on package_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.7+3
+* Extended package_config dependency to include stable 1.0.0 api.
+
 ## 0.9.7+2
 * fixed a regression with generating package docs (#1233)
 

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -39,7 +39,7 @@ export 'src/package_meta.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String version = '0.9.7+2';
+const String version = '0.9.7+3';
 
 final String defaultOutDir = path.join('doc', 'api');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.9.7+2
+version: 0.9.7+3
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   logging: '>=0.9.0 <0.12.0'
   markdown: ^0.10.1
   mustache4dart: ^1.0.9
-  package_config: ^0.1.5
+  package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
   quiver: '>=0.18.0 <0.23.0'
   resource: ^1.1.0

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.9.7+2">
+  <meta name="generator" content="made with love by dartdoc 0.9.7+3">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
package_config has released version 1.0.0, which is compatible with earlier versions.  Relax constraint to <2.0.0.   This could also be changed to ^1.0.0 if you want.