### PR TITLE
0.9.7+4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## unreleased
+## 0.9.7+4
 * fixed an issue with documenting libraries starting with `packages`
 * upgraded our dependency on `html` to 0.13.0
 * upgraded our dependency on `package_config` and `markdown`

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -39,7 +39,7 @@ export 'src/package_meta.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String version = '0.9.7+3';
+const String version = '0.9.7+4';
 
 final String defaultOutDir = path.join('doc', 'api');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.9.7+3
+version: 0.9.7+4
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.9.7+3">
+  <meta name="generator" content="made with love by dartdoc 0.9.7+4">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
Rev dartdoc to 0.9.7+4.

- fixed an issue with documenting libraries starting with `packages`
- upgraded our dependency on `html` to 0.13.0
- upgraded our dependency on `package_config` and `markdown`