### PR TITLE
some cleanup to the stdout messages we print

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -40,7 +40,7 @@ main(List<String> arguments) async {
 
   Directory sdkDir = getSdkDir();
   if (sdkDir == null) {
-    stderr.write(" Error: unable to locate the Dart SDK.");
+    stderr.writeln(" Error: unable to locate the Dart SDK.");
     exit(1);
   }
 
@@ -55,14 +55,14 @@ main(List<String> arguments) async {
 
   var readme = args['sdk-readme'];
   if (readme != null && !(new File(readme).existsSync())) {
-    stderr.write(
+    stderr.writeln(
         " fatal error: unable to locate the SDK description file at $readme.");
     exit(1);
   }
 
   Directory inputDir = new Directory(args['input']);
   if (!inputDir.existsSync()) {
-    stderr.write(
+    stderr.writeln(
         " fatal error: unable to locate the input directory at ${inputDir.path}.");
     exit(1);
   }
@@ -77,7 +77,7 @@ main(List<String> arguments) async {
       args['header'].map(_resolveTildePath).toList() as List<String>;
   for (String headerFilePath in headerFilePaths) {
     if (!new File(headerFilePath).existsSync()) {
-      stderr.write(
+      stderr.writeln(
           " fatal error: unable to locate header file: ${headerFilePath}.");
       exit(1);
     }
@@ -87,7 +87,7 @@ main(List<String> arguments) async {
       args['footer'].map(_resolveTildePath).toList() as List<String>;
   for (String footerFilePath in footerFilePaths) {
     if (!new File(footerFilePath).existsSync()) {
-      stderr.write(
+      stderr.writeln(
           " fatal error: unable to locate footer file: ${footerFilePath}.");
       exit(1);
     }
@@ -97,7 +97,7 @@ main(List<String> arguments) async {
       args['footer-text'].map(_resolveTildePath).toList() as List<String>;
   for (String footerFilePath in footerTextFilePaths) {
     if (!new File(footerFilePath).existsSync()) {
-      stderr.write(
+      stderr.writeln(
           " fatal error: unable to locate footer-text file: ${footerFilePath}.");
       exit(1);
     }
@@ -111,7 +111,7 @@ main(List<String> arguments) async {
 
   if (args.rest.isNotEmpty) {
     var unknownArgs = args.rest.join(' ');
-    stderr.write(
+    stderr.writeln(
         ' fatal error: detected unknown command-line argument(s): $unknownArgs');
     _printUsageAndExit(parser, exitCode: 1);
   }

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -21,6 +21,7 @@ import 'package:analyzer/src/generated/java_io.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
+import 'package:dartdoc/src/utils.dart';
 import 'package:html/dom.dart' show Element, Document;
 import 'package:html/parser.dart' show parse;
 import 'package:package_config/discovery.dart' as package_config;
@@ -173,9 +174,6 @@ class DartDoc {
     }
     package = new Package(libraries, packageMeta, warningOptions);
 
-    print(
-        '\ngenerating docs for libraries ${package.libraries.map((Library l) => l.name).join(', ')}\n');
-
     // Go through docs of every model element in package to prebuild the macros index
     // TODO(jcollins-g): move index building into a cached-on-demand generation
     // like most other bits in [Package].
@@ -189,14 +187,21 @@ class DartDoc {
       writtenFiles.addAll(generator.writtenFiles.map(path.normalize));
     }
 
-    verifyLinks(package, outputDir.path);
-
     double seconds = _stopwatch.elapsedMilliseconds / 1000.0;
     print(
-        "\nDocumented ${package.libraries.length} librar${package.libraries.length == 1 ? 'y' : 'ies'} "
-        "in ${seconds.toStringAsFixed(1)} seconds.");
-    print(
-        "Finished with:  ${package.packageWarningCounter.warningCount} warnings, ${package.packageWarningCounter.errorCount} errors");
+        "documented ${package.libraries.length} librar${package.libraries.length == 1 ? 'y' : 'ies'} "
+        "in ${seconds.toStringAsFixed(1)} seconds");
+    print('');
+
+    verifyLinks(package, outputDir.path);
+    int warnings = package.packageWarningCounter.warningCount;
+    int errors = package.packageWarningCounter.errorCount;
+    if (warnings == 0 && errors == 0) {
+      print("no issues found");
+    } else {
+      print("found ${warnings} ${pluralize('warning', warnings)} "
+          "and ${errors} ${pluralize('error', errors)}");
+    }
 
     if (package.libraries.isEmpty) {
       throw new DartDocFailure(
@@ -351,7 +356,7 @@ class DartDoc {
     final Set<String> visited = new Set();
     final String start = 'index.html';
     visited.add(start);
-    stdout.write('\nvalidating docs');
+    print('validating docs...');
     _doCheck(package, origin, visited, start);
     _doOrphanCheck(package, origin, visited);
   }
@@ -510,9 +515,10 @@ class DartDoc {
           ..sort();
 
     double seconds = _stopwatch.elapsedMilliseconds / 1000.0;
-    print("Parsed ${libraries.length} "
-        "file${libraries.length == 1 ? '' : 's'} in "
-        "${seconds.toStringAsFixed(1)} seconds.\n");
+    print("parsed ${libraries.length} ${pluralize('file', libraries.length)} "
+        "in ${seconds.toStringAsFixed(1)} seconds");
+    print('');
+    _stopwatch.reset();
 
     if (errors.isNotEmpty) {
       errors.forEach(print);

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async' show Future, StreamController;
 import 'dart:convert' show JsonEncoder;
-import 'dart:io' show Directory, File, stdout;
+import 'dart:io' show Directory, File;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart' show compareNatural;
@@ -178,16 +178,13 @@ class HtmlGeneratorInstance implements HtmlOptions {
   }
 
   void generatePackage() {
-    stdout.write('\ndocumenting ${package.name}');
-
     TemplateData data = new PackageTemplateData(this, package, useCategories);
 
     _build('index.html', _templates.indexTemplate, data);
   }
 
   void generateLibrary(Package package, Library lib) {
-    stdout
-        .write('\ngenerating docs for library ${lib.name} from ${lib.path}...');
+    print('generating docs for library ${lib.name} from ${lib.path}...');
     if (!lib.isAnonymous && !lib.hasDocumentation) {
       package.warnOnElement(lib, PackageWarning.noLibraryLevelDocs);
     }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2849,7 +2849,7 @@ class PackageWarningCounter {
     } else {
       if (options.asErrors.contains(kind)) toWrite = "error: ${fullMessage}";
     }
-    if (toWrite != null) stderr.write("\n ${toWrite}");
+    if (toWrite != null) print(" ${toWrite}");
   }
 
   /// Returns true if we've already warned for this.
@@ -3057,7 +3057,7 @@ class Package implements Nameable, Documentable {
         break;
       case PackageWarning.unknownFile:
         warningMessage =
-            'dartdoc detected an unknown file in the doc tree:  ${message}';
+            'dartdoc detected an unknown file in the doc tree: ${message}';
         break;
       case PackageWarning.typeAsHtml:
         // The message for this warning can contain many punctuation and other symbols,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -49,3 +49,5 @@ String truncateString(String str, int length) {
     return str;
   }
 }
+
+String pluralize(String word, int count) => count == 1 ? word : '${word}s';


### PR DESCRIPTION
This normalizes the blank lines and title case of the stdout we print when generating docs. After this change:

```
Generating documentation for 'analysis_server_lib' into /Users/devoncarew/projects/devoncarew/analysis_server_lib/doc/api/

parsing lib/analysis_server_lib.dart...
parsed 14 files in 5.6 seconds

generating docs for library analysis_server_lib from analysis_server_lib.dart...
generating docs for library dart:async from async.dart...
 warning: unresolved doc reference [Stream.groupByMapped], from dart-async.StreamGroup (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/async/stream.dart:1916:7)
 warning: unresolved doc reference [cleanup], from dart-async.Future.wait (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/async/future.dart:316:26)
 warning: unresolved doc reference [GroupBy], from dart-async.StreamGroup.values (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/async/stream.dart:1921:19)
generating docs for library dart:collection from collection.dart...
 warning: unresolved doc reference [contains], from dart-collection.MapBase (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/collection/maps.dart:23:16)
 warning: unresolved doc reference [contains], from dart-collection.MapMixin (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/collection/maps.dart:41:16)
 warning: unresolved doc reference [contains], from dart-collection.UnmodifiableMapBase (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/collection/maps.dart:103:16)
 warning: unresolved doc reference [test], from dart-collection.DoubleLinkedQueue.any (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:333:8)
 warning: unresolved doc reference [test], from dart-collection.DoubleLinkedQueue.every (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:294:8)
 warning: unresolved doc reference [test], from dart-collection.HashSet.any (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:333:8)
 warning: unresolved doc reference [test], from dart-collection.HashSet.every (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:294:8)
 warning: unresolved doc reference [test], from dart-collection.LinkedHashSet.any (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:333:8)
 warning: unresolved doc reference [test], from dart-collection.LinkedHashSet.every (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:294:8)
 warning: unresolved doc reference [a], from dart-collection.List.lastIndexOf (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/list.dart:278:7)
 warning: no canonical library found for dart-_internal.EfficientLengthIterable, not linking (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/internal/iterable.dart:11:16)
 warning: no canonical library found for dart-_internal.ListIterable, not linking (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/internal/iterable.dart:28:16)
 warning: unresolved doc reference [f], from dart-collection.Iterable.forEach (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:225:8)
 warning: unresolved doc reference [test], from dart-collection.Queue.any (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:333:8)
 warning: unresolved doc reference [test], from dart-collection.Queue.every (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:294:8)
 warning: unresolved doc reference [value], from dart-collection.Set.add (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/set.dart:111:8)
 warning: unresolved doc reference [element], from dart-collection.Iterable.contains (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:214:8)
 warning: unresolved doc reference [value], from dart-collection.Set.remove (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/set.dart:126:8)
 warning: no canonical library found for dart-_internal.UnmodifiableListBase, not linking (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/internal/list.dart:200:16)
generating docs for library dart:convert from convert.dart...
generating docs for library dart:core from core.dart...
generating docs for library dart:developer from developer.dart...
generating docs for library dart:io from io.dart...
 warning: unresolved doc reference [host], from dart-io.HttpClient.openUrl (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/http.dart:1377:29)
 warning: unresolved doc reference [RECEIVE], from dart-io.RawSynchronousSocket.shutdown (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/sync_socket.dart:74:8)
 warning: unresolved doc reference [SEND], from dart-io.RawSynchronousSocket.shutdown (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/sync_socket.dart:74:8)
 warning: unresolved doc reference [ZLibDecoder.level], from dart-io.ZLibOption.DEFAULT_LEVEL (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/data_transformer.dart:35:20)
 warning: unresolved doc reference [ZLibDecoder.memLevel], from dart-io.ZLibOption.DEFAULT_MEM_LEVEL (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/data_transformer.dart:47:20)
 warning: unresolved doc reference [ZLibDecoder.level], from dart-io.ZLibOption.MAX_LEVEL (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/data_transformer.dart:31:20)
 warning: unresolved doc reference [ZLibDecoder.memLevel], from dart-io.ZLibOption.MAX_MEM_LEVEL (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/data_transformer.dart:43:20)
 warning: unresolved doc reference [ZLibDecoder.level], from dart-io.ZLibOption.MIN_LEVEL (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/data_transformer.dart:27:20)
 warning: unresolved doc reference [ZLibDecoder.memLevel], from dart-io.ZLibOption.MIN_MEM_LEVEL (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/io/data_transformer.dart:39:20)
generating docs for library dart:isolate from isolate.dart...
 warning: unresolved doc reference [errorAreFatal], from dart-isolate.Isolate.spawn (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/isolate/isolate.dart:227:35)
 warning: unresolved doc reference [errorAreFatal], from dart-isolate.Isolate.spawnUri (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/isolate/isolate.dart:309:35)
generating docs for library dart:math from math.dart...
generating docs for library dart:typed_data from typed_data.dart...
 warning: unresolved doc reference [test], from dart-typed_data.Float32List.any (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:333:8)
 warning: unresolved doc reference [test], from dart-typed_data.Float32List.every (file:///usr/local/Cellar/dart/1.24.0-dev.4.0/libexec/lib/core/iterable.dart:294:8)
generating docs for library internal_style from internal_style.dart...
 warning: unresolved doc reference [parts], from internal_style.Style.relativePathToUri (file:///Users/devoncarew/.pub-cache/hosted/pub.dartlang.org/path-1.4.1/lib/src/style.dart:80:7)
generating docs for library logging from logging.dart...
 warning: logging has no library level documentation comments (file:///Users/devoncarew/.pub-cache/hosted/pub.dartlang.org/logging-0.11.3+1/lib/logging.dart:7:9)
 warning: unresolved doc reference [Handler], from logging.LogRecord (file:///Users/devoncarew/.pub-cache/hosted/pub.dartlang.org/logging-0.11.3+1/lib/logging.dart:339:7)
generating docs for library path from path.dart...
 warning: unresolved doc reference [root], from path.Context.relative (file:///Users/devoncarew/.pub-cache/hosted/pub.dartlang.org/path-1.4.1/lib/src/context.dart:440:10)
documented 13 libraries in 38.4 seconds

validating docs...
found 39 warnings and 0 errors

Success! Docs generated into /Users/devoncarew/projects/devoncarew/analysis_server_lib/doc/api
```

@jcollins-g 