### PR TITLE
Fix failing angular2 docs generation [#1315]

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -180,7 +180,7 @@ String _linkDocReference(String reference, ModelElement element, NodeList<Commen
     // different for doc references. sigh.
     return '<a ${classContent}href="${linkedElement.href}">$label</a>';
   } else {
-    warning("unresolved doc reference '$reference' (in ${_elementLocation(element)}");
+    warning("unresolved doc reference '$reference'${element != null ? " (in ${_elementLocation(element)}" : ""}");
     return '<code>${HTML_ESCAPE.convert(label)}</code>';
   }
 }


### PR DESCRIPTION
It appears when we link the references in comments, sometimes
`ModelElement element` there could be null. So, need to check it before
showing its location in the warning.

Testing: Generated Angular 2 docs successfully

Fixes #1315