### PR TITLE
Fix issue #1401.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+* Fix regression where a property or top level variable can be listed twice
+  under some conditions.  #1401
+
 ## 0.11.0
 
 * Fix resolution of ambiguous classes where the analyzer can help us. #1397

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -44,7 +44,7 @@ export 'src/sdk.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String version = '0.11.0';
+const String version = '0.11.1';
 
 final String defaultOutDir = path.join('doc', 'api');
 

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -293,11 +293,11 @@ MatchingLinkResult _getMatchingLinkElement(
 }
 
 /// Given a set of commentRefs, return the one whose name matches the codeRef.
-Element _getRefElementFromCommentRefs(List<CommentReference> commentRefs, String codeRef) {
+Element _getRefElementFromCommentRefs(
+    List<CommentReference> commentRefs, String codeRef) {
   for (CommentReference ref in commentRefs) {
     if (ref.identifier.name == codeRef) {
-      bool isConstrElement =
-          ref.identifier.staticElement is ConstructorElement;
+      bool isConstrElement = ref.identifier.staticElement is ConstructorElement;
       // Constructors are now handled by library search.
       if (!isConstrElement) {
         return ref.identifier.staticElement;
@@ -338,7 +338,8 @@ Map<String, Set<ModelElement>> _findRefElementCache;
 // TODO(jcollins-g): Subcomponents of this function shouldn't be adding nulls to results, strip the
 //                   removes out that are gratuitous and debug the individual pieces.
 // TODO(jcollins-g): A complex package winds up spending a lot of cycles in here.  Optimize.
-Element _findRefElementInLibrary(String codeRef, ModelElement element, List<CommentReference> commentRefs) {
+Element _findRefElementInLibrary(
+    String codeRef, ModelElement element, List<CommentReference> commentRefs) {
   assert(element.package.allLibrariesAdded);
 
   String codeRefChomped = codeRef.replaceFirst(isConstructor, '');

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1042,7 +1042,8 @@ class Field extends ModelElement
 
   @override
   String get documentation {
-    // Verify that we will show exactly one of the summaries.
+    // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
+    // to prevent displaying more or less than one summary.
     Set<bool> assertCheck = new Set()..addAll([hasSetter, hasGetterNoSetter]);
     assert(assertCheck.containsAll([true, false]));
     return super.documentation;
@@ -3655,7 +3656,8 @@ class TopLevelVariable extends ModelElement
 
   @override
   String get documentation {
-    // Verify that we will show exactly one of the summaries.
+    // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
+    // to prevent displaying more or less than one summary.
     Set<bool> assertCheck = new Set()..addAll([hasSetter, hasGetterNoSetter]);
     assert(assertCheck.containsAll([true, false]));
     return super.documentation;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1040,6 +1040,14 @@ class Field extends ModelElement
     assert(enclosingElement != definingEnclosingElement);
   }
 
+  @override
+  String get documentation {
+    // Verify that we will show exactly one of the summaries.
+    Set<bool> assertCheck = new Set()..addAll([hasSetter, hasGetterNoSetter]);
+    assert(assertCheck.containsAll([true, false]));
+    return super.documentation;
+  }
+
   String get constantValue {
     if (_constantValue != null) return _constantValue;
 
@@ -1190,6 +1198,12 @@ abstract class GetterSetterCombo implements ModelElement {
   }
 
   @override
+  bool get canHaveParameters => hasSetter;
+
+  @override
+  List<Parameter> get parameters => setter.parameters;
+
+  @override
   String get genericParameters {
     if (hasSetter) return setter.genericParameters;
     return null;
@@ -1204,15 +1218,15 @@ abstract class GetterSetterCombo implements ModelElement {
   bool get hasExplicitGetter => hasGetter && !_getter.isSynthetic;
 
   bool get hasExplicitSetter => hasSetter && !_setter.isSynthetic;
+  bool get hasImplicitSetter => hasSetter && _setter.isSynthetic;
+
   bool get hasGetter;
 
   bool get hasNoGetterSetter => !hasExplicitGetter && !hasExplicitSetter;
 
   bool get hasSetter;
 
-  bool get hasGetterOrSetterWithoutParams {
-    return (hasGetter || (hasSetter && !hasExplicitSetter));
-  }
+  bool get hasGetterNoSetter => (hasGetter && !hasSetter);
 
   String get arrow {
     // →
@@ -2114,6 +2128,10 @@ abstract class ModelElement
   String get linkedParamsLines => linkedParams().trim();
 
   String get linkedParamsNoMetadata => linkedParams(showMetadata: false);
+
+  String get linkedParamsNoMetadataOrNames {
+    return linkedParams(showMetadata: false, showNames: false);
+  }
 
   ElementType get modelType => _modelType;
 
@@ -3634,6 +3652,14 @@ class TopLevelVariable extends ModelElement
   }
 
   String get constantValueTruncated => truncateString(constantValue, 200);
+
+  @override
+  String get documentation {
+    // Verify that we will show exactly one of the summaries.
+    Set<bool> assertCheck = new Set()..addAll([hasSetter, hasGetterNoSetter]);
+    assert(assertCheck.containsAll([true, false]));
+    return super.documentation;
+  }
 
   @override
   ModelElement get enclosingElement => library;

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,16 +1,16 @@
-{{ #hasExplicitSetter }}
+{{ #hasSetter }}
 <dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
   <span class="name{{#isDeprecated}} deprecated{{/isDeprecated}}">{{{linkedName}}}</span><span class="signature">{{{genericParameters}}}
-    <span class="returntype parameter">{{{ arrow }}} {{{ linkedParamsNoMetadata }}}</span>
+    <span class="returntype parameter">{{{ arrow }}} {{ #hasExplicitSetter }} {{{ linkedParamsNoMetadata }}} {{/hasExplicitSetter}} {{#hasImplicitSetter}} {{{linkedParamsNoMetadataOrNames}}} {{/hasImplicitSetter}}</span>
   </span>
 </dt>
-{{ /hasExplicitSetter }}
-{{ #hasGetterOrSetterWithoutParams }}
+{{ /hasSetter }}
+{{ #hasGetterNoSetter }}
 <dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
   <span class="name">{{{linkedName}}}</span>
   <span class="signature">{{{ arrow }}} {{{ linkedReturnType }}}</span>
 </dt>
-{{ /hasGetterOrSetterWithoutParams }}
+{{ /hasGetterNoSetter }}
 <dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
   {{{ oneLineDoc }}}
   {{>features}}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.11.0
+version: 0.11.1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -174,6 +174,51 @@ class SuperAwesomeClass {
   }
 }
 
+typedef void myCoolTypedef(Cool x, bool y);
+
+/// Names are actually wrong in this class, but when we extend it,
+/// they are correct.
+class ImplicitProperties {
+  String implicitGetterExplicitSetter;
+  List<int> explicitGetterImplicitSetter;
+}
+
+/// Classes with unusual properties?  I don't think they exist.
+class ClassWithUnusualProperties extends ImplicitProperties {
+
+  @override
+  set implicitGetterExplicitSetter(String x) {}
+
+  @override
+  List<int> get explicitGetterImplicitSetter => new List<int>();
+
+  myCoolTypedef _aFunction;
+
+  myCoolTypedef get explicitGetterSetter {
+    return _aFunction;
+  }
+
+  /// This property is not synthetic, so it might reference [f] -- display it.
+  set explicitGetterSetter(myCoolTypedef f) => _aFunction = f;
+
+  /// This property only has a getter and no setter; no parameters to print.
+  myCoolTypedef get explicitGetter {
+    return _aFunction;
+  }
+
+  /// Set to [f], and don't warn about [bar] or [baz].
+  set explicitSetter(f(int bar, Cool baz, List<int> macTruck)) {}
+
+  final Set finalProperty = new Set();
+
+  Map implicitReadWrite;
+
+  /// Hey there, more things not to warn about: [f], [x], or [q].
+  String aMethod(Function f(Cool x, bool q)) {
+    return 'hi';
+  }
+}
+
 /// This is a very long line spread
 /// across... wait for it... two physical lines.
 ///

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -185,7 +185,6 @@ class ImplicitProperties {
 
 /// Classes with unusual properties?  I don't think they exist.
 class ClassWithUnusualProperties extends ImplicitProperties {
-
   @override
   set implicitGetterExplicitSetter(String x) {}
 

--- a/testing/test_package_docs/css/css-library.html
+++ b/testing/test_package_docs/css/css-library.html
@@ -96,8 +96,9 @@ with directories created by dartdoc.</p>
 
       <dl class="properties">
         <dt id="theOnlyThingInTheLibrary" class="property">
-          <span class="name"><a href="css/theOnlyThingInTheLibrary.html">theOnlyThingInTheLibrary</a></span>
-          <span class="signature">&#8596; String</span>
+          <span class="name"><a href="css/theOnlyThingInTheLibrary.html">theOnlyThingInTheLibrary</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="theOnlyThingInTheLibrary=-param-_theOnlyThingInTheLibrary"><span class="type-annotation">String</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -190,8 +190,9 @@
           <div class="features">final</div>
 </dd>
         <dt id="m" class="property">
-          <span class="name"><a href="ex/Apple/m.html">m</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name"><a href="ex/Apple/m.html">m</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="m=-param-_m"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>The read-write field <code>m</code>.</p>
@@ -199,12 +200,8 @@
 </dd>
         <dt id="s" class="property">
           <span class="name"><a href="ex/Apple/s.html">s</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>  </span>
           </span>
-        </dt>
-        <dt id="s" class="property">
-          <span class="name"><a href="ex/Apple/s.html">s</a></span>
-          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           <p>The getter for <code>s</code></p>
@@ -336,8 +333,9 @@
 
       <dl class="properties">
         <dt id="string" class="property">
-          <span class="name"><a href="ex/Apple/string.html">string</a></span>
-          <span class="signature">&#8596; String</span>
+          <span class="name"><a href="ex/Apple/string.html">string</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="string=-param-_string"><span class="type-annotation">String</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -179,8 +179,9 @@
 
       <dl class="properties">
         <dt id="autoCompress" class="property">
-          <span class="name"><a href="ex/B/autoCompress.html">autoCompress</a></span>
-          <span class="signature">&#8596; bool</span>
+          <span class="name"><a href="ex/B/autoCompress.html">autoCompress</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="autoCompress=-param-_autoCompress"><span class="type-annotation">bool</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>The default value is <code>false</code> (compression disabled).
@@ -196,8 +197,9 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
           <div class="features">@override, read-only</div>
 </dd>
         <dt id="list" class="property">
-          <span class="name"><a href="ex/B/list.html">list</a></span>
-          <span class="signature">&#8596; List&lt;String&gt;</span>
+          <span class="name"><a href="ex/B/list.html">list</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="list=-param-_list"><span class="type-annotation">List&lt;String&gt;</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>A list of Strings</p>
@@ -228,8 +230,9 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="m" class="property inherited">
-          <span class="name"><a href="ex/Apple/m.html">m</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name"><a href="ex/Apple/m.html">m</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="m=-param-_m"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd class="inherited">
           <p>The read-write field <code>m</code>.</p>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -219,8 +219,9 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <div class="features">@protected, final</div>
 </dd>
         <dt id="deprecatedField" class="property">
-          <span class="name"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="deprecatedField=-param-_deprecatedField"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>
@@ -236,7 +237,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 </dd>
         <dt id="deprecatedSetter" class="property">
           <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592; <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span></span>
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
           </span>
         </dt>
         <dd>
@@ -252,8 +253,9 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <div class="features">@override, read-only</div>
 </dd>
         <dt id="name" class="property">
-          <span class="name"><a href="ex/Dog/name.html">name</a></span>
-          <span class="signature">&#8596; String</span>
+          <span class="name"><a href="ex/Dog/name.html">name</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="name=-param-_name"><span class="type-annotation">String</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>
@@ -412,12 +414,8 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 </dd>
         <dt id="staticGetterSetter" class="property">
           <span class="name"><a href="ex/Dog/staticGetterSetter.html">staticGetterSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="staticGetterSetter=-param-x"><span class="parameter-name">x</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="staticGetterSetter=-param-x"><span class="parameter-name">x</span></span>  </span>
           </span>
-        </dt>
-        <dt id="staticGetterSetter" class="property">
-          <span class="name"><a href="ex/Dog/staticGetterSetter.html">staticGetterSetter</a></span>
-          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           <p></p>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -194,8 +194,9 @@
           <div class="features">@protected, final, inherited</div>
 </dd>
         <dt id="deprecatedField" class="property inherited">
-          <span class="name"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="deprecatedField=-param-_deprecatedField"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd class="inherited">
           <p></p>
@@ -211,7 +212,7 @@
 </dd>
         <dt id="deprecatedSetter" class="property inherited">
           <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592; <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span></span>
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
           </span>
         </dt>
         <dd class="inherited">
@@ -235,8 +236,9 @@
           <div class="features">@override, read-only, inherited</div>
 </dd>
         <dt id="name" class="property inherited">
-          <span class="name"><a href="ex/Dog/name.html">name</a></span>
-          <span class="signature">&#8596; String</span>
+          <span class="name"><a href="ex/Dog/name.html">name</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="name=-param-_name"><span class="type-annotation">String</span> </span> </span>
+          </span>
         </dt>
         <dd class="inherited">
           <p></p>

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -168,8 +168,9 @@
 
       <dl class="properties">
         <dt id="prop" class="property">
-          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span>
-          <span class="signature">&#8596; T</span>
+          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="prop=-param-_prop"><span class="type-annotation">T</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -178,8 +178,9 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="prop" class="property inherited">
-          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span>
-          <span class="signature">&#8596; T</span>
+          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="prop=-param-_prop"><span class="type-annotation">T</span> </span> </span>
+          </span>
         </dt>
         <dd class="inherited">
           <p></p>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -341,8 +341,9 @@ that has some operators</p>
 
       <dl class="properties">
         <dt id="deprecatedField" class="property">
-          <span class="name"><a class="deprecated" href="ex/deprecatedField.html">deprecatedField</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name deprecated"><a class="deprecated" href="ex/deprecatedField.html">deprecatedField</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="deprecatedField=-param-_deprecatedField"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>
@@ -358,7 +359,7 @@ that has some operators</p>
 </dd>
         <dt id="deprecatedSetter" class="property">
           <span class="name deprecated"><a class="deprecated" href="ex/deprecatedSetter.html">deprecatedSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592; <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span></span>
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
           </span>
         </dt>
         <dd>
@@ -366,8 +367,9 @@ that has some operators</p>
           <div class="features">write-only</div>
 </dd>
         <dt id="number" class="property">
-          <span class="name"><a href="ex/number.html">number</a></span>
-          <span class="signature">&#8596; double</span>
+          <span class="name"><a href="ex/number.html">number</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="number=-param-_number"><span class="type-annotation">double</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ClassWithUnusualProperties class from the fake library, for the Dart programming language.">
+  <title>ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li class="self-crumb">ClassWithUnusualProperties</li>
+          </ol>
+          <div class="self-name">ClassWithUnusualProperties</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li class="self-crumb">ClassWithUnusualProperties</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">class</span> ClassWithUnusualProperties
+          </h1>
+        </div>
+        <ul class="subnav">
+          <li><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+        </ul>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="desc markdown">
+      <p>Classes with unusual properties?  I don't think they exist.</p>
+    </section>
+    
+    <section>
+      <dl class="dl-horizontal">
+        <dt>Inheritance</dt>
+        <dd><ul class="gt-separated dark clazz-relationships">
+          <li>Object</li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li>ClassWithUnusualProperties</li>
+        </ul></dd>
+
+
+
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ClassWithUnusualProperties" class="callable">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          <p></p>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="explicitGetter" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></span>
+          <span class="signature">&#8594; <a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+        </dt>
+        <dd>
+          <p>This property only has a getter and no setter; no parameters to print.</p>
+          <div class="features">read-only</div>
+</dd>
+        <dt id="explicitGetterImplicitSetter" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span>
+          <span class="signature">&#8594; List&lt;int&gt;</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">@override, read-only</div>
+</dd>
+        <dt id="explicitGetterSetter" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="explicitGetterSetter=-param-f"><span class="type-annotation"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span> <span class="parameter-name">f</span></span>  </span>
+          </span>
+        </dt>
+        <dd>
+          <p>This property is not synthetic, so it might reference <code>f</code> -- display it.</p>
+          <div class="features">read / write</div>
+</dd>
+        <dt id="explicitSetter" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></span><span class="signature">
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List&lt;int&gt;</span> <span class="parameter-name">macTruck</span></span>)</span>  </span>
+          </span>
+        </dt>
+        <dd>
+          <p>Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.</p>
+          <div class="features">write-only</div>
+</dd>
+        <dt id="finalProperty" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></span>
+          <span class="signature">&#8594; Set</span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">final</div>
+</dd>
+        <dt id="implicitGetterExplicitSetter" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></span><span class="signature">
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="implicitGetterExplicitSetter=-param-x"><span class="type-annotation">String</span> <span class="parameter-name">x</span></span>  </span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">@override, write-only</div>
+</dd>
+        <dt id="implicitReadWrite" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="implicitReadWrite=-param-_implicitReadWrite"><span class="type-annotation">Map</span> </span> </span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">read / write</div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>The hash code for this object.</p>
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          <p>A representation of the runtime type of the object.</p>
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="aMethod" class="callable">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></span><span class="signature">(<wbr><span class="parameter" id="aMethod-param-f"><span class="type-annotation">Function</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-x"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="f-param-q"><span class="type-annotation">bool</span> <span class="parameter-name">q</span></span>)</span>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd>
+          <p>Hey there, more things not to warn about: <code>f</code>, <code>x</code>, or <code>q</code>.</p>
+          
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Invoked when a non-existent method or property is accessed.</p>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/ImplicitProperties/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Returns a string representation of this object.</p>
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>The equality operator.</p>
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>ClassWithUnusualProperties</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ClassWithUnusualProperties constructor from the Class ClassWithUnusualProperties class from the fake library, for the Dart programming language.">
+  <title>ClassWithUnusualProperties constructor - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">ClassWithUnusualProperties</li>
+          </ol>
+          <div class="self-name">ClassWithUnusualProperties</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">ClassWithUnusualProperties</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">constructor</span> ClassWithUnusualProperties
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      
+            <span class="name ">ClassWithUnusualProperties</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aMethod method from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>aMethod method - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">aMethod</li>
+          </ol>
+          <div class="self-name">aMethod</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">aMethod</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">method</span> aMethod
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">aMethod</span>(<wbr><span class="parameter" id="aMethod-param-f"><span class="type-annotation">Function</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-x"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="f-param-q"><span class="type-annotation">bool</span> <span class="parameter-name">q</span></span>)</span>)
+    </section>
+    <section class="desc markdown">
+      <p>Hey there, more things not to warn about: <code>f</code>, <code>x</code>, or <code>q</code>.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the explicitGetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>explicitGetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">explicitGetter</li>
+          </ol>
+          <div class="self-name">explicitGetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">explicitGetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> explicitGetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+      <section id="getter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+        <span class="name ">explicitGetter</span></section>
+      
+      <section class="desc markdown">
+  <p>This property only has a getter and no setter; no parameters to print.</p>
+</section>
+</section>
+      
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the explicitGetterImplicitSetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>explicitGetterImplicitSetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">explicitGetterImplicitSetter</li>
+          </ol>
+          <div class="self-name">explicitGetterImplicitSetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">explicitGetterImplicitSetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> explicitGetterImplicitSetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+      <section id="getter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">List&lt;int&gt;</span>
+        <span class="name ">explicitGetterImplicitSetter</span></section>
+      
+      </section>
+      
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the explicitGetterSetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>explicitGetterSetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">explicitGetterSetter</li>
+          </ol>
+          <div class="self-name">explicitGetterSetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">explicitGetterSetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> explicitGetterSetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+      <section id="getter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+        <span class="name ">explicitGetterSetter</span></section>
+      
+      </section>
+      
+
+      <section id="setter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">void</span>
+          <span class="name ">explicitGetterSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterSetter=-param-f"><span class="type-annotation"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span> <span class="parameter-name">f</span></span>)</span>
+      </section>
+      
+      <section class="desc markdown">
+  <p>This property is not synthetic, so it might reference <code>f</code> -- display it.</p>
+</section>
+</section>
+      
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the explicitSetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>explicitSetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">explicitSetter</li>
+          </ol>
+          <div class="self-name">explicitSetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">explicitSetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> explicitSetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+
+      <section id="setter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">void</span>
+          <span class="name ">explicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List&lt;int&gt;</span> <span class="parameter-name">macTruck</span></span>)</span>)</span>
+      </section>
+      
+      <section class="desc markdown">
+  <p>Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.</p>
+</section>
+</section>
+      
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the finalProperty property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>finalProperty property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">finalProperty</li>
+          </ol>
+          <div class="self-name">finalProperty</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">finalProperty</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> finalProperty
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="multi-line-signature">
+      <span class="returntype">Set</span>
+        <span class="name ">finalProperty</span>        <div class="features">final</div>
+    </section>
+
+    
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the implicitGetterExplicitSetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>implicitGetterExplicitSetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">implicitGetterExplicitSetter</li>
+          </ol>
+          <div class="self-name">implicitGetterExplicitSetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">implicitGetterExplicitSetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> implicitGetterExplicitSetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+
+      <section id="setter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">void</span>
+          <span class="name ">implicitGetterExplicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="implicitGetterExplicitSetter=-param-x"><span class="type-annotation">String</span> <span class="parameter-name">x</span></span>)</span>
+      </section>
+      
+      </section>
+      
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the implicitReadWrite property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>implicitReadWrite property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+            <li class="self-crumb">implicitReadWrite</li>
+          </ol>
+          <div class="self-name">implicitReadWrite</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+          <li class="self-crumb">implicitReadWrite</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> implicitReadWrite
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html">ClassWithUnusualProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ClassWithUnusualProperties-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ClassWithUnusualProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="multi-line-signature">
+      <span class="returntype">Map</span>
+        <span class="name ">implicitReadWrite</span>        <div class="features">read / write</div>
+    </section>
+
+    
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
@@ -236,12 +239,8 @@
 </dd>
         <dt id="length" class="property inherited">
           <span class="name"><a href="fake/SpecialList/length.html">length</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span>  </span>
           </span>
-        </dt>
-        <dt id="length" class="property inherited">
-          <span class="name"><a href="fake/SpecialList/length.html">length</a></span>
-          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           <p></p>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -79,12 +79,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -140,6 +142,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ImplicitProperties class from the fake library, for the Dart programming language.">
+  <title>ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li class="self-crumb">ImplicitProperties</li>
+          </ol>
+          <div class="self-name">ImplicitProperties</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li class="self-crumb">ImplicitProperties</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">class</span> ImplicitProperties
+          </h1>
+        </div>
+        <ul class="subnav">
+          <li><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+          <li><a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a></li>
+          <li><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+          <li><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+        </ul>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="desc markdown">
+      <p>Names are actually wrong in this class, but when we extend it,
+they are correct.</p>
+    </section>
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ImplicitProperties" class="callable">
+          <span class="name"><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          <p></p>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="explicitGetterImplicitSetter" class="property">
+          <span class="name"><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="explicitGetterImplicitSetter=-param-_explicitGetterImplicitSetter"><span class="type-annotation">List&lt;int&gt;</span> </span> </span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">read / write</div>
+</dd>
+        <dt id="implicitGetterExplicitSetter" class="property">
+          <span class="name"><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="implicitGetterExplicitSetter=-param-_implicitGetterExplicitSetter"><span class="type-annotation">String</span> </span> </span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+          <div class="features">read / write</div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          <p>The hash code for this object.</p>
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          <p>A representation of the runtime type of the object.</p>
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Invoked when a non-existent method or property is accessed.</p>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/ImplicitProperties/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>Returns a string representation of this object.</p>
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          <p>The equality operator.</p>
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>ImplicitProperties</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ImplicitProperties constructor from the Class ImplicitProperties class from the fake library, for the Dart programming language.">
+  <title>ImplicitProperties constructor - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">ImplicitProperties</li>
+          </ol>
+          <div class="self-name">ImplicitProperties</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">ImplicitProperties</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">constructor</span> ImplicitProperties
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      
+            <span class="name ">ImplicitProperties</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the explicitGetterImplicitSetter property from the ImplicitProperties class, for the Dart programming language.">
+  <title>explicitGetterImplicitSetter property - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">explicitGetterImplicitSetter</li>
+          </ol>
+          <div class="self-name">explicitGetterImplicitSetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">explicitGetterImplicitSetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> explicitGetterImplicitSetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="multi-line-signature">
+      <span class="returntype">List&lt;int&gt;</span>
+        <span class="name ">explicitGetterImplicitSetter</span>        <div class="features">read / write</div>
+    </section>
+
+    
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the ImplicitProperties class, for the Dart programming language.">
+  <title>hashCode property - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">hashCode</li>
+          </ol>
+          <div class="self-name">hashCode</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">hashCode</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> hashCode
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+      <section id="getter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">int</span>
+        <span class="name ">hashCode</span></section>
+      
+      <section class="desc markdown">
+  <p>The hash code for this object.</p>
+<p>A hash code is a single integer which represents the state of the object
+that affects <code>==</code> comparisons.</p>
+<p>All objects have hash codes.
+The default hash code represents only the identity of the object,
+the same way as the default <code>==</code> implementation only considers objects
+equal if they are identical (see <code>identityHashCode</code>).</p>
+<p>If <code>==</code> is overridden to use the object state instead,
+the hash code must also be changed to represent that state.</p>
+<p>Hash codes must be the same for objects that are equal to each other
+according to <code>==</code>.
+The hash code of an object should only change if the object changes
+in a way that affects equality.
+There are no further requirements for the hash codes.
+They need not be consistent between executions of the same program
+and there are no distribution guarantees.</p>
+<p>Objects that are not equal are allowed to have the same hash code,
+it is even technically allowed that all instances have the same hash code,
+but if clashes happen too often, it may reduce the efficiency of hash-based
+data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
+<p>If a subclass overrides <code>hashCode</code>, it should override the
+<code>==</code> operator as well to maintain consistency.</p>
+</section>
+</section>
+      
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the implicitGetterExplicitSetter property from the ImplicitProperties class, for the Dart programming language.">
+  <title>implicitGetterExplicitSetter property - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">implicitGetterExplicitSetter</li>
+          </ol>
+          <div class="self-name">implicitGetterExplicitSetter</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">implicitGetterExplicitSetter</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> implicitGetterExplicitSetter
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+        <span class="name ">implicitGetterExplicitSetter</span>        <div class="features">read / write</div>
+    </section>
+
+    
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the ImplicitProperties class, for the Dart programming language.">
+  <title>noSuchMethod method - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">noSuchMethod</li>
+          </ol>
+          <div class="self-name">noSuchMethod</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">noSuchMethod</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">method</span> noSuchMethod
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    <section class="desc markdown">
+      <p>Invoked when a non-existent method or property is accessed.</p>
+<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
+<p>If a value is returned, it becomes the result of the original invocation.</p>
+<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the ImplicitProperties class, for the Dart programming language.">
+  <title>operator == method - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">operator ==</li>
+          </ol>
+          <div class="self-name">operator ==</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">operator ==</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">method</span> operator ==
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    <section class="desc markdown">
+      <p>The equality operator.</p>
+<p>The default behavior for all <code>Object</code>s is to return true if and
+only if <code>this</code> and <code>other</code> are the same object.</p>
+<p>Override this method to specify a different equality relation on
+a class. The overriding method must still be an equivalence relation.
+That is, it must be:</p><ul><li>
+<p>Total: It must return a boolean for all arguments. It should never throw
+or return <code>null</code>.</p></li><li>
+<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
+<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
+either both be true, or both be false.</p></li><li>
+<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
+<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
+<p>The method should also be consistent over time,
+so whether two objects are equal should only change
+if at least one of the objects was modified.</p>
+<p>If a subclass overrides the equality operator it should override
+the <code>hashCode</code> method as well to maintain consistency.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the ImplicitProperties class, for the Dart programming language.">
+  <title>runtimeType property - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">runtimeType</li>
+          </ol>
+          <div class="self-name">runtimeType</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">runtimeType</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">property</span> runtimeType
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+
+      <section id="getter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">Type</span>
+        <span class="name ">runtimeType</span></section>
+      
+      <section class="desc markdown">
+  <p>A representation of the runtime type of the object.</p>
+</section>
+</section>
+      
+
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ImplicitProperties/toString.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/toString.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the ImplicitProperties class, for the Dart programming language.">
+  <title>toString method - ImplicitProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+            <li class="self-crumb">toString</li>
+          </ol>
+          <div class="self-name">toString</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+          <li class="self-crumb">toString</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">method</span> toString
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <h5><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></h5>
+
+    <ol>
+      <li class="section-title"><a href="fake/ImplicitProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ImplicitProperties/ImplicitProperties.html">ImplicitProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/ImplicitProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
+      <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ImplicitProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Returns a string representation of this object.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -81,12 +81,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -142,6 +144,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
@@ -218,8 +221,9 @@ across... wait for it... two physical lines.</p>
 
       <dl class="properties">
         <dt id="aStringProperty" class="property">
-          <span class="name"><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></span>
-          <span class="signature">&#8596; String</span>
+          <span class="name"><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="aStringProperty=-param-_aStringProperty"><span class="type-annotation">String</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>An instance string property. Readable and writable.</p>
@@ -235,7 +239,7 @@ across... wait for it... two physical lines.</p>
 </dd>
         <dt id="onlySetter" class="property">
           <span class="name"><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592; <span class="parameter" id="onlySetter=-param-d"><span class="type-annotation">double</span> <span class="parameter-name">d</span></span></span>
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="onlySetter=-param-d"><span class="type-annotation">double</span> <span class="parameter-name">d</span></span>  </span>
           </span>
         </dt>
         <dd>
@@ -251,8 +255,9 @@ across... wait for it... two physical lines.</p>
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="powers" class="property inherited">
-          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
-          <span class="signature">&#8596; List&lt;String&gt;</span>
+          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="powers=-param-_powers"><span class="type-annotation">List&lt;String&gt;</span> </span> </span>
+          </span>
         </dt>
         <dd class="inherited">
           <p>In the super class.</p>
@@ -385,8 +390,9 @@ across... wait for it... two physical lines.</p>
 
       <dl class="properties">
         <dt id="meaningOfLife" class="property">
-          <span class="name"><a href="fake/LongFirstLine/meaningOfLife.html">meaningOfLife</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name"><a href="fake/LongFirstLine/meaningOfLife.html">meaningOfLife</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="meaningOfLife=-param-_meaningOfLife"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>A static int property.</p>
@@ -402,7 +408,7 @@ across... wait for it... two physical lines.</p>
 </dd>
         <dt id="staticOnlySetter" class="property">
           <span class="name"><a href="fake/LongFirstLine/staticOnlySetter.html">staticOnlySetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592; <span class="parameter" id="staticOnlySetter=-param-thing"><span class="type-annotation">bool</span> <span class="parameter-name">thing</span></span></span>
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="staticOnlySetter=-param-thing"><span class="type-annotation">bool</span> <span class="parameter-name">thing</span></span>  </span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
@@ -191,12 +194,8 @@
       <dl class="properties">
         <dt id="length" class="property">
           <span class="name"><a href="fake/SpecialList/length.html">length</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span>  </span>
           </span>
-        </dt>
-        <dt id="length" class="property">
-          <span class="name"><a href="fake/SpecialList/length.html">length</a></span>
-          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           <p></p>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
@@ -188,8 +191,9 @@
 
       <dl class="properties">
         <dt id="powers" class="property">
-          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
-          <span class="signature">&#8596; List&lt;String&gt;</span>
+          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="powers=-param-_powers"><span class="type-annotation">List&lt;String&gt;</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>In the super class.</p>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -78,12 +78,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -139,6 +141,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
@@ -185,12 +188,8 @@
       <dl class="properties">
         <dt id="lengthX" class="property">
           <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>  </span>
           </span>
-        </dt>
-        <dt id="lengthX" class="property">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
-          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           <p>Returns a length.</p>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -135,6 +135,12 @@ Don't ask questions.</p>
         <dd>
           <p></p>
         </dd>
+        <dt id="ClassWithUnusualProperties">
+          <span class="name "><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></span>
+        </dt>
+        <dd>
+          <p>Classes with unusual properties?  I don't think they exist.</p>
+        </dd>
         <dt id="ConstantClass">
           <span class="name "><a href="fake/ConstantClass-class.html">ConstantClass</a></span>
         </dt>
@@ -170,6 +176,13 @@ Don't ask questions.</p>
         </dt>
         <dd>
           <p>I have a generic and it extends <a href="fake/Foo2-class.html">Foo2</a></p>
+        </dd>
+        <dt id="ImplicitProperties">
+          <span class="name "><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></span>
+        </dt>
+        <dd>
+          <p>Names are actually wrong in this class, but when we extend it,
+they are correct.</p>
         </dd>
         <dt id="Interface">
           <span class="name "><a href="fake/Interface-class.html">Interface</a></span>
@@ -391,7 +404,7 @@ which is a bit redundant.</p>
 </dd>
         <dt id="justSetter" class="property">
           <span class="name"><a href="fake/justSetter.html">justSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592; <span class="parameter" id="justSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span></span>
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="justSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
           </span>
         </dt>
         <dd>
@@ -399,8 +412,9 @@ which is a bit redundant.</p>
           <div class="features">write-only</div>
 </dd>
         <dt id="mapWithDynamicKeys" class="property">
-          <span class="name"><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></span>
-          <span class="signature">&#8596; Map&lt;dynamic, String&gt;</span>
+          <span class="name"><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="mapWithDynamicKeys=-param-_mapWithDynamicKeys"><span class="type-annotation">Map&lt;dynamic, String&gt;</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>
@@ -416,20 +430,17 @@ which is a bit redundant.</p>
 </dd>
         <dt id="setAndGet" class="property">
           <span class="name"><a href="fake/setAndGet.html">setAndGet</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="setAndGet=-param-thing"><span class="type-annotation">String</span> <span class="parameter-name">thing</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="setAndGet=-param-thing"><span class="type-annotation">String</span> <span class="parameter-name">thing</span></span>  </span>
           </span>
-        </dt>
-        <dt id="setAndGet" class="property">
-          <span class="name"><a href="fake/setAndGet.html">setAndGet</a></span>
-          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           <p>The getter for setAndGet.</p>
           <div class="features">read / write</div>
 </dd>
         <dt id="simpleProperty" class="property">
-          <span class="name"><a href="fake/simpleProperty.html">simpleProperty</a></span>
-          <span class="signature">&#8596; String</span>
+          <span class="name"><a href="fake/simpleProperty.html">simpleProperty</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="simpleProperty=-param-_simpleProperty"><span class="type-annotation">String</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p>Simple property</p>
@@ -607,6 +618,15 @@ default value.</p>
           <p>Lots and lots of parameters.</p>
           
 </dd>
+        <dt id="myCoolTypedef" class="callable">
+          <span class="name"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span><span class="signature">(<wbr><span class="parameter" id="myCoolTypedef-param-x"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="myCoolTypedef-param-y"><span class="type-annotation">bool</span> <span class="parameter-name">y</span></span>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          <p></p>
+          
+</dd>
         <dt id="VoidCallback" class="callable">
           <span class="name"><a href="fake/VoidCallback.html">VoidCallback</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -647,12 +667,14 @@ default value.</p>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -708,6 +730,7 @@ default value.</p>
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the myCoolTypedef property from the fake library, for the Dart programming language.">
+  <title>myCoolTypedef typedef - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Source+Code+Pro|Roboto:500,400italic,300,400' type='text/css'>
+  <link rel="stylesheet" href="static-assets/prettify.css">
+  <link rel="stylesheet" href="static-assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header class="container-fluid" id="title">
+  <nav class="navbar navbar-fixed-top">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 contents">
+          <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+          <ol class="breadcrumbs gt-separated hidden-xs">
+            <li><a href="index.html">test_package</a></li>
+            <li><a href="fake/fake-library.html">fake</a></li>
+            <li class="self-crumb">myCoolTypedef</li>
+          </ol>
+          <div class="self-name">myCoolTypedef</div>
+          <form class="search navbar-right" role="search">
+            <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+          </form>
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div> <!-- /container -->
+  </nav>
+
+  <div class="container masthead">
+    <div class="row">
+      <div class="col-sm-12 contents">
+        <ol class="breadcrumbs gt-separated visible-xs">
+          <li><a href="index.html">test_package</a></li>
+          <li><a href="fake/fake-library.html">fake</a></li>
+          <li class="self-crumb">myCoolTypedef</li>
+        </ol>
+        <div class="title-description">
+          <h1 class="title">
+            <span class="kind">typedef</span> myCoolTypedef
+          </h1>
+        </div>
+      </div> <!-- /col -->
+    </div> <!-- /row -->
+  </div> <!-- /container -->
+
+</header>
+
+<div class="container body">
+  <div class="row">
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5><a href="index.html">test_package</a></h5>
+    <h5><a href="fake/fake-library.html">fake</a></h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="multi-line-signature">
+        <span class="returntype">void</span>
+        <span class="name ">myCoolTypedef</span>(<wbr><span class="parameter" id="myCoolTypedef-param-x"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="myCoolTypedef-param-y"><span class="type-annotation">bool</span> <span class="parameter-name">y</span></span>)
+    </section>
+
+        
+
+  </div> <!-- /.main-content -->
+
+</div> <!-- row -->
+</div> <!-- container -->
+
+<footer>
+  <div class="container-fluid">
+    <div class="container">
+      <p class="text-center">
+        <span class="no-break">
+          test_package 0.0.1
+        </span>
+        &bull;
+        <span class="no-break">
+          <a href="https://www.dartlang.org">
+            <img src="static-assets/favicon.png" alt="Dart" title="Dart" width="16" height="16">
+          </a>
+        </span>
+        &bull;
+        <span class="copyright no-break">
+          <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+        </span>
+
+      </p>
+    </div>
+  </div>
+</footer>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/prettify.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -71,12 +71,14 @@
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
@@ -132,6 +134,7 @@
       <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
       <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
       <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
       <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.11.0">
+  <meta name="generator" content="made with love by dartdoc 0.11.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -510,23 +510,23 @@
  {
   "name": "Cat",
   "qualifiedName": "ex.Cat",
-  "href": "ex/Cat-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ex",
-   "type": "library"
-  }
- },
- {
-  "name": "Cat",
-  "qualifiedName": "ex.Cat",
   "href": "ex/Cat/Cat.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "Cat",
    "type": "class"
+  }
+ },
+ {
+  "name": "Cat",
+  "qualifiedName": "ex.Cat",
+  "href": "ex/Cat-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
   }
  },
  {
@@ -609,23 +609,23 @@
  {
   "name": "CatString",
   "qualifiedName": "ex.CatString",
-  "href": "ex/CatString-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ex",
-   "type": "library"
-  }
- },
- {
-  "name": "CatString",
-  "qualifiedName": "ex.CatString",
   "href": "ex/CatString/CatString.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "CatString",
    "type": "class"
+  }
+ },
+ {
+  "name": "CatString",
+  "qualifiedName": "ex.CatString",
+  "href": "ex/CatString-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
   }
  },
  {
@@ -774,23 +774,23 @@
  {
   "name": "ConstantCat",
   "qualifiedName": "ex.ConstantCat",
-  "href": "ex/ConstantCat/ConstantCat.html",
-  "type": "constructor",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ConstantCat",
-   "type": "class"
-  }
- },
- {
-  "name": "ConstantCat",
-  "qualifiedName": "ex.ConstantCat",
   "href": "ex/ConstantCat-class.html",
   "type": "class",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "ex",
    "type": "library"
+  }
+ },
+ {
+  "name": "ConstantCat",
+  "qualifiedName": "ex.ConstantCat",
+  "href": "ex/ConstantCat/ConstantCat.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstantCat",
+   "type": "class"
   }
  },
  {
@@ -884,23 +884,23 @@
  {
   "name": "Deprecated",
   "qualifiedName": "ex.Deprecated",
-  "href": "ex/Deprecated-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ex",
-   "type": "library"
-  }
- },
- {
-  "name": "Deprecated",
-  "qualifiedName": "ex.Deprecated",
   "href": "ex/Deprecated/Deprecated.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "Deprecated",
    "type": "class"
+  }
+ },
+ {
+  "name": "Deprecated",
+  "qualifiedName": "ex.Deprecated",
+  "href": "ex/Deprecated-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
   }
  },
  {
@@ -972,23 +972,23 @@
  {
   "name": "Dog",
   "qualifiedName": "ex.Dog",
-  "href": "ex/Dog/Dog.html",
-  "type": "constructor",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "Dog",
-   "type": "class"
-  }
- },
- {
-  "name": "Dog",
-  "qualifiedName": "ex.Dog",
   "href": "ex/Dog-class.html",
   "type": "class",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "ex",
    "type": "library"
+  }
+ },
+ {
+  "name": "Dog",
+  "qualifiedName": "ex.Dog",
+  "href": "ex/Dog/Dog.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
   }
  },
  {
@@ -1368,23 +1368,23 @@
  {
   "name": "F",
   "qualifiedName": "ex.F",
-  "href": "ex/F-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ex",
-   "type": "library"
-  }
- },
- {
-  "name": "F",
-  "qualifiedName": "ex.F",
   "href": "ex/F/F.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "F",
    "type": "class"
+  }
+ },
+ {
+  "name": "F",
+  "qualifiedName": "ex.F",
+  "href": "ex/F-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
   }
  },
  {
@@ -1577,23 +1577,23 @@
  {
   "name": "Helper",
   "qualifiedName": "ex.Helper",
-  "href": "ex/Helper-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ex",
-   "type": "library"
-  }
- },
- {
-  "name": "Helper",
-  "qualifiedName": "ex.Helper",
   "href": "ex/Helper/Helper.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "Helper",
    "type": "class"
+  }
+ },
+ {
+  "name": "Helper",
+  "qualifiedName": "ex.Helper",
+  "href": "ex/Helper-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
   }
  },
  {
@@ -1984,23 +1984,23 @@
  {
   "name": "MyException",
   "qualifiedName": "ex.MyException",
-  "href": "ex/MyException-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "ex",
-   "type": "library"
-  }
- },
- {
-  "name": "MyException",
-  "qualifiedName": "ex.MyException",
   "href": "ex/MyException/MyException.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "MyException",
    "type": "class"
+  }
+ },
+ {
+  "name": "MyException",
+  "qualifiedName": "ex.MyException",
+  "href": "ex/MyException-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
   }
  },
  {
@@ -3331,6 +3331,116 @@
   }
  },
  {
+  "name": "ClassWithUnusualProperties",
+  "qualifiedName": "fake.ClassWithUnusualProperties",
+  "href": "fake/ClassWithUnusualProperties-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ClassWithUnusualProperties",
+  "qualifiedName": "fake.ClassWithUnusualProperties",
+  "href": "fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "aMethod",
+  "qualifiedName": "fake.ClassWithUnusualProperties.aMethod",
+  "href": "fake/ClassWithUnusualProperties/aMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitGetter",
+  "qualifiedName": "fake.ClassWithUnusualProperties.explicitGetter",
+  "href": "fake/ClassWithUnusualProperties/explicitGetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitGetterImplicitSetter",
+  "qualifiedName": "fake.ClassWithUnusualProperties.explicitGetterImplicitSetter",
+  "href": "fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitGetterSetter",
+  "qualifiedName": "fake.ClassWithUnusualProperties.explicitGetterSetter",
+  "href": "fake/ClassWithUnusualProperties/explicitGetterSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitSetter",
+  "qualifiedName": "fake.ClassWithUnusualProperties.explicitSetter",
+  "href": "fake/ClassWithUnusualProperties/explicitSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "finalProperty",
+  "qualifiedName": "fake.ClassWithUnusualProperties.finalProperty",
+  "href": "fake/ClassWithUnusualProperties/finalProperty.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "implicitGetterExplicitSetter",
+  "qualifiedName": "fake.ClassWithUnusualProperties.implicitGetterExplicitSetter",
+  "href": "fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "implicitReadWrite",
+  "qualifiedName": "fake.ClassWithUnusualProperties.implicitReadWrite",
+  "href": "fake/ClassWithUnusualProperties/implicitReadWrite.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
   "name": "Color",
   "qualifiedName": "fake.Color",
   "href": "fake/Color-class.html",
@@ -4046,13 +4156,101 @@
   }
  },
  {
-  "name": "Interface",
-  "qualifiedName": "fake.Interface",
-  "href": "fake/Interface/Interface.html",
+  "name": "ImplicitProperties",
+  "qualifiedName": "fake.ImplicitProperties",
+  "href": "fake/ImplicitProperties/ImplicitProperties.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
-   "name": "Interface",
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "ImplicitProperties",
+  "qualifiedName": "fake.ImplicitProperties",
+  "href": "fake/ImplicitProperties-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.ImplicitProperties.==",
+  "href": "fake/ImplicitProperties/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitGetterImplicitSetter",
+  "qualifiedName": "fake.ImplicitProperties.explicitGetterImplicitSetter",
+  "href": "fake/ImplicitProperties/explicitGetterImplicitSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.ImplicitProperties.hashCode",
+  "href": "fake/ImplicitProperties/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "implicitGetterExplicitSetter",
+  "qualifiedName": "fake.ImplicitProperties.implicitGetterExplicitSetter",
+  "href": "fake/ImplicitProperties/implicitGetterExplicitSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.ImplicitProperties.noSuchMethod",
+  "href": "fake/ImplicitProperties/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.ImplicitProperties.runtimeType",
+  "href": "fake/ImplicitProperties/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.ImplicitProperties.toString",
+  "href": "fake/ImplicitProperties/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
    "type": "class"
   }
  },
@@ -4065,6 +4263,17 @@
   "enclosedBy": {
    "name": "fake",
    "type": "library"
+  }
+ },
+ {
+  "name": "Interface",
+  "qualifiedName": "fake.Interface",
+  "href": "fake/Interface/Interface.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Interface",
+   "type": "class"
   }
  },
  {
@@ -4125,23 +4334,23 @@
  {
   "name": "LongFirstLine",
   "qualifiedName": "fake.LongFirstLine",
-  "href": "fake/LongFirstLine-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "fake",
-   "type": "library"
-  }
- },
- {
-  "name": "LongFirstLine",
-  "qualifiedName": "fake.LongFirstLine",
   "href": "fake/LongFirstLine/LongFirstLine.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "LongFirstLine",
    "type": "class"
+  }
+ },
+ {
+  "name": "LongFirstLine",
+  "qualifiedName": "fake.LongFirstLine",
+  "href": "fake/LongFirstLine-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
   }
  },
  {
@@ -4455,23 +4664,23 @@
  {
   "name": "Oops",
   "qualifiedName": "fake.Oops",
-  "href": "fake/Oops/Oops.html",
-  "type": "constructor",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "Oops",
-   "type": "class"
-  }
- },
- {
-  "name": "Oops",
-  "qualifiedName": "fake.Oops",
   "href": "fake/Oops-class.html",
   "type": "class",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",
    "type": "library"
+  }
+ },
+ {
+  "name": "Oops",
+  "qualifiedName": "fake.Oops",
+  "href": "fake/Oops/Oops.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Oops",
+   "type": "class"
   }
  },
  {
@@ -4543,23 +4752,23 @@
  {
   "name": "OperatorReferenceClass",
   "qualifiedName": "fake.OperatorReferenceClass",
-  "href": "fake/OperatorReferenceClass-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "fake",
-   "type": "library"
-  }
- },
- {
-  "name": "OperatorReferenceClass",
-  "qualifiedName": "fake.OperatorReferenceClass",
   "href": "fake/OperatorReferenceClass/OperatorReferenceClass.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "OperatorReferenceClass",
    "type": "class"
+  }
+ },
+ {
+  "name": "OperatorReferenceClass",
+  "qualifiedName": "fake.OperatorReferenceClass",
+  "href": "fake/OperatorReferenceClass-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
   }
  },
  {
@@ -4719,23 +4928,23 @@
  {
   "name": "SpecialList",
   "qualifiedName": "fake.SpecialList",
-  "href": "fake/SpecialList-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "fake",
-   "type": "library"
-  }
- },
- {
-  "name": "SpecialList",
-  "qualifiedName": "fake.SpecialList",
   "href": "fake/SpecialList/SpecialList.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "SpecialList",
    "type": "class"
+  }
+ },
+ {
+  "name": "SpecialList",
+  "qualifiedName": "fake.SpecialList",
+  "href": "fake/SpecialList-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
   }
  },
  {
@@ -5368,23 +5577,23 @@
  {
   "name": "SubForDocComments",
   "qualifiedName": "fake.SubForDocComments",
-  "href": "fake/SubForDocComments/SubForDocComments.html",
-  "type": "constructor",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "SubForDocComments",
-   "type": "class"
-  }
- },
- {
-  "name": "SubForDocComments",
-  "qualifiedName": "fake.SubForDocComments",
   "href": "fake/SubForDocComments-class.html",
   "type": "class",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",
    "type": "library"
+  }
+ },
+ {
+  "name": "SubForDocComments",
+  "qualifiedName": "fake.SubForDocComments",
+  "href": "fake/SubForDocComments/SubForDocComments.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "SubForDocComments",
+   "type": "class"
   }
  },
  {
@@ -5533,23 +5742,23 @@
  {
   "name": "WithGetterAndSetter",
   "qualifiedName": "fake.WithGetterAndSetter",
-  "href": "fake/WithGetterAndSetter-class.html",
-  "type": "class",
-  "overriddenDepth": 0,
-  "enclosedBy": {
-   "name": "fake",
-   "type": "library"
-  }
- },
- {
-  "name": "WithGetterAndSetter",
-  "qualifiedName": "fake.WithGetterAndSetter",
   "href": "fake/WithGetterAndSetter/WithGetterAndSetter.html",
   "type": "constructor",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "WithGetterAndSetter",
    "type": "class"
+  }
+ },
+ {
+  "name": "WithGetterAndSetter",
+  "qualifiedName": "fake.WithGetterAndSetter",
+  "href": "fake/WithGetterAndSetter-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
   }
  },
  {
@@ -5744,6 +5953,17 @@
   "qualifiedName": "fake.meaningOfLife",
   "href": "fake/meaningOfLife.html",
   "type": "top-level property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "myCoolTypedef",
+  "qualifiedName": "fake.myCoolTypedef",
+  "href": "fake/myCoolTypedef.html",
+  "type": "typedef",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",

--- a/testing/test_package_docs/two_exports/BaseClass-class.html
+++ b/testing/test_package_docs/two_exports/BaseClass-class.html
@@ -137,12 +137,8 @@
 </dd>
         <dt id="lengthX" class="property inherited">
           <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>  </span>
           </span>
-        </dt>
-        <dt id="lengthX" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
-          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           <p>Returns a length.</p>

--- a/testing/test_package_docs/two_exports/ExtendingClass-class.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass-class.html
@@ -139,12 +139,8 @@
 </dd>
         <dt id="lengthX" class="property inherited">
           <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span><span class="signature">
-            <span class="returntype parameter">&#8596; <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span></span>
+            <span class="returntype parameter">&#8596;  <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>  </span>
           </span>
-        </dt>
-        <dt id="lengthX" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
-          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           <p>Returns a length.</p>

--- a/testing/test_package_docs/two_exports/two_exports-library.html
+++ b/testing/test_package_docs/two_exports/two_exports-library.html
@@ -111,8 +111,9 @@
 
       <dl class="properties">
         <dt id="topLevelVariable" class="property">
-          <span class="name"><a href="two_exports/topLevelVariable.html">topLevelVariable</a></span>
-          <span class="signature">&#8596; int</span>
+          <span class="name"><a href="two_exports/topLevelVariable.html">topLevelVariable</a></span><span class="signature">
+            <span class="returntype parameter">&#8596;   <span class="parameter" id="topLevelVariable=-param-_topLevelVariable"><span class="type-annotation">int</span> </span> </span>
+          </span>
         </dt>
         <dd>
           <p></p>


### PR DESCRIPTION
There's no framework currently for end-to-end testing of our template output outside manual review of the outputted HTML.   To make that easier:

Before:
![before](https://cloud.githubusercontent.com/assets/14116827/25814793/834fb956-33d3-11e7-8f7d-47c34696d196.png)

After:
![after](https://cloud.githubusercontent.com/assets/14116827/25814798/8777fd0e-33d3-11e7-8f4a-53fd0a12b7ec.png)

Regression for this issue is prevented by an assert for now.