### PR TITLE
rev the dep on http_parser

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -108,7 +108,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   isolate:
     description:
       name: isolate

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   cli_util: ^0.0.1
   collection: ^1.2.0
   html: '>=0.12.1 <0.14.0'
+  # We don't use http_parser directly; this dep exists to ensure that we get at
+  # least version 3.0.3 to work around an issue with 3.0.2.
+  http_parser: '>=3.0.3 <4.0.0'
   logging: '>=0.9.0 <0.12.0'
   markdown: ^0.11.1
   mustache4dart: ^1.0.9


### PR DESCRIPTION
- rev the dep on `http_parser` to capture a fix in its pubspec.yaml file (unblock https://github.com/dart-lang/dartdoc/pull/1273)

@jcollins-g 