### PR TITLE
Remove appveyor hack

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ install:
   - set PATH=%PATH%;C:\tools\dart-sdk\bin
   - set PATH=%PATH%;%APPDATA%\Pub\Cache\bin
   - pub get
-  - cmd: cd testing
-  - cmd: cd test_package
-  - cmd: pub get
-  - cmd: cd ..
-  - cmd: cd ..
 
 build: off
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -307,6 +307,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.24+6"
+  test_package_imported:
+    description:
+      path: "testing/test_package_imported"
+      relative: true
+    source: path
+    version: "0.0.1"
   tuple:
     description:
       name: tuple

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,5 +29,7 @@ dev_dependencies:
   meta: ^1.0.0
   pub_semver: ^1.0.0
   test: '^0.12.20+24'
+  test_package_imported:
+    path: 'testing/test_package_imported'
 executables:
   dartdoc: null


### PR DESCRIPTION
pub global activate -spath . seems to have bugs relating to relative paths in pubspec.yaml.  Only needed for testing purposes in this package.

The appveyor hack fixes appveyor, and something like it has to be done locally too to complete grind test.  We can avoid the hack through this PR, but then we break flutter with the spath bug.  Creating this PR to reference in an upcoming SDK bug, and to have a branch pub developers can check out to reproduce the problem.