### PR TITLE
Use only canonical elements when resolving unresolved refs in comments

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -139,7 +139,7 @@ MatchingLinkResult _findRefElementInLibrary(String codeRef, ModelElement element
   final Package package = library.package;
   final Map<String, ModelElement> result = {};
 
-  for (final modelElement in package.allModelElements) {
+  for (final modelElement in package.allCanonicalModelElements) {
     if (codeRef == modelElement.fullyQualifiedName) {
       result[modelElement.fullyQualifiedName] = modelElement;
     }
@@ -147,7 +147,7 @@ MatchingLinkResult _findRefElementInLibrary(String codeRef, ModelElement element
 
   // Only look for partially qualified matches if we didn't find a fully qualified one.
   if (result.isEmpty) {
-    for (final modelElement in library.allModelElements) {
+    for (final modelElement in library.allCanonicalModelElements) {
       if (codeRef == modelElement.fullyQualifiedNameWithoutLibrary) {
         result[modelElement.fullyQualifiedName] = modelElement;
       }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1243,7 +1243,7 @@ class Library extends ModelElement {
   }
 
   List<ModelElement> _allModelElements;
-  List<ModelElement> get allModelElements {
+  Iterable<ModelElement> get allModelElements {
     if (_allModelElements == null) {
       final List<ModelElement> results = [];
       results
@@ -1266,6 +1266,11 @@ class Library extends ModelElement {
     }
 
     return _allModelElements;
+  }
+
+  List<ModelElement> _allCanonicalModelElements;
+  Iterable<ModelElement> get allCanonicalModelElements {
+    return (_allCanonicalModelElements ??= allModelElements.where((e) => e.isCanonical).toList());
   }
 }
 
@@ -2235,7 +2240,7 @@ class Package implements Nameable, Documentable {
   }
 
   List<ModelElement> _allModelElements;
-  List<ModelElement> get allModelElements {
+  Iterable<ModelElement> get allModelElements {
     if (_allModelElements == null) {
       _allModelElements = [];
       this.libraries.forEach((library) {
@@ -2243,6 +2248,11 @@ class Package implements Nameable, Documentable {
       });
     }
     return _allModelElements;
+  }
+
+  List<ModelElement> _allCanonicalModelElements;
+  Iterable<ModelElement> get allCanonicalModelElements {
+    return (_allCanonicalModelElements ??= allModelElements.where((e) => e.isCanonical).toList());
   }
 
   ExportGraph _exportGraph;


### PR DESCRIPTION
If we don't do that, dartdoc will think there's ambiguity if several
libs export the same elements (like in Flutter, e.g. `widgets` exports
`Flexible` and `material` exports `Flexible`). And we won't get links
for these references and will get warnings about ambiguity in
stderr.

Testing: Generated Flutter docs, made sure `fit` from `Flexible` class
resolves correctly and doesn't produce a warning

Fixes #1328