### PR TITLE
adjust @example warning message

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1752,7 +1752,7 @@ abstract class ModelElement implements Comparable, Nameable, Documentable {
       } else {
         // TODO: is this the proper way to handle warnings?
         var filePath = this.element.source.fullName.substring(dirPath.length + 1);
-        final msg = 'Warning: ${filePath}: @example file not found, $fragmentFile';
+        final msg = '\nwarning: ${filePath}: @example file not found, ${fragmentFile.path}';
         stderr.write(msg);
       }
       return replacement;

--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -134,8 +134,8 @@ void main() {
       }
 
       if (!result.stderr
-          .contains(new RegExp(r'Warning:.*file-does-not-exist\.js'))) {
-        fail('Warning missing for nonexistent @example: \nstdout: ${result.stdout} \nstderr: ${result.stderr}');
+          .contains(new RegExp(r'warning:.*file-does-not-exist\.js'))) {
+        fail('Missing warning for nonexistent @example: \nstdout: ${result.stdout} \nstderr: ${result.stderr}');
       }
     });
 


### PR DESCRIPTION
Make “file missing” warning message more consistent with other warning messages, and add missing newline. Followup to #1295.

cc @filiph @kwalrath