### PR TITLE
Deemphasize and resort the inherited members [#641]

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -754,3 +754,16 @@ li.inherited a {
   opacity: 0.65;
   font-style: italic;
 }
+
+#instance-methods dt.inherited .name,
+#instance-properties dt.inherited .name,
+#operators dt.inherited .name {
+  font-weight: 300;
+  font-style: italic;
+}
+
+#instance-methods dt.inherited .signature,
+#instance-properties dt.inherited .signature,
+#operators dt.inherited .signature {
+  font-weight: 300;
+}

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -204,9 +204,8 @@ class Class extends ModelElement implements EnclosedElement {
   List<Method> get allInstanceMethods {
     if (_allInstanceMethods != null) return _allInstanceMethods;
     _allInstanceMethods = []
-      ..addAll(instanceMethods)
-      ..addAll(inheritedMethods)
-      ..sort(byName);
+      ..addAll([]..addAll(instanceMethods)..sort(byName))
+      ..addAll([]..addAll(inheritedMethods)..sort(byName));
     return _allInstanceMethods;
   }
 
@@ -218,9 +217,8 @@ class Class extends ModelElement implements EnclosedElement {
 
     // TODO best way to make this a fixed length list?
     _allInstanceProperties = []
-      ..addAll(instanceProperties)
-      ..addAll(inheritedProperties)
-      ..sort(byName);
+      ..addAll([]..addAll(instanceProperties)..sort(byName))
+      ..addAll([]..addAll(inheritedProperties)..sort(byName));
 
     return _allInstanceProperties;
   }
@@ -231,9 +229,8 @@ class Class extends ModelElement implements EnclosedElement {
   List<Operator> get allOperators {
     if (_allOperators != null) return _allOperators;
     _allOperators = []
-      ..addAll(operators)
-      ..addAll(inheritedOperators)
-      ..sort(byName);
+      ..addAll([]..addAll(operators)..sort(byName))
+      ..addAll([]..addAll(inheritedOperators)..sort(byName));
     return _allOperators;
   }
 

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -192,16 +192,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/Animal/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="index" class="property">
           <span class="name">index</span>
           <span class="signature">&#8594; int</span>
@@ -210,6 +200,16 @@
           
           <div class="features">
     read-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/Animal/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -281,8 +281,8 @@
       <li class="section-title">
         <a href="ex/Animal-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Animal/hashCode.html">hashCode</a></li>
       <li>index</li>
+      <li class="inherited"><a href="ex/Animal/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Animal/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Animal-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -227,16 +227,6 @@
     read-only
   </div>
 </dd>
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/Apple/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="m" class="property">
           <span class="name"><a href="ex/Apple/m.html">m</a></span>
           <span class="signature">&#8594; int</span>
@@ -247,16 +237,6 @@
     read / write
   </div>
 </dd>
-        <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="ex/Apple/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
-        </dt>
-        <dd class="inherited">
-          <p>A representation of the runtime type of the object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="s" class="property">
           <span class="name"><a href="ex/Apple/s.html">s</a></span>
           <span class="signature">&#8594; String</span>
@@ -265,6 +245,26 @@
           <p>The getter for <code>s</code></p>
           <div class="features">
     read / write
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/Apple/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
+  </div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="ex/Apple/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          <p>A representation of the runtime type of the object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
       </dl>
@@ -320,15 +320,6 @@
         <dd>
           <p></p>
         </dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>Invoked when a non-existent method or property is accessed.</p>
-          <div class="features">inherited</div>
-        </dd>
         <dt id="paramFromExportLib" class="callable">
           <span class="name"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></span><span class="signature">(<wbr><span class="parameter" id="paramFromExportLib-param-helper"><span class="type-annotation"><a href="ex/Helper-class.html">Helper</a></span> <span class="parameter-name">helper</span></span>)
             <span class="returntype parameter">&#8594; void</span>
@@ -344,6 +335,15 @@
         </dt>
         <dd>
           <p></p>
+        </dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Invoked when a non-existent method or property is accessed.</p>
+          <div class="features">inherited</div>
         </dd>
         <dt id="toString" class="callable inherited">
           <span class="name"><a href="ex/Apple/toString.html">toString</a></span><span class="signature">(<wbr>)
@@ -377,10 +377,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -390,9 +390,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Apple/Apple.fromString.html
+++ b/testing/test_package_docs/ex/Apple/Apple.fromString.html
@@ -89,10 +89,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -102,9 +102,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/Apple.html
+++ b/testing/test_package_docs/ex/Apple/Apple.html
@@ -89,10 +89,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -102,9 +102,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
+++ b/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/isGreaterThan.html
+++ b/testing/test_package_docs/ex/Apple/isGreaterThan.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/m.html
+++ b/testing/test_package_docs/ex/Apple/m.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/m1.html
+++ b/testing/test_package_docs/ex/Apple/m1.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/methodWithTypedefParam.html
+++ b/testing/test_package_docs/ex/Apple/methodWithTypedefParam.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/n-constant.html
+++ b/testing/test_package_docs/ex/Apple/n-constant.html
@@ -89,10 +89,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -102,9 +102,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Apple/noSuchMethod.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/operator_equals.html
+++ b/testing/test_package_docs/ex/Apple/operator_equals.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/operator_multiply.html
+++ b/testing/test_package_docs/ex/Apple/operator_multiply.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/paramFromExportLib.html
+++ b/testing/test_package_docs/ex/Apple/paramFromExportLib.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/printMsg.html
+++ b/testing/test_package_docs/ex/Apple/printMsg.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/runtimeType.html
+++ b/testing/test_package_docs/ex/Apple/runtimeType.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/s.html
+++ b/testing/test_package_docs/ex/Apple/s.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/string.html
+++ b/testing/test_package_docs/ex/Apple/string.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/Apple/toString.html
+++ b/testing/test_package_docs/ex/Apple/toString.html
@@ -88,10 +88,10 @@
         <a href="ex/Apple-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
       <li><a href="ex/Apple/m.html">m</a></li>
-      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
       <li><a href="ex/Apple/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Apple/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Apple-class.html#operators">Operators</a></li>
       <li><a href="ex/Apple/operator_multiply.html">operator *</a></li>
@@ -101,9 +101,9 @@
       <li><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/Apple/m1.html">m1</a></li>
       <li><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
-      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li><a href="ex/Apple/printMsg.html">printMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -193,26 +193,6 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
     read / write
   </div>
 </dd>
-        <dt id="fieldWithTypedef" class="property inherited">
-          <span class="name"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></span>
-          <span class="signature">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a>&lt;bool&gt;</span>
-        </dt>
-        <dd class="inherited">
-          <p>fieldWithTypedef docs here</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/B/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="isImplemented" class="property">
           <span class="name"><a href="ex/B/isImplemented.html">isImplemented</a></span>
           <span class="signature">&#8594; bool</span>
@@ -233,6 +213,36 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
     read / write
   </div>
 </dd>
+        <dt id="s" class="property">
+          <span class="name"><a href="ex/B/s.html">s</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">
+    read-only
+  </div>
+</dd>
+        <dt id="fieldWithTypedef" class="property inherited">
+          <span class="name"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></span>
+          <span class="signature">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a>&lt;bool&gt;</span>
+        </dt>
+        <dd class="inherited">
+          <p>fieldWithTypedef docs here</p>
+          <div class="features">
+    read-only, inherited
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/B/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
+  </div>
+</dd>
         <dt id="m" class="property inherited">
           <span class="name"><a href="ex/Apple/m.html">m</a></span>
           <span class="signature">&#8594; int</span>
@@ -251,16 +261,6 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
           <p>A representation of the runtime type of the object.</p>
           <div class="features">
     read-only, inherited
-  </div>
-</dd>
-        <dt id="s" class="property">
-          <span class="name"><a href="ex/B/s.html">s</a></span>
-          <span class="signature">&#8594; String</span>
-        </dt>
-        <dd>
-          <p></p>
-          <div class="features">
-    read-only
   </div>
 </dd>
         <dt id="s" class="property inherited">
@@ -319,6 +319,22 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
         <dd>
           <p></p>
         </dd>
+        <dt id="m1" class="callable">
+          <span class="name"><a href="ex/B/m1.html">m1</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          <p>This is a method.</p>
+        </dd>
+        <dt id="writeMsg" class="callable">
+          <span class="name"><a href="ex/B/writeMsg.html">writeMsg</a></span><span class="signature">(<wbr><span class="parameter" id="writeMsg-param-msg"><span class="type-annotation">String</span> <span class="parameter-name">msg</span>, [</span> <span class="parameter" id="writeMsg-param-transformMsg"><span class="type-annotation">String</span> <span class="parameter-name">transformMsg</span>(<span class="parameter" id="transformMsg-param-origMsg"><span class="type-annotation">String</span> <span class="parameter-name">origMsg</span>, </span> <span class="parameter" id="transformMsg-param-flag"><span class="type-annotation">bool</span> <span class="parameter-name">flag</span></span>)</span> ])
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+        </dd>
         <dt id="isGreaterThan" class="callable inherited">
           <span class="name"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></span><span class="signature">(<wbr><span class="parameter" id="isGreaterThan-param-number"><span class="type-annotation">int</span> <span class="parameter-name">number</span>, {</span> <span class="parameter" id="isGreaterThan-param-check"><span class="type-annotation">int</span> <span class="parameter-name">check</span>: <span class="default-value">5</span></span> })
             <span class="returntype parameter">&#8594; bool</span>
@@ -327,14 +343,6 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
         <dd class="inherited">
           <p></p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="m1" class="callable">
-          <span class="name"><a href="ex/B/m1.html">m1</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd>
-          <p>This is a method.</p>
         </dd>
         <dt id="methodWithTypedefParam" class="callable inherited">
           <span class="name"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></span><span class="signature">(<wbr><span class="parameter" id="methodWithTypedefParam-param-p"><span class="type-annotation"><a href="ex/processMessage.html">processMessage</a></span> <span class="parameter-name">p</span></span>)
@@ -381,14 +389,6 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
           <p>Returns a string representation of this object.</p>
           <div class="features">inherited</div>
         </dd>
-        <dt id="writeMsg" class="callable">
-          <span class="name"><a href="ex/B/writeMsg.html">writeMsg</a></span><span class="signature">(<wbr><span class="parameter" id="writeMsg-param-msg"><span class="type-annotation">String</span> <span class="parameter-name">msg</span>, [</span> <span class="parameter" id="writeMsg-param-transformMsg"><span class="type-annotation">String</span> <span class="parameter-name">transformMsg</span>(<span class="parameter" id="transformMsg-param-origMsg"><span class="type-annotation">String</span> <span class="parameter-name">origMsg</span>, </span> <span class="parameter" id="transformMsg-param-flag"><span class="type-annotation">bool</span> <span class="parameter-name">flag</span></span>)</span> ])
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd>
-          <p></p>
-        </dd>
       </dl>
     </section>
 
@@ -407,13 +407,13 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -423,14 +423,14 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->
 

--- a/testing/test_package_docs/ex/B/B.html
+++ b/testing/test_package_docs/ex/B/B.html
@@ -84,13 +84,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -100,14 +100,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/B/abstractMethod.html
+++ b/testing/test_package_docs/ex/B/abstractMethod.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/autoCompress.html
+++ b/testing/test_package_docs/ex/B/autoCompress.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/doNothing.html
+++ b/testing/test_package_docs/ex/B/doNothing.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/hashCode.html
+++ b/testing/test_package_docs/ex/B/hashCode.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/isImplemented.html
+++ b/testing/test_package_docs/ex/B/isImplemented.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/list.html
+++ b/testing/test_package_docs/ex/B/list.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/m1.html
+++ b/testing/test_package_docs/ex/B/m1.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/noSuchMethod.html
+++ b/testing/test_package_docs/ex/B/noSuchMethod.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/operator_equals.html
+++ b/testing/test_package_docs/ex/B/operator_equals.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/runtimeType.html
+++ b/testing/test_package_docs/ex/B/runtimeType.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/s.html
+++ b/testing/test_package_docs/ex/B/s.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/toString.html
+++ b/testing/test_package_docs/ex/B/toString.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/B/writeMsg.html
+++ b/testing/test_package_docs/ex/B/writeMsg.html
@@ -83,13 +83,13 @@
         <a href="ex/B-class.html#instance-properties">Properties</a>
       </li>
       <li><a href="ex/B/autoCompress.html">autoCompress</a></li>
-      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
-      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li><a href="ex/B/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/B/list.html">list</a></li>
+      <li><a href="ex/B/s.html">s</a></li>
+      <li class="inherited"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></li>
+      <li class="inherited"><a href="ex/B/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Apple/m.html">m</a></li>
       <li class="inherited"><a href="ex/B/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/B/s.html">s</a></li>
       <li class="inherited"><a href="ex/Apple/s.html">s</a></li>
     
       <li class="section-title inherited"><a href="ex/B-class.html#operators">Operators</a></li>
@@ -99,14 +99,14 @@
       <li class="section-title"><a href="ex/B-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/B/abstractMethod.html">abstractMethod</a></li>
       <li><a class="deprecated" href="ex/B/doNothing.html">doNothing</a></li>
-      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li><a href="ex/B/m1.html">m1</a></li>
+      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
+      <li class="inherited"><a href="ex/Apple/isGreaterThan.html">isGreaterThan</a></li>
       <li class="inherited"><a href="ex/Apple/methodWithTypedefParam.html">methodWithTypedefParam</a></li>
       <li class="inherited"><a href="ex/B/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/Apple/paramFromExportLib.html">paramFromExportLib</a></li>
       <li class="inherited"><a href="ex/Apple/printMsg.html">printMsg</a></li>
       <li class="inherited"><a href="ex/B/toString.html">toString</a></li>
-      <li><a href="ex/B/writeMsg.html">writeMsg</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Cat-class.html
+++ b/testing/test_package_docs/ex/Cat-class.html
@@ -173,16 +173,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/Cat/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="isImplemented" class="property">
           <span class="name"><a href="ex/Cat/isImplemented.html">isImplemented</a></span>
           <span class="signature">&#8594; bool</span>
@@ -191,6 +181,16 @@
           <p></p>
           <div class="features">
     read-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/Cat/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -267,8 +267,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/Cat.html
+++ b/testing/test_package_docs/ex/Cat/Cat.html
@@ -83,8 +83,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/abstractMethod.html
+++ b/testing/test_package_docs/ex/Cat/abstractMethod.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/isImplemented.html
+++ b/testing/test_package_docs/ex/Cat/isImplemented.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Cat/noSuchMethod.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/operator_equals.html
+++ b/testing/test_package_docs/ex/Cat/operator_equals.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/runtimeType.html
+++ b/testing/test_package_docs/ex/Cat/runtimeType.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Cat/toString.html
+++ b/testing/test_package_docs/ex/Cat/toString.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/Cat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
+      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -174,16 +174,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/ConstantCat/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="isImplemented" class="property">
           <span class="name"><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></span>
           <span class="signature">&#8594; bool</span>
@@ -202,6 +192,16 @@
           <p></p>
           <div class="features">
     read-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/ConstantCat/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -278,9 +278,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
+++ b/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
@@ -83,9 +83,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/abstractMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/abstractMethod.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/isImplemented.html
+++ b/testing/test_package_docs/ex/ConstantCat/isImplemented.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/name.html
+++ b/testing/test_package_docs/ex/ConstantCat/name.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/operator_equals.html
+++ b/testing/test_package_docs/ex/ConstantCat/operator_equals.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/runtimeType.html
+++ b/testing/test_package_docs/ex/ConstantCat/runtimeType.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/ConstantCat/toString.html
+++ b/testing/test_package_docs/ex/ConstantCat/toString.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ConstantCat-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li><a href="ex/ConstantCat/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/ConstantCat/name.html">name</a></li>
+      <li class="inherited"><a href="ex/ConstantCat/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ConstantCat/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/ConstantCat-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -239,6 +239,14 @@ annotated feature.</p>
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
+        <dt id="toString" class="callable">
+          <span class="name"><a href="ex/Deprecated/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd>
+          <p>Returns a string representation of this object.</p>
+        </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
@@ -247,14 +255,6 @@ annotated feature.</p>
         <dd class="inherited">
           <p>Invoked when a non-existent method or property is accessed.</p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="toString" class="callable">
-          <span class="name"><a href="ex/Deprecated/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
-          </span>
-        </dt>
-        <dd>
-          <p>Returns a string representation of this object.</p>
         </dd>
       </dl>
     </section>
@@ -281,8 +281,8 @@ annotated feature.</p>
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->
 

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -91,8 +91,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Deprecated/toString.html
+++ b/testing/test_package_docs/ex/Deprecated/toString.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -241,16 +241,6 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
     write-only
   </div>
 </dd>
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/Dog/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="isImplemented" class="property">
           <span class="name"><a href="ex/Dog/isImplemented.html">isImplemented</a></span>
           <span class="signature">&#8594; bool</span>
@@ -269,6 +259,16 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <p></p>
           <div class="features">
     read / write
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/Dog/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -325,15 +325,6 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         <dd>
           <p></p>
         </dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>Invoked when a non-existent method or property is accessed.</p>
-          <div class="features">inherited</div>
-        </dd>
         <dt id="testGeneric" class="callable">
           <span class="name"><a href="ex/Dog/testGeneric.html">testGeneric</a></span><span class="signature">(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map&lt;String, dynamic&gt;</span> <span class="parameter-name">args</span></span>)
             <span class="returntype parameter">&#8594; void</span>
@@ -358,15 +349,6 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         <dd>
           <p></p>
         </dd>
-        <dt id="toString" class="callable inherited">
-          <span class="name"><a href="ex/Dog/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>Returns a string representation of this object.</p>
-          <div class="features">inherited</div>
-        </dd>
         <dt id="withMacro" class="callable">
           <span class="name"><a href="ex/Dog/withMacro.html">withMacro</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -382,6 +364,24 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         </dt>
         <dd>
           <p>Foo macro content</p>
+        </dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Invoked when a non-existent method or property is accessed.</p>
+          <div class="features">inherited</div>
+        </dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="ex/Dog/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Returns a string representation of this object.</p>
+          <div class="features">inherited</div>
         </dd>
       </dl>
     </section>
@@ -406,9 +406,9 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -418,13 +418,13 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->
 

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -89,9 +89,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -101,13 +101,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -89,9 +89,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -101,13 +101,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Dog/noSuchMethod.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/toString.html
+++ b/testing/test_package_docs/ex/Dog/toString.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/withMacro.html
+++ b/testing/test_package_docs/ex/Dog/withMacro.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -88,9 +88,9 @@
       <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
       <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
-      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
       <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
@@ -100,13 +100,13 @@
       <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li><a href="ex/Dog/foo.html">foo</a></li>
       <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
-      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -264,6 +264,14 @@
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
+        <dt id="methodWithGenericParam" class="callable">
+          <span class="name"><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></span><span class="signature">(<wbr>[<span class="parameter" id="methodWithGenericParam-param-msgs"><span class="type-annotation">List&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span> <span class="parameter-name">msgs</span></span> ])
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+        </dd>
         <dt id="abstractMethod" class="callable inherited">
           <span class="name"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -290,14 +298,6 @@
         <dd class="inherited">
           <p></p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="methodWithGenericParam" class="callable">
-          <span class="name"><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></span><span class="signature">(<wbr>[<span class="parameter" id="methodWithGenericParam-param-msgs"><span class="type-annotation">List&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span> <span class="parameter-name">msgs</span></span> ])
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd>
-          <p></p>
         </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
@@ -400,10 +400,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -95,10 +95,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/hashCode.html
+++ b/testing/test_package_docs/ex/F/hashCode.html
@@ -94,10 +94,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -94,10 +94,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/noSuchMethod.html
+++ b/testing/test_package_docs/ex/F/noSuchMethod.html
@@ -94,10 +94,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/runtimeType.html
+++ b/testing/test_package_docs/ex/F/runtimeType.html
@@ -94,10 +94,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -94,10 +94,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/F/toString.html
+++ b/testing/test_package_docs/ex/F/toString.html
@@ -94,10 +94,10 @@
       <li class="inherited"><a href="ex/Dog/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/F-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
       <li class="inherited"><a href="ex/Dog/foo.html">foo</a></li>
       <li class="inherited"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
-      <li><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></li>
       <li class="inherited"><a href="ex/F/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/F/test.html">test</a></li>
       <li class="inherited"><a href="ex/Dog/testGeneric.html">testGeneric</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -160,6 +160,16 @@
       <h2>Properties</h2>
 
       <dl class="properties">
+        <dt id="value" class="property">
+          <span class="name"><a href="ex/ForAnnotation/value.html">value</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">
+    read-only
+  </div>
+</dd>
         <dt id="hashCode" class="property inherited">
           <span class="name"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span>
@@ -178,16 +188,6 @@
           <p>A representation of the runtime type of the object.</p>
           <div class="features">
     read-only, inherited
-  </div>
-</dd>
-        <dt id="value" class="property">
-          <span class="name"><a href="ex/ForAnnotation/value.html">value</a></span>
-          <span class="signature">&#8594; String</span>
-        </dt>
-        <dd>
-          <p></p>
-          <div class="features">
-    read-only
   </div>
 </dd>
       </dl>
@@ -246,9 +246,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
+++ b/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
@@ -83,9 +83,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/toString.html
+++ b/testing/test_package_docs/ex/ForAnnotation/toString.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation/value.html
+++ b/testing/test_package_docs/ex/ForAnnotation/value.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/ForAnnotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/ForAnnotation/value.html">value</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/ForAnnotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="ex/ForAnnotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/ForAnnotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -219,6 +219,14 @@
         <dd>
           <p>A method</p>
         </dd>
+        <dt id="toString" class="callable">
+          <span class="name"><a href="ex/Klass/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd>
+          <p>A shadowed method</p>
+        </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
@@ -227,14 +235,6 @@
         <dd class="inherited">
           <p>Invoked when a non-existent method or property is accessed.</p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="toString" class="callable">
-          <span class="name"><a href="ex/Klass/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd>
-          <p>A shadowed method</p>
         </dd>
       </dl>
     </section>
@@ -262,8 +262,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->
 

--- a/testing/test_package_docs/ex/Klass/Klass.html
+++ b/testing/test_package_docs/ex/Klass/Klass.html
@@ -92,8 +92,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Klass/another.html
+++ b/testing/test_package_docs/ex/Klass/another.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Klass/method.html
+++ b/testing/test_package_docs/ex/Klass/method.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Klass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Klass/noSuchMethod.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Klass/operator_equals.html
+++ b/testing/test_package_docs/ex/Klass/operator_equals.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Klass/runtimeType.html
+++ b/testing/test_package_docs/ex/Klass/runtimeType.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Klass/toString.html
+++ b/testing/test_package_docs/ex/Klass/toString.html
@@ -91,8 +91,8 @@
       <li class="section-title"><a href="ex/Klass-class.html#instance-methods">Methods</a></li>
       <li><a href="ex/Klass/another.html">another</a></li>
       <li><a href="ex/Klass/method.html">method</a></li>
-      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/Klass/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Klass/noSuchMethod.html">noSuchMethod</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -173,6 +173,16 @@
       <h2>Properties</h2>
 
       <dl class="properties">
+        <dt id="stackTrace" class="property">
+          <span class="name"><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></span>
+          <span class="signature">&#8594; StackTrace</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">
+    read-only
+  </div>
+</dd>
         <dt id="hashCode" class="property inherited">
           <span class="name"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span>
@@ -191,16 +201,6 @@
           <p>A representation of the runtime type of the object.</p>
           <div class="features">
     read-only, inherited
-  </div>
-</dd>
-        <dt id="stackTrace" class="property">
-          <span class="name"><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></span>
-          <span class="signature">&#8594; StackTrace</span>
-        </dt>
-        <dd>
-          <p></p>
-          <div class="features">
-    read-only
   </div>
 </dd>
       </dl>
@@ -259,9 +259,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
@@ -83,9 +83,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements/toString.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/toString.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="ex/MyErrorImplements-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/runtimeType.html">runtimeType</a></li>
-      <li><a href="ex/MyErrorImplements/stackTrace.html">stackTrace</a></li>
     
       <li class="section-title inherited"><a href="ex/MyErrorImplements-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="ex/MyErrorImplements/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -200,6 +200,14 @@
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
+        <dt id="test" class="callable">
+          <span class="name"><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+        </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
@@ -208,14 +216,6 @@
         <dd class="inherited">
           <p>Invoked when a non-existent method or property is accessed.</p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="test" class="callable">
-          <span class="name"><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd>
-          <p></p>
         </dd>
         <dt id="toString" class="callable inherited">
           <span class="name"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></span><span class="signature">(<wbr>)
@@ -250,8 +250,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/test.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/test.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="ex/PublicClassImplementsPrivateInterface-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface/test.html">test</a></li>
+      <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/PublicClassImplementsPrivateInterface/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -171,16 +171,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/WithGeneric/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="prop" class="property">
           <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span>
           <span class="signature">&#8594; T</span>
@@ -189,6 +179,16 @@
           <p></p>
           <div class="features">
     read / write
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/WithGeneric/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -257,8 +257,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
+++ b/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
@@ -83,8 +83,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
+++ b/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/WithGeneric/toString.html
+++ b/testing/test_package_docs/ex/WithGeneric/toString.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="ex/WithGeneric-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li><a href="ex/WithGeneric/prop.html">prop</a></li>
+      <li class="inherited"><a href="ex/WithGeneric/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/WithGeneric/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="ex/WithGeneric-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -177,6 +177,16 @@
       <h2>Properties</h2>
 
       <dl class="properties">
+        <dt id="value" class="property">
+          <span class="name"><a href="fake/Annotation/value.html">value</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">
+    read-only
+  </div>
+</dd>
         <dt id="hashCode" class="property inherited">
           <span class="name"><a href="fake/Annotation/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span>
@@ -195,16 +205,6 @@
           <p>A representation of the runtime type of the object.</p>
           <div class="features">
     read-only, inherited
-  </div>
-</dd>
-        <dt id="value" class="property">
-          <span class="name"><a href="fake/Annotation/value.html">value</a></span>
-          <span class="signature">&#8594; String</span>
-        </dt>
-        <dd>
-          <p></p>
-          <div class="features">
-    read-only
   </div>
 </dd>
       </dl>
@@ -263,9 +263,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/Annotation.html
+++ b/testing/test_package_docs/fake/Annotation/Annotation.html
@@ -83,9 +83,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Annotation/noSuchMethod.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/operator_equals.html
+++ b/testing/test_package_docs/fake/Annotation/operator_equals.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/runtimeType.html
+++ b/testing/test_package_docs/fake/Annotation/runtimeType.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/toString.html
+++ b/testing/test_package_docs/fake/Annotation/toString.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Annotation/value.html
+++ b/testing/test_package_docs/fake/Annotation/value.html
@@ -82,9 +82,9 @@
       <li class="section-title">
         <a href="fake/Annotation-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/Annotation/value.html">value</a></li>
       <li class="inherited"><a href="fake/Annotation/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Annotation/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/Annotation/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/Annotation-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/Annotation/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -250,16 +250,6 @@ Some constants have long docs.</p>
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/Color/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="index" class="property">
           <span class="name">index</span>
           <span class="signature">&#8594; int</span>
@@ -268,6 +258,16 @@ Some constants have long docs.</p>
           
           <div class="features">
     read-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/Color/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -343,8 +343,8 @@ Some constants have long docs.</p>
       <li class="section-title">
         <a href="fake/Color-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Color/hashCode.html">hashCode</a></li>
       <li>index</li>
+      <li class="inherited"><a href="fake/Color/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Color/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Color-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -197,6 +197,16 @@ Go ahead, it's fun.</p>
       <h2>Properties</h2>
 
       <dl class="properties">
+        <dt id="value" class="property">
+          <span class="name"><a href="fake/ConstantClass/value.html">value</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">
+    read-only
+  </div>
+</dd>
         <dt id="hashCode" class="property inherited">
           <span class="name"><a href="fake/ConstantClass/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span>
@@ -215,16 +225,6 @@ Go ahead, it's fun.</p>
           <p>A representation of the runtime type of the object.</p>
           <div class="features">
     read-only, inherited
-  </div>
-</dd>
-        <dt id="value" class="property">
-          <span class="name"><a href="fake/ConstantClass/value.html">value</a></span>
-          <span class="signature">&#8594; String</span>
-        </dt>
-        <dd>
-          <p></p>
-          <div class="features">
-    read-only
   </div>
 </dd>
       </dl>
@@ -285,9 +285,9 @@ Go ahead, it's fun.</p>
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
@@ -85,9 +85,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
@@ -85,9 +85,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
@@ -85,9 +85,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -84,9 +84,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
@@ -84,9 +84,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstantClass/operator_equals.html
@@ -84,9 +84,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstantClass/runtimeType.html
@@ -84,9 +84,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/toString.html
+++ b/testing/test_package_docs/fake/ConstantClass/toString.html
@@ -84,9 +84,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/value.html
+++ b/testing/test_package_docs/fake/ConstantClass/value.html
@@ -84,9 +84,9 @@
       <li class="section-title">
         <a href="fake/ConstantClass-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ConstantClass/value.html">value</a></li>
       <li class="inherited"><a href="fake/ConstantClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ConstantClass/runtimeType.html">runtimeType</a></li>
-      <li><a href="fake/ConstantClass/value.html">value</a></li>
     
       <li class="section-title inherited"><a href="fake/ConstantClass-class.html#operators">Operators</a></li>
       <li class="inherited"><a href="fake/ConstantClass/operator_equals.html">operator ==</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -217,6 +217,14 @@
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
+        <dt id="returnCool" class="callable">
+          <span class="name"><a href="fake/Cool/returnCool.html">returnCool</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; <a href="fake/Cool-class.html">Cool</a></span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+        </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
@@ -225,14 +233,6 @@
         <dd class="inherited">
           <p>Invoked when a non-existent method or property is accessed.</p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="returnCool" class="callable">
-          <span class="name"><a href="fake/Cool/returnCool.html">returnCool</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; <a href="fake/Cool-class.html">Cool</a></span>
-          </span>
-        </dt>
-        <dd>
-          <p></p>
         </dd>
         <dt id="toString" class="callable inherited">
           <span class="name"><a href="fake/Cool/toString.html">toString</a></span><span class="signature">(<wbr>)
@@ -267,8 +267,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/Cool/Cool.html
+++ b/testing/test_package_docs/fake/Cool/Cool.html
@@ -90,8 +90,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Cool/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Cool/noSuchMethod.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Cool/operator_equals.html
+++ b/testing/test_package_docs/fake/Cool/operator_equals.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Cool/returnCool.html
+++ b/testing/test_package_docs/fake/Cool/returnCool.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Cool/runtimeType.html
+++ b/testing/test_package_docs/fake/Cool/runtimeType.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Cool/toString.html
+++ b/testing/test_package_docs/fake/Cool/toString.html
@@ -89,8 +89,8 @@
       <li class="inherited"><a href="fake/Cool/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/Cool-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/Cool/returnCool.html">returnCool</a></li>
+      <li class="inherited"><a href="fake/Cool/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/Cool/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -204,16 +204,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/Foo2/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="index" class="property">
           <span class="name"><a href="fake/Foo2/index.html">index</a></span>
           <span class="signature">&#8594; int</span>
@@ -222,6 +212,16 @@
           <p></p>
           <div class="features">
     read-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/Foo2/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -293,8 +293,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/BAR-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAR-constant.html
@@ -86,8 +86,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/BAZ-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAZ-constant.html
@@ -86,8 +86,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/Foo2.html
+++ b/testing/test_package_docs/fake/Foo2/Foo2.html
@@ -86,8 +86,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -85,8 +85,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/index.html
+++ b/testing/test_package_docs/fake/Foo2/index.html
@@ -85,8 +85,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Foo2/noSuchMethod.html
@@ -85,8 +85,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/operator_equals.html
+++ b/testing/test_package_docs/fake/Foo2/operator_equals.html
@@ -85,8 +85,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/runtimeType.html
+++ b/testing/test_package_docs/fake/Foo2/runtimeType.html
@@ -85,8 +85,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Foo2/toString.html
+++ b/testing/test_package_docs/fake/Foo2/toString.html
@@ -85,8 +85,8 @@
       <li class="section-title">
         <a href="fake/Foo2-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li><a href="fake/Foo2/index.html">index</a></li>
+      <li class="inherited"><a href="fake/Foo2/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Foo2/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Foo2-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -230,15 +230,6 @@
         <dd>
           <p></p>
         </dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>Invoked when a non-existent method or property is accessed.</p>
-          <div class="features">inherited</div>
-        </dd>
         <dt id="returnX" class="callable">
           <span class="name"><a href="fake/HasGenerics/returnX.html">returnX</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; X</span>
@@ -254,6 +245,15 @@
         </dt>
         <dd>
           <p></p>
+        </dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Invoked when a non-existent method or property is accessed.</p>
+          <div class="features">inherited</div>
         </dd>
         <dt id="toString" class="callable inherited">
           <span class="name"><a href="fake/HasGenerics/toString.html">toString</a></span><span class="signature">(<wbr>)
@@ -290,9 +290,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
+++ b/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
@@ -92,9 +92,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/convertToMap.html
+++ b/testing/test_package_docs/fake/HasGenerics/convertToMap.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/doStuff.html
+++ b/testing/test_package_docs/fake/HasGenerics/doStuff.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/returnX.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnX.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/returnZ.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnZ.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/HasGenerics/toString.html
+++ b/testing/test_package_docs/fake/HasGenerics/toString.html
@@ -91,9 +91,9 @@
       <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
       <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
       <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
       <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
+      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
     </ol>
 

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -325,16 +325,6 @@ across... wait for it... two physical lines.</p>
     read-only
   </div>
 </dd>
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="onlySetter" class="property">
           <span class="name"><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></span>
           <span class="signature">&#8594; double</span>
@@ -343,6 +333,16 @@ across... wait for it... two physical lines.</p>
           <p>Only a setter, with a single param, of type double.</p>
           <div class="features">
     write-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="powers" class="property inherited">
@@ -411,15 +411,6 @@ across... wait for it... two physical lines.</p>
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
-        <dt id="fly" class="callable inherited">
-          <span class="name"><a href="fake/SuperAwesomeClass/fly.html">fly</a></span><span class="signature">(<wbr><span class="parameter" id="fly-param-height"><span class="type-annotation">int</span> <span class="parameter-name">height</span>, </span> <span class="parameter" id="fly-param-superCool"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">superCool</span>, {</span> <span class="parameter" id="fly-param-msg"><span class="type-annotation">String</span> <span class="parameter-name">msg</span></span> })
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>In the super class.</p>
-          <div class="features">inherited</div>
-        </dd>
         <dt id="noParams" class="callable">
           <span class="name deprecated"><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -427,15 +418,6 @@ across... wait for it... two physical lines.</p>
         </dt>
         <dd>
           <p>No params.</p>
-        </dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>Invoked when a non-existent method or property is accessed.</p>
-          <div class="features">inherited</div>
         </dd>
         <dt id="optionalParams" class="callable">
           <span class="name"><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></span><span class="signature">(<wbr><span class="parameter" id="optionalParams-param-first"><span class="parameter-name">first</span>, {</span> <span class="parameter" id="optionalParams-param-second"><span class="parameter-name">second</span>, </span> <span class="parameter" id="optionalParams-param-third"><span class="type-annotation">int</span> <span class="parameter-name">third</span></span> })
@@ -453,6 +435,32 @@ across... wait for it... two physical lines.</p>
         <dd>
           <p>Returns a single string.</p>
         </dd>
+        <dt id="twoParams" class="callable">
+          <span class="name"><a href="fake/LongFirstLine/twoParams.html">twoParams</a></span><span class="signature">(<wbr><span class="parameter" id="twoParams-param-one"><span class="type-annotation">String</span> <span class="parameter-name">one</span>, </span> <span class="parameter" id="twoParams-param-two"><span class="parameter-name">two</span></span>)
+            <span class="returntype parameter">&#8594; int</span>
+          </span>
+        </dt>
+        <dd>
+          <p>Two params, the first has a type annotation, the second does not.</p>
+        </dd>
+        <dt id="fly" class="callable inherited">
+          <span class="name"><a href="fake/SuperAwesomeClass/fly.html">fly</a></span><span class="signature">(<wbr><span class="parameter" id="fly-param-height"><span class="type-annotation">int</span> <span class="parameter-name">height</span>, </span> <span class="parameter" id="fly-param-superCool"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">superCool</span>, {</span> <span class="parameter" id="fly-param-msg"><span class="type-annotation">String</span> <span class="parameter-name">msg</span></span> })
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>In the super class.</p>
+          <div class="features">inherited</div>
+        </dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Invoked when a non-existent method or property is accessed.</p>
+          <div class="features">inherited</div>
+        </dd>
         <dt id="toString" class="callable inherited">
           <span class="name"><a href="fake/LongFirstLine/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
@@ -461,14 +469,6 @@ across... wait for it... two physical lines.</p>
         <dd class="inherited">
           <p>Returns a string representation of this object.</p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="twoParams" class="callable">
-          <span class="name"><a href="fake/LongFirstLine/twoParams.html">twoParams</a></span><span class="signature">(<wbr><span class="parameter" id="twoParams-param-one"><span class="type-annotation">String</span> <span class="parameter-name">one</span>, </span> <span class="parameter" id="twoParams-param-two"><span class="parameter-name">two</span></span>)
-            <span class="returntype parameter">&#8594; int</span>
-          </span>
-        </dt>
-        <dd>
-          <p>Two params, the first has a type annotation, the second does not.</p>
         </dd>
       </dl>
     </section>
@@ -501,8 +501,8 @@ across... wait for it... two physical lines.</p>
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -513,13 +513,13 @@ across... wait for it... two physical lines.</p>
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->
 

--- a/testing/test_package_docs/fake/LongFirstLine/ANSWER-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/ANSWER-constant.html
@@ -97,8 +97,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -109,13 +109,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
@@ -97,8 +97,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -109,13 +109,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
@@ -97,8 +97,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -109,13 +109,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
@@ -97,8 +97,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -109,13 +109,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
@@ -97,8 +97,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -109,13 +109,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
+++ b/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/hashCode.html
+++ b/testing/test_package_docs/fake/LongFirstLine/hashCode.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
+++ b/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/noParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/noParams.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/noSuchMethod.html
+++ b/testing/test_package_docs/fake/LongFirstLine/noSuchMethod.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/operator_equals.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_equals.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/operator_multiply.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_multiply.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/operator_plus.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_plus.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/optionalParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/optionalParams.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/returnString.html
+++ b/testing/test_package_docs/fake/LongFirstLine/returnString.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/runtimeType.html
+++ b/testing/test_package_docs/fake/LongFirstLine/runtimeType.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/staticMethodNoParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticMethodNoParams.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/staticMethodReturnsVoid.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticMethodReturnsVoid.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/toString.html
+++ b/testing/test_package_docs/fake/LongFirstLine/toString.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/LongFirstLine/twoParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/twoParams.html
@@ -96,8 +96,8 @@
       </li>
       <li><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></li>
       <li><a href="fake/LongFirstLine/dynamicGetter.html">dynamicGetter</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
       <li class="inherited"><a href="fake/LongFirstLine/runtimeType.html">runtimeType</a></li>
     
@@ -108,13 +108,13 @@
       <li class="inherited"><a href="fake/LongFirstLine/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/LongFirstLine-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
       <li><a class="deprecated" href="fake/LongFirstLine/noParams.html">noParams</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
       <li><a href="fake/LongFirstLine/optionalParams.html">optionalParams</a></li>
       <li><a href="fake/LongFirstLine/returnString.html">returnString</a></li>
-      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
       <li><a href="fake/LongFirstLine/twoParams.html">twoParams</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/fly.html">fly</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/LongFirstLine/toString.html">toString</a></li>
     </ol>
 
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -190,16 +190,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/Oops/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="message" class="property">
           <span class="name"><a href="fake/Oops/message.html">message</a></span>
           <span class="signature">&#8594; String</span>
@@ -208,6 +198,16 @@
           <p></p>
           <div class="features">
     read-only
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/Oops/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -276,8 +276,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/Oops.html
+++ b/testing/test_package_docs/fake/Oops/Oops.html
@@ -83,8 +83,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/message.html
+++ b/testing/test_package_docs/fake/Oops/message.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Oops/noSuchMethod.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/operator_equals.html
+++ b/testing/test_package_docs/fake/Oops/operator_equals.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/runtimeType.html
+++ b/testing/test_package_docs/fake/Oops/runtimeType.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/Oops/toString.html
+++ b/testing/test_package_docs/fake/Oops/toString.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/Oops-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li><a href="fake/Oops/message.html">message</a></li>
+      <li class="inherited"><a href="fake/Oops/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/Oops/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/Oops-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -194,6 +194,16 @@
       <h2>Properties</h2>
 
       <dl class="properties">
+        <dt id="length" class="property">
+          <span class="name"><a href="fake/SpecialList/length.html">length</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">
+    read / write
+  </div>
+</dd>
         <dt id="first" class="property inherited">
           <span class="name"><a href="fake/SpecialList/first.html">first</a></span>
           <span class="signature">&#8594; E</span>
@@ -254,16 +264,6 @@
     read-only, inherited
   </div>
 </dd>
-        <dt id="length" class="property">
-          <span class="name"><a href="fake/SpecialList/length.html">length</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd>
-          <p></p>
-          <div class="features">
-    read / write
-  </div>
-</dd>
         <dt id="reversed" class="property inherited">
           <span class="name"><a href="fake/SpecialList/reversed.html">reversed</a></span>
           <span class="signature">&#8594; Iterable&lt;E&gt;</span>
@@ -300,15 +300,6 @@
     <section class="summary offset-anchor" id="operators">
       <h2>Operators</h2>
       <dl class="callables">
-        <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          <p>The equality operator.</p>
-          <div class="features">inherited</div>
-        </dd>
         <dt id="operator []" class="callable">
           <span class="name"><a href="fake/SpecialList/operator_get.html">operator []</a></span><span class="signature">(<wbr><span class="parameter" id="[]-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span></span>)
             <span class="returntype parameter">&#8594; E</span>
@@ -324,6 +315,15 @@
         </dt>
         <dd>
           <p></p>
+        </dd>
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/SpecialList/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>The equality operator.</p>
+          <div class="features">inherited</div>
         </dd>
       </dl>
     </section>
@@ -759,21 +759,21 @@ predicate <code>test</code>.</p>
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/SpecialList.html
+++ b/testing/test_package_docs/fake/SpecialList/SpecialList.html
@@ -83,21 +83,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/add.html
+++ b/testing/test_package_docs/fake/SpecialList/add.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/addAll.html
+++ b/testing/test_package_docs/fake/SpecialList/addAll.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/any.html
+++ b/testing/test_package_docs/fake/SpecialList/any.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/asMap.html
+++ b/testing/test_package_docs/fake/SpecialList/asMap.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/clear.html
+++ b/testing/test_package_docs/fake/SpecialList/clear.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/elementAt.html
+++ b/testing/test_package_docs/fake/SpecialList/elementAt.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/every.html
+++ b/testing/test_package_docs/fake/SpecialList/every.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/expand.html
+++ b/testing/test_package_docs/fake/SpecialList/expand.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/fold.html
+++ b/testing/test_package_docs/fake/SpecialList/fold.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/forEach.html
+++ b/testing/test_package_docs/fake/SpecialList/forEach.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/indexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/indexOf.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/insert.html
+++ b/testing/test_package_docs/fake/SpecialList/insert.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/insertAll.html
+++ b/testing/test_package_docs/fake/SpecialList/insertAll.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/join.html
+++ b/testing/test_package_docs/fake/SpecialList/join.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/operator_get.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_get.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/operator_put.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_put.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/reduce.html
+++ b/testing/test_package_docs/fake/SpecialList/reduce.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/remove.html
+++ b/testing/test_package_docs/fake/SpecialList/remove.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/removeAt.html
+++ b/testing/test_package_docs/fake/SpecialList/removeAt.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/removeLast.html
+++ b/testing/test_package_docs/fake/SpecialList/removeLast.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/removeWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/removeWhere.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/retainWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/retainWhere.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/setAll.html
+++ b/testing/test_package_docs/fake/SpecialList/setAll.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/shuffle.html
+++ b/testing/test_package_docs/fake/SpecialList/shuffle.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/singleWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/singleWhere.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/sort.html
+++ b/testing/test_package_docs/fake/SpecialList/sort.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/sublist.html
+++ b/testing/test_package_docs/fake/SpecialList/sublist.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/take.html
+++ b/testing/test_package_docs/fake/SpecialList/take.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/takeWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/takeWhile.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/toList.html
+++ b/testing/test_package_docs/fake/SpecialList/toList.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/toSet.html
+++ b/testing/test_package_docs/fake/SpecialList/toSet.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/toString.html
+++ b/testing/test_package_docs/fake/SpecialList/toString.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -82,21 +82,21 @@
       <li class="section-title">
         <a href="fake/SpecialList-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/first.html">first</a></li>
       <li class="inherited"><a href="fake/SpecialList/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SpecialList/isEmpty.html">isEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/isNotEmpty.html">isNotEmpty</a></li>
       <li class="inherited"><a href="fake/SpecialList/iterator.html">iterator</a></li>
       <li class="inherited"><a href="fake/SpecialList/last.html">last</a></li>
-      <li><a href="fake/SpecialList/length.html">length</a></li>
       <li class="inherited"><a href="fake/SpecialList/reversed.html">reversed</a></li>
       <li class="inherited"><a href="fake/SpecialList/runtimeType.html">runtimeType</a></li>
       <li class="inherited"><a href="fake/SpecialList/single.html">single</a></li>
     
       <li class="section-title"><a href="fake/SpecialList-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
       <li><a href="fake/SpecialList/operator_get.html">operator []</a></li>
       <li><a href="fake/SpecialList/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/SpecialList/operator_equals.html">operator ==</a></li>
     
       <li class="section-title inherited"><a href="fake/SpecialList-class.html#instance-methods">Methods</a></li>
       <li class="inherited"><a href="fake/SpecialList/add.html">add</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -231,6 +231,14 @@
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
+        <dt id="localMethod" class="callable">
+          <span class="name"><a href="fake/SubForDocComments/localMethod.html">localMethod</a></span><span class="signature">(<wbr><span class="parameter" id="localMethod-param-foo"><span class="type-annotation">String</span> <span class="parameter-name">foo</span>, </span> <span class="parameter" id="localMethod-param-bar"><span class="parameter-name">bar</span></span>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          <p>Reference to <code>foo</code> and <code>bar</code></p>
+        </dd>
         <dt id="anotherMethod" class="callable inherited">
           <span class="name"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -248,14 +256,6 @@
         <dd class="inherited">
           <p>Takes a <code>value</code> and returns a String.</p>
           <div class="features">inherited</div>
-        </dd>
-        <dt id="localMethod" class="callable">
-          <span class="name"><a href="fake/SubForDocComments/localMethod.html">localMethod</a></span><span class="signature">(<wbr><span class="parameter" id="localMethod-param-foo"><span class="type-annotation">String</span> <span class="parameter-name">foo</span>, </span> <span class="parameter" id="localMethod-param-bar"><span class="parameter-name">bar</span></span>)
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd>
-          <p>Reference to <code>foo</code> and <code>bar</code></p>
         </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
@@ -299,9 +299,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
+++ b/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
@@ -90,9 +90,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/SubForDocComments/hashCode.html
@@ -89,9 +89,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/localMethod.html
+++ b/testing/test_package_docs/fake/SubForDocComments/localMethod.html
@@ -89,9 +89,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SubForDocComments/noSuchMethod.html
@@ -89,9 +89,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/operator_equals.html
+++ b/testing/test_package_docs/fake/SubForDocComments/operator_equals.html
@@ -89,9 +89,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/runtimeType.html
+++ b/testing/test_package_docs/fake/SubForDocComments/runtimeType.html
@@ -89,9 +89,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SubForDocComments/toString.html
+++ b/testing/test_package_docs/fake/SubForDocComments/toString.html
@@ -89,9 +89,9 @@
       <li class="inherited"><a href="fake/SubForDocComments/operator_equals.html">operator ==</a></li>
     
       <li class="section-title"><a href="fake/SubForDocComments-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/anotherMethod.html">anotherMethod</a></li>
       <li class="inherited"><a href="fake/BaseForDocComments/doAwesomeStuff.html">doAwesomeStuff</a></li>
-      <li><a href="fake/SubForDocComments/localMethod.html">localMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="fake/SubForDocComments/toString.html">toString</a></li>
     </ol>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -192,16 +192,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="powers" class="property">
           <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
           <span class="signature">&#8594; List&lt;String&gt;</span>
@@ -210,6 +200,16 @@
           <p>In the super class.</p>
           <div class="features">
     read / write
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -294,8 +294,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
@@ -83,8 +83,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/fly.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/fly.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_minus.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_minus.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/SuperAwesomeClass-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li><a href="fake/SuperAwesomeClass/powers.html">powers</a></li>
+      <li class="inherited"><a href="fake/SuperAwesomeClass/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/SuperAwesomeClass/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="fake/SuperAwesomeClass-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -188,16 +188,6 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          <p>Get a hash code for this object.</p>
-          <div class="features">
-    read-only, inherited
-  </div>
-</dd>
         <dt id="lengthX" class="property">
           <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
           <span class="signature">&#8594; int</span>
@@ -206,6 +196,16 @@
           <p>Returns a length.</p>
           <div class="features">
     read / write
+  </div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>Get a hash code for this object.</p>
+          <div class="features">
+    read-only, inherited
   </div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -274,8 +274,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
@@ -83,8 +83,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
@@ -82,8 +82,8 @@
       <li class="section-title">
         <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
+      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -754,3 +754,16 @@ li.inherited a {
   opacity: 0.65;
   font-style: italic;
 }
+
+#instance-methods dt.inherited .name,
+#instance-properties dt.inherited .name,
+#operators dt.inherited .name {
+  font-weight: 300;
+  font-style: italic;
+}
+
+#instance-methods dt.inherited .signature,
+#instance-properties dt.inherited .signature,
+#operators dt.inherited .signature {
+  font-weight: 300;
+}


### PR DESCRIPTION
@sethladd asked to reorder the list of methods and properties in a way
that the inherited members go last, and also deemphasized in the output
(the names will be nonbold and italic).

This way it will be easier to grasp when skimming through the docs what
are the new methods/fields of a class, but you still can see all of them
and we don't introduce any new togglers/switchers, which would
complicate the UI/UX.

Testing: Generated Flutter docs, made sure the inherited members are
nonbold/italic and go last.

Fixes #641