### PR TITLE
improve sdk docs validation

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -20,7 +20,6 @@ then
   # silence stdout but echo stderr
   echo ""
   echo "Building and validating SDK docs..."
-  grind build-sdk-docs
   grind validate-sdk-docs
   echo "SDK docs process finished"
 else


### PR DESCRIPTION
- add a test for https://github.com/dart-lang/dartdoc/issues/1230; improve the sdk docs validation to also check the number of `dart:` libs listed in index.html.
- fix an issue w/ how we were using `await` in the `buildSdkDocs` task

@keertip 
