### PR TITLE
Add homepage link to index

### DIFF
--- a/lib/src/html/template_data.dart
+++ b/lib/src/html/template_data.dart
@@ -40,6 +40,9 @@ abstract class TemplateData<T extends Documentable> {
 
   bool get includeVersion => false;
 
+  bool get hasHomepage => false;
+  String get homepage => null;
+
   bool get hasSubNav => subnavItems.isNotEmpty;
 
   List<Subnav> get subnavItems {
@@ -97,6 +100,11 @@ class PackageTemplateData extends TemplateData<Package> {
   Iterable<Subnav> getSubNavItems() {
     return [new Subnav('Libraries', '${package.href}#libraries')];
   }
+
+  @override
+  bool get hasHomepage => package.hasHomepage;
+  @override
+  String get homepage => package.homepage;
 
   @override
   String get kind => (useCategories || package.isSdk) ? '' : 'package';

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -13,7 +13,6 @@ import 'package:analyzer/dart/ast/ast.dart'
     show
         AnnotatedNode,
         Declaration,
-        FormalParameter,
         FieldDeclaration,
         VariableDeclaration,
         VariableDeclarationList;
@@ -3630,6 +3629,10 @@ class Package extends Nameable implements Documentable {
   }
 
   List<Library> get libraries => _libraries.toList(growable: false);
+
+  bool get hasHomepage =>
+      packageMeta.homepage != null && packageMeta.homepage.isNotEmpty;
+  String get homepage => packageMeta.homepage;
 
   @override
   String get name => packageMeta.name;

--- a/lib/templates/_head.html
+++ b/lib/templates/_head.html
@@ -37,7 +37,12 @@
     {{#navLinks}}
     <li><a href="{{href}}">{{name}}</a></li>
     {{/navLinks}}
+    {{^hasHomepage}}
     <li class="self-crumb">{{{ layoutTitle }}}</li>
+    {{/hasHomepage}}
+    {{#hasHomepage}}
+    <li><a href="{{homepage}}">{{{ layoutTitle }}}</a></li>
+    {{/hasHomepage}}
   </ol>
   <div class="self-name">{{self.name}}</div>
   <form class="search navbar-right" role="search">

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -67,6 +67,7 @@ void main() {
 
       Package p = results.package;
       expect(p.name, 'test_package_small');
+      expect(p.hasHomepage, isFalse);
       expect(p.hasDocumentationFile, isFalse);
       expect(p.libraries, hasLength(1));
     });

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -54,6 +54,11 @@ void main() {
         expect(package.libraries, hasLength(8));
       });
 
+      test('homepage', () {
+        expect(package.hasHomepage, true);
+        expect(package.homepage, equals('http://github.com/dart-lang'));
+      });
+
       test('categories', () {
         expect(package.categories, hasLength(1));
 
@@ -92,6 +97,12 @@ void main() {
 
       test('sdk name', () {
         expect(sdkAsPackage.name, equals('Dart SDK'));
+      });
+
+      test('sdk homepage', () {
+        expect(sdkAsPackage.hasHomepage, isTrue);
+        expect(
+            sdkAsPackage.homepage, equals('https://github.com/dart-lang/sdk'));
       });
 
       test('sdk version', () {

--- a/testing/test_package/pubspec.yaml
+++ b/testing/test_package/pubspec.yaml
@@ -1,4 +1,5 @@
 name: test_package
+homepage: http://github.com/dart-lang
 description: Best package ever.
 version: 0.0.1
 dependencies:

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -21,7 +21,7 @@
 
 <header id="title">
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    <li class="self-crumb">package test_package</li>
+    <li><a href="http://github.com/dart-lang">package test_package</a></li>
   </ol>
   <div class="self-name">test_package</div>
   <form class="search navbar-right" role="search">


### PR DESCRIPTION
Fix #1460 by linking the name of the package in the upper left to the homepage of the package, but only for the index page.  Other pages continue to link to the API index page here.