### PR TITLE
use analyzer to help resolve commentRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.11.0
 
+* Fix resolution of ambiguous classes where the analyzer can help us. #1397
 * Many cleanups to dartdoc stdout/stderr, error messages, and warnings:
   * Display fatal errors with 'fatal error' string to distinguish them from ordinary errors
   * Upgrades to new Package.warn system.

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -292,10 +292,8 @@ MatchingLinkResult _getMatchingLinkElement(
   return new MatchingLinkResult(refModelElement, null);
 }
 
+/// Given a set of commentRefs, return the one whose name matches the codeRef.
 Element _getRefElementFromCommentRefs(List<CommentReference> commentRefs, String codeRef) {
-  // This is faster but does not take canonicalization into account; try
-  // only as a last resort. TODO(jcollins-g): make analyzer comment references
-  // dartdoc-canonicalization-aware?
   for (CommentReference ref in commentRefs) {
     if (ref.identifier.name == codeRef) {
       bool isConstrElement =

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3027,11 +3027,6 @@ class Package implements Nameable, Documentable, Locatable {
         warningMessage = 'generic type handled as HTML: """${message}"""';
         break;
     }
-    // warningMessage should not contain "file:" or "dart:" -- confuses IntelliJ.
-    ['file:', 'dart:'].forEach((s) {
-      // message can contain user text; nothing we can do about that.
-      assert(!warningMessage.contains(s) || message.contains(s));
-    });
     String fullMessage =
         "${warningMessage} ${modelElement != null ? modelElement.elementLocation : ''}";
     packageWarningCounter.addWarning(


### PR DESCRIPTION
I tried to write a test for this case but ran into difficulties with the setup of analyzer where it works in the real world but not in the test environment.  I've already got a reworking of how test setup happens on deck but that's too large to finish up for our deadline.  So we'll just have to base this that the referenced warning no longer appears in the flutter bot output:

```
warning: ambiguous doc reference in flutter_markdown.MarkdownStyleSheet: [TextStyle] => 'dart:ui.TextStyle', 'painting.TextStyle' (file:///usr/local/google/home/jcollins/dart/flutter/packages/flutter_markdown/lib/src/style_sheet.dart:8:7)
```