### PR TITLE
Regenerate docs and remove missing file from example to let grind tes…

### DIFF
--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -222,8 +222,6 @@ class ConstantCat implements Cat {
 /// {@example dog/food}
 /// {@example dog/food.txt region=meat}
 ///
-/// {@example test.html}
-///
 /// {@example test.dart region=template lang=html}
 ///
 /// {@example test.dart region=}

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -144,8 +144,6 @@
 A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 <pre class="language-html prettyprint"><code class="language-html">&lt;h1&gt;Hello &lt;b&gt;World&lt;/b&gt;!&lt;/h1&gt;
 </code></pre>
-<pre class="language-html prettyprint"><code class="language-html">&lt;h1&gt;Hello &lt;b&gt;World&lt;/b&gt;!&lt;/h1&gt;
-</code></pre>
 <pre class="language-dart prettyprint"><code class="language-dart">var test = 1;
 </code></pre>
 <pre class="prettyprint language-dart"><code>var test = 1;

--- a/testing/test_package_docs/fake/ExtraSpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/fillRange.html
@@ -155,7 +155,10 @@
     <section class="desc markdown">
       <p>Sets the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
 to the given <code>fillValue</code>.</p>
-<p>An error occurs if <code>start</code>..<code>end</code> is not a valid range for <code>this</code>.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
     </section>
     
     

--- a/testing/test_package_docs/fake/ExtraSpecialList/getRange.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/getRange.html
@@ -155,11 +155,13 @@
     <section class="desc markdown">
       <p>Returns an <code>Iterable</code> that iterates over the objects in the range
 <code>start</code> inclusive to <code>end</code> exclusive.</p>
-<p>An error occurs if <code>end</code> is before <code>start</code>.</p>
-<p>An error occurs if the <code>start</code> and <code>end</code> are not valid ranges at the time
-of the call to this method. The returned <code>Iterable</code> behaves like
-<code>skip(start).take(end - start)</code>. That is, it does not throw exceptions
-if <code>this</code> changes size.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid at the time
+of the call.</p>
+<p>A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
+<p>The returned <code>Iterable</code> behaves like <code>skip(start).take(end - start)</code>.
+That is, it does <em>not</em> throw if this list changes size.</p>
 <pre class="prettyprint language-dart"><code>List&lt;String&gt; colors = ['red', 'green', 'blue', 'orange', 'pink'];
 Iterable&lt;String&gt; range = colors.getRange(1, 4);
 range.join(', ');  // 'green, blue, orange'

--- a/testing/test_package_docs/fake/ExtraSpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/removeRange.html
@@ -154,8 +154,10 @@
     </section>
     <section class="desc markdown">
       <p>Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive.</p>
-<p>The <code>start</code> and <code>end</code> indices must be in the range
-<code>0 ≤ index ≤ length</code>, and <code>start ≤ end</code>.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
 <p>Throws an <code>UnsupportedError</code> if this is a fixed-length list. In that case
 the list is not modified.</p>
     </section>

--- a/testing/test_package_docs/fake/ExtraSpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/replaceRange.html
@@ -159,7 +159,10 @@ and inserts the contents of <code>replacement</code> in its place.</p>
 list.replaceRange(1, 4, [6, 7]);
 list.join(', '); // '1, 6, 7, 5'
 </code></pre>
-<p>An error occurs if <code>start</code>..<code>end</code> is not a valid range for <code>this</code>.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
 <p>This method does not work on fixed-length lists, even when <code>replacement</code>
 has the same number of elements as the replaced range. In that case use
 <code>setRange</code> instead.</p>

--- a/testing/test_package_docs/fake/ExtraSpecialList/setRange.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/setRange.html
@@ -162,13 +162,15 @@ List&lt;int&gt; list2 = [5, 6, 7, 8, 9];
 list1.setRange(1, 3, list2, 3);
 list1.join(', '); // '1, 8, 9, 4'
 </code></pre>
-<p>The <code>start</code> and <code>end</code> indices must satisfy <code>0 ≤ start ≤ end ≤ length</code>.
-If <code>start</code> equals <code>end</code>, this method has no effect.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
 <p>The <code>iterable</code> must have enough objects to fill the range from <code>start</code>
 to <code>end</code> after skipping <code>skipCount</code> objects.</p>
-<p>If <code>iterable</code> is this list, the operation will copy the elements originally
-in the range from <code>skipCount</code> to <code>skipCount + (end - start)</code> to the
-range <code>start</code> to <code>end</code>, even if the two ranges overlap.</p>
+<p>If <code>iterable</code> is this list, the operation will copies the elements
+originally in the range from <code>skipCount</code> to <code>skipCount + (end - start)</code> to
+the range <code>start</code> to <code>end</code>, even if the two ranges overlap.</p>
 <p>If <code>iterable</code> depends on this list in some other way, no guarantees are
 made.</p>
     </section>

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -155,7 +155,10 @@
     <section class="desc markdown">
       <p>Sets the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
 to the given <code>fillValue</code>.</p>
-<p>An error occurs if <code>start</code>..<code>end</code> is not a valid range for <code>this</code>.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -155,11 +155,13 @@
     <section class="desc markdown">
       <p>Returns an <code>Iterable</code> that iterates over the objects in the range
 <code>start</code> inclusive to <code>end</code> exclusive.</p>
-<p>An error occurs if <code>end</code> is before <code>start</code>.</p>
-<p>An error occurs if the <code>start</code> and <code>end</code> are not valid ranges at the time
-of the call to this method. The returned <code>Iterable</code> behaves like
-<code>skip(start).take(end - start)</code>. That is, it does not throw exceptions
-if <code>this</code> changes size.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid at the time
+of the call.</p>
+<p>A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
+<p>The returned <code>Iterable</code> behaves like <code>skip(start).take(end - start)</code>.
+That is, it does <em>not</em> throw if this list changes size.</p>
 <pre class="prettyprint language-dart"><code>List&lt;String&gt; colors = ['red', 'green', 'blue', 'orange', 'pink'];
 Iterable&lt;String&gt; range = colors.getRange(1, 4);
 range.join(', ');  // 'green, blue, orange'

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -154,8 +154,10 @@
     </section>
     <section class="desc markdown">
       <p>Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive.</p>
-<p>The <code>start</code> and <code>end</code> indices must be in the range
-<code>0 ≤ index ≤ length</code>, and <code>start ≤ end</code>.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
 <p>Throws an <code>UnsupportedError</code> if this is a fixed-length list. In that case
 the list is not modified.</p>
     </section>

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -159,7 +159,10 @@ and inserts the contents of <code>replacement</code> in its place.</p>
 list.replaceRange(1, 4, [6, 7]);
 list.join(', '); // '1, 6, 7, 5'
 </code></pre>
-<p>An error occurs if <code>start</code>..<code>end</code> is not a valid range for <code>this</code>.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
 <p>This method does not work on fixed-length lists, even when <code>replacement</code>
 has the same number of elements as the replaced range. In that case use
 <code>setRange</code> instead.</p>

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -162,13 +162,15 @@ List&lt;int&gt; list2 = [5, 6, 7, 8, 9];
 list1.setRange(1, 3, list2, 3);
 list1.join(', '); // '1, 8, 9, 4'
 </code></pre>
-<p>The <code>start</code> and <code>end</code> indices must satisfy <code>0 ≤ start ≤ end ≤ length</code>.
-If <code>start</code> equals <code>end</code>, this method has no effect.</p>
+<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
+A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
+<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
+<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
 <p>The <code>iterable</code> must have enough objects to fill the range from <code>start</code>
 to <code>end</code> after skipping <code>skipCount</code> objects.</p>
-<p>If <code>iterable</code> is this list, the operation will copy the elements originally
-in the range from <code>skipCount</code> to <code>skipCount + (end - start)</code> to the
-range <code>start</code> to <code>end</code>, even if the two ranges overlap.</p>
+<p>If <code>iterable</code> is this list, the operation will copies the elements
+originally in the range from <code>skipCount</code> to <code>skipCount + (end - start)</code> to
+the range <code>start</code> to <code>end</code>, even if the two ranges overlap.</p>
 <p>If <code>iterable</code> depends on this list in some other way, no guarantees are
 made.</p>
     </section>


### PR DESCRIPTION
The critical change here is the deleted reference to test.html from example.dart (everything else is just a grind update-test-package-docs of the docs using SDK 1.22.0-dev.9.0).   Without this, grind fails locally for me with the following error:

  warning: dartdoc/testing/test_package/lib/example.dart: @example file not found, testing/test_package/test.dart.md

(Which is actually not the file it seems to care about, strangely).