### PR TITLE
Re-add 1.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.0
+
 * fix grind check-links and check-sdk-links (#1360)
 * fix multiple issues in annotation/feature list handling (#1268, #1162, #1081)
 * Added `pretty-index-json` command line flag.


### PR DESCRIPTION
Put 1.0.0 back in the changelog. #1358 