### PR TITLE
Reimplement nodoc handling to be less buggy and more useful

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -487,7 +487,7 @@ class DartDoc {
       sources.add(source);
       if (context.computeKindOf(source) == SourceKind.LIBRARY) {
         LibraryElement library = context.computeLibraryElement(source);
-        if (!isPrivate(library)) libraries.add(library);
+        if (!hasPrivateName(library)) libraries.add(library);
       }
     }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -474,10 +474,13 @@ class Class extends ModelElement implements EnclosedElement {
   List<Constructor> get constructors {
     if (_constructors != null) return _constructors;
 
-    _constructors = _cls.constructors.map((e) {
-      return new ModelElement.from(e, library);
-    }).where((e) => e.isPublic).toList(growable: true)
-      ..sort(byName);
+    _constructors = _cls.constructors
+        .map((e) {
+          return new ModelElement.from(e, library);
+        })
+        .where((e) => e.isPublic)
+        .toList(growable: true)
+          ..sort(byName);
 
     return _constructors;
   }
@@ -934,7 +937,8 @@ class Class extends ModelElement implements EnclosedElement {
     if ((getter == null || getter.isInherited) &&
         (setter == null || setter.isInherited)) {
       // Field is 100% inherited.
-      field = new ModelElement.from(f, library, enclosingClass: this, getter: getter, setter: setter);
+      field = new ModelElement.from(f, library,
+          enclosingClass: this, getter: getter, setter: setter);
     } else {
       // Field is <100% inherited (could be half-inherited).
       // TODO(jcollins-g): Navigation is probably still confusing for
@@ -952,10 +956,13 @@ class Class extends ModelElement implements EnclosedElement {
   List<Method> get _methods {
     if (_allMethods != null) return _allMethods;
 
-    _allMethods = _cls.methods.map((e) {
-      return new ModelElement.from(e, library);
-    }).where((e) => e.isPublic).toList(growable: false)
-      ..sort(byName);
+    _allMethods = _cls.methods
+        .map((e) {
+          return new ModelElement.from(e, library);
+        })
+        .where((e) => e.isPublic)
+        .toList(growable: false)
+          ..sort(byName);
 
     return _allMethods;
   }
@@ -1079,11 +1086,11 @@ class Enum extends Class {
     var index = -1;
 
     _enumFields = [];
-    for (FieldElement f
-        in _cls.fields.where((f) => f.isConst)) {
+    for (FieldElement f in _cls.fields.where((f) => f.isConst)) {
       // Enums do not have inheritance.
       Accessor accessor = new ModelElement.from(f.getter, library);
-      EnumField enumField = new ModelElement.from(f, library, index: index++, getter: accessor);
+      EnumField enumField =
+          new ModelElement.from(f, library, index: index++, getter: accessor);
       if (enumField.isPublic) _enumFields.add(enumField);
     }
     _enumFields.sort(byName);
@@ -1206,7 +1213,8 @@ class Field extends ModelElement
   String get documentation {
     // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
     // to prevent displaying more or less than one summary.
-    Set<bool> assertCheck = new Set()..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
+    Set<bool> assertCheck = new Set()
+      ..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
     assert(assertCheck.containsAll([true, false]));
     return super.documentation;
   }
@@ -1631,10 +1639,13 @@ class Library extends ModelElement {
     elements.addAll(_exportedNamespace.definedNames.values
         .where((element) => element is FunctionElement));
 
-    _functions = elements.map((e) {
-      return new ModelElement.from(e, this);
-    }).where((e) => e.isPublic).toList(growable: false)
-      ..sort(byName);
+    _functions = elements
+        .map((e) {
+          return new ModelElement.from(e, this);
+        })
+        .where((e) => e.isPublic)
+        .toList(growable: false)
+          ..sort(byName);
 
     return _functions;
   }
@@ -1820,7 +1831,8 @@ class Library extends ModelElement {
       Accessor setter;
       if (element.setter != null)
         setter = new ModelElement.from(element.setter, this);
-      ModelElement me = new ModelElement.from(element, this, getter: getter, setter: setter);
+      ModelElement me =
+          new ModelElement.from(element, this, getter: getter, setter: setter);
       if (me.isPublic) _variables.add(me);
     }
 
@@ -2354,7 +2366,8 @@ abstract class ModelElement extends Nameable
       if (docComment == null) {
         _isPublic = hasPublicName(element);
       } else {
-        _isPublic = hasPublicName(element) && !(docComment.contains('@nodoc') || docComment.contains('<nodoc>'));
+        _isPublic = hasPublicName(element) &&
+            !(docComment.contains('@nodoc') || docComment.contains('<nodoc>'));
       }
     }
     return _isPublic;
@@ -4422,7 +4435,8 @@ class TopLevelVariable extends ModelElement
   String get documentation {
     // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
     // to prevent displaying more or less than one summary.
-    Set<bool> assertCheck = new Set()..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
+    Set<bool> assertCheck = new Set()
+      ..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
     assert(assertCheck.containsAll([true, false]));
     return super.documentation;
   }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -53,7 +53,7 @@ bool isInExportedLibraries(
 }
 
 final RegExp slashes = new RegExp('[\/]');
-bool isPrivate(Element e) {
+bool hasPrivateName(Element e) {
   if (e.name.startsWith('_') ||
       (e is LibraryElement &&
           (e.identifier == 'dart:_internal' ||
@@ -70,30 +70,7 @@ bool isPrivate(Element e) {
   return false;
 }
 
-// TODO(jcollins-g): this does not take into account inheritance
-bool isPublic(Element e) {
-  if (isPrivate(e)) return false;
-  // check to see if element is part of the public api, that is it does not
-  // have a '<nodoc>' or '@nodoc' in the documentation comment
-  if (e is PropertyAccessorElement && e.isSynthetic) {
-    var accessor = (e as PropertyAccessorElement);
-    if (accessor.correspondingSetter != null &&
-        !accessor.correspondingSetter.isSynthetic) {
-      e = accessor.correspondingSetter;
-    } else if (accessor.correspondingGetter != null &&
-        !accessor.correspondingGetter.isSynthetic) {
-      e = accessor.correspondingGetter;
-    } else if (accessor.variable != null) {
-      e = accessor.variable;
-    }
-  }
-
-  var docComment = e.documentationComment;
-  if (docComment != null &&
-      (docComment.contains('<nodoc>') || docComment.contains('@nodoc')))
-    return false;
-  return true;
-}
+bool hasPublicName(Element e) => !hasPrivateName(e);
 
 /// Strip leading dartdoc comments from the given source code.
 String stripDartdocCommentsFromSource(String source) {

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,16 +1,16 @@
-{{ #hasSetter }}
+{{ #hasPublicSetter }}
 <dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
   <span class="name{{#isDeprecated}} deprecated{{/isDeprecated}}">{{{linkedName}}}</span><span class="signature">{{{genericParameters}}}
     <span class="returntype parameter">{{{ arrow }}} {{ #hasExplicitSetter }} {{{ linkedParamsNoMetadata }}} {{/hasExplicitSetter}} {{#hasImplicitSetter}} {{{linkedParamsNoMetadataOrNames}}} {{/hasImplicitSetter}}</span>
   </span>
 </dt>
-{{ /hasSetter }}
-{{ #hasGetterNoSetter }}
+{{ /hasPublicSetter }}
+{{ #hasPublicGetterNoSetter }}
 <dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
   <span class="name">{{{linkedName}}}</span>
   <span class="signature">{{{ arrow }}} {{{ linkedReturnType }}}</span>
 </dt>
-{{ /hasGetterNoSetter }}
+{{ /hasPublicGetterNoSetter }}
 <dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
   {{{ oneLineDoc }}}
   {{>features}}

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1225,8 +1225,9 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((e) => e.name == 'implicitGetterExplicitSetter');
       explicitGetterImplicitSetter = UnusualProperties.allModelElements
           .firstWhere((e) => e.name == 'explicitGetterImplicitSetter');
-      explicitNonDocumentedInBaseClassGetter = UnusualProperties.allModelElements
-          .firstWhere((e) => e.name == 'explicitNonDocumentedInBaseClassGetter');
+      explicitNonDocumentedInBaseClassGetter =
+          UnusualProperties.allModelElements.firstWhere(
+              (e) => e.name == 'explicitNonDocumentedInBaseClassGetter');
       documentedPartialFieldInSubclassOnly = UnusualProperties.allModelElements
           .firstWhere((e) => e.name == 'documentedPartialFieldInSubclassOnly');
 
@@ -1261,26 +1262,36 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('@nodoc on simple property works', () {
-      Field simpleHidden = UnusualProperties.allModelElements.firstWhere((e) => e.name == 'simpleHidden', orElse: () => null);
+      Field simpleHidden = UnusualProperties.allModelElements
+          .firstWhere((e) => e.name == 'simpleHidden', orElse: () => null);
       expect(simpleHidden, isNull);
     });
 
     test('@nodoc on explicit getters/setters hides entire field', () {
-      Field explicitNodocGetterSetter = UnusualProperties.allModelElements.firstWhere((e) => e.name == 'explicitNodocGetterSetter', orElse: () => null);
+      Field explicitNodocGetterSetter = UnusualProperties.allModelElements
+          .firstWhere((e) => e.name == 'explicitNodocGetterSetter',
+              orElse: () => null);
       expect(explicitNodocGetterSetter, isNull);
     });
 
-    test('@nodoc overridden in subclass with explicit getter over simple property works', () {
+    test(
+        '@nodoc overridden in subclass with explicit getter over simple property works',
+        () {
       expect(documentedPartialFieldInSubclassOnly.isPublic, isTrue);
       expect(documentedPartialFieldInSubclassOnly.readOnly, isTrue);
-      expect(documentedPartialFieldInSubclassOnly.computeDocumentationComment, contains('This getter is documented'));
-      expect(documentedPartialFieldInSubclassOnly.annotations.contains('inherited-setter'), isFalse);
+      expect(documentedPartialFieldInSubclassOnly.computeDocumentationComment,
+          contains('This getter is documented'));
+      expect(
+          documentedPartialFieldInSubclassOnly.annotations
+              .contains('inherited-setter'),
+          isFalse);
     });
 
     test('@nodoc overridden in subclass for getter works', () {
       expect(explicitNonDocumentedInBaseClassGetter.isPublic, isTrue);
       expect(explicitNonDocumentedInBaseClassGetter.hasPublicGetter, isTrue);
-      expect(explicitNonDocumentedInBaseClassGetter.computeDocumentationComment, contains('I should be documented'));
+      expect(explicitNonDocumentedInBaseClassGetter.computeDocumentationComment,
+          contains('I should be documented'));
       expect(explicitNonDocumentedInBaseClassGetter.readOnly, isTrue);
     });
 
@@ -1488,10 +1499,10 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     setUp(() {
       v = exLibrary.properties.firstWhere((p) => p.name == 'number');
       v3 = exLibrary.properties.firstWhere((p) => p.name == 'y');
-      nodocGetter =
-          fakeLibrary.properties.firstWhere((p) => p.name == 'getterSetterNodocGetter');
-      nodocSetter =
-          fakeLibrary.properties.firstWhere((p) => p.name == 'getterSetterNodocSetter');
+      nodocGetter = fakeLibrary.properties
+          .firstWhere((p) => p.name == 'getterSetterNodocGetter');
+      nodocSetter = fakeLibrary.properties
+          .firstWhere((p) => p.name == 'getterSetterNodocSetter');
       justGetter =
           fakeLibrary.properties.firstWhere((p) => p.name == 'justGetter');
       justSetter =
@@ -1503,25 +1514,31 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('@nodoc on simple property works', () {
-      TopLevelVariable nodocSimple = fakeLibrary.properties.firstWhere((p) => p.name == 'simplePropertyHidden', orElse: () => null);
+      TopLevelVariable nodocSimple = fakeLibrary.properties.firstWhere(
+          (p) => p.name == 'simplePropertyHidden',
+          orElse: () => null);
       expect(nodocSimple, isNull);
     });
 
     test('@nodoc on both hides both', () {
-      TopLevelVariable nodocBoth = fakeLibrary.properties.firstWhere((p) => p.name == 'getterSetterNodocBoth', orElse: () => null);
+      TopLevelVariable nodocBoth = fakeLibrary.properties.firstWhere(
+          (p) => p.name == 'getterSetterNodocBoth',
+          orElse: () => null);
       expect(nodocBoth, isNull);
     });
 
     test('@nodoc on setter only works', () {
       expect(nodocSetter.isPublic, isTrue);
       expect(nodocSetter.readOnly, isTrue);
-      expect(nodocSetter.computeDocumentationComment, equals('Getter docs should be shown.'));
+      expect(nodocSetter.computeDocumentationComment,
+          equals('Getter docs should be shown.'));
     });
 
     test('@nodoc on getter only works', () {
       expect(nodocGetter.isPublic, isTrue);
       expect(nodocGetter.writeOnly, isTrue);
-      expect(nodocGetter.computeDocumentationComment, equals('Setter docs should be shown.'));
+      expect(nodocGetter.computeDocumentationComment,
+          equals('Setter docs should be shown.'));
     });
 
     test('has a fully qualified name', () {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1260,6 +1260,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((p) => p.name == 'autoCompress');
     });
 
+    test('@nodoc on simple property works', () {
+      Field simpleHidden = UnusualProperties.allModelElements.firstWhere((e) => e.name == 'simpleHidden', orElse: () => null);
+      expect(simpleHidden, isNull);
+    });
+
     test('@nodoc on explicit getters/setters hides entire field', () {
       Field explicitNodocGetterSetter = UnusualProperties.allModelElements.firstWhere((e) => e.name == 'explicitNodocGetterSetter', orElse: () => null);
       expect(explicitNodocGetterSetter, isNull);

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -199,6 +199,7 @@ class ImplicitProperties {
 
   /// but documented here.
   double get explicitPartiallyDocumentedField => 1.3;
+
   /// @nodoc here, you should never see this
   set explicitPartiallyDocumentedField(double foo) {}
 
@@ -225,6 +226,7 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   set implicitGetterExplicitSetter(String x) {}
 
   @override
+
   /// Getter doc for explicitGetterImplicitSetter
   List<int> get explicitGetterImplicitSetter => new List<int>();
 
@@ -244,6 +246,7 @@ class ClassWithUnusualProperties extends ImplicitProperties {
 
   /// @nodoc on setter
   set explicitNodocGetterSetter(String s) {}
+
   /// @nodoc on getter
   String get explicitNodocGetterSetter => "something";
 
@@ -396,16 +399,19 @@ String simplePropertyHidden;
 
 /// Setter docs should be shown.
 set getterSetterNodocGetter(int value) {}
+
 /// @nodoc on getter.
 int get getterSetterNodocGetter => 3;
 
 /// @nodoc on setter
 set getterSetterNodocSetter(int value) {}
+
 /// Getter docs should be shown.
 int get getterSetterNodocSetter => 4;
 
 /// @nodoc on the setter
 set getterSetterNodocBoth(String value) {}
+
 /// And @nodoc on the getter, so entire TopLevelVariable should be invisible.
 String get getterSetterNodocBoth => "I do not exist";
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -199,9 +199,11 @@ class ImplicitProperties {
 
   /// but documented here.
   double get explicitPartiallyDocumentedField => 1.3;
-  /// @nodoc here.
+  /// @nodoc here, you should never see this
   set explicitPartiallyDocumentedField(double foo) {}
 
+  /// @nodoc here, you should never see this
+  String documentedPartialFieldInSubclassOnly;
 
   /// Explicit getter for inheriting.
   int get explicitGetterSetterForInheriting => 12;
@@ -215,11 +217,14 @@ class ImplicitProperties {
 /// Or rather, dartdoc used to think they didn't exist.  Check the variations
 /// on inheritance and overrides here.
 class ClassWithUnusualProperties extends ImplicitProperties {
+  /// This getter is documented, so we should see a read-only property here.
+  @override
+  String get documentedPartialFieldInSubclassOnly => "overridden getter";
+
   @override
   set implicitGetterExplicitSetter(String x) {}
 
   @override
-
   /// Getter doc for explicitGetterImplicitSetter
   List<int> get explicitGetterImplicitSetter => new List<int>();
 
@@ -233,6 +238,11 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   myCoolTypedef get explicitGetterSetter {
     return _aFunction;
   }
+
+  /// @nodoc on setter
+  set explicitNodocGetterSetter(String s) {}
+  /// @nodoc on getter
+  String get explicitNodocGetterSetter => "something";
 
   /// This property is not synthetic, so it might reference [f] -- display it.
   set explicitGetterSetter(myCoolTypedef f) => _aFunction = f;
@@ -377,6 +387,24 @@ final int meaningOfLife = 42;
 
 /// Simple property
 String simpleProperty;
+
+/// Simple @nodoc property.
+String simplePropertyHidden;
+
+/// Setter docs should be shown.
+set getterSetterNodocGetter(int value) {}
+/// @nodoc on getter.
+int get getterSetterNodocGetter => 3;
+
+/// @nodoc on setter
+set getterSetterNodocSetter(int value) {}
+/// Getter docs should be shown.
+int get getterSetterNodocSetter => 4;
+
+/// @nodoc on the setter
+set getterSetterNodocBoth(String value) {}
+/// And @nodoc on the getter, so entire TopLevelVariable should be invisible.
+String get getterSetterNodocBoth => "I do not exist";
 
 /// Just a setter. No partner getter.
 void set justSetter(int value) {}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -239,6 +239,9 @@ class ClassWithUnusualProperties extends ImplicitProperties {
     return _aFunction;
   }
 
+  /// @nodoc for a simple hidden property.
+  String simpleHidden;
+
   /// @nodoc on setter
   set explicitNodocGetterSetter(String s) {}
   /// @nodoc on getter

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -191,6 +191,18 @@ class ImplicitProperties {
   /// A simple property to inherit.
   int forInheriting;
 
+  /// @nodoc for you
+  String get explicitNonDocumentedGetter => "something";
+
+  /// @nodoc for you but check downstream
+  String get explicitNonDocumentedInBaseClassGetter => "something else";
+
+  /// but documented here.
+  double get explicitPartiallyDocumentedField => 1.3;
+  /// @nodoc here.
+  set explicitPartiallyDocumentedField(double foo) {}
+
+
   /// Explicit getter for inheriting.
   int get explicitGetterSetterForInheriting => 12;
 
@@ -212,6 +224,10 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   List<int> get explicitGetterImplicitSetter => new List<int>();
 
   myCoolTypedef _aFunction;
+
+  /// Since I have a different doc, I should be documented.
+  @override
+  String get explicitNonDocumentedInBaseClassGetter => "something else";
 
   /// Getter doc for explicitGetterSetter.
   myCoolTypedef get explicitGetterSetter {

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
@@ -156,6 +158,14 @@ on inheritance and overrides here.</p>
       <h2>Properties</h2>
 
       <dl class="properties">
+        <dt id="documentedPartialFieldInSubclassOnly" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          This getter is documented, so we should see a read-only property here.
+          <div class="features">@override, read-only</div>
+</dd>
         <dt id="explicitGetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></span>
           <span class="signature">&#8594; <a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
@@ -181,6 +191,14 @@ on inheritance and overrides here.</p>
         <dd>
           Getter doc for explicitGetterSetter.
           <div class="features">read / write</div>
+</dd>
+        <dt id="explicitNonDocumentedInBaseClassGetter" class="property">
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          Since I have a different doc, I should be documented.
+          <div class="features">@override, read-only</div>
 </dd>
         <dt id="explicitSetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></span><span class="signature">
@@ -225,6 +243,14 @@ on inheritance and overrides here.</p>
         <dd class="inherited">
           Explicit getter for inheriting.
           <div class="features">read / write, inherited</div>
+</dd>
+        <dt id="explicitPartiallyDocumentedField" class="property inherited">
+          <span class="name"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></span>
+          <span class="signature">&#8594; double</span>
+        </dt>
+        <dd class="inherited">
+          but documented here.
+          <div class="features">read-only, inherited</div>
 </dd>
         <dt id="forInheriting" class="property inherited">
           <span class="name"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></span><span class="signature">
@@ -316,14 +342,17 @@ on inheritance and overrides here.</p>
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the explicitGetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
-  <title>explicitGetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the documentedPartialFieldInSubclassOnly property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>documentedPartialFieldInSubclassOnly property - ClassWithUnusualProperties class - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
     <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
-    <li class="self-crumb">property explicitGetter</li>
+    <li class="self-crumb">property documentedPartialFieldInSubclassOnly</li>
   </ol>
-  <div class="self-name">explicitGetter</div>
+  <div class="self-name">documentedPartialFieldInSubclassOnly</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -79,11 +79,11 @@
       <section id="getter">
       
       <section class="multi-line-signature">
-        <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-        <span class="name ">explicitGetter</span></section>
+        <span class="returntype">String</span>
+        <span class="name ">documentedPartialFieldInSubclassOnly</span></section>
       
       <section class="desc markdown">
-  <p>This property only has a getter and no setter; no parameters to print.</p>
+  <p>This getter is documented, so we should see a read-only property here.</p>
 </section>
 </section>
       
@@ -92,7 +92,7 @@
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <h5>property explicitGetter</h5>
+    <h5>property documentedPartialFieldInSubclassOnly</h5>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the explicitGetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
-  <title>explicitGetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the explicitNonDocumentedInBaseClassGetter property from the ClassWithUnusualProperties class, for the Dart programming language.">
+  <title>explicitNonDocumentedInBaseClassGetter property - ClassWithUnusualProperties class - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
     <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
-    <li class="self-crumb">property explicitGetter</li>
+    <li class="self-crumb">property explicitNonDocumentedInBaseClassGetter</li>
   </ol>
-  <div class="self-name">explicitGetter</div>
+  <div class="self-name">explicitNonDocumentedInBaseClassGetter</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -79,11 +79,11 @@
       <section id="getter">
       
       <section class="multi-line-signature">
-        <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-        <span class="name ">explicitGetter</span></section>
+        <span class="returntype">String</span>
+        <span class="name ">explicitNonDocumentedInBaseClassGetter</span></section>
       
       <section class="desc markdown">
-  <p>This property only has a getter and no setter; no parameters to print.</p>
+  <p>Since I have a different doc, I should be documented.</p>
 </section>
 </section>
       
@@ -92,7 +92,7 @@
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <h5>property explicitGetter</h5>
+    <h5>property explicitNonDocumentedInBaseClassGetter</h5>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
@@ -45,14 +45,17 @@
       <li class="section-title">
         <a href="fake/ClassWithUnusualProperties-class.html#instance-properties">Properties</a>
       </li>
+      <li><a href="fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html">documentedPartialFieldInSubclassOnly</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></li>
+      <li><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/finalProperty.html">finalProperty</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li class="inherited"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/runtimeType.html">runtimeType</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
@@ -171,6 +173,14 @@ they are correct.</p>
           Explicit getter for inheriting.
           <div class="features">read / write</div>
 </dd>
+        <dt id="explicitPartiallyDocumentedField" class="property">
+          <span class="name"><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></span>
+          <span class="signature">&#8594; double</span>
+        </dt>
+        <dd>
+          but documented here.
+          <div class="features">read-only</div>
+</dd>
         <dt id="forInheriting" class="property">
           <span class="name"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></span><span class="signature">
             <span class="returntype parameter">&#8596;   <span class="parameter" id="forInheriting=-param-_forInheriting"><span class="type-annotation">int</span></span> </span>
@@ -263,6 +273,7 @@ they are correct.</p>
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the hashCode property from the ImplicitProperties class, for the Dart programming language.">
-  <title>hashCode property - ImplicitProperties class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the explicitPartiallyDocumentedField property from the ImplicitProperties class, for the Dart programming language.">
+  <title>explicitPartiallyDocumentedField property - ImplicitProperties class - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
     <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
-    <li class="self-crumb">property hashCode</li>
+    <li class="self-crumb">property explicitPartiallyDocumentedField</li>
   </ol>
-  <div class="self-name">hashCode</div>
+  <div class="self-name">explicitPartiallyDocumentedField</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -71,17 +71,20 @@
       <section id="getter">
       
       <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
+        <span class="returntype">double</span>
+        <span class="name ">explicitPartiallyDocumentedField</span></section>
       
-      </section>
+      <section class="desc markdown">
+  <p>but documented here.</p>
+</section>
+</section>
       
 
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <h5>property hashCode</h5>
+    <h5>property explicitPartiallyDocumentedField</h5>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/toString.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/toString.html
@@ -47,6 +47,7 @@
       </li>
       <li><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></li>
       <li><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></li>
+      <li><a href="fake/ImplicitProperties/explicitPartiallyDocumentedField.html">explicitPartiallyDocumentedField</a></li>
       <li><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></li>
       <li><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></li>
       <li class="inherited"><a href="fake/ImplicitProperties/hashCode.html">hashCode</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -359,6 +359,23 @@ which is a bit redundant.
           A dynamic getter.
           <div class="features">read-only</div>
 </dd>
+        <dt id="getterSetterNodocGetter" class="property">
+          <span class="name"><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></span><span class="signature">
+            <span class="returntype parameter">&#8592;  <span class="parameter" id="getterSetterNodocGetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
+          </span>
+        </dt>
+        <dd>
+          Setter docs should be shown.
+          <div class="features">write-only</div>
+</dd>
+        <dt id="getterSetterNodocSetter" class="property">
+          <span class="name"><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd>
+          Getter docs should be shown.
+          <div class="features">read-only</div>
+</dd>
         <dt id="justGetter" class="property">
           <span class="name"><a href="fake/justGetter.html">justGetter</a></span>
           <span class="signature">&#8594; bool</span>
@@ -684,6 +701,8 @@ default value.
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the HasGenerics class from the fake library, for the Dart programming language.">
-  <title>HasGenerics class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the getterSetterNodocGetter property from the fake library, for the Dart programming language.">
+  <title>getterSetterNodocGetter property - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">class HasGenerics&lt;X, Y, Z&gt;</li>
+    <li class="self-crumb">property getterSetterNodocGetter</li>
   </ol>
-  <div class="self-name">HasGenerics</div>
+  <div class="self-name">getterSetterNodocGetter</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -116,154 +116,29 @@
       <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
       <li><a href="fake/Oops-class.html">Oops</a></li>
     </ol>
-  </div>
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    
-
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">
-        <dt id="HasGenerics" class="callable">
-          <span class="name"><a href="fake/HasGenerics/HasGenerics.html">HasGenerics</a></span><span class="signature">(<span class="parameter" id="-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="-param-y"><span class="type-annotation">Y</span> <span class="parameter-name">y</span>, </span> <span class="parameter" id="-param-z"><span class="type-annotation">Z</span> <span class="parameter-name">z</span></span>)</span>
-        </dt>
-        <dd>
-          
-        </dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="instance-properties">
-      <h2>Properties</h2>
-
-      <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/HasGenerics/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-        <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="fake/HasGenerics/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor" id="instance-methods">
-      <h2>Methods</h2>
-      <dl class="callables">
-        <dt id="convertToMap" class="callable">
-          <span class="name"><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map&lt;X, Y&gt;</span>
-          </span>
-        </dt>
-        <dd>
-          Converts itself to a map.
-          
-</dd>
-        <dt id="doStuff" class="callable">
-          <span class="name"><a href="fake/HasGenerics/doStuff.html">doStuff</a></span><span class="signature">(<wbr><span class="parameter" id="doStuff-param-s"><span class="type-annotation">String</span> <span class="parameter-name">s</span>, </span> <span class="parameter" id="doStuff-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span></span>)
-            <span class="returntype parameter">&#8594; Z</span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="returnX" class="callable">
-          <span class="name"><a href="fake/HasGenerics/returnX.html">returnX</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; X</span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="returnZ" class="callable">
-          <span class="name"><a href="fake/HasGenerics/returnZ.html">returnZ</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Z</span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-        <dt id="toString" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="operators">
-      <h2>Operators</h2>
-      <dl class="callables">
-        <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
 
 
-
+      <section id="setter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">void</span>
+          <span class="name ">getterSetterNodocGetter=</span><span class="signature">(<wbr><span class="parameter" id="getterSetterNodocGetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
+      </section>
+      
+      <section class="desc markdown">
+  <p>Setter docs should be shown.</p>
+</section>
+</section>
+      
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <h5>class HasGenerics</h5>
-    <ol>
-      <li class="section-title"><a href="fake/HasGenerics-class.html#constructors">Constructors</a></li>
-      <li><a href="fake/HasGenerics/HasGenerics.html">HasGenerics</a></li>
-    
-      <li class="section-title inherited">
-        <a href="fake/HasGenerics-class.html#instance-properties">Properties</a>
-      </li>
-      <li class="inherited"><a href="fake/HasGenerics/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/runtimeType.html">runtimeType</a></li>
-    
-      <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
-      <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
-      <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
-      <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
-    
-      <li class="section-title inherited"><a href="fake/HasGenerics-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/operator_equals.html">operator ==</a></li>
-    
-    
-    
-    </ol>
+    <h5>top-level property getterSetterNodocGetter</h5>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the HasGenerics class from the fake library, for the Dart programming language.">
-  <title>HasGenerics class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the getterSetterNodocSetter property from the fake library, for the Dart programming language.">
+  <title>getterSetterNodocSetter property - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">class HasGenerics&lt;X, Y, Z&gt;</li>
+    <li class="self-crumb">property getterSetterNodocSetter</li>
   </ol>
-  <div class="self-name">HasGenerics</div>
+  <div class="self-name">getterSetterNodocSetter</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -116,154 +116,28 @@
       <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
       <li><a href="fake/Oops-class.html">Oops</a></li>
     </ol>
-  </div>
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    
 
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">
-        <dt id="HasGenerics" class="callable">
-          <span class="name"><a href="fake/HasGenerics/HasGenerics.html">HasGenerics</a></span><span class="signature">(<span class="parameter" id="-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="-param-y"><span class="type-annotation">Y</span> <span class="parameter-name">y</span>, </span> <span class="parameter" id="-param-z"><span class="type-annotation">Z</span> <span class="parameter-name">z</span></span>)</span>
-        </dt>
-        <dd>
-          
-        </dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="instance-properties">
-      <h2>Properties</h2>
-
-      <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/HasGenerics/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-        <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="fake/HasGenerics/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor" id="instance-methods">
-      <h2>Methods</h2>
-      <dl class="callables">
-        <dt id="convertToMap" class="callable">
-          <span class="name"><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map&lt;X, Y&gt;</span>
-          </span>
-        </dt>
-        <dd>
-          Converts itself to a map.
-          
-</dd>
-        <dt id="doStuff" class="callable">
-          <span class="name"><a href="fake/HasGenerics/doStuff.html">doStuff</a></span><span class="signature">(<wbr><span class="parameter" id="doStuff-param-s"><span class="type-annotation">String</span> <span class="parameter-name">s</span>, </span> <span class="parameter" id="doStuff-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span></span>)
-            <span class="returntype parameter">&#8594; Z</span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="returnX" class="callable">
-          <span class="name"><a href="fake/HasGenerics/returnX.html">returnX</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; X</span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="returnZ" class="callable">
-          <span class="name"><a href="fake/HasGenerics/returnZ.html">returnZ</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Z</span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-        <dt id="toString" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="operators">
-      <h2>Operators</h2>
-      <dl class="callables">
-        <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="fake/HasGenerics/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-
+      <section id="getter">
+      
+      <section class="multi-line-signature">
+        <span class="returntype">int</span>
+        <span class="name ">getterSetterNodocSetter</span></section>
+      
+      <section class="desc markdown">
+  <p>Getter docs should be shown.</p>
+</section>
+</section>
+      
 
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <h5>class HasGenerics</h5>
-    <ol>
-      <li class="section-title"><a href="fake/HasGenerics-class.html#constructors">Constructors</a></li>
-      <li><a href="fake/HasGenerics/HasGenerics.html">HasGenerics</a></li>
-    
-      <li class="section-title inherited">
-        <a href="fake/HasGenerics-class.html#instance-properties">Properties</a>
-      </li>
-      <li class="inherited"><a href="fake/HasGenerics/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/runtimeType.html">runtimeType</a></li>
-    
-      <li class="section-title"><a href="fake/HasGenerics-class.html#instance-methods">Methods</a></li>
-      <li><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></li>
-      <li><a href="fake/HasGenerics/doStuff.html">doStuff</a></li>
-      <li><a href="fake/HasGenerics/returnX.html">returnX</a></li>
-      <li><a href="fake/HasGenerics/returnZ.html">returnZ</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/toString.html">toString</a></li>
-    
-      <li class="section-title inherited"><a href="fake/HasGenerics-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/HasGenerics/operator_equals.html">operator ==</a></li>
-    
-    
-    
-    </ol>
+    <h5>top-level property getterSetterNodocSetter</h5>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -76,6 +76,8 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -3364,6 +3364,17 @@
   }
  },
  {
+  "name": "documentedPartialFieldInSubclassOnly",
+  "qualifiedName": "fake.ClassWithUnusualProperties.documentedPartialFieldInSubclassOnly",
+  "href": "fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
   "name": "explicitGetter",
   "qualifiedName": "fake.ClassWithUnusualProperties.explicitGetter",
   "href": "fake/ClassWithUnusualProperties/explicitGetter.html",
@@ -3389,6 +3400,17 @@
   "name": "explicitGetterSetter",
   "qualifiedName": "fake.ClassWithUnusualProperties.explicitGetterSetter",
   "href": "fake/ClassWithUnusualProperties/explicitGetterSetter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ClassWithUnusualProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitNonDocumentedInBaseClassGetter",
+  "qualifiedName": "fake.ClassWithUnusualProperties.explicitNonDocumentedInBaseClassGetter",
+  "href": "fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html",
   "type": "property",
   "overriddenDepth": 0,
   "enclosedBy": {
@@ -4203,6 +4225,17 @@
   "name": "explicitGetterSetterForInheriting",
   "qualifiedName": "fake.ImplicitProperties.explicitGetterSetterForInheriting",
   "href": "fake/ImplicitProperties/explicitGetterSetterForInheriting.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ImplicitProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "explicitPartiallyDocumentedField",
+  "qualifiedName": "fake.ImplicitProperties.explicitPartiallyDocumentedField",
+  "href": "fake/ImplicitProperties/explicitPartiallyDocumentedField.html",
   "type": "property",
   "overriddenDepth": 0,
   "enclosedBy": {
@@ -5909,6 +5942,28 @@
   "qualifiedName": "fake.functionWithFunctionParameters",
   "href": "fake/functionWithFunctionParameters.html",
   "type": "function",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "getterSetterNodocGetter",
+  "qualifiedName": "fake.getterSetterNodocGetter",
+  "href": "fake/getterSetterNodocGetter.html",
+  "type": "top-level property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "getterSetterNodocSetter",
+  "qualifiedName": "fake.getterSetterNodocSetter",
+  "href": "fake/getterSetterNodocSetter.html",
+  "type": "top-level property",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",


### PR DESCRIPTION
Fixes #1352 and #1337, and makes public/private generally a bit more consistent in dartdoc (which will help future work regarding multiple package handling).   `@nodoc` will now propagate consistently like I think most users would expect through inheritance and doc borrowing, and when used on half of a combo Field or TopLevelVariable will correctly hide/display half of a field.