### PR TITLE
Add flag and rebuild test package docs

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -295,6 +295,7 @@ ArgParser _createArgsParser() {
         "Drop all text for SDK components.  Helpful for integration tests for dartdoc, probably not useful for anything else.",
     negatable: true,
     defaultsTo: false,
+    hide: true,
   );
 
   return parser;

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -158,6 +158,28 @@ main(List<String> arguments) async {
   DartSdk sdk = new FolderBasedDartSdk(PhysicalResourceProvider.INSTANCE,
       PhysicalResourceProvider.INSTANCE.getFolder(sdkDir.path));
 
+  List<String> dropTextFrom = [];
+  if (args['hide-sdk-text']) {
+    dropTextFrom.addAll([
+      'dart.async',
+      'dart.collection',
+      'dart.convert',
+      'dart.core',
+      'dart.developer',
+      'dart.html',
+      'dart.indexed_db',
+      'dart.io',
+      'dart.lisolate',
+      'dart.js',
+      'dart.js_util',
+      'dart.math',
+      'dart.mirrors',
+      'dart.svg',
+      'dart.typed_data',
+      'dart.web_audio'
+    ]);
+  }
+
   setConfig(
       addCrossdart: addCrossdart,
       examplePathPrefix: args['example-path-prefix'],
@@ -166,7 +188,8 @@ main(List<String> arguments) async {
       inputDir: inputDir,
       sdkVersion: sdk.sdkVersion,
       autoIncludeDependencies: args['auto-include-dependencies'],
-      categoryOrder: args['category-order']);
+      categoryOrder: args['category-order'],
+      dropTextFrom: dropTextFrom);
 
   DartDoc dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
       outputDir, packageMeta, includeLibraries,
@@ -266,6 +289,14 @@ ArgParser _createArgsParser() {
           "Generates `index.json` with indentation and newlines. The file is larger, but it's also easier to diff.",
       negatable: false,
       defaultsTo: false);
+  parser.addFlag(
+    'hide-sdk-text',
+    help:
+        "Drop all text for SDK components.  Helpful for integration tests for dartdoc, probably not useful for anything else.",
+    negatable: true,
+    defaultsTo: false,
+  );
+
   return parser;
 }
 

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -16,6 +16,7 @@ class Config {
   final String sdkVersion;
   final bool autoIncludeDependencies;
   final List<String> categoryOrder;
+  final List<String> dropTextFrom;
   Config._(
       this.inputDir,
       this.showWarnings,
@@ -24,7 +25,8 @@ class Config {
       this.includeSource,
       this.sdkVersion,
       this.autoIncludeDependencies,
-      this.categoryOrder);
+      this.categoryOrder,
+      this.dropTextFrom);
 }
 
 Config _config;
@@ -38,9 +40,13 @@ void setConfig(
     bool includeSource: true,
     String sdkVersion,
     bool autoIncludeDependencies: false,
-    List<String> categoryOrder}) {
+    List<String> categoryOrder,
+    List<String> dropTextFrom}) {
   if (categoryOrder == null) {
     categoryOrder = new UnmodifiableListView<String>([]);
+  }
+  if (dropTextFrom == null) {
+    dropTextFrom = new UnmodifiableListView<String>([]);
   }
   _config = new Config._(
       inputDir,
@@ -50,5 +56,6 @@ void setConfig(
       includeSource,
       sdkVersion,
       autoIncludeDependencies,
-      categoryOrder);
+      categoryOrder,
+      dropTextFrom);
 }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -42,12 +42,8 @@ void setConfig(
     bool autoIncludeDependencies: false,
     List<String> categoryOrder,
     List<String> dropTextFrom}) {
-  if (categoryOrder == null) {
-    categoryOrder = new UnmodifiableListView<String>([]);
-  }
-  if (dropTextFrom == null) {
-    dropTextFrom = new UnmodifiableListView<String>([]);
-  }
+  categoryOrder ??= new UnmodifiableListView<String>([]);
+  dropTextFrom ??= new UnmodifiableListView<String>([]);
   _config = new Config._(
       inputDir,
       showWarnings,

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -6,7 +6,6 @@
 library dartdoc.markdown_processor;
 
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:analyzer/dart/ast/ast.dart';

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1970,10 +1970,7 @@ abstract class ModelElement implements Comparable, Nameable, Documentable {
 
   /// Returns the docs, stripped of their leading comments syntax.
   @override
-  String get documentation {
-    String x = documentationFrom._documentationLocal;
-    return x;
-  }
+  String get documentation => documentationFrom._documentationLocal;
 
   Library get definingLibrary => package.findOrCreateLibraryFor(element);
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1956,17 +1956,24 @@ abstract class ModelElement implements Comparable, Nameable, Documentable {
 
   String get _documentationLocal {
     if (_rawDocs != null) return _rawDocs;
-    _rawDocs = _computeDocumentationComment ?? '';
-    _rawDocs = stripComments(_rawDocs) ?? '';
-    _rawDocs = _injectExamples(_rawDocs);
-    _rawDocs = _stripMacroTemplatesAndAddToIndex(_rawDocs);
-    _rawDocs = _injectMacros(_rawDocs);
+    if (config.dropTextFrom.contains(element.library.name)) {
+      _rawDocs = '';
+    } else {
+      _rawDocs = _computeDocumentationComment ?? '';
+      _rawDocs = stripComments(_rawDocs) ?? '';
+      _rawDocs = _injectExamples(_rawDocs);
+      _rawDocs = _stripMacroTemplatesAndAddToIndex(_rawDocs);
+      _rawDocs = _injectMacros(_rawDocs);
+    }
     return _rawDocs;
   }
 
   /// Returns the docs, stripped of their leading comments syntax.
   @override
-  String get documentation => documentationFrom._documentationLocal;
+  String get documentation {
+    String x = documentationFrom._documentationLocal;
+    return x;
+  }
 
   Library get definingLibrary => package.findOrCreateLibraryFor(element);
 

--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -54,6 +54,7 @@ void main() {
         '--auto-include-dependencies',
         '--example-path-prefix',
         'examples',
+        '--hide-sdk-text',
         '--exclude',
         'dart.async,dart.collection,dart.convert,dart.core,dart.math,dart.typed_data,meta',
         '--no-include-source',

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -21,6 +21,7 @@ void main() {
 
     setUp(() {
       tempDir = Directory.systemTemp.createTempSync('dartdoc.test.');
+      setConfig();
     });
 
     tearDown(() {

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -182,7 +182,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -190,7 +190,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -205,7 +205,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -214,7 +214,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -229,7 +229,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Animal/hashCode.html
+++ b/testing/test_package_docs/ex/Animal/hashCode.html
@@ -83,31 +83,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Animal/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Animal/noSuchMethod.html
@@ -79,12 +79,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Animal/operator_equals.html
+++ b/testing/test_package_docs/ex/Animal/operator_equals.html
@@ -79,26 +79,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Animal/runtimeType.html
+++ b/testing/test_package_docs/ex/Animal/runtimeType.html
@@ -83,10 +83,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Animal/toString.html
+++ b/testing/test_package_docs/ex/Animal/toString.html
@@ -79,9 +79,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -184,7 +184,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -192,7 +192,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -261,7 +261,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -270,7 +270,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -294,7 +294,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -94,31 +94,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Apple/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Apple/noSuchMethod.html
@@ -90,12 +90,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Apple/operator_equals.html
+++ b/testing/test_package_docs/ex/Apple/operator_equals.html
@@ -90,26 +90,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Apple/runtimeType.html
+++ b/testing/test_package_docs/ex/Apple/runtimeType.html
@@ -94,10 +94,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Apple/toString.html
+++ b/testing/test_package_docs/ex/Apple/toString.html
@@ -90,9 +90,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -200,7 +200,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="m" class="property inherited">
@@ -217,7 +217,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -286,7 +286,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="paramFromExportLib" class="callable inherited">
@@ -313,7 +313,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="whataclass" class="callable inherited">
@@ -346,7 +346,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Cat-class.html
+++ b/testing/test_package_docs/ex/Cat-class.html
@@ -156,7 +156,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -164,7 +164,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -188,7 +188,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -197,7 +197,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -212,7 +212,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -81,31 +81,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Cat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Cat/noSuchMethod.html
@@ -77,12 +77,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Cat/operator_equals.html
+++ b/testing/test_package_docs/ex/Cat/operator_equals.html
@@ -77,26 +77,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Cat/runtimeType.html
+++ b/testing/test_package_docs/ex/Cat/runtimeType.html
@@ -81,10 +81,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Cat/toString.html
+++ b/testing/test_package_docs/ex/Cat/toString.html
@@ -77,9 +77,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString-class.html
+++ b/testing/test_package_docs/ex/CatString-class.html
@@ -148,7 +148,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="isEmpty" class="property inherited">
@@ -156,7 +156,7 @@
           <span class="signature">&#8594; bool</span>
         </dt>
         <dd class="inherited">
-          Returns whether the buffer is empty. This is a constant-time operation.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="isNotEmpty" class="property inherited">
@@ -164,8 +164,7 @@
           <span class="signature">&#8594; bool</span>
         </dt>
         <dd class="inherited">
-          Returns whether the buffer is not empty. This is a constant-time
-operation.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="length" class="property inherited">
@@ -173,8 +172,7 @@ operation.
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns the length of the content that has been accumulated so far.
-This is a constant-time operation.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -182,7 +180,7 @@ This is a constant-time operation.
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -197,7 +195,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Clears the string buffer.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
@@ -206,7 +204,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -215,7 +213,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the contents of buffer as a concatenated string.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="write" class="callable inherited">
@@ -224,7 +222,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Adds the contents of <code>obj</code>, converted to a string, to the buffer.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="writeAll" class="callable inherited">
@@ -233,7 +231,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Iterates over the given <code>objects</code> and <a href="ex/CatString/write.html">write</a>s them in sequence.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="writeCharCode" class="callable inherited">
@@ -242,7 +240,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Adds the string representation of <code>charCode</code> to the buffer.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="writeln" class="callable inherited">
@@ -251,8 +249,7 @@ This is a constant-time operation.
           </span>
         </dt>
         <dd class="inherited">
-          Converts <code>obj</code> to a String by invoking <code>Object.toString</code> and 
-adds the result to <code>this</code>, followed by a newline.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -267,7 +264,7 @@ adds the result to <code>this</code>, followed by a newline.
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/CatString/clear.html
+++ b/testing/test_package_docs/ex/CatString/clear.html
@@ -83,9 +83,6 @@
       <span class="returntype">void</span>
       <span class="name ">clear</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Clears the string buffer.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/hashCode.html
+++ b/testing/test_package_docs/ex/CatString/hashCode.html
@@ -87,31 +87,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/CatString/isEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isEmpty.html
@@ -87,10 +87,7 @@
         <span class="returntype">bool</span>
         <span class="name ">isEmpty</span></section>
       
-      <section class="desc markdown">
-  <p>Returns whether the buffer is empty. This is a constant-time operation.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/CatString/isNotEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isNotEmpty.html
@@ -87,11 +87,7 @@
         <span class="returntype">bool</span>
         <span class="name ">isNotEmpty</span></section>
       
-      <section class="desc markdown">
-  <p>Returns whether the buffer is not empty. This is a constant-time
-operation.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/CatString/length.html
+++ b/testing/test_package_docs/ex/CatString/length.html
@@ -87,11 +87,7 @@
         <span class="returntype">int</span>
         <span class="name ">length</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the length of the content that has been accumulated so far.
-This is a constant-time operation.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/CatString/noSuchMethod.html
+++ b/testing/test_package_docs/ex/CatString/noSuchMethod.html
@@ -83,12 +83,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/operator_equals.html
+++ b/testing/test_package_docs/ex/CatString/operator_equals.html
@@ -83,26 +83,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/runtimeType.html
+++ b/testing/test_package_docs/ex/CatString/runtimeType.html
@@ -87,10 +87,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/CatString/toString.html
+++ b/testing/test_package_docs/ex/CatString/toString.html
@@ -83,9 +83,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns the contents of buffer as a concatenated string.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/write.html
+++ b/testing/test_package_docs/ex/CatString/write.html
@@ -83,9 +83,6 @@
       <span class="returntype">void</span>
       <span class="name ">write</span>(<wbr><span class="parameter" id="write-param-obj"><span class="type-annotation">Object</span> <span class="parameter-name">obj</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Adds the contents of <code>obj</code>, converted to a string, to the buffer.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/writeAll.html
+++ b/testing/test_package_docs/ex/CatString/writeAll.html
@@ -83,9 +83,6 @@
       <span class="returntype">void</span>
       <span class="name ">writeAll</span>(<wbr><span class="parameter" id="writeAll-param-objects"><span class="type-annotation">Iterable</span> <span class="parameter-name">objects</span>, [</span> <span class="parameter" id="writeAll-param-separator"><span class="type-annotation">String</span> <span class="parameter-name">separator</span> = <span class="default-value">""</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Iterates over the given <code>objects</code> and <a href="ex/CatString/write.html">write</a>s them in sequence.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/writeCharCode.html
+++ b/testing/test_package_docs/ex/CatString/writeCharCode.html
@@ -83,9 +83,6 @@
       <span class="returntype">void</span>
       <span class="name ">writeCharCode</span>(<wbr><span class="parameter" id="writeCharCode-param-charCode"><span class="type-annotation">int</span> <span class="parameter-name">charCode</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Adds the string representation of <code>charCode</code> to the buffer.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/CatString/writeln.html
+++ b/testing/test_package_docs/ex/CatString/writeln.html
@@ -83,10 +83,6 @@
       <span class="returntype">void</span>
       <span class="name ">writeln</span>(<wbr>[<span class="parameter" id="writeln-param-obj"><span class="type-annotation">Object</span> <span class="parameter-name">obj</span> = <span class="default-value">""</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Converts <code>obj</code> to a String by invoking <code>Object.toString</code> and 
-adds the result to <code>this</code>, followed by a newline.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -165,7 +165,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -173,7 +173,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -197,7 +197,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -206,7 +206,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -221,7 +221,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -82,31 +82,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
@@ -78,12 +78,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ConstantCat/operator_equals.html
+++ b/testing/test_package_docs/ex/ConstantCat/operator_equals.html
@@ -78,26 +78,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ConstantCat/runtimeType.html
+++ b/testing/test_package_docs/ex/ConstantCat/runtimeType.html
@@ -82,10 +82,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/ConstantCat/toString.html
+++ b/testing/test_package_docs/ex/ConstantCat/toString.html
@@ -78,9 +78,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -110,33 +110,6 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="desc markdown">
-      <p>The annotation <code>@Deprecated('expires when')</code> marks a feature as deprecated.</p>
-<p>The annotation <code>@deprecated</code> is a shorthand for deprecating until
-an unspecified "next release".</p>
-<p>The intent of the <code>@Deprecated</code> annotation is to inform users of a feature
-that they should change their code, even if it is currently still working
-correctly.</p>
-<p>A deprecated feature is scheduled to be removed at a later time, possibly
-specified as the "expires" field of the annotation.
-This means that a deprecated feature should not be used, or code using it
-will break at some point in the future. If there is code using the feature,
-that code should be rewritten to not use the deprecated feature.</p>
-<p>A deprecated feature should document how the same effect can be achieved,
-so the programmer knows how to rewrite the code.</p>
-<p>The <code>@Deprecated</code> annotation applies to libraries, top-level declarations
-(variables, getters, setters, functions, classes and typedefs),
-class-level declarations (variables, getters, setters, methods, operators or
-constructors, whether static or not), named optional arguments and
-trailing optional positional parameters.</p>
-<p>Deprecation is transitive:</p><ul><li>If a library is deprecated, so is every member of it.</li><li>If a class is deprecated, so is every member of it.</li><li>If a variable is deprecated, so are its implicit getter and setter.</li></ul>
-<p>A tool that processes Dart source code may report when:</p><ul><li>the code imports a deprecated library.</li><li>the code exports a deprecated library, or any deprecated member of &nbsp;a non-deprecated library.</li><li>the code refers statically to a deprecated declaration.</li><li>the code dynamically uses a member of an object with a statically known
-type, where the member is deprecated on the static type of the object.</li><li>the code dynamically calls a method with an argument where the
-corresponding optional parameter is deprecated on the object's static type.</li></ul>
-<p>If the deprecated use is inside a library, class or method which is itself
-deprecated, the tool should not bother the user about it.
-A deprecated feature is expected to use other deprecated features.</p>
-    </section>
     
 
     <section class="summary offset-anchor" id="constructors">
@@ -147,8 +120,7 @@ A deprecated feature is expected to use other deprecated features.</p>
           <span class="name"><a href="ex/Deprecated/Deprecated.html">Deprecated</a></span><span class="signature">(<span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)</span>
         </dt>
         <dd>
-          Create a deprecation annotation which specifies the expiration of the
-annotated feature.
+          
           <div class="constructor-modifier features">const</div>
         </dd>
       </dl>
@@ -163,7 +135,7 @@ annotated feature.
           <span class="signature">&#8594; String</span>
         </dt>
         <dd>
-          A description of when the deprecated feature is expected to be retired.
+          
           <div class="features">final</div>
 </dd>
         <dt id="hashCode" class="property inherited">
@@ -171,7 +143,7 @@ annotated feature.
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -179,7 +151,7 @@ annotated feature.
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -194,7 +166,7 @@ annotated feature.
           </span>
         </dt>
         <dd>
-          Returns a string representation of this object.
+          
           
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
@@ -203,7 +175,7 @@ annotated feature.
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -218,7 +190,7 @@ annotated feature.
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -77,14 +77,6 @@
             <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)
     </section>
 
-    <section class="desc markdown">
-      <p>Create a deprecation annotation which specifies the expiration of the
-annotated feature.</p>
-<p>The <code>expires</code> argument should be readable by programmers, and should state
-when an annotated feature is expected to be removed.
-This can be specified, for example, as a date, as a release number, or
-as relative to some other change (like "when bug 4418 is fixed").</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -78,9 +78,6 @@
         <span class="name ">expires</span>        <div class="features">final</div>
     </section>
 
-    <section class="desc markdown">
-      <p>A description of when the deprecated feature is expected to be retired.</p>
-    </section>
     
 
 

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Deprecated/toString.html
+++ b/testing/test_package_docs/ex/Deprecated/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -237,7 +237,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -245,7 +245,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -341,7 +341,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -350,7 +350,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -365,7 +365,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           </span>
         </dt>
         <dd>
-          The equality operator.
+          
           
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -104,31 +104,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Dog/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Dog/noSuchMethod.html
@@ -100,12 +100,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -105,26 +105,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -104,10 +104,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Dog/toString.html
+++ b/testing/test_package_docs/ex/Dog/toString.html
@@ -100,9 +100,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/E-class.html
+++ b/testing/test_package_docs/ex/E-class.html
@@ -146,7 +146,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -154,7 +154,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -169,7 +169,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -178,7 +178,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -193,7 +193,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/E/hashCode.html
+++ b/testing/test_package_docs/ex/E/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/E/noSuchMethod.html
+++ b/testing/test_package_docs/ex/E/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/E/operator_equals.html
+++ b/testing/test_package_docs/ex/E/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/E/runtimeType.html
+++ b/testing/test_package_docs/ex/E/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/E/toString.html
+++ b/testing/test_package_docs/ex/E/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -198,7 +198,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="isImplemented" class="property inherited">
@@ -223,7 +223,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -283,7 +283,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="test" class="callable inherited">
@@ -328,7 +328,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="withMacro" class="callable inherited">
@@ -361,7 +361,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -143,7 +143,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -151,7 +151,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -166,7 +166,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -175,7 +175,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -190,7 +190,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/ForAnnotation/toString.html
+++ b/testing/test_package_docs/ex/ForAnnotation/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs/ex/HasAnnotation-class.html
@@ -146,7 +146,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -154,7 +154,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -169,7 +169,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -178,7 +178,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -193,7 +193,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/HasAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/HasAnnotation/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/HasAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/HasAnnotation/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/HasAnnotation/toString.html
+++ b/testing/test_package_docs/ex/HasAnnotation/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Helper-class.html
+++ b/testing/test_package_docs/ex/Helper-class.html
@@ -139,7 +139,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -147,7 +147,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -171,7 +171,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -180,7 +180,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -195,7 +195,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Helper/hashCode.html
+++ b/testing/test_package_docs/ex/Helper/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Helper/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Helper/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Helper/operator_equals.html
+++ b/testing/test_package_docs/ex/Helper/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Helper/runtimeType.html
+++ b/testing/test_package_docs/ex/Helper/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Helper/toString.html
+++ b/testing/test_package_docs/ex/Helper/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -137,7 +137,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -145,7 +145,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -214,7 +214,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -229,7 +229,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -84,31 +84,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/Klass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Klass/noSuchMethod.html
@@ -80,12 +80,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Klass/operator_equals.html
+++ b/testing/test_package_docs/ex/Klass/operator_equals.html
@@ -80,26 +80,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/Klass/runtimeType.html
+++ b/testing/test_package_docs/ex/Klass/runtimeType.html
@@ -84,10 +84,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyError-class.html
+++ b/testing/test_package_docs/ex/MyError-class.html
@@ -148,7 +148,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -156,7 +156,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="stackTrace" class="property inherited">
@@ -179,7 +179,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -188,7 +188,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -203,7 +203,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/MyError/hashCode.html
+++ b/testing/test_package_docs/ex/MyError/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyError/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyError/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyError/operator_equals.html
+++ b/testing/test_package_docs/ex/MyError/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyError/runtimeType.html
+++ b/testing/test_package_docs/ex/MyError/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyError/toString.html
+++ b/testing/test_package_docs/ex/MyError/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -156,7 +156,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -164,7 +164,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -179,7 +179,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -188,7 +188,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -203,7 +203,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyErrorImplements/toString.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyException-class.html
+++ b/testing/test_package_docs/ex/MyException-class.html
@@ -148,7 +148,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -156,7 +156,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -171,7 +171,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -180,7 +180,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -195,7 +195,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/MyException/hashCode.html
+++ b/testing/test_package_docs/ex/MyException/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyException/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyException/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyException/operator_equals.html
+++ b/testing/test_package_docs/ex/MyException/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyException/runtimeType.html
+++ b/testing/test_package_docs/ex/MyException/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyException/toString.html
+++ b/testing/test_package_docs/ex/MyException/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements-class.html
@@ -148,7 +148,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -156,7 +156,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -171,7 +171,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -180,7 +180,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -195,7 +195,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/toString.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
@@ -147,7 +147,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -155,7 +155,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -170,7 +170,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="test" class="callable inherited">
@@ -188,7 +188,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -203,7 +203,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/toString.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -134,7 +134,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -142,7 +142,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -166,7 +166,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -175,7 +175,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -190,7 +190,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -141,7 +141,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="name" class="property inherited">
@@ -157,7 +157,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -172,7 +172,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -181,7 +181,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -196,7 +196,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/ShapeType/hashCode.html
+++ b/testing/test_package_docs/ex/ShapeType/hashCode.html
@@ -81,31 +81,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/ShapeType/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ShapeType/noSuchMethod.html
@@ -77,12 +77,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ShapeType/operator_equals.html
+++ b/testing/test_package_docs/ex/ShapeType/operator_equals.html
@@ -77,26 +77,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/ShapeType/runtimeType.html
+++ b/testing/test_package_docs/ex/ShapeType/runtimeType.html
@@ -81,10 +81,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/ShapeType/toString.html
+++ b/testing/test_package_docs/ex/ShapeType/toString.html
@@ -82,9 +82,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs/ex/SpecializedDuration-class.html
@@ -160,7 +160,7 @@ that has some operators</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns the number of whole days spanned by this Duration.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="inHours" class="property inherited">
@@ -168,7 +168,7 @@ that has some operators</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns the number of whole hours spanned by this Duration.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="inMicroseconds" class="property inherited">
@@ -176,7 +176,7 @@ that has some operators</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns number of whole microseconds spanned by this Duration.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="inMilliseconds" class="property inherited">
@@ -184,7 +184,7 @@ that has some operators</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns number of whole milliseconds spanned by this Duration.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="inMinutes" class="property inherited">
@@ -192,7 +192,7 @@ that has some operators</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns the number of whole minutes spanned by this Duration.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="inSeconds" class="property inherited">
@@ -200,7 +200,7 @@ that has some operators</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          Returns the number of whole seconds spanned by this Duration.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="isNegative" class="property inherited">
@@ -208,7 +208,7 @@ that has some operators</p>
           <span class="signature">&#8594; bool</span>
         </dt>
         <dd class="inherited">
-          Returns whether this <code>Duration</code> is negative.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -216,7 +216,7 @@ that has some operators</p>
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -231,8 +231,7 @@ that has some operators</p>
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new <code>Duration</code> representing the absolute value of this
-<code>Duration</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="compareTo" class="callable inherited">
@@ -241,7 +240,7 @@ that has some operators</p>
           </span>
         </dt>
         <dd class="inherited">
-          Compares this Duration to <code>other</code>, returning zero if the values are equal.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
@@ -250,7 +249,7 @@ that has some operators</p>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -259,7 +258,7 @@ that has some operators</p>
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this <code>Duration</code>.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -274,8 +273,7 @@ that has some operators</p>
           </span>
         </dt>
         <dd class="inherited">
-          Multiplies this Duration by the given <code>factor</code> and returns the result
-as a new Duration object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator +" class="callable inherited">
@@ -284,8 +282,7 @@ as a new Duration object.
           </span>
         </dt>
         <dd class="inherited">
-          Adds this Duration and <code>other</code> and
-returns the sum as a new Duration object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator -" class="callable inherited">
@@ -294,8 +291,7 @@ returns the sum as a new Duration object.
           </span>
         </dt>
         <dd class="inherited">
-          Subtracts <code>other</code> from this Duration and
-returns the difference as a new Duration object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator &lt;" class="callable inherited">
@@ -304,8 +300,7 @@ returns the difference as a new Duration object.
           </span>
         </dt>
         <dd class="inherited">
-          Returns <code>true</code> if the value of this Duration
-is less than the value of <code>other</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator &lt;=" class="callable inherited">
@@ -314,8 +309,7 @@ is less than the value of <code>other</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns <code>true</code> if the value of this Duration
-is less than or equal to the value of <code>other</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator ==" class="callable inherited">
@@ -324,7 +318,7 @@ is less than or equal to the value of <code>other</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns <code>true</code> if this Duration is the same object as <code>other</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator &gt;" class="callable inherited">
@@ -333,8 +327,7 @@ is less than or equal to the value of <code>other</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns <code>true</code> if the value of this Duration
-is greater than the value of <code>other</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator &gt;=" class="callable inherited">
@@ -343,8 +336,7 @@ is greater than the value of <code>other</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns <code>true</code> if the value of this Duration
-is greater than or equal to the value of <code>other</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator unary-" class="callable inherited">
@@ -353,7 +345,7 @@ is greater than or equal to the value of <code>other</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new <code>Duration</code> representing this <code>Duration</code> negated.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator ~/" class="callable inherited">
@@ -362,8 +354,7 @@ is greater than or equal to the value of <code>other</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Divides this Duration by the given <code>quotient</code> and returns the truncated
-result as a new Duration object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/SpecializedDuration/abs.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/abs.html
@@ -93,12 +93,6 @@
       <span class="returntype">Duration</span>
       <span class="name ">abs</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a new <code>Duration</code> representing the absolute value of this
-<code>Duration</code>.</p>
-<p>The returned <code>Duration</code> has the same length as this one, but is always
-positive.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/compareTo.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/compareTo.html
@@ -93,14 +93,6 @@
       <span class="returntype">int</span>
       <span class="name ">compareTo</span>(<wbr><span class="parameter" id="compareTo-param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Compares this Duration to <code>other</code>, returning zero if the values are equal.</p>
-<p>Returns a negative integer if this <code>Duration</code> is shorter than
-<code>other</code>, or a positive integer if it is longer.</p>
-<p>A negative <code>Duration</code> is always considered shorter than a positive one.</p>
-<p>It is always the case that <code>duration1.compareTo(duration2) &lt; 0</code> iff
-<code>(someDate + duration1).compareTo(someDate + duration2) &lt; 0</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
@@ -97,31 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inDays.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inDays.html
@@ -97,10 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">inDays</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the number of whole days spanned by this Duration.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inHours.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inHours.html
@@ -97,11 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">inHours</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the number of whole hours spanned by this Duration.</p>
-<p>The returned value can be greater than 23.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
@@ -97,10 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">inMicroseconds</span></section>
       
-      <section class="desc markdown">
-  <p>Returns number of whole microseconds spanned by this Duration.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
@@ -97,11 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">inMilliseconds</span></section>
       
-      <section class="desc markdown">
-  <p>Returns number of whole milliseconds spanned by this Duration.</p>
-<p>The returned value can be greater than 999.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
@@ -97,11 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">inMinutes</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the number of whole minutes spanned by this Duration.</p>
-<p>The returned value can be greater than 59.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
@@ -97,11 +97,7 @@
         <span class="returntype">int</span>
         <span class="name ">inSeconds</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the number of whole seconds spanned by this Duration.</p>
-<p>The returned value can be greater than 59.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
@@ -97,12 +97,7 @@
         <span class="returntype">bool</span>
         <span class="name ">isNegative</span></section>
       
-      <section class="desc markdown">
-  <p>Returns whether this <code>Duration</code> is negative.</p>
-<p>A negative <code>Duration</code> represents the difference from a later time to an
-earlier time.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/noSuchMethod.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/noSuchMethod.html
@@ -93,12 +93,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_equals.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_equals.html
@@ -93,9 +93,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns <code>true</code> if this Duration is the same object as <code>other</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_greater.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_greater.html
@@ -93,10 +93,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator &gt;</span>(<wbr><span class="parameter" id=">-param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns <code>true</code> if the value of this Duration
-is greater than the value of <code>other</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_greater_equal.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_greater_equal.html
@@ -93,10 +93,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator &gt;=</span>(<wbr><span class="parameter" id=">=-param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns <code>true</code> if the value of this Duration
-is greater than or equal to the value of <code>other</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_less.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_less.html
@@ -93,10 +93,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator &lt;</span>(<wbr><span class="parameter" id="<-param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns <code>true</code> if the value of this Duration
-is less than the value of <code>other</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_less_equal.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_less_equal.html
@@ -93,10 +93,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator &lt;=</span>(<wbr><span class="parameter" id="<=-param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns <code>true</code> if the value of this Duration
-is less than or equal to the value of <code>other</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_minus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_minus.html
@@ -93,10 +93,6 @@
       <span class="returntype">Duration</span>
       <span class="name ">operator -</span>(<wbr><span class="parameter" id="--param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Subtracts <code>other</code> from this Duration and
-returns the difference as a new Duration object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_multiply.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_multiply.html
@@ -93,12 +93,6 @@
       <span class="returntype">Duration</span>
       <span class="name ">operator *</span>(<wbr><span class="parameter" id="*-param-factor"><span class="type-annotation">num</span> <span class="parameter-name">factor</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Multiplies this Duration by the given <code>factor</code> and returns the result
-as a new Duration object.</p>
-<p>Note that when <code>factor</code> is a double, and the duration is greater than
-53 bits, precision is lost because of double-precision arithmetic.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_plus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_plus.html
@@ -93,10 +93,6 @@
       <span class="returntype">Duration</span>
       <span class="name ">operator +</span>(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation">Duration</span> <span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Adds this Duration and <code>other</code> and
-returns the sum as a new Duration object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_truncate_divide.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_truncate_divide.html
@@ -93,11 +93,6 @@
       <span class="returntype">Duration</span>
       <span class="name ">operator ~/</span>(<wbr><span class="parameter" id="~/-param-quotient"><span class="type-annotation">int</span> <span class="parameter-name">quotient</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Divides this Duration by the given <code>quotient</code> and returns the truncated
-result as a new Duration object.</p>
-<p>Throws an <code>IntegerDivisionByZeroException</code> if <code>quotient</code> is <code>0</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_unary_minus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_unary_minus.html
@@ -93,11 +93,6 @@
       <span class="returntype">Duration</span>
       <span class="name ">operator unary-</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a new <code>Duration</code> representing this <code>Duration</code> negated.</p>
-<p>The returned <code>Duration</code> has the same length as this one, but will have the
-opposite sign of this one.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
@@ -97,10 +97,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/SpecializedDuration/toString.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/toString.html
@@ -93,14 +93,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this <code>Duration</code>.</p>
-<p>Returns a string with hours, minutes, seconds, and microseconds, in the
-following format: <code>HH:MM:SS.mmmmmm</code>. For example,</p>
-<pre class="prettyprint language-dart"><code>var d = new Duration(days:1, hours:1, minutes:33, microseconds: 500);
-d.toString();  // "25:33:00.000500"
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -155,7 +155,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -163,7 +163,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -178,7 +178,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -187,7 +187,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -202,7 +202,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
+++ b/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/WithGeneric/toString.html
+++ b/testing/test_package_docs/ex/WithGeneric/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -148,7 +148,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="prop" class="property inherited">
@@ -165,7 +165,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -180,7 +180,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -189,7 +189,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -204,7 +204,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/aThingToDo-class.html
+++ b/testing/test_package_docs/ex/aThingToDo-class.html
@@ -154,7 +154,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -162,7 +162,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -177,7 +177,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -186,7 +186,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -201,7 +201,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/ex/aThingToDo/hashCode.html
+++ b/testing/test_package_docs/ex/aThingToDo/hashCode.html
@@ -81,31 +81,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/aThingToDo/noSuchMethod.html
+++ b/testing/test_package_docs/ex/aThingToDo/noSuchMethod.html
@@ -77,12 +77,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/aThingToDo/operator_equals.html
+++ b/testing/test_package_docs/ex/aThingToDo/operator_equals.html
@@ -77,26 +77,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/aThingToDo/runtimeType.html
+++ b/testing/test_package_docs/ex/aThingToDo/runtimeType.html
@@ -81,10 +81,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/ex/aThingToDo/toString.html
+++ b/testing/test_package_docs/ex/aThingToDo/toString.html
@@ -77,9 +77,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -116,9 +116,6 @@
         
     </section>
 
-      <section class="desc markdown">
-        <p>Marks a feature as <a href="ex/Deprecated-class.html">Deprecated</a> until the next release.</p>
-      </section>
             
 
   </div> <!-- /.main-content -->

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -117,7 +117,7 @@
           <span class="name "><a href="ex/Deprecated-class.html">Deprecated</a></span>
         </dt>
         <dd>
-          The annotation <code>@Deprecated('expires when')</code> marks a feature as deprecated.
+          
         </dd>
         <dt id="Dog">
           <span class="name "><a href="ex/Dog-class.html">Dog</a></span>
@@ -256,7 +256,7 @@ that has some operators
           <span class="signature">&#8594; <a href="ex/Deprecated-class.html">Deprecated</a></span>
         </dt>
         <dd>
-          Marks a feature as <a href="ex/Deprecated-class.html">Deprecated</a> until the next release.
+          
           
   <div>
             <span class="signature"><code>const <a href="ex/Deprecated-class.html">Deprecated</a>(&quot;next release&quot;)</code></span>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -164,7 +164,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -172,7 +172,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -187,7 +187,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -196,7 +196,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -211,7 +211,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Annotation/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Annotation/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Annotation/operator_equals.html
+++ b/testing/test_package_docs/fake/Annotation/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Annotation/runtimeType.html
+++ b/testing/test_package_docs/fake/Annotation/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Annotation/toString.html
+++ b/testing/test_package_docs/fake/Annotation/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -167,7 +167,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -175,7 +175,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -190,7 +190,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -199,7 +199,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -214,7 +214,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/AnotherInterface/hashCode.html
+++ b/testing/test_package_docs/fake/AnotherInterface/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/AnotherInterface/noSuchMethod.html
+++ b/testing/test_package_docs/fake/AnotherInterface/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
+++ b/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
+++ b/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/AnotherInterface/toString.html
+++ b/testing/test_package_docs/fake/AnotherInterface/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -164,7 +164,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -172,7 +172,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -205,7 +205,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -214,7 +214,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -229,7 +229,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
@@ -81,31 +81,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/BaseForDocComments/noSuchMethod.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/noSuchMethod.html
@@ -77,12 +77,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
@@ -77,26 +77,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
@@ -81,10 +81,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/BaseForDocComments/toString.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/toString.html
@@ -77,9 +77,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -229,7 +229,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -237,7 +237,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -261,7 +261,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -270,7 +270,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -285,7 +285,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -248,7 +248,7 @@ Some constants have long docs.</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -256,7 +256,7 @@ Some constants have long docs.</p>
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -271,7 +271,7 @@ Some constants have long docs.</p>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -280,7 +280,7 @@ Some constants have long docs.</p>
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -295,7 +295,7 @@ Some constants have long docs.</p>
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Color/hashCode.html
+++ b/testing/test_package_docs/fake/Color/hashCode.html
@@ -87,31 +87,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Color/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Color/noSuchMethod.html
@@ -83,12 +83,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Color/operator_equals.html
+++ b/testing/test_package_docs/fake/Color/operator_equals.html
@@ -83,26 +83,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Color/runtimeType.html
+++ b/testing/test_package_docs/fake/Color/runtimeType.html
@@ -87,10 +87,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Color/toString.html
+++ b/testing/test_package_docs/fake/Color/toString.html
@@ -83,9 +83,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -184,7 +184,7 @@ Go ahead, it's fun.
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -192,7 +192,7 @@ Go ahead, it's fun.
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -207,7 +207,7 @@ Go ahead, it's fun.
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -216,7 +216,7 @@ Go ahead, it's fun.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -231,7 +231,7 @@ Go ahead, it's fun.
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -82,31 +82,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
@@ -78,12 +78,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ConstantClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstantClass/operator_equals.html
@@ -78,26 +78,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ConstantClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstantClass/runtimeType.html
@@ -82,10 +82,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/ConstantClass/toString.html
+++ b/testing/test_package_docs/fake/ConstantClass/toString.html
@@ -78,9 +78,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -155,7 +155,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -163,7 +163,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -187,7 +187,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -196,7 +196,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -211,7 +211,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Cool/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Cool/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Cool/operator_equals.html
+++ b/testing/test_package_docs/fake/Cool/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Cool/runtimeType.html
+++ b/testing/test_package_docs/fake/Cool/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Cool/toString.html
+++ b/testing/test_package_docs/fake/Cool/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -173,7 +173,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -181,7 +181,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="stackTrace" class="property inherited">
@@ -204,7 +204,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -213,7 +213,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -228,7 +228,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Doh/hashCode.html
+++ b/testing/test_package_docs/fake/Doh/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Doh/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Doh/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Doh/operator_equals.html
+++ b/testing/test_package_docs/fake/Doh/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Doh/runtimeType.html
+++ b/testing/test_package_docs/fake/Doh/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Doh/toString.html
+++ b/testing/test_package_docs/fake/Doh/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -178,7 +178,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="isEmpty" class="property inherited">
@@ -235,7 +235,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="single" class="property inherited">
@@ -258,8 +258,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Adds <code>value</code> to the end of this list,
-extending the length by one.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="addAll" class="callable inherited">
@@ -268,7 +267,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Appends all objects of <code>iterable</code> to the end of this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="any" class="callable inherited">
@@ -277,7 +276,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Checks whether any element of this iterable satisfies <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="asMap" class="callable inherited">
@@ -286,7 +285,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Returns an unmodifiable <code>Map</code> view of <code>this</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="clear" class="callable inherited">
@@ -295,8 +294,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Removes all objects from this list;
-the length of the list becomes zero.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="contains" class="callable inherited">
@@ -305,7 +303,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Returns true if the collection contains an element equal to <code>element</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="elementAt" class="callable inherited">
@@ -314,7 +312,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the <code>index</code>th element.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="every" class="callable inherited">
@@ -323,7 +321,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Checks whether every element of this iterable satisfies <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="expand" class="callable inherited">
@@ -332,7 +330,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Expands each element of this <code>Iterable</code> into zero or more elements.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="fillRange" class="callable inherited">
@@ -341,8 +339,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Sets the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
-to the given <code>fillValue</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="firstWhere" class="callable inherited">
@@ -351,7 +348,7 @@ to the given <code>fillValue</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the first element that satisfies the given predicate <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="fold" class="callable inherited">
@@ -360,8 +357,7 @@ to the given <code>fillValue</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Reduces a collection to a single value by iteratively combining each
-element of the collection with an existing value
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="forEach" class="callable inherited">
@@ -370,8 +366,7 @@ element of the collection with an existing value
           </span>
         </dt>
         <dd class="inherited">
-          Applies the function <code>f</code> to each element of this collection in iteration
-order.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="getRange" class="callable inherited">
@@ -380,8 +375,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Returns an <code>Iterable</code> that iterates over the objects in the range
-<code>start</code> inclusive to <code>end</code> exclusive.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="indexOf" class="callable inherited">
@@ -390,7 +384,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the first index of <code>element</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="insert" class="callable inherited">
@@ -399,7 +393,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Inserts the object at position <code>index</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="insertAll" class="callable inherited">
@@ -408,7 +402,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Inserts all objects of <code>iterable</code> at position <code>index</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="join" class="callable inherited">
@@ -417,7 +411,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Converts each element to a <code>String</code> and concatenates the strings.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="lastIndexOf" class="callable inherited">
@@ -426,9 +420,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the last index in the list <code>a</code> of the given <code>element</code>, starting
-the search at index <code>startIndex</code> to 0.
-Returns -1 if <code>element</code> is not found.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="lastWhere" class="callable inherited">
@@ -437,7 +429,7 @@ Returns -1 if <code>element</code> is not found.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the last element that satisfies the given predicate <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="map" class="callable inherited">
@@ -446,8 +438,7 @@ Returns -1 if <code>element</code> is not found.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new lazy <code>Iterable</code> with elements that are created by
-calling <code>f</code> on each element of this <code>Iterable</code> in iteration order.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
@@ -456,7 +447,7 @@ calling <code>f</code> on each element of this <code>Iterable</code> in iteratio
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="reduce" class="callable inherited">
@@ -465,8 +456,7 @@ calling <code>f</code> on each element of this <code>Iterable</code> in iteratio
           </span>
         </dt>
         <dd class="inherited">
-          Reduces a collection to a single value by iteratively combining elements
-of the collection using the provided function.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="remove" class="callable inherited">
@@ -475,7 +465,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the first occurrence of <code>value</code> from this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeAt" class="callable inherited">
@@ -484,7 +474,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the object at position <code>index</code> from this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeLast" class="callable inherited">
@@ -493,7 +483,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Pops and returns the last object in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeRange" class="callable inherited">
@@ -502,7 +492,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeWhere" class="callable inherited">
@@ -511,7 +501,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes all objects from this list that satisfy <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="replaceRange" class="callable inherited">
@@ -520,8 +510,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
-and inserts the contents of <code>replacement</code> in its place.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="retainWhere" class="callable inherited">
@@ -530,7 +519,7 @@ and inserts the contents of <code>replacement</code> in its place.
           </span>
         </dt>
         <dd class="inherited">
-          Removes all objects from this list that fail to satisfy <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="setAll" class="callable inherited">
@@ -539,8 +528,7 @@ and inserts the contents of <code>replacement</code> in its place.
           </span>
         </dt>
         <dd class="inherited">
-          Overwrites objects of <code>this</code> with the objects of <code>iterable</code>, starting
-at position <code>index</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="setRange" class="callable inherited">
@@ -549,8 +537,7 @@ at position <code>index</code> in this list.
           </span>
         </dt>
         <dd class="inherited">
-          Copies the objects of <code>iterable</code>, skipping <code>skipCount</code> objects first,
-into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of the list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="shuffle" class="callable inherited">
@@ -559,7 +546,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Shuffles the elements of this list randomly.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="singleWhere" class="callable inherited">
@@ -568,7 +555,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns the single element that satisfies <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="skip" class="callable inherited">
@@ -577,7 +564,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="skipWhile" class="callable inherited">
@@ -586,7 +573,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="sort" class="callable inherited">
@@ -595,7 +582,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Sorts this list according to the order specified by the <code>compare</code> function.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="sublist" class="callable inherited">
@@ -604,8 +591,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new list containing the objects from <code>start</code> inclusive to <code>end</code>
-exclusive.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="take" class="callable inherited">
@@ -614,7 +600,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a lazy iterable of the <code>count</code> first elements of this iterable.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="takeWhile" class="callable inherited">
@@ -623,7 +609,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a lazy iterable of the leading elements satisfying <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toList" class="callable inherited">
@@ -632,7 +618,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Creates a <code>List</code> containing the elements of this <code>Iterable</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toSet" class="callable inherited">
@@ -641,7 +627,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Creates a <code>Set</code> containing the same elements as this iterable.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -650,7 +636,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="where" class="callable inherited">
@@ -659,8 +645,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new lazy <code>Iterable</code> with all elements that satisfy the
-predicate <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -675,7 +660,7 @@ predicate <code>test</code>.
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="operator []" class="callable inherited">

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -164,7 +164,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -172,7 +172,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -187,7 +187,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -196,7 +196,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -211,7 +211,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -83,31 +83,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Foo2/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Foo2/noSuchMethod.html
@@ -79,12 +79,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Foo2/operator_equals.html
+++ b/testing/test_package_docs/fake/Foo2/operator_equals.html
@@ -79,26 +79,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Foo2/runtimeType.html
+++ b/testing/test_package_docs/fake/Foo2/runtimeType.html
@@ -83,10 +83,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Foo2/toString.html
+++ b/testing/test_package_docs/fake/Foo2/toString.html
@@ -79,9 +79,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -155,7 +155,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -163,7 +163,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -178,7 +178,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -187,7 +187,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -202,7 +202,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -152,7 +152,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -160,7 +160,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -211,7 +211,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -220,7 +220,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -235,7 +235,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -83,31 +83,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
@@ -79,12 +79,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -79,26 +79,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -83,10 +83,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/HasGenerics/toString.html
+++ b/testing/test_package_docs/fake/HasGenerics/toString.html
@@ -79,9 +79,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -186,7 +186,7 @@ they are correct.</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -194,7 +194,7 @@ they are correct.</p>
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -209,7 +209,7 @@ they are correct.</p>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -218,7 +218,7 @@ they are correct.</p>
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -233,7 +233,7 @@ they are correct.</p>
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
@@ -81,31 +81,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
@@ -77,12 +77,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
@@ -77,26 +77,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -81,10 +81,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/ImplicitProperties/toString.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/toString.html
@@ -77,9 +77,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -167,7 +167,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -175,7 +175,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -190,7 +190,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -199,7 +199,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -214,7 +214,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Interface/hashCode.html
+++ b/testing/test_package_docs/fake/Interface/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Interface/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Interface/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Interface/operator_equals.html
+++ b/testing/test_package_docs/fake/Interface/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Interface/runtimeType.html
+++ b/testing/test_package_docs/fake/Interface/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Interface/toString.html
+++ b/testing/test_package_docs/fake/Interface/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -224,7 +224,7 @@ across... wait for it... two physical lines.</p>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="powers" class="property inherited">
@@ -241,7 +241,7 @@ across... wait for it... two physical lines.</p>
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -301,7 +301,7 @@ across... wait for it... two physical lines.</p>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -310,7 +310,7 @@ across... wait for it... two physical lines.</p>
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -352,7 +352,7 @@ across... wait for it... two physical lines.</p>
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -167,7 +167,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -175,7 +175,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -190,7 +190,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -199,7 +199,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -214,7 +214,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/MixMeIn/hashCode.html
+++ b/testing/test_package_docs/fake/MixMeIn/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/MixMeIn/noSuchMethod.html
+++ b/testing/test_package_docs/fake/MixMeIn/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/MixMeIn/operator_equals.html
+++ b/testing/test_package_docs/fake/MixMeIn/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/MixMeIn/runtimeType.html
+++ b/testing/test_package_docs/fake/MixMeIn/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/MixMeIn/toString.html
+++ b/testing/test_package_docs/fake/MixMeIn/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -177,7 +177,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -185,7 +185,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -200,7 +200,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -209,7 +209,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -224,7 +224,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Oops/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Oops/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Oops/operator_equals.html
+++ b/testing/test_package_docs/fake/Oops/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/Oops/runtimeType.html
+++ b/testing/test_package_docs/fake/Oops/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/Oops/toString.html
+++ b/testing/test_package_docs/fake/Oops/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -155,7 +155,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -163,7 +163,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -178,7 +178,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -187,7 +187,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -202,7 +202,7 @@
           </span>
         </dt>
         <dd>
-          The equality operator.
+          
           
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
@@ -80,26 +80,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/toString.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -152,7 +152,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -160,7 +160,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -184,7 +184,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -193,7 +193,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -208,7 +208,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/toString.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -190,7 +190,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="isEmpty" class="property inherited">
@@ -238,7 +238,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="single" class="property inherited">
@@ -261,8 +261,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Adds <code>value</code> to the end of this list,
-extending the length by one.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="addAll" class="callable inherited">
@@ -271,7 +270,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Appends all objects of <code>iterable</code> to the end of this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="any" class="callable inherited">
@@ -280,7 +279,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Checks whether any element of this iterable satisfies <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="asMap" class="callable inherited">
@@ -289,7 +288,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Returns an unmodifiable <code>Map</code> view of <code>this</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="clear" class="callable inherited">
@@ -298,8 +297,7 @@ extending the length by one.
           </span>
         </dt>
         <dd class="inherited">
-          Removes all objects from this list;
-the length of the list becomes zero.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="contains" class="callable inherited">
@@ -308,7 +306,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Returns true if the collection contains an element equal to <code>element</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="elementAt" class="callable inherited">
@@ -317,7 +315,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the <code>index</code>th element.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="every" class="callable inherited">
@@ -326,7 +324,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Checks whether every element of this iterable satisfies <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="expand" class="callable inherited">
@@ -335,7 +333,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Expands each element of this <code>Iterable</code> into zero or more elements.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="fillRange" class="callable inherited">
@@ -344,8 +342,7 @@ the length of the list becomes zero.
           </span>
         </dt>
         <dd class="inherited">
-          Sets the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
-to the given <code>fillValue</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="firstWhere" class="callable inherited">
@@ -354,7 +351,7 @@ to the given <code>fillValue</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the first element that satisfies the given predicate <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="fold" class="callable inherited">
@@ -363,8 +360,7 @@ to the given <code>fillValue</code>.
           </span>
         </dt>
         <dd class="inherited">
-          Reduces a collection to a single value by iteratively combining each
-element of the collection with an existing value
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="forEach" class="callable inherited">
@@ -373,8 +369,7 @@ element of the collection with an existing value
           </span>
         </dt>
         <dd class="inherited">
-          Applies the function <code>f</code> to each element of this collection in iteration
-order.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="getRange" class="callable inherited">
@@ -383,8 +378,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Returns an <code>Iterable</code> that iterates over the objects in the range
-<code>start</code> inclusive to <code>end</code> exclusive.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="indexOf" class="callable inherited">
@@ -393,7 +387,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the first index of <code>element</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="insert" class="callable inherited">
@@ -402,7 +396,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Inserts the object at position <code>index</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="insertAll" class="callable inherited">
@@ -411,7 +405,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Inserts all objects of <code>iterable</code> at position <code>index</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="join" class="callable inherited">
@@ -420,7 +414,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Converts each element to a <code>String</code> and concatenates the strings.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="lastIndexOf" class="callable inherited">
@@ -429,9 +423,7 @@ order.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the last index in the list <code>a</code> of the given <code>element</code>, starting
-the search at index <code>startIndex</code> to 0.
-Returns -1 if <code>element</code> is not found.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="lastWhere" class="callable inherited">
@@ -440,7 +432,7 @@ Returns -1 if <code>element</code> is not found.
           </span>
         </dt>
         <dd class="inherited">
-          Returns the last element that satisfies the given predicate <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="map" class="callable inherited">
@@ -449,8 +441,7 @@ Returns -1 if <code>element</code> is not found.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new lazy <code>Iterable</code> with elements that are created by
-calling <code>f</code> on each element of this <code>Iterable</code> in iteration order.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
@@ -459,7 +450,7 @@ calling <code>f</code> on each element of this <code>Iterable</code> in iteratio
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="reduce" class="callable inherited">
@@ -468,8 +459,7 @@ calling <code>f</code> on each element of this <code>Iterable</code> in iteratio
           </span>
         </dt>
         <dd class="inherited">
-          Reduces a collection to a single value by iteratively combining elements
-of the collection using the provided function.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="remove" class="callable inherited">
@@ -478,7 +468,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the first occurrence of <code>value</code> from this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeAt" class="callable inherited">
@@ -487,7 +477,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the object at position <code>index</code> from this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeLast" class="callable inherited">
@@ -496,7 +486,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Pops and returns the last object in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeRange" class="callable inherited">
@@ -505,7 +495,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="removeWhere" class="callable inherited">
@@ -514,7 +504,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes all objects from this list that satisfy <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="replaceRange" class="callable inherited">
@@ -523,8 +513,7 @@ of the collection using the provided function.
           </span>
         </dt>
         <dd class="inherited">
-          Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
-and inserts the contents of <code>replacement</code> in its place.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="retainWhere" class="callable inherited">
@@ -533,7 +522,7 @@ and inserts the contents of <code>replacement</code> in its place.
           </span>
         </dt>
         <dd class="inherited">
-          Removes all objects from this list that fail to satisfy <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="setAll" class="callable inherited">
@@ -542,8 +531,7 @@ and inserts the contents of <code>replacement</code> in its place.
           </span>
         </dt>
         <dd class="inherited">
-          Overwrites objects of <code>this</code> with the objects of <code>iterable</code>, starting
-at position <code>index</code> in this list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="setRange" class="callable inherited">
@@ -552,8 +540,7 @@ at position <code>index</code> in this list.
           </span>
         </dt>
         <dd class="inherited">
-          Copies the objects of <code>iterable</code>, skipping <code>skipCount</code> objects first,
-into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of the list.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="shuffle" class="callable inherited">
@@ -562,7 +549,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Shuffles the elements of this list randomly.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="singleWhere" class="callable inherited">
@@ -571,7 +558,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns the single element that satisfies <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="skip" class="callable inherited">
@@ -580,7 +567,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="skipWhile" class="callable inherited">
@@ -589,7 +576,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="sort" class="callable inherited">
@@ -598,7 +585,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Sorts this list according to the order specified by the <code>compare</code> function.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="sublist" class="callable inherited">
@@ -607,8 +594,7 @@ into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new list containing the objects from <code>start</code> inclusive to <code>end</code>
-exclusive.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="take" class="callable inherited">
@@ -617,7 +603,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a lazy iterable of the <code>count</code> first elements of this iterable.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="takeWhile" class="callable inherited">
@@ -626,7 +612,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a lazy iterable of the leading elements satisfying <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toList" class="callable inherited">
@@ -635,7 +621,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Creates a <code>List</code> containing the elements of this <code>Iterable</code>.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toSet" class="callable inherited">
@@ -644,7 +630,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Creates a <code>Set</code> containing the same elements as this iterable.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -653,7 +639,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="where" class="callable inherited">
@@ -662,8 +648,7 @@ exclusive.
           </span>
         </dt>
         <dd class="inherited">
-          Returns a new lazy <code>Iterable</code> with all elements that satisfy the
-predicate <code>test</code>.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -696,7 +681,7 @@ predicate <code>test</code>.
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/SpecialList/add.html
+++ b/testing/test_package_docs/fake/SpecialList/add.html
@@ -127,11 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">add</span>(<wbr><span class="parameter" id="add-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Adds <code>value</code> to the end of this list,
-extending the length by one.</p>
-<p>Throws an <code>UnsupportedError</code> if the list is fixed-length.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/addAll.html
+++ b/testing/test_package_docs/fake/SpecialList/addAll.html
@@ -127,11 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">addAll</span>(<wbr><span class="parameter" id="addAll-param-iterable"><span class="type-annotation">Iterable&lt;E&gt;</span> <span class="parameter-name">iterable</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Appends all objects of <code>iterable</code> to the end of this list.</p>
-<p>Extends the length of the list by the number of objects in <code>iterable</code>.
-Throws an <code>UnsupportedError</code> if this list is fixed-length.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/any.html
+++ b/testing/test_package_docs/fake/SpecialList/any.html
@@ -127,11 +127,6 @@
       <span class="returntype">bool</span>
       <span class="name ">any</span>(<wbr><span class="parameter" id="any-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Checks whether any element of this iterable satisfies <code>test</code>.</p>
-<p>Checks every element in iteration order, and returns <code>true</code> if
-any of them make <code>test</code> return <code>true</code>, otherwise returns false.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/asMap.html
+++ b/testing/test_package_docs/fake/SpecialList/asMap.html
@@ -127,17 +127,6 @@
       <span class="returntype">Map&lt;int, E&gt;</span>
       <span class="name ">asMap</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns an unmodifiable <code>Map</code> view of <code>this</code>.</p>
-<p>The map uses the indices of this list as keys and the corresponding objects
-as values. The <code>Map.keys</code> <code>Iterable</code> iterates the indices of this list
-in numerical order.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; words = ['fee', 'fi', 'fo', 'fum'];
-Map&lt;int, String&gt; map = words.asMap();
-map[0] + map[1];   // 'feefi';
-map.keys.toList(); // [0, 1, 2, 3]
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/clear.html
+++ b/testing/test_package_docs/fake/SpecialList/clear.html
@@ -127,12 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">clear</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Removes all objects from this list;
-the length of the list becomes zero.</p>
-<p>Throws an <code>UnsupportedError</code>, and retains all objects, if this
-is a fixed-length list.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -127,19 +127,6 @@
       <span class="returntype">bool</span>
       <span class="name ">contains</span>(<wbr><span class="parameter" id="contains-param-element"><span class="type-annotation">Object</span> <span class="parameter-name">element</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns true if the collection contains an element equal to <code>element</code>.</p>
-<p>This operation will check each element in order for being equal to
-<code>element</code>, unless it has a more efficient way to find an element
-equal to <code>element</code>.</p>
-<p>The equality used to determine whether <code>element</code> is equal to an element of
-the iterable defaults to the <code>Object.==</code> of the element.</p>
-<p>Some types of iterable may have a different equality used for its elements.
-For example, a <code>Set</code> may have a custom equality
-(see <code>Set.identity</code>) that its <code>contains</code> uses.
-Likewise the <code>Iterable</code> returned by a <code>Map.keys</code> call
-should use the same equality that the <code>Map</code> uses for keys.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/elementAt.html
+++ b/testing/test_package_docs/fake/SpecialList/elementAt.html
@@ -127,15 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">elementAt</span>(<wbr><span class="parameter" id="elementAt-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns the <code>index</code>th element.</p>
-<p>The <code>index</code> must be non-negative and less than <a href="fake/SpecialList/length.html">length</a>.
-Index zero represents the first element (so <code>iterable.elementAt(0)</code> is
-equivalent to <code>iterable.first</code>).</p>
-<p>May iterate through the elements in iteration order, skipping the
-first <code>index</code> elements and returning the next.
-Some iterable may have more efficient ways to find the element.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/every.html
+++ b/testing/test_package_docs/fake/SpecialList/every.html
@@ -127,11 +127,6 @@
       <span class="returntype">bool</span>
       <span class="name ">every</span>(<wbr><span class="parameter" id="every-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Checks whether every element of this iterable satisfies <code>test</code>.</p>
-<p>Checks every element in iteration order, and returns <code>false</code> if
-any of them make <code>test</code> return <code>false</code>, otherwise returns <code>true</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/expand.html
+++ b/testing/test_package_docs/fake/SpecialList/expand.html
@@ -127,22 +127,6 @@
       <span class="returntype">Iterable&lt;T&gt;</span>
       <span class="name ">expand</span>&lt;T&gt;(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable&lt;T&gt;</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Expands each element of this <code>Iterable</code> into zero or more elements.</p>
-<p>The resulting Iterable runs through the elements returned
-by <code>f</code> for each element of this, in iteration order.</p>
-<p>The returned <code>Iterable</code> is lazy, and calls <code>f</code> for each element
-of this every time it's iterated.</p>
-<p>Example:</p>
-<pre class="prettyprint language-dart"><code>var pairs = [[1, 2], [3, 4]];
-var flattened = pairs.expand((pair) =&gt; pair).toList();
-print(flattened); // =&gt; [1, 2, 3, 4];
-
-var input = [1, 2, 3];
-var duplicated = input.expand((i) =&gt; [i, i]).toList();
-print(duplicated); // =&gt; [1, 1, 2, 2, 3, 3]
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -127,14 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">fillRange</span>(<wbr><span class="parameter" id="fillRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="fillRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, [</span> <span class="parameter" id="fillRange-param-fill"><span class="type-annotation">E</span> <span class="parameter-name">fill</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Sets the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
-to the given <code>fillValue</code>.</p>
-<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
-A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
-<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
-<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -131,13 +131,7 @@
         <span class="returntype">E</span>
         <span class="name ">first</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the first element.</p>
-<p>Throws a <code>StateError</code> if <code>this</code> is empty.
-Otherwise returns the first element in the iteration order,
-equivalent to <code>this.elementAt(0)</code>.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -127,13 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">firstWhere</span>(<wbr><span class="parameter" id="firstWhere-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>), {</span> <span class="parameter" id="firstWhere-param-orElse"><span class="type-annotation">E</span> <span class="parameter-name">orElse</span>()</span> })
     </section>
-    <section class="desc markdown">
-      <p>Returns the first element that satisfies the given predicate <code>test</code>.</p>
-<p>Iterates through elements and returns the first to satisfy <code>test</code>.</p>
-<p>If no element satisfies <code>test</code>, the result of invoking the <code>orElse</code>
-function is returned.
-If <code>orElse</code> is omitted, it defaults to throwing a <code>StateError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/fold.html
+++ b/testing/test_package_docs/fake/SpecialList/fold.html
@@ -127,22 +127,6 @@
       <span class="returntype">T</span>
       <span class="name ">fold</span>&lt;T&gt;(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Reduces a collection to a single value by iteratively combining each
-element of the collection with an existing value</p>
-<p>Uses <code>initialValue</code> as the initial value,
-then iterates through the elements and updates the value with
-each element using the <code>combine</code> function, as if by:</p>
-<pre class="prettyprint language-dart"><code>var value = initialValue;
-for (E element in this) {
-  value = combine(value, element);
-}
-return value;
-</code></pre>
-<p>Example of calculating the sum of an iterable:</p>
-<pre class="prettyprint language-dart"><code>iterable.fold(0, (prev, element) =&gt; prev + element);
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/forEach.html
+++ b/testing/test_package_docs/fake/SpecialList/forEach.html
@@ -127,10 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">forEach</span>(<wbr><span class="parameter" id="forEach-param-action"><span class="type-annotation">void</span> <span class="parameter-name">action</span>(<span class="parameter" id="action-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Applies the function <code>f</code> to each element of this collection in iteration
-order.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -127,23 +127,6 @@
       <span class="returntype">Iterable&lt;E&gt;</span>
       <span class="name ">getRange</span>(<wbr><span class="parameter" id="getRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="getRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns an <code>Iterable</code> that iterates over the objects in the range
-<code>start</code> inclusive to <code>end</code> exclusive.</p>
-<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid at the time
-of the call.</p>
-<p>A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
-<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
-<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
-<p>The returned <code>Iterable</code> behaves like <code>skip(start).take(end - start)</code>.
-That is, it does <em>not</em> throw if this list changes size.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; colors = ['red', 'green', 'blue', 'orange', 'pink'];
-Iterable&lt;String&gt; range = colors.getRange(1, 4);
-range.join(', ');  // 'green, blue, orange'
-colors.length = 3;
-range.join(', ');  // 'green, blue'
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -131,31 +131,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/indexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/indexOf.html
@@ -127,19 +127,6 @@
       <span class="returntype">int</span>
       <span class="name ">indexOf</span>(<wbr><span class="parameter" id="indexOf-param-element"><span class="type-annotation">Object</span> <span class="parameter-name">element</span>, [</span> <span class="parameter" id="indexOf-param-startIndex"><span class="type-annotation">int</span> <span class="parameter-name">startIndex</span> = <span class="default-value">0</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Returns the first index of <code>element</code> in this list.</p>
-<p>Searches the list from index <code>start</code> to the end of the list.
-The first time an object <code>o</code> is encountered so that <code>o == element</code>,
-the index of <code>o</code> is returned.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; notes = ['do', 're', 'mi', 're'];
-notes.indexOf('re');    // 1
-notes.indexOf('re', 2); // 3
-</code></pre>
-<p>Returns -1 if <code>element</code> is not found.</p>
-<pre class="prettyprint language-dart"><code>notes.indexOf('fa');    // -1
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/insert.html
+++ b/testing/test_package_docs/fake/SpecialList/insert.html
@@ -127,13 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">insert</span>(<wbr><span class="parameter" id="insert-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="insert-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Inserts the object at position <code>index</code> in this list.</p>
-<p>This increases the length of the list by one and shifts all objects
-at or after the index towards the end of the list.</p>
-<p>An error occurs if the <code>index</code> is less than 0 or greater than length.
-An <code>UnsupportedError</code> occurs if the list is fixed-length.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/insertAll.html
+++ b/testing/test_package_docs/fake/SpecialList/insertAll.html
@@ -127,13 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">insertAll</span>(<wbr><span class="parameter" id="insertAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="insertAll-param-iterable"><span class="type-annotation">Iterable&lt;E&gt;</span> <span class="parameter-name">iterable</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Inserts all objects of <code>iterable</code> at position <code>index</code> in this list.</p>
-<p>This increases the length of the list by the length of <code>iterable</code> and
-shifts all later objects towards the end of the list.</p>
-<p>An error occurs if the <code>index</code> is less than 0 or greater than length.
-An <code>UnsupportedError</code> occurs if the list is fixed-length.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -131,11 +131,7 @@
         <span class="returntype">bool</span>
         <span class="name ">isEmpty</span></section>
       
-      <section class="desc markdown">
-  <p>Returns <code>true</code> if there are no elements in this collection.</p>
-<p>May be computed by checking if <code>iterator.moveNext()</code> returns <code>false</code>.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -131,11 +131,7 @@
         <span class="returntype">bool</span>
         <span class="name ">isNotEmpty</span></section>
       
-      <section class="desc markdown">
-  <p>Returns true if there is at least one element in this collection.</p>
-<p>May be computed by checking if <code>iterator.moveNext()</code> returns <code>true</code>.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -131,31 +131,7 @@
         <span class="returntype">Iterator&lt;E&gt;</span>
         <span class="name ">iterator</span></section>
       
-      <section class="desc markdown">
-  <p>Returns a new <code>Iterator</code> that allows iterating the elements of this
-<code>Iterable</code>.</p>
-<p>Iterable classes may specify the iteration order of their elements
-(for example <code>List</code> always iterate in index order),
-or they may leave it unspecified (for example a hash-based <code>Set</code>
-may iterate in any order).</p>
-<p>Each time <code>iterator</code> is read, it returns a new iterator,
-which can be used to iterate through all the elements again.
-The iterators of the same iterable can be stepped through independently,
-but should return the same elements in the same order,
-as long as the underlying collection isn't changed.</p>
-<p>Modifying the collection may cause new iterators to produce
-different elements, and may change the order of existing elements.
-A <code>List</code> specifies its iteration order precisely,
-so modifying the list changes the iteration order predictably.
-A hash-based <code>Set</code> may change its iteration order completely
-when adding a new element to the set.</p>
-<p>Modifying the underlying collection after creating the new iterator
-may cause an error the next time <code>Iterator.moveNext</code> is called
-on that iterator.
-Any <em>modifiable</em> iterable class should specify which operations will
-break iteration.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/join.html
+++ b/testing/test_package_docs/fake/SpecialList/join.html
@@ -127,13 +127,6 @@
       <span class="returntype">String</span>
       <span class="name ">join</span>(<wbr>[<span class="parameter" id="join-param-separator"><span class="type-annotation">String</span> <span class="parameter-name">separator</span> = <span class="default-value">""</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Converts each element to a <code>String</code> and concatenates the strings.</p>
-<p>Iterates through elements of this iterable,
-converts each one to a <code>String</code> by calling <code>Object.toString</code>,
-and then concatenates the strings, with the
-<code>separator</code> string interleaved between the elements.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -131,16 +131,7 @@
         <span class="returntype">E</span>
         <span class="name ">last</span></section>
       
-      <section class="desc markdown">
-  <p>Returns the last element.</p>
-<p>Throws a <code>StateError</code> if <code>this</code> is empty.
-Otherwise may iterate through the elements and returns the last one
-seen.
-Some iterables may have more efficient ways to find the last element
-(for example a list can directly access the last element,
-without iterating through the previous ones).</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
@@ -127,11 +127,6 @@
       <span class="returntype">int</span>
       <span class="name ">lastIndexOf</span>(<wbr><span class="parameter" id="lastIndexOf-param-element"><span class="type-annotation">Object</span> <span class="parameter-name">element</span>, [</span> <span class="parameter" id="lastIndexOf-param-startIndex"><span class="type-annotation">int</span> <span class="parameter-name">startIndex</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Returns the last index in the list <code>a</code> of the given <code>element</code>, starting
-the search at index <code>startIndex</code> to 0.
-Returns -1 if <code>element</code> is not found.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -127,18 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">lastWhere</span>(<wbr><span class="parameter" id="lastWhere-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>), {</span> <span class="parameter" id="lastWhere-param-orElse"><span class="type-annotation">E</span> <span class="parameter-name">orElse</span>()</span> })
     </section>
-    <section class="desc markdown">
-      <p>Returns the last element that satisfies the given predicate <code>test</code>.</p>
-<p>An iterable that can access its elements directly may check its
-elements in any order (for example a list starts by checking the
-last element and then moves towards the start of the list).
-The default implementation iterates elements in iteration order,
-checks <code>test(element)</code> for each,
-and finally returns that last one that matched.</p>
-<p>If no element satisfies <code>test</code>, the result of invoking the <code>orElse</code>
-function is returned.
-If <code>orElse</code> is omitted, it defaults to throwing a <code>StateError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -127,18 +127,6 @@
       <span class="returntype">Iterable&lt;T&gt;</span>
       <span class="name ">map</span>&lt;T&gt;(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a new lazy <code>Iterable</code> with elements that are created by
-calling <code>f</code> on each element of this <code>Iterable</code> in iteration order.</p>
-<p>This method returns a view of the mapped elements. As long as the
-returned <code>Iterable</code> is not iterated over, the supplied function <code>f</code> will
-not be invoked. The transformed elements will not be cached. Iterating
-multiple times over the returned <code>Iterable</code> will invoke the supplied
-function <code>f</code> multiple times on the same element.</p>
-<p>Methods on the returned iterable are allowed to omit calling <code>f</code>
-on any element where the result isn't needed.
-For example, <a href="fake/SpecialList/elementAt.html">elementAt</a> may call <code>f</code> only once.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
@@ -127,12 +127,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -127,26 +127,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/reduce.html
+++ b/testing/test_package_docs/fake/SpecialList/reduce.html
@@ -127,24 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">reduce</span>(<wbr><span class="parameter" id="reduce-param-combine"><span class="type-annotation">E</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">E</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Reduces a collection to a single value by iteratively combining elements
-of the collection using the provided function.</p>
-<p>The iterable must have at least one element.
-If it has only one element, that element is returned.</p>
-<p>Otherwise this method starts with the first element from the iterator,
-and then combines it with the remaining elements in iteration order,
-as if by:</p>
-<pre class="prettyprint language-dart"><code>E value = iterable.first;
-iterable.skip(1).forEach((element) {
-  value = combine(value, element);
-});
-return value;
-</code></pre>
-<p>Example of calculating the sum of an iterable:</p>
-<pre class="prettyprint language-dart"><code>iterable.reduce((value, element) =&gt; value + element);
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/remove.html
+++ b/testing/test_package_docs/fake/SpecialList/remove.html
@@ -127,20 +127,6 @@
       <span class="returntype">bool</span>
       <span class="name ">remove</span>(<wbr><span class="parameter" id="remove-param-element"><span class="type-annotation">Object</span> <span class="parameter-name">element</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Removes the first occurrence of <code>value</code> from this list.</p>
-<p>Returns true if <code>value</code> was in the list, false otherwise.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; parts = ['head', 'shoulders', 'knees', 'toes'];
-parts.remove('head'); // true
-parts.join(', ');     // 'shoulders, knees, toes'
-</code></pre>
-<p>The method has no effect if <code>value</code> was not in the list.</p>
-<pre class="prettyprint language-dart"><code>// Note: 'head' has already been removed.
-parts.remove('head'); // false
-parts.join(', ');     // 'shoulders, knees, toes'
-</code></pre>
-<p>An <code>UnsupportedError</code> occurs if the list is fixed-length.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/removeAt.html
+++ b/testing/test_package_docs/fake/SpecialList/removeAt.html
@@ -127,15 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">removeAt</span>(<wbr><span class="parameter" id="removeAt-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Removes the object at position <code>index</code> from this list.</p>
-<p>This method reduces the length of <code>this</code> by one and moves all later objects
-down by one position.</p>
-<p>Returns the removed object.</p>
-<p>The <code>index</code> must be in the range <code>0 ≤ index &lt; length</code>.</p>
-<p>Throws an <code>UnsupportedError</code> if this is a fixed-length list. In that case
-the list is not modified.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/removeLast.html
+++ b/testing/test_package_docs/fake/SpecialList/removeLast.html
@@ -127,10 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">removeLast</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Pops and returns the last object in this list.</p>
-<p>Throws an <code>UnsupportedError</code> if this is a fixed-length list.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -127,15 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">removeRange</span>(<wbr><span class="parameter" id="removeRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="removeRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive.</p>
-<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
-A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
-<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
-<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
-<p>Throws an <code>UnsupportedError</code> if this is a fixed-length list. In that case
-the list is not modified.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/removeWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/removeWhere.html
@@ -127,15 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">removeWhere</span>(<wbr><span class="parameter" id="removeWhere-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Removes all objects from this list that satisfy <code>test</code>.</p>
-<p>An object <code>o</code> satisfies <code>test</code> if <code>test(o)</code> is true.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; numbers = ['one', 'two', 'three', 'four'];
-numbers.removeWhere((item) =&gt; item.length == 3);
-numbers.join(', '); // 'three, four'
-</code></pre>
-<p>Throws an <code>UnsupportedError</code> if this is a fixed-length list.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -127,21 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">replaceRange</span>(<wbr><span class="parameter" id="replaceRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="replaceRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="replaceRange-param-newContents"><span class="type-annotation">Iterable&lt;E&gt;</span> <span class="parameter-name">newContents</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Removes the objects in the range <code>start</code> inclusive to <code>end</code> exclusive
-and inserts the contents of <code>replacement</code> in its place.</p>
-<pre class="prettyprint language-dart"><code>List&lt;int&gt; list = [1, 2, 3, 4, 5];
-list.replaceRange(1, 4, [6, 7]);
-list.join(', '); // '1, 6, 7, 5'
-</code></pre>
-<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
-A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
-<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
-<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
-<p>This method does not work on fixed-length lists, even when <code>replacement</code>
-has the same number of elements as the replaced range. In that case use
-<a href="fake/SpecialList/setRange.html">setRange</a> instead.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/retainWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/retainWhere.html
@@ -127,15 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">retainWhere</span>(<wbr><span class="parameter" id="retainWhere-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Removes all objects from this list that fail to satisfy <code>test</code>.</p>
-<p>An object <code>o</code> satisfies <code>test</code> if <code>test(o)</code> is true.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; numbers = ['one', 'two', 'three', 'four'];
-numbers.retainWhere((item) =&gt; item.length == 3);
-numbers.join(', '); // 'one, two'
-</code></pre>
-<p>Throws an <code>UnsupportedError</code> if this is a fixed-length list.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -131,10 +131,7 @@
         <span class="returntype">Iterable&lt;E&gt;</span>
         <span class="name ">reversed</span></section>
       
-      <section class="desc markdown">
-  <p>Returns an <code>Iterable</code> of the objects in this list in reverse order.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -131,10 +131,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/setAll.html
+++ b/testing/test_package_docs/fake/SpecialList/setAll.html
@@ -127,20 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">setAll</span>(<wbr><span class="parameter" id="setAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="setAll-param-iterable"><span class="type-annotation">Iterable&lt;E&gt;</span> <span class="parameter-name">iterable</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Overwrites objects of <code>this</code> with the objects of <code>iterable</code>, starting
-at position <code>index</code> in this list.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; list = ['a', 'b', 'c'];
-list.setAll(1, ['bee', 'sea']);
-list.join(', '); // 'a, bee, sea'
-</code></pre>
-<p>This operation does not increase the length of <code>this</code>.</p>
-<p>The <code>index</code> must be non-negative and no greater than <a href="fake/SpecialList/length.html">length</a>.</p>
-<p>The <code>iterable</code> must not have more elements than what can fit from <code>index</code>
-to <a href="fake/SpecialList/length.html">length</a>.</p>
-<p>If <code>iterable</code> is based on this list, its values may change /during/ the
-<code>setAll</code> operation.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -127,28 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">setRange</span>(<wbr><span class="parameter" id="setRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="setRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="setRange-param-iterable"><span class="type-annotation">Iterable&lt;E&gt;</span> <span class="parameter-name">iterable</span>, [</span> <span class="parameter" id="setRange-param-skipCount"><span class="type-annotation">int</span> <span class="parameter-name">skipCount</span> = <span class="default-value">0</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Copies the objects of <code>iterable</code>, skipping <code>skipCount</code> objects first,
-into the range <code>start</code>, inclusive, to <code>end</code>, exclusive, of the list.</p>
-<pre class="prettyprint language-dart"><code>List&lt;int&gt; list1 = [1, 2, 3, 4];
-List&lt;int&gt; list2 = [5, 6, 7, 8, 9];
-// Copies the 4th and 5th items in list2 as the 2nd and 3rd items
-// of list1.
-list1.setRange(1, 3, list2, 3);
-list1.join(', '); // '1, 8, 9, 4'
-</code></pre>
-<p>The provide range, given by <code>start</code> and <code>end</code>, must be valid.
-A range from <code>start</code> to <code>end</code> is valid if <code>0 &lt;= start &lt;= end &lt;= len</code>, where
-<code>len</code> is this list's <code>length</code>. The range starts at <code>start</code> and has length
-<code>end - start</code>. An empty range (with <code>end == start</code>) is valid.</p>
-<p>The <code>iterable</code> must have enough objects to fill the range from <code>start</code>
-to <code>end</code> after skipping <code>skipCount</code> objects.</p>
-<p>If <code>iterable</code> is this list, the operation copies the elements
-originally in the range from <code>skipCount</code> to <code>skipCount + (end - start)</code> to
-the range <code>start</code> to <code>end</code>, even if the two ranges overlap.</p>
-<p>If <code>iterable</code> depends on this list in some other way, no guarantees are
-made.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/shuffle.html
+++ b/testing/test_package_docs/fake/SpecialList/shuffle.html
@@ -127,9 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">shuffle</span>(<wbr>[<span class="parameter" id="shuffle-param-random"><span class="type-annotation">Random</span> <span class="parameter-name">random</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Shuffles the elements of this list randomly.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -131,11 +131,7 @@
         <span class="returntype">E</span>
         <span class="name ">single</span></section>
       
-      <section class="desc markdown">
-  <p>Checks that this iterable has only one element, and returns that element.</p>
-<p>Throws a <code>StateError</code> if <code>this</code> is empty or has more than one element.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SpecialList/singleWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/singleWhere.html
@@ -127,13 +127,6 @@
       <span class="returntype">E</span>
       <span class="name ">singleWhere</span>(<wbr><span class="parameter" id="singleWhere-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns the single element that satisfies <code>test</code>.</p>
-<p>Checks all elements to see if <code>test(element)</code> returns true.
-If exactly one element satisfies <code>test</code>, that element is returned.
-Otherwise, if there are no matching elements, or if there is more than
-one matching element, a <code>StateError</code> is thrown.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -127,19 +127,6 @@
       <span class="returntype">Iterable&lt;E&gt;</span>
       <span class="name ">skip</span>(<wbr><span class="parameter" id="skip-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns an <code>Iterable</code> that provides all but the first <code>count</code> elements.</p>
-<p>When the returned iterable is iterated, it starts iterating over <code>this</code>,
-first skipping past the initial <code>count</code> elements.
-If <code>this</code> has fewer than <code>count</code> elements, then the resulting Iterable is
-empty.
-After that, the remaining elements are iterated in the same order as
-in this iterable.</p>
-<p>Some iterables may be able to find later elements without first iterating
-through earlier elements, for example when iterating a <code>List</code>.
-Such iterables are allowed to ignore the initial skipped elements.</p>
-<p>The <code>count</code> must not be negative.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -127,16 +127,6 @@
       <span class="returntype">Iterable&lt;E&gt;</span>
       <span class="name ">skipWhile</span>(<wbr><span class="parameter" id="skipWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns an <code>Iterable</code> that skips leading elements while <code>test</code> is satisfied.</p>
-<p>The filtering happens lazily. Every new <code>Iterator</code> of the returned
-iterable iterates over all elements of <code>this</code>.</p>
-<p>The returned iterable provides elements by iterating this iterable,
-but skipping over all initial elements where <code>test(element)</code> returns
-true. If all elements satisfy <code>test</code> the resulting iterable is empty,
-otherwise it iterates the remaining elements in their original order,
-starting with the first element for which <code>test(element)</code> returns <code>false</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/sort.html
+++ b/testing/test_package_docs/fake/SpecialList/sort.html
@@ -127,29 +127,6 @@
       <span class="returntype">void</span>
       <span class="name ">sort</span>(<wbr>[<span class="parameter" id="sort-param-compare"><span class="type-annotation">int</span> <span class="parameter-name">compare</span>(<span class="parameter" id="compare-param-a"><span class="type-annotation">E</span> <span class="parameter-name">a</span>, </span> <span class="parameter" id="compare-param-b"><span class="type-annotation">E</span> <span class="parameter-name">b</span></span>)</span> ])
     </section>
-    <section class="desc markdown">
-      <p>Sorts this list according to the order specified by the <code>compare</code> function.</p>
-<p>The <code>compare</code> function must act as a <code>Comparator</code>.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; numbers = ['two', 'three', 'four'];
-// Sort from shortest to longest.
-numbers.sort((a, b) =&gt; a.length.compareTo(b.length));
-print(numbers);  // [two, four, three]
-</code></pre>
-<p>The default List implementations use <code>Comparable.compare</code> if
-<code>compare</code> is omitted.</p>
-<pre class="prettyprint language-dart"><code>List&lt;int&gt; nums = [13, 2, -11];
-nums.sort();
-print(nums);  // [-11, 2, 13]
-</code></pre>
-<p>A <code>Comparator</code> may compare objects as equal (return zero), even if they
-are distinct objects.
-The sort function is not guaranteed to be stable, so distinct objects
-that compare as equal may occur in any order in the result:</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; numbers = ['one', 'two', 'three', 'four'];
-numbers.sort((a, b) =&gt; a.length.compareTo(b.length));
-print(numbers);  // [one, two, four, three] OR [two, one, four, three]
-</code></pre>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/sublist.html
+++ b/testing/test_package_docs/fake/SpecialList/sublist.html
@@ -127,18 +127,6 @@
       <span class="returntype">List&lt;E&gt;</span>
       <span class="name ">sublist</span>(<wbr><span class="parameter" id="sublist-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, [</span> <span class="parameter" id="sublist-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span> ])
     </section>
-    <section class="desc markdown">
-      <p>Returns a new list containing the objects from <code>start</code> inclusive to <code>end</code>
-exclusive.</p>
-<pre class="prettyprint language-dart"><code>List&lt;String&gt; colors = ['red', 'green', 'blue', 'orange', 'pink'];
-colors.sublist(1, 3); // ['green', 'blue']
-</code></pre>
-<p>If <code>end</code> is omitted, the <a href="fake/SpecialList/length.html">length</a> of <code>this</code> is used.</p>
-<pre class="prettyprint language-dart"><code>colors.sublist(1);  // ['green', 'blue', 'orange', 'pink']
-</code></pre>
-<p>An error occurs if <code>start</code> is outside the range <code>0</code> .. <code>length</code> or if
-<code>end</code> is outside the range <code>start</code> .. <code>length</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/take.html
+++ b/testing/test_package_docs/fake/SpecialList/take.html
@@ -127,14 +127,6 @@
       <span class="returntype">Iterable&lt;E&gt;</span>
       <span class="name ">take</span>(<wbr><span class="parameter" id="take-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a lazy iterable of the <code>count</code> first elements of this iterable.</p>
-<p>The returned <code>Iterable</code> may contain fewer than <code>count</code> elements, if <code>this</code>
-contains fewer than <code>count</code> elements.</p>
-<p>The elements can be computed by stepping through <a href="fake/SpecialList/iterator.html">iterator</a> until <code>count</code>
-elements have been seen.</p>
-<p>The <code>count</code> must not be negative.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/takeWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/takeWhile.html
@@ -127,14 +127,6 @@
       <span class="returntype">Iterable&lt;E&gt;</span>
       <span class="name ">takeWhile</span>(<wbr><span class="parameter" id="takeWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a lazy iterable of the leading elements satisfying <code>test</code>.</p>
-<p>The filtering happens lazily. Every new iterator of the returned
-iterable starts iterating over the elements of <code>this</code>.</p>
-<p>The elements can be computed by stepping through <a href="fake/SpecialList/iterator.html">iterator</a> until an
-element is found where <code>test(element)</code> is false. At that point,
-the returned iterable stops (its <code>moveNext()</code> returns false).</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/toList.html
+++ b/testing/test_package_docs/fake/SpecialList/toList.html
@@ -127,11 +127,6 @@
       <span class="returntype">List&lt;E&gt;</span>
       <span class="name ">toList</span>(<wbr>{<span class="parameter" id="toList-param-growable"><span class="type-annotation">bool</span> <span class="parameter-name">growable</span>: <span class="default-value">true</span></span> })
     </section>
-    <section class="desc markdown">
-      <p>Creates a <code>List</code> containing the elements of this <code>Iterable</code>.</p>
-<p>The elements are in iteration order.
-The list is fixed-length if <code>growable</code> is false.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/toSet.html
+++ b/testing/test_package_docs/fake/SpecialList/toSet.html
@@ -127,14 +127,6 @@
       <span class="returntype">Set&lt;E&gt;</span>
       <span class="name ">toSet</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Creates a <code>Set</code> containing the same elements as this iterable.</p>
-<p>The set may contain fewer elements than the iterable,
-if the iterable contains an element more than once,
-or it contains one or more elements that are equal.
-The order of the elements in the set is not guaranteed to be the same
-as for the iterable.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/toString.html
+++ b/testing/test_package_docs/fake/SpecialList/toString.html
@@ -127,9 +127,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -127,18 +127,6 @@
       <span class="returntype">Iterable&lt;E&gt;</span>
       <span class="name ">where</span>(<wbr><span class="parameter" id="where-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a new lazy <code>Iterable</code> with all elements that satisfy the
-predicate <code>test</code>.</p>
-<p>The matching elements have the same order in the returned iterable
-as they have in <a href="fake/SpecialList/iterator.html">iterator</a>.</p>
-<p>This method returns a view of the mapped elements.
-As long as the returned <code>Iterable</code> is not iterated over,
-the supplied function <code>test</code> will not be invoked.
-Iterating will not cache results, and thus iterating multiple times over
-the returned <code>Iterable</code> may invoke the supplied
-function <code>test</code> multiple times on the same element.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -169,7 +169,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -177,7 +177,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -219,7 +219,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -228,7 +228,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -243,7 +243,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -180,7 +180,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -188,7 +188,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -212,7 +212,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -221,7 +221,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -245,7 +245,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -82,31 +82,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
@@ -78,12 +78,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
@@ -78,26 +78,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
@@ -82,10 +82,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
@@ -78,9 +78,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -176,7 +176,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -184,7 +184,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -199,7 +199,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -208,7 +208,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -223,7 +223,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -80,31 +80,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
@@ -76,12 +76,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <code>noSuchMethod</code> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
@@ -76,26 +76,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <code>hashCode</code> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
@@ -80,10 +80,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
@@ -76,9 +76,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
@@ -89,7 +89,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -97,7 +97,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -112,7 +112,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -121,7 +121,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -136,7 +136,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <a href="test_package_imported.main/Whataclass/noSuchMethod.html">noSuchMethod</a> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <a href="test_package_imported.main/Whataclass/hashCode.html">hashCode</a> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2-class.html
@@ -89,7 +89,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
@@ -97,7 +97,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -112,7 +112,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -121,7 +121,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -136,7 +136,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
@@ -79,31 +79,7 @@
         <span class="returntype">int</span>
         <span class="name ">hashCode</span></section>
       
-      <section class="desc markdown">
-  <p>The hash code for this object.</p>
-<p>A hash code is a single integer which represents the state of the object
-that affects <code>==</code> comparisons.</p>
-<p>All objects have hash codes.
-The default hash code represents only the identity of the object,
-the same way as the default <code>==</code> implementation only considers objects
-equal if they are identical (see <code>identityHashCode</code>).</p>
-<p>If <code>==</code> is overridden to use the object state instead,
-the hash code must also be changed to represent that state.</p>
-<p>Hash codes must be the same for objects that are equal to each other
-according to <code>==</code>.
-The hash code of an object should only change if the object changes
-in a way that affects equality.
-There are no further requirements for the hash codes.
-They need not be consistent between executions of the same program
-and there are no distribution guarantees.</p>
-<p>Objects that are not equal are allowed to have the same hash code,
-it is even technically allowed that all instances have the same hash code,
-but if clashes happen too often, it may reduce the efficiency of hash-based
-data structures like <code>HashSet</code> or <code>HashMap</code>.</p>
-<p>If a subclass overrides <code>hashCode</code>, it should override the
-<code>==</code> operator as well to maintain consistency.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/noSuchMethod.html
@@ -75,12 +75,6 @@
       <span class="returntype">dynamic</span>
       <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>Invoked when a non-existent method or property is accessed.</p>
-<p>Classes can override <a href="test_package_imported.main/Whataclass2/noSuchMethod.html">noSuchMethod</a> to provide custom behavior.</p>
-<p>If a value is returned, it becomes the result of the original invocation.</p>
-<p>The default behavior is to throw a <code>NoSuchMethodError</code>.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
@@ -75,26 +75,6 @@
       <span class="returntype">bool</span>
       <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>
-    <section class="desc markdown">
-      <p>The equality operator.</p>
-<p>The default behavior for all <code>Object</code>s is to return true if and
-only if <code>this</code> and <code>other</code> are the same object.</p>
-<p>Override this method to specify a different equality relation on
-a class. The overriding method must still be an equivalence relation.
-That is, it must be:</p><ul><li>
-<p>Total: It must return a boolean for all arguments. It should never throw
-or return <code>null</code>.</p></li><li>
-<p>Reflexive: For all objects <code>o</code>, <code>o == o</code> must be true.</p></li><li>
-<p>Symmetric: For all objects <code>o1</code> and <code>o2</code>, <code>o1 == o2</code> and <code>o2 == o1</code> must
-either both be true, or both be false.</p></li><li>
-<p>Transitive: For all objects <code>o1</code>, <code>o2</code>, and <code>o3</code>, if <code>o1 == o2</code> and
-<code>o2 == o3</code> are true, then <code>o1 == o3</code> must be true.</p></li></ul>
-<p>The method should also be consistent over time,
-so whether two objects are equal should only change
-if at least one of the objects was modified.</p>
-<p>If a subclass overrides the equality operator it should override
-the <a href="test_package_imported.main/Whataclass2/hashCode.html">hashCode</a> method as well to maintain consistency.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
@@ -79,10 +79,7 @@
         <span class="returntype">Type</span>
         <span class="name ">runtimeType</span></section>
       
-      <section class="desc markdown">
-  <p>A representation of the runtime type of the object.</p>
-</section>
-</section>
+      </section>
       
 
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/toString.html
@@ -75,9 +75,6 @@
       <span class="returntype">String</span>
       <span class="name ">toString</span>(<wbr>)
     </section>
-    <section class="desc markdown">
-      <p>Returns a string representation of this object.</p>
-    </section>
     
     
 

--- a/testing/test_package_docs/two_exports/BaseClass-class.html
+++ b/testing/test_package_docs/two_exports/BaseClass-class.html
@@ -106,7 +106,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="lengthX" class="property inherited">
@@ -123,7 +123,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -138,7 +138,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -147,7 +147,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -162,7 +162,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/testing/test_package_docs/two_exports/ExtendingClass-class.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass-class.html
@@ -108,7 +108,7 @@
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
-          The hash code for this object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="lengthX" class="property inherited">
@@ -125,7 +125,7 @@
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
-          A representation of the runtime type of the object.
+          
           <div class="features">read-only, inherited</div>
 </dd>
       </dl>
@@ -140,7 +140,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed.
+          
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
@@ -149,7 +149,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          Returns a string representation of this object.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>
@@ -164,7 +164,7 @@
           </span>
         </dt>
         <dd class="inherited">
-          The equality operator.
+          
           <div class="features">inherited</div>
 </dd>
       </dl>

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -214,6 +214,7 @@ updateTestPackageDocs() {
         'examples',
         '--no-include-source',
         '--pretty-index-json',
+        '--hide-sdk-text',
         '--exclude',
         'dart.async,dart.collection,dart.convert,dart.core,dart.math,dart.typed_data,meta',
         '--output',


### PR DESCRIPTION
Fixes #1456 and should enable dartdoc tests to work reliably in the SDK.

As discussed before, add a flag to hide the imported SDK docs in the integration tests.