### PR TITLE
Update README with triage priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 0.12.0
+* Miscellaneous performance enhancements, ~10-20% on complex packages.
 * Enable support for generic function types.  #1321
-* Update analyzer to 0.30.  #1403
+* Update analyzer to 0.30.  Minimum Dart SDK 1.23 now required.  #1403
 * Enhancements to css style to better match dartlang.org.  #1372 (partial)
 
 ## 0.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
-## 0.12.0
-* Miscellaneous performance enhancements, ~10-20% on complex packages.
 * Enable support for generic function types.  #1321
-* Update analyzer to 0.30.  Minimum Dart SDK 1.23 now required.  #1403
+* Update analyzer to 0.30.  #1403
 * Enhancements to css style to better match dartlang.org.  #1372 (partial)
 
 ## 0.11.2

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Some examples of likely triage priorities:
   * Default-on warnings that are misleading or wrong, widespread
   * Generation problems that should be detected but aren't warned, widespread
   * Enhancements that have significant data around them indicating they are a big win
+  * User performance problem (e.g. page load, search), widespread
 
 * P2
   * Incorrect doc contents, not widespread
@@ -151,14 +152,15 @@ Some examples of likely triage priorities:
   * Default-on warnings that are misleading or wrong, few or on edge cases  
   * Non-default warnings that are misleading or wrong, widespread
   * Enhancements considered important but without significant data indicating they are a big win
-  * Performance problem, widespread
+  * User performance problem (e.g. page load, search), not widespread
+  * Generation performance problem, widespread
 
 * P3
   * Theoretical or extremely rare problems with generation
   * Minor display warts on edge cases only
   * Non-default warnings that are misleading or wrong, few or on edge cases
   * Enhancements whose importance is uncertain
-  * Performance problem, limited impact or not widespread
+  * Generation performance problem, limited impact or not widespread
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -121,7 +121,45 @@ all the used libraries, even from other packages, to the list of the documented 
 
 ## Issues and bugs
 
-Please file reports on the [GitHub Issue Tracker][].
+Please file reports on the [GitHub Issue Tracker][].  Issues are labeled with
+priority based on how much impact to the ecosystem the issue addresses and
+the number of generated pages that show the anomaly (widespread vs. not
+widespread).
+
+Some examples of likely triage priorities:
+
+* P0
+  * Broken links, widespread
+  * Uncaught exceptions, widespread
+  * Incorrect linkage, widespread
+  * Very ugly or navigation impaired generated pages, widespread
+
+* P1
+  * Broken links, few or on edge cases
+  * Uncaught exceptions, very rare or with simple workarounds
+  * Incorrect linkage, few or on edge cases
+  * Incorrect doc contents, widespread or with high impact
+  * Minor display warts not significantly impeding navigation, widespread
+  * Default-on warnings that are misleading or wrong, widespread
+  * Generation problems that should be detected but aren't warned, widespread
+  * Enhancements that have significant data around them indicating they are a big win
+
+* P2
+  * Incorrect doc contents, not widespread
+  * Minor display warts not significantly impeding navigation, not widespread
+  * Generation problems that should be detected but aren't warned, not widespread
+  * Default-on warnings that are misleading or wrong, few or on edge cases  
+  * Non-default warnings that are misleading or wrong, widespread
+  * Enhancements considered important but without significant data indicating they are a big win
+  * Performance problem, widespread
+
+* P3
+  * Theoretical or extremely rare problems with generation
+  * Minor display warts on edge cases only
+  * Non-default warnings that are misleading or wrong, few or on edge cases
+  * Enhancements whose importance is uncertain
+  * Performance problem, limited impact or not widespread
+
 
 ## License
 


### PR DESCRIPTION
@chalin 

Since I've been actively trying to triage dartdoc bugs, update the README with my triage priorities for transparency.  These are more like guidelines than actual rules.