### PR TITLE
Add warning/error handling for --include-external

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -254,16 +254,36 @@ class DartDoc {
     }
 
     // Use the includeExternals.
-    for (Source source in context.librarySources) {
+    bool matchesLibrary(String includeExternal, Source source) {
       LibraryElement library = context.computeLibraryElement(source);
       String libraryName = Library.getLibraryName(library);
-      var fullPath = source.fullName;
-      if (includeExternals.any((string) => fullPath.endsWith(string))) {
-        if (libraries.map(Library.getLibraryName).contains(libraryName)) {
-          continue;
-        }
-        libraries.add(library);
+      return source.fullName.endsWith(includeExternal);
+    }
+
+    for (String includeExternal in includeExternals) {
+      var quotedArgString = "'--include-external $includeExternal'";
+      List<Source> matchedSources = context.librarySources
+          .where((library) => matchesLibrary(includeExternal, library));
+      if (matchedSources.isEmpty) {
+        print("  warning: $quotedArgString -- " +
+            "no library found matching $includeExternal.");
+        continue;
       }
+      if (matchedSources.length > 1) {
+        var indentedMatchedPaths =
+            '  ' + matchedSources.map((source) => source.fullName).join('\n  ');
+        throw new DartDocFailure("$quotedArgString -- " +
+            "multiple libraries found matching $includeExternal:\n" +
+            "$indentedMatchedPaths");
+      }
+      Source source = matchedSources.first;
+      LibraryElement library = context.computeLibraryElement(source);
+      String libraryName = Library.getLibraryName(library);
+      if (libraries.map(Library.getLibraryName).contains(libraryName)) {
+        print("  info: $quotedArgString ignored, $libraryName already seen.");
+        continue;
+      }
+      libraries.add(library);
     }
 
     List<AnalysisErrorInfo> errorInfos = [];


### PR DESCRIPTION
This makes --include-external a bit harder to use incorrectly (with surprising results).

Cases I would like to test (but don't see an easy way how would include):
1. `--external-library asldkfjsdf` hit the "warn no libraries found" case
2. `--external-library dart` hit the "multiple libraries found" case
3. `--external-library dartdoc.dart` hit the "library already found" case

I looked at adding tests to test/dartdoc_test.dart, but those do not seem set up to handle logging.  I looked briefly ad breaking this logic out into its own function, but it wasn't clear how to provide the necessary AnalysisContext with sources.

I've been able to trigger the first two test cases manually, but not yet seen the 3rd.