### PR TITLE
Fix issue with generation of 'null' value enum fields

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2137,25 +2137,11 @@ abstract class ModelElement extends Nameable
       if (e is FieldElement) {
         assert(getter != null || setter != null);
         if (enclosingClass == null) {
-          if (e.enclosingElement.isEnum) {
-            int index =
-                e.computeConstantValue()?.getField('index')?.toIntValue();
-            if (index != null) {
-              // We should never build a Field for something that should be
-              // a EnumField.forConstant with an index, instead (#1445).
-              // "Special" enum-only fields including 'values' and confusingly,
-              // 'index', will return a null for index, so this is guaranteed
-              // to be one of the constants associated with the enum.
-              // TODO(jcollins-g): is this actually true?
-              assert(e.isConst);
-              assert(getter != null);
-              assert(setter == null);
-              newModelElement =
-                  new EnumField.forConstant(index, e, library, getter);
-            } else {
-              assert(['index', 'values'].contains(e.name));
-              newModelElement = new EnumField(e, library, getter, setter);
-            }
+          if (e.isEnumConstant) {
+            int index = e.computeConstantValue().getField('index').toIntValue();
+            newModelElement = new EnumField.forConstant(index, e, library, getter);
+          } else if (e.enclosingElement.isEnum) {
+            newModelElement = new EnumField(e, library, getter, setter);
           } else {
             newModelElement = new Field(e, library, getter, setter);
           }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -842,6 +842,9 @@ void main() {
 
     setUp(() {
       animal = exLibrary.enums.firstWhere((e) => e.name == 'Animal');
+
+      /// Trigger code reference resolution
+      animal.documentationAsHtml;
     });
 
     test('has a fully qualified name', () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -67,6 +67,8 @@ typedef String processMessage<T>(String msg);
 
 typedef String ParameterizedTypedef<T>(T msg, int foo);
 
+/// Referencing [processMessage] (or other things) here should not break
+/// enum constants ala #1445
 enum Animal {
   /// Single line docs.
   CAT,

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -100,6 +100,10 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="desc markdown">
+      <p>Referencing <a href="ex/processMessage.html">processMessage</a> (or other things) here should not break
+enum constants ala #1445</p>
+    </section>
     
 
     <section class="summary offset-anchor" id="constants">

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -384,7 +384,8 @@ that has some operators
           <a href="ex/Animal-class.html">Animal</a>
         </dt>
         <dd>
-          
+          Referencing <a href="ex/processMessage.html">processMessage</a> (or other things) here should not break
+enum constants ala #1445
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
Fixes #1445.  Adding Paul to the reviewers as a comment in ConstFieldElementImpl suggested he might have context as to whether the [change to how we compute enum indexes](https://github.com/dart-lang/dartdoc/compare/null-enums?expand=1#diff-4d22582de7e25fdddcfff99652835a1eR2142) is actually an improvement over some variant of the original hack.

