### PR TITLE
pubspec didn't have 0.9.13 in it even though lib/dartdoc.dart did.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.9.12
+version: 0.9.13
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc


### PR DESCRIPTION
Not sure how I missed this.  Now 0.9.13 will be ready to publish.