### PR TITLE
add a bot to test Flutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build/
-doc/api/
-doc/sdk/
+doc/
 testing/test_package/doc
 testing/test_package_small/doc
 packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: dart
 sudo: false
 dart:
   - dev
-# Disabled - re-enable once dev goes stable (see #1290).
-#  - stable
 env:
-  - GEN_SDK_DOCS=true
-  - GEN_SDK_DOCS=false
+  - DARTDOC_BOT=main
+  # TODO(devoncarew): add angulardart support
+  #- DARTDOC_BOT=angular
+  - DARTDOC_BOT=flutter
+  - DARTDOC_BOT=sdk-docs
 script: ./tool/travis.sh
 branches:
   only:

--- a/dartdoc.iml
+++ b/dartdoc.iml
@@ -9,6 +9,7 @@
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/tool" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/bin/packages" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/doc" />
       <excludeFolder url="file://$MODULE_DIR$/example/packages" />

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -4,41 +4,58 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-# Fast fail the script on failures.
-set -e
-
-pub global activate grinder
-
-pub global activate dart_style
+# Fast fail the script on failures, and echo commands as they execute.
+set -ex
 
 # add globally activated packages to the path
 export PATH="$PATH":"~/.pub-cache/bin"
 
-if [ "$GEN_SDK_DOCS" = "true" ]
-then
+if [ "$DARTDOC_BOT" = "sdk-docs" ]; then
   # Build the SDK docs
   # silence stdout but echo stderr
   echo ""
   echo "Building and validating SDK docs..."
-  grind validate-sdk-docs
+
+  pub run grinder validate-sdk-docs
+
   echo "SDK docs process finished"
-else
-  echo ""
-  echo "Skipping SDK docs, because GEN_SDK_DOCS is $GEN_SDK_DOCS"
-  echo ""
+elif [ "$DARTDOC_BOT" = "flutter" ]; then
+  echo "Running flutter dartdoc bot"
 
   # Verify that the libraries are error free.
-  grind analyze
+  pub run grinder analyze
+
+  # Set up dartdoc so the flutter doc script can locate it.
+  pub global activate -spath .
+
+  # Clone flutter.
+  rm -rf doc/flutter
+  git clone --depth 1 https://github.com/flutter/flutter.git doc/flutter
+
+  # Build the flutter docs.
+  cd doc/flutter
+  ./bin/flutter --version
+  ./bin/flutter precache
+  ( cd  dev/tools; pub get )
+  ./bin/cache/dart-sdk/bin/dart dev/tools/dartdoc.dart
+
+  # The above script validates the generation; we echo the main file here.
+  cat dev/docs/doc/index.html
+else
+  echo "Running main dartdoc bot"
+
+  # Verify that the libraries are error free.
+  pub run grinder analyze
 
   # Run dartdoc on test_package.
   (cd testing/test_package; dart -c ../../bin/dartdoc.dart)
 
-  # checks the test_package results
-  grind check-links
+  # Checks the test_package results.
+  pub run grinder check-links
 
   # And on test_package_small.
   (cd testing/test_package_small; dart -c ../../bin/dartdoc.dart)
 
   # Run the tests.
-  grind test
+  pub run grinder test
 fi


### PR DESCRIPTION
Some work towards https://github.com/dart-lang/dartdoc/issues/1317:

- add a bot to test Flutter (we now have the main bot, the dart sdk generation bot, and a flutter bot)
- also, echo bash commands as we execute them, and some minor tweaks and cleanup to the bash script

@jcollins-g 
