### PR TITLE
small twaek to the css

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -392,6 +392,7 @@ footer .container-fluid {
   background-position: center;
   content: "\00a0";
   margin: 0 6px 0 4px;
+  padding: 0 3px 0 0;
 }
 
 .gt-separated.dark li:before {

--- a/testing/test_package_docs/ex/Animal/hashCode.html
+++ b/testing/test_package_docs/ex/Animal/hashCode.html
@@ -110,12 +110,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Animal/operator_equals.html
+++ b/testing/test_package_docs/ex/Animal/operator_equals.html
@@ -116,7 +116,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -121,12 +121,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Apple/operator_equals.html
+++ b/testing/test_package_docs/ex/Apple/operator_equals.html
@@ -127,7 +127,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -108,12 +108,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Cat/operator_equals.html
+++ b/testing/test_package_docs/ex/Cat/operator_equals.html
@@ -114,7 +114,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/CatString/hashCode.html
+++ b/testing/test_package_docs/ex/CatString/hashCode.html
@@ -114,12 +114,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/CatString/operator_equals.html
+++ b/testing/test_package_docs/ex/CatString/operator_equals.html
@@ -120,7 +120,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -109,12 +109,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/ConstantCat/operator_equals.html
+++ b/testing/test_package_docs/ex/ConstantCat/operator_equals.html
@@ -115,7 +115,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -131,12 +131,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -142,7 +142,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/E/hashCode.html
+++ b/testing/test_package_docs/ex/E/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/E/operator_equals.html
+++ b/testing/test_package_docs/ex/E/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/HasAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/HasAnnotation/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/Helper/hashCode.html
+++ b/testing/test_package_docs/ex/Helper/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Helper/operator_equals.html
+++ b/testing/test_package_docs/ex/Helper/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -111,12 +111,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/Klass/operator_equals.html
+++ b/testing/test_package_docs/ex/Klass/operator_equals.html
@@ -117,7 +117,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/MyError/hashCode.html
+++ b/testing/test_package_docs/ex/MyError/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/MyError/operator_equals.html
+++ b/testing/test_package_docs/ex/MyError/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/MyException/hashCode.html
+++ b/testing/test_package_docs/ex/MyException/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/MyException/operator_equals.html
+++ b/testing/test_package_docs/ex/MyException/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/ShapeType/hashCode.html
+++ b/testing/test_package_docs/ex/ShapeType/hashCode.html
@@ -108,12 +108,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/ShapeType/operator_equals.html
+++ b/testing/test_package_docs/ex/ShapeType/operator_equals.html
@@ -114,7 +114,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
@@ -124,12 +124,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/ex/aThingToDo/hashCode.html
+++ b/testing/test_package_docs/ex/aThingToDo/hashCode.html
@@ -108,12 +108,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/ex/aThingToDo/operator_equals.html
+++ b/testing/test_package_docs/ex/aThingToDo/operator_equals.html
@@ -114,7 +114,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Annotation/operator_equals.html
+++ b/testing/test_package_docs/fake/Annotation/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/AnotherInterface/hashCode.html
+++ b/testing/test_package_docs/fake/AnotherInterface/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
+++ b/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
@@ -108,12 +108,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
@@ -114,7 +114,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Color/hashCode.html
+++ b/testing/test_package_docs/fake/Color/hashCode.html
@@ -114,12 +114,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Color/operator_equals.html
+++ b/testing/test_package_docs/fake/Color/operator_equals.html
@@ -120,7 +120,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -109,12 +109,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/ConstantClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstantClass/operator_equals.html
@@ -115,7 +115,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Cool/operator_equals.html
+++ b/testing/test_package_docs/fake/Cool/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Doh/hashCode.html
+++ b/testing/test_package_docs/fake/Doh/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Doh/operator_equals.html
+++ b/testing/test_package_docs/fake/Doh/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -110,12 +110,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Foo2/operator_equals.html
+++ b/testing/test_package_docs/fake/Foo2/operator_equals.html
@@ -116,7 +116,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -110,12 +110,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -116,7 +116,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Interface/hashCode.html
+++ b/testing/test_package_docs/fake/Interface/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Interface/operator_equals.html
+++ b/testing/test_package_docs/fake/Interface/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/MixMeIn/hashCode.html
+++ b/testing/test_package_docs/fake/MixMeIn/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/MixMeIn/operator_equals.html
+++ b/testing/test_package_docs/fake/MixMeIn/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/Oops/operator_equals.html
+++ b/testing/test_package_docs/fake/Oops/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
@@ -117,7 +117,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -159,7 +159,7 @@ equal to <code>element</code>.</p>
 the iterable defaults to the <code>Object.==</code> of the element.</p>
 <p>Some types of iterable may have a different equality used for its elements.
 For example, a <code>Set</code> may have a custom equality
-(see <code>Set.identical</code>) that its <code>contains</code> uses.
+(see <code>Set.identity</code>) that its <code>contains</code> uses.
 Likewise the <code>Iterable</code> returned by a <code>Map.keys</code> call
 should use the same equality that the <code>Map</code> uses for keys.</p>
     </section>

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -158,12 +158,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -164,7 +164,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -109,12 +109,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
@@ -115,7 +115,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -107,12 +107,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
@@ -113,7 +113,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -392,6 +392,7 @@ footer .container-fluid {
   background-position: center;
   content: "\00a0";
   margin: 0 6px 0 4px;
+  padding: 0 3px 0 0;
 }
 
 .gt-separated.dark li:before {

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
@@ -106,12 +106,12 @@
   <p>The hash code for this object.</p>
 <p>A hash code is a single integer which represents the state of the object
 that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes. 
-The default hash code represents only the identity of the object, 
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
 the same way as the default <code>==</code> implementation only considers objects
 equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead, 
-the hash code must also be changed to represent that state. </p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
 <p>Hash codes must be the same for objects that are equal to each other
 according to <code>==</code>.
 The hash code of an object should only change if the object changes

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
@@ -112,7 +112,7 @@ or return <code>null</code>.</p></li><li>
 either both be true, or both be false.</p></li><li>
 <p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
 <code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time, 
+<p>The method should also be consistent over time,
 so whether two objects are equal should only change
 if at least one of the objects was modified.</p>
 <p>If a subclass overrides the equality operator it should override


### PR DESCRIPTION
A small tweak to the css to fix the right-hand side of some chars being cut off:

<img width="168" alt="screen shot 2017-05-04 at 9 14 47 am" src="https://cloud.githubusercontent.com/assets/1269969/25713873/07e89966-30ab-11e7-82dd-ece32484886f.png">

@jcollins-g 