### PR TITLE
Fix stack overflows on complex packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * added a new `--footer-text` command-line option, to allow adding additional
   text in the package name and copyright section of the footer
+* Reduced stack depth by not recomputing findCanonicalLibraryFor (#1381)
 
 ## 0.10.0
 

--- a/dartdoc.iml
+++ b/dartdoc.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/bin" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
@@ -33,7 +33,7 @@
       <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart SDK" level="application" />
   </component>
 </module>

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -46,7 +46,8 @@ class HtmlGenerator extends Generator {
   static Future<HtmlGenerator> create(
       {HtmlGeneratorOptions options,
       List<String> headers,
-      List<String> footers, List<String> footerTexts}) async {
+      List<String> footers,
+      List<String> footerTexts}) async {
     var templates = await Templates.create(
         headerPaths: headers,
         footerPaths: footers,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2797,6 +2797,7 @@ class Package implements Nameable, Documentable {
   String toString() => isSdk ? 'SDK' : 'Package $name';
 
   final Map<Element, Library> _canonicalLibraryFor = new Map();
+
   /// Tries to find a top level library that references this element.
   Library findCanonicalLibraryFor(Element e) {
     assert(allLibrariesAdded);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2796,16 +2796,24 @@ class Package implements Nameable, Documentable {
   @override
   String toString() => isSdk ? 'SDK' : 'Package $name';
 
+  final Map<Element, Library> _canonicalLibraryFor = new Map();
   /// Tries to find a top level library that references this element.
   Library findCanonicalLibraryFor(Element e) {
+    assert(allLibrariesAdded);
+
+    if (_canonicalLibraryFor.containsKey(e)) {
+      return _canonicalLibraryFor[e];
+    }
+    _canonicalLibraryFor[e] = null;
     for (Library library in libraries) {
       if (library.modelElementsMap.containsKey(e)) {
         if (library.modelElementsMap[e].isCanonical) {
-          return library;
+          _canonicalLibraryFor[e] = library;
+          break;
         }
       }
     }
-    return null;
+    return _canonicalLibraryFor[e];
   }
 
   /// Tries to find a canonical ModelElement for this element.


### PR DESCRIPTION
Recursion depth was just too large in some instances where it doesn't need to be; we can cache findCanonicalLibraryFor.  #1381 