### PR TITLE
Update jquery to 3.2.1.

### DIFF
--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -12,7 +12,7 @@
   <!-- footer-text placeholder -->
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/anonymous_library/anonymous_library-library.html
+++ b/testing/test_package_docs/anonymous_library/anonymous_library-library.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/anonymous_library/doesStuff.html
+++ b/testing/test_package_docs/anonymous_library/doesStuff.html
@@ -77,7 +77,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/another_anonymous_lib/another_anonymous_lib-library.html
+++ b/testing/test_package_docs/another_anonymous_lib/another_anonymous_lib-library.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/another_anonymous_lib/greeting.html
+++ b/testing/test_package_docs/another_anonymous_lib/greeting.html
@@ -77,7 +77,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/code_in_comments/code_in_comments-library.html
+++ b/testing/test_package_docs/code_in_comments/code_in_comments-library.html
@@ -101,7 +101,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/css/css-library.html
+++ b/testing/test_package_docs/css/css-library.html
@@ -111,7 +111,7 @@ with directories created by dartdoc.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
+++ b/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
@@ -78,7 +78,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -270,7 +270,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Animal/hashCode.html
+++ b/testing/test_package_docs/ex/Animal/hashCode.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Animal/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Animal/noSuchMethod.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Animal/operator_equals.html
+++ b/testing/test_package_docs/ex/Animal/operator_equals.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Animal/runtimeType.html
+++ b/testing/test_package_docs/ex/Animal/runtimeType.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Animal/toString.html
+++ b/testing/test_package_docs/ex/Animal/toString.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -379,7 +379,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/Apple.fromString.html
+++ b/testing/test_package_docs/ex/Apple/Apple.fromString.html
@@ -103,7 +103,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/Apple.html
+++ b/testing/test_package_docs/ex/Apple/Apple.html
@@ -106,7 +106,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
+++ b/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/isGreaterThan.html
+++ b/testing/test_package_docs/ex/Apple/isGreaterThan.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/m.html
+++ b/testing/test_package_docs/ex/Apple/m.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/m1.html
+++ b/testing/test_package_docs/ex/Apple/m1.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/methodWithTypedefParam.html
+++ b/testing/test_package_docs/ex/Apple/methodWithTypedefParam.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/n-constant.html
+++ b/testing/test_package_docs/ex/Apple/n-constant.html
@@ -104,7 +104,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Apple/noSuchMethod.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/operator_equals.html
+++ b/testing/test_package_docs/ex/Apple/operator_equals.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/operator_multiply.html
+++ b/testing/test_package_docs/ex/Apple/operator_multiply.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/paramFromExportLib.html
+++ b/testing/test_package_docs/ex/Apple/paramFromExportLib.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/printMsg.html
+++ b/testing/test_package_docs/ex/Apple/printMsg.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/runtimeType.html
+++ b/testing/test_package_docs/ex/Apple/runtimeType.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/s.html
+++ b/testing/test_package_docs/ex/Apple/s.html
@@ -122,7 +122,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/string.html
+++ b/testing/test_package_docs/ex/Apple/string.html
@@ -104,7 +104,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/toString.html
+++ b/testing/test_package_docs/ex/Apple/toString.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Apple/whataclass.html
+++ b/testing/test_package_docs/ex/Apple/whataclass.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -401,7 +401,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/B.html
+++ b/testing/test_package_docs/ex/B/B.html
@@ -104,7 +104,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/abstractMethod.html
+++ b/testing/test_package_docs/ex/B/abstractMethod.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/autoCompress.html
+++ b/testing/test_package_docs/ex/B/autoCompress.html
@@ -109,7 +109,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/doNothing.html
+++ b/testing/test_package_docs/ex/B/doNothing.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/isImplemented.html
+++ b/testing/test_package_docs/ex/B/isImplemented.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/list.html
+++ b/testing/test_package_docs/ex/B/list.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/m1.html
+++ b/testing/test_package_docs/ex/B/m1.html
@@ -113,7 +113,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/s.html
+++ b/testing/test_package_docs/ex/B/s.html
@@ -123,7 +123,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/B/writeMsg.html
+++ b/testing/test_package_docs/ex/B/writeMsg.html
@@ -103,7 +103,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/COLOR-constant.html
+++ b/testing/test_package_docs/ex/COLOR-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/COLOR_GREEN-constant.html
+++ b/testing/test_package_docs/ex/COLOR_GREEN-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
+++ b/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
+++ b/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat-class.html
+++ b/testing/test_package_docs/ex/Cat-class.html
@@ -252,7 +252,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/Cat.html
+++ b/testing/test_package_docs/ex/Cat/Cat.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/abstractMethod.html
+++ b/testing/test_package_docs/ex/Cat/abstractMethod.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/isImplemented.html
+++ b/testing/test_package_docs/ex/Cat/isImplemented.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Cat/noSuchMethod.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/operator_equals.html
+++ b/testing/test_package_docs/ex/Cat/operator_equals.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/runtimeType.html
+++ b/testing/test_package_docs/ex/Cat/runtimeType.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Cat/toString.html
+++ b/testing/test_package_docs/ex/Cat/toString.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString-class.html
+++ b/testing/test_package_docs/ex/CatString-class.html
@@ -310,7 +310,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/CatString.html
+++ b/testing/test_package_docs/ex/CatString/CatString.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/clear.html
+++ b/testing/test_package_docs/ex/CatString/clear.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/hashCode.html
+++ b/testing/test_package_docs/ex/CatString/hashCode.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/isEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isEmpty.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/isNotEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isNotEmpty.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/length.html
+++ b/testing/test_package_docs/ex/CatString/length.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/noSuchMethod.html
+++ b/testing/test_package_docs/ex/CatString/noSuchMethod.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/operator_equals.html
+++ b/testing/test_package_docs/ex/CatString/operator_equals.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/runtimeType.html
+++ b/testing/test_package_docs/ex/CatString/runtimeType.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/toString.html
+++ b/testing/test_package_docs/ex/CatString/toString.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/write.html
+++ b/testing/test_package_docs/ex/CatString/write.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/writeAll.html
+++ b/testing/test_package_docs/ex/CatString/writeAll.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/writeCharCode.html
+++ b/testing/test_package_docs/ex/CatString/writeCharCode.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/CatString/writeln.html
+++ b/testing/test_package_docs/ex/CatString/writeln.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -262,7 +262,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
+++ b/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/abstractMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/abstractMethod.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/isImplemented.html
+++ b/testing/test_package_docs/ex/ConstantCat/isImplemented.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/name.html
+++ b/testing/test_package_docs/ex/ConstantCat/name.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/operator_equals.html
+++ b/testing/test_package_docs/ex/ConstantCat/operator_equals.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/runtimeType.html
+++ b/testing/test_package_docs/ex/ConstantCat/runtimeType.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ConstantCat/toString.html
+++ b/testing/test_package_docs/ex/ConstantCat/toString.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -229,7 +229,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Deprecated/toString.html
+++ b/testing/test_package_docs/ex/Deprecated/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -482,7 +482,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -113,7 +113,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -113,7 +113,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -118,7 +118,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Dog/noSuchMethod.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -126,7 +126,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/toString.html
+++ b/testing/test_package_docs/ex/Dog/toString.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/withMacro.html
+++ b/testing/test_package_docs/ex/Dog/withMacro.html
@@ -117,7 +117,7 @@ More docs</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -115,7 +115,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E-class.html
+++ b/testing/test_package_docs/ex/E-class.html
@@ -231,7 +231,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E/E.html
+++ b/testing/test_package_docs/ex/E/E.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E/hashCode.html
+++ b/testing/test_package_docs/ex/E/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E/noSuchMethod.html
+++ b/testing/test_package_docs/ex/E/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E/operator_equals.html
+++ b/testing/test_package_docs/ex/E/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E/runtimeType.html
+++ b/testing/test_package_docs/ex/E/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/E/toString.html
+++ b/testing/test_package_docs/ex/E/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -418,7 +418,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -107,7 +107,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -106,7 +106,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -106,7 +106,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -229,7 +229,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
+++ b/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/toString.html
+++ b/testing/test_package_docs/ex/ForAnnotation/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ForAnnotation/value.html
+++ b/testing/test_package_docs/ex/ForAnnotation/value.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs/ex/HasAnnotation-class.html
@@ -231,7 +231,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation/HasAnnotation.html
+++ b/testing/test_package_docs/ex/HasAnnotation/HasAnnotation.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/HasAnnotation/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/HasAnnotation/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/HasAnnotation/toString.html
+++ b/testing/test_package_docs/ex/HasAnnotation/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper-class.html
+++ b/testing/test_package_docs/ex/Helper-class.html
@@ -234,7 +234,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/Helper.html
+++ b/testing/test_package_docs/ex/Helper/Helper.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/getContents.html
+++ b/testing/test_package_docs/ex/Helper/getContents.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/hashCode.html
+++ b/testing/test_package_docs/ex/Helper/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Helper/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/operator_equals.html
+++ b/testing/test_package_docs/ex/Helper/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/runtimeType.html
+++ b/testing/test_package_docs/ex/Helper/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Helper/toString.html
+++ b/testing/test_package_docs/ex/Helper/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -272,7 +272,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/Klass.html
+++ b/testing/test_package_docs/ex/Klass/Klass.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/another.html
+++ b/testing/test_package_docs/ex/Klass/another.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/anotherMethod.html
+++ b/testing/test_package_docs/ex/Klass/anotherMethod.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/imAFactoryNoReally.html
+++ b/testing/test_package_docs/ex/Klass/imAFactoryNoReally.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/imProtected.html
+++ b/testing/test_package_docs/ex/Klass/imProtected.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/method.html
+++ b/testing/test_package_docs/ex/Klass/method.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Klass/noSuchMethod.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/operator_equals.html
+++ b/testing/test_package_docs/ex/Klass/operator_equals.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/runtimeType.html
+++ b/testing/test_package_docs/ex/Klass/runtimeType.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/Klass/toString.html
+++ b/testing/test_package_docs/ex/Klass/toString.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MY_CAT-constant.html
+++ b/testing/test_package_docs/ex/MY_CAT-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError-class.html
+++ b/testing/test_package_docs/ex/MyError-class.html
@@ -242,7 +242,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/MyError.html
+++ b/testing/test_package_docs/ex/MyError/MyError.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/hashCode.html
+++ b/testing/test_package_docs/ex/MyError/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyError/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/operator_equals.html
+++ b/testing/test_package_docs/ex/MyError/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/runtimeType.html
+++ b/testing/test_package_docs/ex/MyError/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/stackTrace.html
+++ b/testing/test_package_docs/ex/MyError/stackTrace.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyError/toString.html
+++ b/testing/test_package_docs/ex/MyError/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -242,7 +242,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyErrorImplements/toString.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException-class.html
+++ b/testing/test_package_docs/ex/MyException-class.html
@@ -233,7 +233,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException/MyException.html
+++ b/testing/test_package_docs/ex/MyException/MyException.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException/hashCode.html
+++ b/testing/test_package_docs/ex/MyException/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyException/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException/operator_equals.html
+++ b/testing/test_package_docs/ex/MyException/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException/runtimeType.html
+++ b/testing/test_package_docs/ex/MyException/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyException/toString.html
+++ b/testing/test_package_docs/ex/MyException/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements-class.html
@@ -233,7 +233,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements/MyExceptionImplements.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/MyExceptionImplements.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/MyExceptionImplements/toString.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
+++ b/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ParameterizedTypedef.html
+++ b/testing/test_package_docs/ex/ParameterizedTypedef.html
@@ -126,7 +126,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
@@ -242,7 +242,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/PublicClassExtendsPrivateClass.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/PublicClassExtendsPrivateClass.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/test.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/test.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/toString.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -229,7 +229,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/test.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/test.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -264,7 +264,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/hashCode.html
+++ b/testing/test_package_docs/ex/ShapeType/hashCode.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/name.html
+++ b/testing/test_package_docs/ex/ShapeType/name.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ShapeType/noSuchMethod.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/operator_equals.html
+++ b/testing/test_package_docs/ex/ShapeType/operator_equals.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/rect-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/rect-constant.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/runtimeType.html
+++ b/testing/test_package_docs/ex/ShapeType/runtimeType.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ShapeType/toString.html
+++ b/testing/test_package_docs/ex/ShapeType/toString.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs/ex/SpecializedDuration-class.html
@@ -410,7 +410,7 @@ that has some operators</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/SpecializedDuration.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/SpecializedDuration.html
@@ -106,7 +106,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/abs.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/abs.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/compareTo.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/compareTo.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/inDays.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inDays.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/inHours.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inHours.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/noSuchMethod.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/noSuchMethod.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_equals.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_equals.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_greater.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_greater.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_greater_equal.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_greater_equal.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_less.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_less.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_less_equal.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_less_equal.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_minus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_minus.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_multiply.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_multiply.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_plus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_plus.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_truncate_divide.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_truncate_divide.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_unary_minus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_unary_minus.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/SpecializedDuration/toString.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/toString.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -241,7 +241,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
+++ b/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
+++ b/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGeneric/toString.html
+++ b/testing/test_package_docs/ex/WithGeneric/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -243,7 +243,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/WithGenericSub/WithGenericSub.html
+++ b/testing/test_package_docs/ex/WithGenericSub/WithGenericSub.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo-class.html
+++ b/testing/test_package_docs/ex/aThingToDo-class.html
@@ -241,7 +241,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/aThingToDo.html
+++ b/testing/test_package_docs/ex/aThingToDo/aThingToDo.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/hashCode.html
+++ b/testing/test_package_docs/ex/aThingToDo/hashCode.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/noSuchMethod.html
+++ b/testing/test_package_docs/ex/aThingToDo/noSuchMethod.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/operator_equals.html
+++ b/testing/test_package_docs/ex/aThingToDo/operator_equals.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/runtimeType.html
+++ b/testing/test_package_docs/ex/aThingToDo/runtimeType.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/toString.html
+++ b/testing/test_package_docs/ex/aThingToDo/toString.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/what.html
+++ b/testing/test_package_docs/ex/aThingToDo/what.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/aThingToDo/who.html
+++ b/testing/test_package_docs/ex/aThingToDo/who.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/deprecatedField.html
+++ b/testing/test_package_docs/ex/deprecatedField.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/deprecatedGetter.html
@@ -130,7 +130,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/deprecatedSetter.html
@@ -131,7 +131,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -523,7 +523,7 @@ that has some operators
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/function1.html
+++ b/testing/test_package_docs/ex/function1.html
@@ -126,7 +126,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/genericFunction.html
+++ b/testing/test_package_docs/ex/genericFunction.html
@@ -126,7 +126,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReference-constant.html
@@ -130,7 +130,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
@@ -130,7 +130,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/number.html
+++ b/testing/test_package_docs/ex/number.html
@@ -127,7 +127,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/processMessage.html
+++ b/testing/test_package_docs/ex/processMessage.html
@@ -126,7 +126,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/ex/y.html
+++ b/testing/test_package_docs/ex/y.html
@@ -130,7 +130,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -252,7 +252,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/Annotation.html
+++ b/testing/test_package_docs/fake/Annotation/Annotation.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Annotation/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/operator_equals.html
+++ b/testing/test_package_docs/fake/Annotation/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/runtimeType.html
+++ b/testing/test_package_docs/fake/Annotation/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/toString.html
+++ b/testing/test_package_docs/fake/Annotation/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Annotation/value.html
+++ b/testing/test_package_docs/fake/Annotation/value.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -254,7 +254,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface/AnotherInterface.html
+++ b/testing/test_package_docs/fake/AnotherInterface/AnotherInterface.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface/hashCode.html
+++ b/testing/test_package_docs/fake/AnotherInterface/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface/noSuchMethod.html
+++ b/testing/test_package_docs/fake/AnotherInterface/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
+++ b/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
+++ b/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/AnotherInterface/toString.html
+++ b/testing/test_package_docs/fake/AnotherInterface/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -271,7 +271,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/BaseForDocComments.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/BaseForDocComments.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/anotherMethod.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/anotherMethod.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/doAwesomeStuff.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/doAwesomeStuff.html
@@ -108,7 +108,7 @@ the name <a href="two_exports/BaseClass-class.html">BaseClass</a> xx</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/noSuchMethod.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/noSuchMethod.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/BaseForDocComments/toString.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/toString.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -147,7 +147,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -146,7 +146,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -383,7 +383,7 @@ on inheritance and overrides here.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
@@ -101,7 +101,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
@@ -103,7 +103,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -120,7 +120,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
@@ -108,7 +108,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -109,7 +109,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
@@ -109,7 +109,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
@@ -102,7 +102,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -342,7 +342,7 @@ Some constants have long docs.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Color/hashCode.html
+++ b/testing/test_package_docs/fake/Color/hashCode.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Color/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Color/noSuchMethod.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Color/operator_equals.html
+++ b/testing/test_package_docs/fake/Color/operator_equals.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Color/runtimeType.html
+++ b/testing/test_package_docs/fake/Color/runtimeType.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Color/toString.html
+++ b/testing/test_package_docs/fake/Color/toString.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -274,7 +274,7 @@ Go ahead, it's fun.
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
@@ -95,7 +95,7 @@ Go ahead, it's fun.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstantClass/operator_equals.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstantClass/runtimeType.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/toString.html
+++ b/testing/test_package_docs/fake/ConstantClass/toString.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ConstantClass/value.html
+++ b/testing/test_package_docs/fake/ConstantClass/value.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -252,7 +252,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/Cool.html
+++ b/testing/test_package_docs/fake/Cool/Cool.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Cool/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/operator_equals.html
+++ b/testing/test_package_docs/fake/Cool/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/returnCool.html
+++ b/testing/test_package_docs/fake/Cool/returnCool.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/runtimeType.html
+++ b/testing/test_package_docs/fake/Cool/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Cool/toString.html
+++ b/testing/test_package_docs/fake/Cool/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -269,7 +269,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/Doh.html
+++ b/testing/test_package_docs/fake/Doh/Doh.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/hashCode.html
+++ b/testing/test_package_docs/fake/Doh/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Doh/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/operator_equals.html
+++ b/testing/test_package_docs/fake/Doh/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/runtimeType.html
+++ b/testing/test_package_docs/fake/Doh/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/stackTrace.html
+++ b/testing/test_package_docs/fake/Doh/stackTrace.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Doh/toString.html
+++ b/testing/test_package_docs/fake/Doh/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -770,7 +770,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
@@ -140,7 +140,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -154,7 +154,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -283,7 +283,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/BAR-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAR-constant.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/BAZ-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAZ-constant.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/Foo2.html
+++ b/testing/test_package_docs/fake/Foo2/Foo2.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/index.html
+++ b/testing/test_package_docs/fake/Foo2/index.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Foo2/noSuchMethod.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/operator_equals.html
+++ b/testing/test_package_docs/fake/Foo2/operator_equals.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/runtimeType.html
+++ b/testing/test_package_docs/fake/Foo2/runtimeType.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Foo2/toString.html
+++ b/testing/test_package_docs/fake/Foo2/toString.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -242,7 +242,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -279,7 +279,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
+++ b/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/convertToMap.html
+++ b/testing/test_package_docs/fake/HasGenerics/convertToMap.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/doStuff.html
+++ b/testing/test_package_docs/fake/HasGenerics/doStuff.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/returnX.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnX.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/returnZ.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnZ.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -96,7 +96,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/HasGenerics/toString.html
+++ b/testing/test_package_docs/fake/HasGenerics/toString.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -304,7 +304,7 @@ they are correct.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
@@ -100,7 +100,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ImplicitProperties/toString.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/toString.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -254,7 +254,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface/Interface.html
+++ b/testing/test_package_docs/fake/Interface/Interface.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface/hashCode.html
+++ b/testing/test_package_docs/fake/Interface/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Interface/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface/operator_equals.html
+++ b/testing/test_package_docs/fake/Interface/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface/runtimeType.html
+++ b/testing/test_package_docs/fake/Interface/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Interface/toString.html
+++ b/testing/test_package_docs/fake/Interface/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -499,7 +499,7 @@ across... wait for it... two physical lines.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/ANSWER-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/ANSWER-constant.html
@@ -113,7 +113,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
@@ -112,7 +112,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
@@ -116,7 +116,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
@@ -115,7 +115,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
@@ -113,7 +113,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
+++ b/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
@@ -116,7 +116,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
@@ -119,7 +119,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
+++ b/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
@@ -116,7 +116,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/noParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/noParams.html
@@ -119,7 +119,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
@@ -120,7 +120,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/operator_multiply.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_multiply.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/operator_plus.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_plus.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/optionalParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/optionalParams.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/returnString.html
+++ b/testing/test_package_docs/fake/LongFirstLine/returnString.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
@@ -116,7 +116,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/staticMethodNoParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticMethodNoParams.html
@@ -115,7 +115,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/staticMethodReturnsVoid.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticMethodReturnsVoid.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
@@ -117,7 +117,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LongFirstLine/twoParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/twoParams.html
@@ -114,7 +114,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -254,7 +254,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn/MixMeIn.html
+++ b/testing/test_package_docs/fake/MixMeIn/MixMeIn.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn/hashCode.html
+++ b/testing/test_package_docs/fake/MixMeIn/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn/noSuchMethod.html
+++ b/testing/test_package_docs/fake/MixMeIn/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn/operator_equals.html
+++ b/testing/test_package_docs/fake/MixMeIn/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn/runtimeType.html
+++ b/testing/test_package_docs/fake/MixMeIn/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/MixMeIn/toString.html
+++ b/testing/test_package_docs/fake/MixMeIn/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -147,7 +147,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -147,7 +147,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -265,7 +265,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/Oops.html
+++ b/testing/test_package_docs/fake/Oops/Oops.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/message.html
+++ b/testing/test_package_docs/fake/Oops/message.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Oops/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/operator_equals.html
+++ b/testing/test_package_docs/fake/Oops/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/runtimeType.html
+++ b/testing/test_package_docs/fake/Oops/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/Oops/toString.html
+++ b/testing/test_package_docs/fake/Oops/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -242,7 +242,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/OperatorReferenceClass.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/OperatorReferenceClass.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/toString.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -249,7 +249,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/convert.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/convert.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/OtherGenericsThing/toString.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -773,7 +773,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/SpecialList.html
+++ b/testing/test_package_docs/fake/SpecialList/SpecialList.html
@@ -140,7 +140,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/add.html
+++ b/testing/test_package_docs/fake/SpecialList/add.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/addAll.html
+++ b/testing/test_package_docs/fake/SpecialList/addAll.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/any.html
+++ b/testing/test_package_docs/fake/SpecialList/any.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/asMap.html
+++ b/testing/test_package_docs/fake/SpecialList/asMap.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/clear.html
+++ b/testing/test_package_docs/fake/SpecialList/clear.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/elementAt.html
+++ b/testing/test_package_docs/fake/SpecialList/elementAt.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/every.html
+++ b/testing/test_package_docs/fake/SpecialList/every.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/expand.html
+++ b/testing/test_package_docs/fake/SpecialList/expand.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/fold.html
+++ b/testing/test_package_docs/fake/SpecialList/fold.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/forEach.html
+++ b/testing/test_package_docs/fake/SpecialList/forEach.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/indexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/indexOf.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/insert.html
+++ b/testing/test_package_docs/fake/SpecialList/insert.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/insertAll.html
+++ b/testing/test_package_docs/fake/SpecialList/insertAll.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/join.html
+++ b/testing/test_package_docs/fake/SpecialList/join.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -153,7 +153,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/operator_get.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_get.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/operator_put.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_put.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/reduce.html
+++ b/testing/test_package_docs/fake/SpecialList/reduce.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/remove.html
+++ b/testing/test_package_docs/fake/SpecialList/remove.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/removeAt.html
+++ b/testing/test_package_docs/fake/SpecialList/removeAt.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/removeLast.html
+++ b/testing/test_package_docs/fake/SpecialList/removeLast.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/removeWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/removeWhere.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/retainWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/retainWhere.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/setAll.html
+++ b/testing/test_package_docs/fake/SpecialList/setAll.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/shuffle.html
+++ b/testing/test_package_docs/fake/SpecialList/shuffle.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -144,7 +144,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/singleWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/singleWhere.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/sort.html
+++ b/testing/test_package_docs/fake/SpecialList/sort.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/sublist.html
+++ b/testing/test_package_docs/fake/SpecialList/sublist.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/take.html
+++ b/testing/test_package_docs/fake/SpecialList/take.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/takeWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/takeWhile.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/toList.html
+++ b/testing/test_package_docs/fake/SpecialList/toList.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/toSet.html
+++ b/testing/test_package_docs/fake/SpecialList/toSet.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/toString.html
+++ b/testing/test_package_docs/fake/SpecialList/toString.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -139,7 +139,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -286,7 +286,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
+++ b/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SubForDocComments/localMethod.html
+++ b/testing/test_package_docs/fake/SubForDocComments/localMethod.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -288,7 +288,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
@@ -91,7 +91,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/fly.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/fly.html
@@ -94,7 +94,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_minus.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_minus.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
@@ -95,7 +95,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
@@ -90,7 +90,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -151,7 +151,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -146,7 +146,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -264,7 +264,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
@@ -110,7 +110,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -151,7 +151,7 @@ which is a bit redundant.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -153,7 +153,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -756,7 +756,7 @@ default value.
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -154,7 +154,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -153,7 +153,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -153,7 +153,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -154,7 +154,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -147,7 +147,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -146,7 +146,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -154,7 +154,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -147,7 +147,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -165,7 +165,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -150,7 +150,7 @@ default value.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -150,7 +150,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -149,7 +149,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -164,7 +164,7 @@ It has two lines.</p>
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -162,7 +162,7 @@ with directories created by dartdoc.
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/is_deprecated/is_deprecated-library.html
+++ b/testing/test_package_docs/is_deprecated/is_deprecated-library.html
@@ -93,7 +93,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass-class.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass-class.html
@@ -173,7 +173,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/SomeOtherClass.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/SomeOtherClass.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/toString.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_one/reexport_one-library.html
+++ b/testing/test_package_docs/reexport_one/reexport_one-library.html
@@ -128,7 +128,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass-class.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass-class.html
@@ -173,7 +173,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass/AUnicornClass.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/AUnicornClass.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/AUnicornClass/toString.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass-class.html
+++ b/testing/test_package_docs/reexport_two/SomeClass-class.html
@@ -173,7 +173,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass/SomeClass.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/SomeClass.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/SomeClass/toString.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass-class.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass-class.html
@@ -173,7 +173,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/YetAnotherClass.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/YetAnotherClass.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/toString.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/reexport_two/reexport_two-library.html
+++ b/testing/test_package_docs/reexport_two/reexport_two-library.html
@@ -128,7 +128,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
@@ -174,7 +174,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2-class.html
@@ -174,7 +174,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/Whataclass2.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/Whataclass2.html
@@ -88,7 +88,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/noSuchMethod.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
@@ -92,7 +92,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/toString.html
@@ -87,7 +87,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/test_package_imported.main/test_package_imported.main-library.html
+++ b/testing/test_package_docs/test_package_imported.main/test_package_imported.main-library.html
@@ -111,7 +111,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/two_exports/BaseClass-class.html
+++ b/testing/test_package_docs/two_exports/BaseClass-class.html
@@ -201,7 +201,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/two_exports/BaseClass/BaseClass.html
+++ b/testing/test_package_docs/two_exports/BaseClass/BaseClass.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/two_exports/ExtendingClass-class.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass-class.html
@@ -203,7 +203,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/two_exports/ExtendingClass/ExtendingClass.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass/ExtendingClass.html
@@ -89,7 +89,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/two_exports/topLevelVariable.html
+++ b/testing/test_package_docs/two_exports/topLevelVariable.html
@@ -81,7 +81,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/testing/test_package_docs/two_exports/two_exports-library.html
+++ b/testing/test_package_docs/two_exports/two_exports-library.html
@@ -128,7 +128,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/prettify.js"></script>
 <script src="static-assets/URI.js"></script>


### PR DESCRIPTION
Fixes #1473.  Tested by hand that typeahead and other search box features still work, which seems to be all we use jquery for.