### PR TITLE
Search box shouldn't always use the first suggestion

### DIFF
--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -189,21 +189,24 @@ function initSearch() {
 
     var typeaheadElement = $('#search-box.typeahead');
     var typeaheadElementParent = typeaheadElement.parent();
+    var selectedSuggestion;
 
     typeaheadElement.on("keydown", function (e) {
       if (e.keyCode === 13) { // Enter
-        var suggestion = typeaheadElementParent.find(".tt-suggestion.tt-selectable:eq(0)");
-        if (suggestion.length > 0) {
-          var href = suggestion.data("href");
-          if (href != null) {
-            window.location = href;
+        if (selectedSuggestion == null) {
+          var suggestion = typeaheadElementParent.find(".tt-suggestion.tt-selectable:eq(0)");
+          if (suggestion.length > 0) {
+            var href = suggestion.data("href");
+            if (href != null) {
+              window.location = href;
+            }
           }
         }
-        console.log(typeaheadElement.typeahead("val"));
       }
     });
 
     typeaheadElement.bind('typeahead:select', function(ev, suggestion) {
+        selectedSuggestion = suggestion;
         window.location = suggestion.href;
     });
   }

--- a/testing/test_package_docs/static-assets/script.js
+++ b/testing/test_package_docs/static-assets/script.js
@@ -189,21 +189,24 @@ function initSearch() {
 
     var typeaheadElement = $('#search-box.typeahead');
     var typeaheadElementParent = typeaheadElement.parent();
+    var selectedSuggestion;
 
     typeaheadElement.on("keydown", function (e) {
       if (e.keyCode === 13) { // Enter
-        var suggestion = typeaheadElementParent.find(".tt-suggestion.tt-selectable:eq(0)");
-        if (suggestion.length > 0) {
-          var href = suggestion.data("href");
-          if (href != null) {
-            window.location = href;
+        if (selectedSuggestion == null) {
+          var suggestion = typeaheadElementParent.find(".tt-suggestion.tt-selectable:eq(0)");
+          if (suggestion.length > 0) {
+            var href = suggestion.data("href");
+            if (href != null) {
+              window.location = href;
+            }
           }
         }
-        console.log(typeaheadElement.typeahead("val"));
       }
     });
 
     typeaheadElement.bind('typeahead:select', function(ev, suggestion) {
+        selectedSuggestion = suggestion;
         window.location = suggestion.href;
     });
   }


### PR DESCRIPTION
When you select an item from the search box dropdown, we were processing
the event twice: once in typeahead:select and once on keydown. The
second handler was overwriting the window.location generated by the
first and always sending the user to the first suggestion even if they
had selected a different suggestion.

Fixes #1330