### PR TITLE
Add more ways where to locate crossdart.json files

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -27,26 +27,34 @@ import 'model_utils.dart';
 import 'package_meta.dart' show PackageMeta, FileContents;
 import 'utils.dart';
 
-Map<String, Map<String, List<Map<String, dynamic>>>> __crossdartJson;
+Map<String, Map<String, Map<String, List<Map<String, dynamic>>>>> __crossdartJson = {};
 
 final Map<Class, List<Class>> _implementors = new Map();
 
-Map<String, Map<String, List<Map<String, dynamic>>>> get _crossdartJson {
-  if (__crossdartJson == null) {
+Map<String, Map<String, List<Map<String, dynamic>>>> _crossdartJson(Element element) {
+  var packagePath = element.source.uri.path;
+  var packageName = p.split(packagePath).first;
+  if (__crossdartJson[packageName] == null) {
     if (config != null) {
       var crossdartFile =
           new File(p.join(config.inputDir.path, "crossdart.json"));
-      if (crossdartFile.existsSync()) {
-        __crossdartJson = JSON.decode(crossdartFile.readAsStringSync())
+      if (!crossdartFile.existsSync()) {
+        var relativePath = p.joinAll(p.split(packagePath).skip(1));
+        var absolutePath = element.source.fullName;
+        var dir = new Directory(absolutePath.replaceFirst(relativePath, ""));
+        crossdartFile = Library._getCrossdartJsonFile(dir);
+      }
+      if (crossdartFile != null && crossdartFile.existsSync()) {
+        __crossdartJson[packageName] = JSON.decode(crossdartFile.readAsStringSync())
             as Map<String, Map<String, List<Map<String, dynamic>>>>;
       } else {
-        __crossdartJson = {};
+        __crossdartJson[packageName] = {};
       }
     } else {
-      __crossdartJson = {};
+      __crossdartJson[packageName] = {};
     }
   }
-  return __crossdartJson;
+  return __crossdartJson[packageName];
 }
 
 int byName(Nameable a, Nameable b) =>
@@ -1202,16 +1210,44 @@ class Library extends ModelElement {
   }
 
   static String _getPackageName(Directory dir) {
+    var file = _searchForFile(dir, "pubspec.yaml");
+    if (file != null) {
+      PackageMeta meta = new PackageMeta.fromDir(file.parent);
+      return meta.name;
+    } else {
+      return null;
+    }
+  }
+
+  static String _getPackageVersion(Directory dir) {
+    var file = _searchForFile(dir, "pubspec.yaml");
+    if (file != null) {
+      PackageMeta meta = new PackageMeta.fromDir(file.parent);
+      return meta.version;
+    } else {
+      return null;
+    }
+  }
+
+  static File _getCrossdartJsonFile(Directory dir) {
+    print("Looking for a crossdart.json file");
+    return _searchForFile(dir, "crossdart.json");
+  }
+
+  static File _searchForFile(Directory dir, String filename) {
     if (!dir.existsSync() || !dir.path.contains(Platform.pathSeparator)) {
       return null;
     }
 
-    File pubspec = new File(p.join(dir.path, 'pubspec.yaml'));
-    if (pubspec.existsSync()) {
-      PackageMeta meta = new PackageMeta.fromDir(dir);
-      return meta.name;
+    File file = new File(p.join(dir.path, filename));
+    if (file.existsSync()) {
+      return file;
     } else {
-      return _getPackageName(dir.parent);
+      if (p.split(dir.path).length > 1) {
+        return _searchForFile(dir.parent, filename);
+      } else {
+        return null;
+      }
     }
   }
 }
@@ -2061,7 +2097,7 @@ abstract class SourceCodeMixin {
         String source = contents.substring(start, node.end);
 
         if (config != null && config.addCrossdart) {
-          source = crossdartifySource(_crossdartJson, source, element, start);
+          source = crossdartifySource(_crossdartJson(element), source, element, start);
         } else {
           source = const HtmlEscape().convert(source);
         }
@@ -2088,6 +2124,7 @@ abstract class SourceCodeMixin {
         var splittedUri =
             uri.replaceAll(new RegExp(r"^package:"), "").split("/");
         var packageName = splittedUri.first;
+        var relativePath = p.joinAll(splittedUri.skip(1));
         var packageVersion;
         if (packageName == packageMeta.name) {
           packageVersion = packageMeta.version;
@@ -2099,8 +2136,12 @@ abstract class SourceCodeMixin {
             packageVersion = match[2];
           }
         }
+        if (packageVersion == null) {
+          var packagePath = filePath.replaceFirst(relativePath, "");
+          packageVersion = Library._getPackageVersion(new Directory(packagePath));
+        }
         if (packageVersion != null) {
-          return "${packageName}/${packageVersion}/${splittedUri.skip(1).join("/")}";
+          return "${packageName}/${packageVersion}/${relativePath}";
         } else {
           return null;
         }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -7,6 +7,7 @@ library dartdoc.model_utils;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/generated/engine.dart';
@@ -130,8 +131,18 @@ String crossdartifySource(
   String newSource;
   if (json.isNotEmpty) {
     var node = element.computeNode();
-    var file = element.source.fullName
-        .replaceAll("${config.inputDir.path}${Platform.pathSeparator}", "");
+
+    var uri = element.source.uri;
+    String file;
+    if (uri.scheme == "package") {
+      var splittedUri =
+        uri.toString().replaceAll(new RegExp(r"^package:"), "").split("/");
+      file = p.join("lib", p.joinAll(splittedUri.skip(1)));
+    } else {
+      file = element.source.fullName
+          .replaceAll("${config.inputDir.path}${Platform.pathSeparator}", "");
+    }
+
     var filesData = json[file];
     if (filesData != null) {
       var data = filesData["references"]


### PR DESCRIPTION
This change is mostly for Flutter, to add crossdart links to
docs.flutter.io.

The way Flutter generates docs - it consists of several packages, and
then there's one 'artificial' project which imports all of those
packages. We run dartdoc on that "project", this way generating docs for
all the flutter packages together, so it looks like one package.

To support that for CrossDart support in DartDoc, I need to make some
changes. Before, we just looked for 'crossdart.json' file in the project
root, and if it's there - then use it to add CrossDart information to
the generated docs.

This commit adds looking for 'crossdart.json' files in dependent
packages as well. If we analyze a file during docs generation, and it's
from a different package, we check for a crossdart.json file in the root
of that package, and if it's there - use it for augmenting docs with
crossdart stuff.

Testing: Unit tests pass, I also deployed this version of dartdoc to
www.dartdocs.org and ran it there for several days to check if there
will be any errors.