### PR TITLE
fix an issue generating libraries named 'packages'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+* fixed an issue with documenting libraries starting with `packages`
+
 ## 0.9.7+3
 * Extended package_config dependency to include stable 1.0.0 api.
 

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -51,6 +51,8 @@ Iterable<String> _doList(String dir, Set<String> listedDirectories,
 /// Given a package name, explore the directory and pull out all top level
 /// library files in the "lib" directory to document.
 Iterable<String> findFilesToDocumentInPackage(String packageDir) sync* {
+  final String sep = path.separator;
+
   var packageLibDir = path.join(packageDir, 'lib');
   var packageLibSrcDir = path.join(packageLibDir, 'src');
 
@@ -60,8 +62,8 @@ Iterable<String> findFilesToDocumentInPackage(String packageDir) sync* {
   for (var lib
       in listDir(packageDir, recursive: true, listDir: _packageDirList)) {
     if (lib.endsWith('.dart') &&
-        (!lib.contains('${path.separator}packages') ||
-            packageDir.contains('${path.separator}packages'))) {
+        (!lib.contains('${sep}packages${sep}') ||
+            packageDir.contains('${sep}packages${sep}'))) {
       // Only include libraries within the lib dir that are not in lib/src
       if (path.isWithin(packageLibDir, lib) &&
           !path.isWithin(packageLibSrcDir, lib)) {


### PR DESCRIPTION
- fix https://github.com/dart-lang/dartdoc/issues/1231
- fix an issue generating libraries named 'packages'

@keertip 