### PR TITLE
stdout/stderr cleanup

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -125,6 +125,7 @@ class DartDoc {
   /// analysis error in the code. Any other exception can be throw if there is an
   /// unexpected failure.
   Future<DartDocResults> generateDocs() async {
+
     _stopwatch = new Stopwatch()..start();
 
     List<String> files = packageMeta.isSdk
@@ -187,21 +188,20 @@ class DartDoc {
       writtenFiles.addAll(generator.writtenFiles.map(path.normalize));
     }
 
-    double seconds = _stopwatch.elapsedMilliseconds / 1000.0;
-    print(
-        "documented ${package.libraries.length} librar${package.libraries.length == 1 ? 'y' : 'ies'} "
-        "in ${seconds.toStringAsFixed(1)} seconds");
-    print('');
-
     verifyLinks(package, outputDir.path);
     int warnings = package.packageWarningCounter.warningCount;
     int errors = package.packageWarningCounter.errorCount;
     if (warnings == 0 && errors == 0) {
-      print("no issues found");
+      print("\nno issues found");
     } else {
-      print("found ${warnings} ${pluralize('warning', warnings)} "
+      print("\nfound ${warnings} ${pluralize('warning', warnings)} "
           "and ${errors} ${pluralize('error', errors)}");
     }
+
+    double seconds = _stopwatch.elapsedMilliseconds / 1000.0;
+    print(
+        "\ndocumented ${package.libraries.length} librar${package.libraries.length == 1 ? 'y' : 'ies'} "
+        "in ${seconds.toStringAsFixed(1)} seconds");
 
     if (package.libraries.isEmpty) {
       throw new DartDocFailure(
@@ -356,7 +356,7 @@ class DartDoc {
     final Set<String> visited = new Set();
     final String start = 'index.html';
     visited.add(start);
-    print('validating docs...');
+    stdout.write('\nvalidating docs...');
     _doCheck(package, origin, visited, start);
     _doOrphanCheck(package, origin, visited);
   }

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -517,7 +517,6 @@ class DartDoc {
     double seconds = _stopwatch.elapsedMilliseconds / 1000.0;
     print("parsed ${libraries.length} ${pluralize('file', libraries.length)} "
         "in ${seconds.toStringAsFixed(1)} seconds");
-    print('');
     _stopwatch.reset();
 
     if (errors.isNotEmpty) {

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -125,7 +125,6 @@ class DartDoc {
   /// analysis error in the code. Any other exception can be throw if there is an
   /// unexpected failure.
   Future<DartDocResults> generateDocs() async {
-
     _stopwatch = new Stopwatch()..start();
 
     List<String> files = packageMeta.isSdk

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async' show Future, StreamController;
 import 'dart:convert' show JsonEncoder;
-import 'dart:io' show Directory, File;
+import 'dart:io' show Directory, File, stdout;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart' show compareNatural;
@@ -181,12 +181,13 @@ class HtmlGeneratorInstance implements HtmlOptions {
 
   void generatePackage() {
     TemplateData data = new PackageTemplateData(this, package, useCategories);
+    stdout.write('\ndocumenting ${package.name}');
 
     _build('index.html', _templates.indexTemplate, data);
   }
 
   void generateLibrary(Package package, Library lib) {
-    print('generating docs for library ${lib.name} from ${lib.path}...');
+    stdout.write('\ngenerating docs for library ${lib.name} from ${lib.path}...');
     if (!lib.isAnonymous && !lib.hasDocumentation) {
       package.warnOnElement(lib, PackageWarning.noLibraryLevelDocs);
     }

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -187,7 +187,8 @@ class HtmlGeneratorInstance implements HtmlOptions {
   }
 
   void generateLibrary(Package package, Library lib) {
-    stdout.write('\ngenerating docs for library ${lib.name} from ${lib.path}...');
+    stdout
+        .write('\ngenerating docs for library ${lib.name} from ${lib.path}...');
     if (!lib.isAnonymous && !lib.hasDocumentation) {
       package.warnOnElement(lib, PackageWarning.noLibraryLevelDocs);
     }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2850,7 +2850,7 @@ class PackageWarningCounter {
     } else {
       if (options.asErrors.contains(kind)) toWrite = "error: ${fullMessage}";
     }
-    if (toWrite != null) print(" ${toWrite}");
+    if (toWrite != null) stderr.write("\n ${toWrite}");
   }
 
   /// Returns true if we've already warned for this.


### PR DESCRIPTION
Correct some issues with #1413:
 - restore progress dots to the end of lines
 - restore stderr output for most warnings

screenshots from IntelliJ console:

![screen-angular2](https://cloud.githubusercontent.com/assets/14116827/26167601/09390ae4-3aec-11e7-9d82-aa4ef1ea012c.png)
![sdk end](https://cloud.githubusercontent.com/assets/14116827/26167604/0b76c17a-3aec-11e7-8ecc-5c8bd0eb9aea.png)
![sdk begin](https://cloud.githubusercontent.com/assets/14116827/26167606/0dd4cec6-3aec-11e7-9440-fee26f34f52d.png)

Note red coloring (stderr seems automatically colored that way by intellij, we lost that in #1413).