### PR TITLE
Go to the first suggestion in the search field on Enter [#1149]

### DIFF
--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -172,7 +172,7 @@ function initSearch() {
       templates: {
         suggestion: function(match) {
           return [
-            '<div>',
+            '<div data-href="' + match.href + '">',
               match.name,
               ' ',
               match.type.toLowerCase(),
@@ -186,7 +186,23 @@ function initSearch() {
       }
     });
 
-    $('#search-box.typeahead').bind('typeahead:select', function(ev, suggestion) {
+    var typeaheadElement = $('#search-box.typeahead');
+    var typeaheadElementParent = typeaheadElement.parent();
+
+    typeaheadElement.on("keydown", function (e) {
+      if (e.keyCode === 13) { // Enter
+        var suggestion = typeaheadElementParent.find(".tt-suggestion.tt-selectable:eq(0)");
+        if (suggestion.length > 0) {
+          var href = suggestion.data("href");
+          if (href != null) {
+            window.location = href;
+          }
+        }
+        console.log(typeaheadElement.typeahead("val"));
+      }
+    });
+
+    typeaheadElement.bind('typeahead:select', function(ev, suggestion) {
         window.location = suggestion.href;
     });
   }

--- a/testing/test_package_docs/static-assets/script.js
+++ b/testing/test_package_docs/static-assets/script.js
@@ -172,7 +172,7 @@ function initSearch() {
       templates: {
         suggestion: function(match) {
           return [
-            '<div>',
+            '<div data-href="' + match.href + '">',
               match.name,
               ' ',
               match.type.toLowerCase(),
@@ -186,7 +186,23 @@ function initSearch() {
       }
     });
 
-    $('#search-box.typeahead').bind('typeahead:select', function(ev, suggestion) {
+    var typeaheadElement = $('#search-box.typeahead');
+    var typeaheadElementParent = typeaheadElement.parent();
+
+    typeaheadElement.on("keydown", function (e) {
+      if (e.keyCode === 13) { // Enter
+        var suggestion = typeaheadElementParent.find(".tt-suggestion.tt-selectable:eq(0)");
+        if (suggestion.length > 0) {
+          var href = suggestion.data("href");
+          if (href != null) {
+            window.location = href;
+          }
+        }
+        console.log(typeaheadElement.typeahead("val"));
+      }
+    });
+
+    typeaheadElement.bind('typeahead:select', function(ev, suggestion) {
         window.location = suggestion.href;
     });
   }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -202,7 +202,7 @@ updateTestPackageDocs() {
   var options = new RunOptions(workingDirectory: 'testing/test_package');
   delete(getDir('test_package_docs'));
   Dart.run('../../bin/dartdoc.dart',
-      arguments: ['--no-include-source', '--output', '../test_package_docs'],
+      arguments: ['--no-include-source', '--output', '../test_package_docs', '--example-path-prefix', 'examples'],
       runOptions: options);
 }
 


### PR DESCRIPTION
Unfortunately, typeahead.js doesn't give us any API for fetching current
suggesions, so we workaround that by adding `href` of a suggesion into
a data attribute of HTML for that suggestion, and then fetching
suggestions from DOM, choosing the first one, and using it's
`data-href`. Quite dirty though :( I'd prefer to do something like
`typeAheadElement.typeadead('suggestions')[0].href` instead.

Testing: Checked that functionality in latest Chrome, Firefox and Safari

Fixes #1149