### PR TITLE
operator== becomes ==

### DIFF
--- a/testing/test_package_docs/fake/ExtraSpecialList/contains.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/contains.html
@@ -158,7 +158,7 @@
 <code>element</code>, unless it has a more efficient way to find an element
 equal to <code>element</code>.</p>
 <p>The equality used to determine whether <code>element</code> is equal to an element of
-the iterable defaults to the <code>Object.operator==</code> of the element.</p>
+the iterable defaults to the <code>Object.==</code> of the element.</p>
 <p>Some types of iterable may have a different equality used for its elements.
 For example, a <code>Set</code> may have a custom equality
 (see <code>Set.identical</code>) that its <code>contains</code> uses.

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -158,7 +158,7 @@
 <code>element</code>, unless it has a more efficient way to find an element
 equal to <code>element</code>.</p>
 <p>The equality used to determine whether <code>element</code> is equal to an element of
-the iterable defaults to the <code>Object.operator==</code> of the element.</p>
+the iterable defaults to the <code>Object.==</code> of the element.</p>
 <p>Some types of iterable may have a different equality used for its elements.
 For example, a <code>Set</code> may have a custom equality
 (see <code>Set.identical</code>) that its <code>contains</code> uses.


### PR DESCRIPTION
Possibly the result of an analyzer change beneath us, it looks like how the == operator method is represented has changed.  @keertip @devoncarew 