### PR TITLE
don't use short links when generating for crossdart

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -19,6 +19,7 @@ import 'package:analyzer/dart/element/element.dart'
 import 'package:html/parser.dart' show parse;
 import 'package:markdown/markdown.dart' as md;
 
+import 'config.dart';
 import 'model.dart';
 
 const bool _emitWarning = false;
@@ -26,10 +27,14 @@ const bool _emitWarning = false;
 // We don't emit warnings currently: #572.
 const List<String> _oneLinerSkipTags = const ["code", "pre"];
 
-final List<md.InlineSyntax> _markdown_syntaxes = [
+final List<md.InlineSyntax> _regularSyntaxes = [
   new _InlineCodeSyntax(),
   new _AutolinkWithoutScheme()
 ];
+final List<md.InlineSyntax> _crossdartSyntaxes = [new _InlineCodeSyntax()];
+
+List<md.InlineSyntax> get markdownSyntaxes =>
+    config.addCrossdart ? _crossdartSyntaxes : _regularSyntaxes;
 
 // Remove these schemas from the display text for hyperlinks.
 final RegExp _hide_schemes = new RegExp('^(http|https)://');
@@ -161,7 +166,7 @@ String _renderMarkdownToHtml(String text, [ModelElement element]) {
   }
 
   return md.markdownToHtml(text,
-      inlineSyntaxes: _markdown_syntaxes, linkResolver: _linkResolver);
+      inlineSyntaxes: markdownSyntaxes, linkResolver: _linkResolver);
 }
 
 class Documentation {


### PR DESCRIPTION
@jcollins-g, when we're in the 'generating for crossdart' mode, don't use the short form for hyperlinks. I didn't get to the root of the issue, but the short reference form and crossdart are at odds somehow.