### PR TITLE
remove the creative commons footer text

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -5,6 +5,7 @@
 library dartdoc.bin;
 
 import 'dart:io';
+import 'dart:isolate' show Isolate;
 
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/src/dart/sdk/sdk.dart';
@@ -44,10 +45,7 @@ main(List<String> arguments) async {
     exit(1);
   }
 
-  bool sdkDocs = false;
-  if (args['sdk-docs']) {
-    sdkDocs = true;
-  }
+  final bool sdkDocs = args['sdk-docs'];
 
   if (args['show-progress']) {
     _showProgress = true;
@@ -63,7 +61,8 @@ main(List<String> arguments) async {
   Directory inputDir = new Directory(args['input']);
   if (!inputDir.existsSync()) {
     stderr.writeln(
-        " fatal error: unable to locate the input directory at ${inputDir.path}.");
+        " fatal error: unable to locate the input directory at ${inputDir
+            .path}.");
     exit(1);
   }
 
@@ -95,6 +94,14 @@ main(List<String> arguments) async {
 
   List<String> footerTextFilePaths =
       args['footer-text'].map(_resolveTildePath).toList() as List<String>;
+
+  // If we're generating docs for the Dart SDK, we insert a copyright footer.
+  if (sdkDocs) {
+    Uri footerCopyrightUri = await Isolate.resolvePackageUri(
+        Uri.parse('package:dartdoc/src/sdk_footer_text.html'));
+    footerTextFilePaths = [footerCopyrightUri.toFilePath()];
+  }
+
   for (String footerFilePath in footerTextFilePaths) {
     if (!new File(footerFilePath).existsSync()) {
       stderr.writeln(
@@ -122,8 +129,10 @@ main(List<String> arguments) async {
       : new PackageMeta.fromDir(inputDir);
 
   if (!packageMeta.isValid) {
-    stderr.writeln(
-        ' fatal error: Unable to generate documentation: ${packageMeta.getInvalidReasons().first}.');
+    stderr
+        .writeln(' fatal error: Unable to generate documentation: ${packageMeta
+        .getInvalidReasons()
+        .first}.');
     exit(1);
   }
 
@@ -245,8 +254,8 @@ ArgParser _createArgsParser() {
   parser.addOption('footer-text',
       allowMultiple: true,
       splitCommas: true,
-      help:
-          'paths to footer-text files (optional text next to the copyright).');
+      help: 'paths to footer-text files '
+          '(optional text next to the package name and version).');
   parser.addOption('exclude',
       allowMultiple: true, splitCommas: true, help: 'Library names to ignore.');
   parser.addOption('include',
@@ -311,6 +320,7 @@ ArgParser _createArgsParser() {
 }
 
 int _progressCounter = 0;
+
 void _onProgress(var file) {
   if (_showProgress && _progressCounter % 5 == 0) {
     stdout.write('.');

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -129,10 +129,9 @@ main(List<String> arguments) async {
       : new PackageMeta.fromDir(inputDir);
 
   if (!packageMeta.isValid) {
-    stderr
-        .writeln(' fatal error: Unable to generate documentation: ${packageMeta
-        .getInvalidReasons()
-        .first}.');
+    final String firstError = packageMeta.getInvalidReasons().first;
+    stderr.writeln(
+        ' fatal error: Unable to generate documentation: $firstError.');
     exit(1);
   }
 

--- a/lib/src/sdk_footer_text.html
+++ b/lib/src/sdk_footer_text.html
@@ -1,0 +1,4 @@
+&bull;
+<span class="copyright no-break">
+  <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
+</span>

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -4,10 +4,6 @@
   <span class="no-break">
     {{package.name}} {{package.version}}
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
   <!-- footer-text placeholder -->
 </footer>

--- a/testing/test_package_docs/anonymous_library/anonymous_library-library.html
+++ b/testing/test_package_docs/anonymous_library/anonymous_library-library.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/anonymous_library/doesStuff.html
+++ b/testing/test_package_docs/anonymous_library/doesStuff.html
@@ -70,10 +70,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/another_anonymous_lib/another_anonymous_lib-library.html
+++ b/testing/test_package_docs/another_anonymous_lib/another_anonymous_lib-library.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/another_anonymous_lib/greeting.html
+++ b/testing/test_package_docs/another_anonymous_lib/greeting.html
@@ -70,10 +70,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/code_in_comments/code_in_comments-library.html
+++ b/testing/test_package_docs/code_in_comments/code_in_comments-library.html
@@ -94,10 +94,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/css/css-library.html
+++ b/testing/test_package_docs/css/css-library.html
@@ -104,10 +104,6 @@ with directories created by dartdoc.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
+++ b/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
@@ -71,10 +71,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -269,10 +269,6 @@ enum constants ala #1445</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Animal/hashCode.html
+++ b/testing/test_package_docs/ex/Animal/hashCode.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Animal/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Animal/noSuchMethod.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Animal/operator_equals.html
+++ b/testing/test_package_docs/ex/Animal/operator_equals.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Animal/runtimeType.html
+++ b/testing/test_package_docs/ex/Animal/runtimeType.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Animal/toString.html
+++ b/testing/test_package_docs/ex/Animal/toString.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -374,10 +374,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/Apple.fromString.html
+++ b/testing/test_package_docs/ex/Apple/Apple.fromString.html
@@ -96,10 +96,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/Apple.html
+++ b/testing/test_package_docs/ex/Apple/Apple.html
@@ -99,10 +99,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
+++ b/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/isGreaterThan.html
+++ b/testing/test_package_docs/ex/Apple/isGreaterThan.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/m.html
+++ b/testing/test_package_docs/ex/Apple/m.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/m1.html
+++ b/testing/test_package_docs/ex/Apple/m1.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/methodWithTypedefParam.html
+++ b/testing/test_package_docs/ex/Apple/methodWithTypedefParam.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/n-constant.html
+++ b/testing/test_package_docs/ex/Apple/n-constant.html
@@ -97,10 +97,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Apple/noSuchMethod.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/operator_equals.html
+++ b/testing/test_package_docs/ex/Apple/operator_equals.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/operator_multiply.html
+++ b/testing/test_package_docs/ex/Apple/operator_multiply.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/paramFromExportLib.html
+++ b/testing/test_package_docs/ex/Apple/paramFromExportLib.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/printMsg.html
+++ b/testing/test_package_docs/ex/Apple/printMsg.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/runtimeType.html
+++ b/testing/test_package_docs/ex/Apple/runtimeType.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/s.html
+++ b/testing/test_package_docs/ex/Apple/s.html
@@ -115,10 +115,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/string.html
+++ b/testing/test_package_docs/ex/Apple/string.html
@@ -97,10 +97,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/toString.html
+++ b/testing/test_package_docs/ex/Apple/toString.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Apple/whataclass.html
+++ b/testing/test_package_docs/ex/Apple/whataclass.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -396,10 +396,6 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/B.html
+++ b/testing/test_package_docs/ex/B/B.html
@@ -97,10 +97,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/abstractMethod.html
+++ b/testing/test_package_docs/ex/B/abstractMethod.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/autoCompress.html
+++ b/testing/test_package_docs/ex/B/autoCompress.html
@@ -102,10 +102,6 @@ To enable, set <code>autoCompress</code> to <code>true</code>.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/doNothing.html
+++ b/testing/test_package_docs/ex/B/doNothing.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/isImplemented.html
+++ b/testing/test_package_docs/ex/B/isImplemented.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/list.html
+++ b/testing/test_package_docs/ex/B/list.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/m1.html
+++ b/testing/test_package_docs/ex/B/m1.html
@@ -106,10 +106,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/s.html
+++ b/testing/test_package_docs/ex/B/s.html
@@ -116,10 +116,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/B/writeMsg.html
+++ b/testing/test_package_docs/ex/B/writeMsg.html
@@ -96,10 +96,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/COLOR-constant.html
+++ b/testing/test_package_docs/ex/COLOR-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/COLOR_GREEN-constant.html
+++ b/testing/test_package_docs/ex/COLOR_GREEN-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
+++ b/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
+++ b/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat-class.html
+++ b/testing/test_package_docs/ex/Cat-class.html
@@ -247,10 +247,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/Cat.html
+++ b/testing/test_package_docs/ex/Cat/Cat.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/abstractMethod.html
+++ b/testing/test_package_docs/ex/Cat/abstractMethod.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/isImplemented.html
+++ b/testing/test_package_docs/ex/Cat/isImplemented.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Cat/noSuchMethod.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/operator_equals.html
+++ b/testing/test_package_docs/ex/Cat/operator_equals.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/runtimeType.html
+++ b/testing/test_package_docs/ex/Cat/runtimeType.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Cat/toString.html
+++ b/testing/test_package_docs/ex/Cat/toString.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString-class.html
+++ b/testing/test_package_docs/ex/CatString-class.html
@@ -305,10 +305,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/CatString.html
+++ b/testing/test_package_docs/ex/CatString/CatString.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/clear.html
+++ b/testing/test_package_docs/ex/CatString/clear.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/hashCode.html
+++ b/testing/test_package_docs/ex/CatString/hashCode.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/isEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isEmpty.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/isNotEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isNotEmpty.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/length.html
+++ b/testing/test_package_docs/ex/CatString/length.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/noSuchMethod.html
+++ b/testing/test_package_docs/ex/CatString/noSuchMethod.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/operator_equals.html
+++ b/testing/test_package_docs/ex/CatString/operator_equals.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/runtimeType.html
+++ b/testing/test_package_docs/ex/CatString/runtimeType.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/toString.html
+++ b/testing/test_package_docs/ex/CatString/toString.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/write.html
+++ b/testing/test_package_docs/ex/CatString/write.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/writeAll.html
+++ b/testing/test_package_docs/ex/CatString/writeAll.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/writeCharCode.html
+++ b/testing/test_package_docs/ex/CatString/writeCharCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/CatString/writeln.html
+++ b/testing/test_package_docs/ex/CatString/writeln.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -257,10 +257,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
+++ b/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/abstractMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/abstractMethod.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/isImplemented.html
+++ b/testing/test_package_docs/ex/ConstantCat/isImplemented.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/name.html
+++ b/testing/test_package_docs/ex/ConstantCat/name.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ConstantCat/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/operator_equals.html
+++ b/testing/test_package_docs/ex/ConstantCat/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/runtimeType.html
+++ b/testing/test_package_docs/ex/ConstantCat/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ConstantCat/toString.html
+++ b/testing/test_package_docs/ex/ConstantCat/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -224,10 +224,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Deprecated/toString.html
+++ b/testing/test_package_docs/ex/Deprecated/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -477,10 +477,6 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -106,10 +106,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -106,10 +106,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -111,10 +111,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Dog/noSuchMethod.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -119,10 +119,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/toString.html
+++ b/testing/test_package_docs/ex/Dog/toString.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/withMacro.html
+++ b/testing/test_package_docs/ex/Dog/withMacro.html
@@ -110,10 +110,6 @@ More docs</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -108,10 +108,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E-class.html
+++ b/testing/test_package_docs/ex/E-class.html
@@ -226,10 +226,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E/E.html
+++ b/testing/test_package_docs/ex/E/E.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E/hashCode.html
+++ b/testing/test_package_docs/ex/E/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E/noSuchMethod.html
+++ b/testing/test_package_docs/ex/E/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E/operator_equals.html
+++ b/testing/test_package_docs/ex/E/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E/runtimeType.html
+++ b/testing/test_package_docs/ex/E/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/E/toString.html
+++ b/testing/test_package_docs/ex/E/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -413,10 +413,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -100,10 +100,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -99,10 +99,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -99,10 +99,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -224,10 +224,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
+++ b/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ForAnnotation/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/ForAnnotation/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/toString.html
+++ b/testing/test_package_docs/ex/ForAnnotation/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ForAnnotation/value.html
+++ b/testing/test_package_docs/ex/ForAnnotation/value.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs/ex/HasAnnotation-class.html
@@ -226,10 +226,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation/HasAnnotation.html
+++ b/testing/test_package_docs/ex/HasAnnotation/HasAnnotation.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/HasAnnotation/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/ex/HasAnnotation/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
+++ b/testing/test_package_docs/ex/HasAnnotation/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/HasAnnotation/toString.html
+++ b/testing/test_package_docs/ex/HasAnnotation/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper-class.html
+++ b/testing/test_package_docs/ex/Helper-class.html
@@ -229,10 +229,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/Helper.html
+++ b/testing/test_package_docs/ex/Helper/Helper.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/getContents.html
+++ b/testing/test_package_docs/ex/Helper/getContents.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/hashCode.html
+++ b/testing/test_package_docs/ex/Helper/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Helper/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/operator_equals.html
+++ b/testing/test_package_docs/ex/Helper/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/runtimeType.html
+++ b/testing/test_package_docs/ex/Helper/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Helper/toString.html
+++ b/testing/test_package_docs/ex/Helper/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -267,10 +267,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/Klass.html
+++ b/testing/test_package_docs/ex/Klass/Klass.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/another.html
+++ b/testing/test_package_docs/ex/Klass/another.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/anotherMethod.html
+++ b/testing/test_package_docs/ex/Klass/anotherMethod.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/imAFactoryNoReally.html
+++ b/testing/test_package_docs/ex/Klass/imAFactoryNoReally.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/imProtected.html
+++ b/testing/test_package_docs/ex/Klass/imProtected.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/method.html
+++ b/testing/test_package_docs/ex/Klass/method.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Klass/noSuchMethod.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/operator_equals.html
+++ b/testing/test_package_docs/ex/Klass/operator_equals.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/runtimeType.html
+++ b/testing/test_package_docs/ex/Klass/runtimeType.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/Klass/toString.html
+++ b/testing/test_package_docs/ex/Klass/toString.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MY_CAT-constant.html
+++ b/testing/test_package_docs/ex/MY_CAT-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError-class.html
+++ b/testing/test_package_docs/ex/MyError-class.html
@@ -237,10 +237,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/MyError.html
+++ b/testing/test_package_docs/ex/MyError/MyError.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/hashCode.html
+++ b/testing/test_package_docs/ex/MyError/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyError/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/operator_equals.html
+++ b/testing/test_package_docs/ex/MyError/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/runtimeType.html
+++ b/testing/test_package_docs/ex/MyError/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/stackTrace.html
+++ b/testing/test_package_docs/ex/MyError/stackTrace.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyError/toString.html
+++ b/testing/test_package_docs/ex/MyError/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -237,10 +237,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyErrorImplements/toString.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException-class.html
+++ b/testing/test_package_docs/ex/MyException-class.html
@@ -228,10 +228,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException/MyException.html
+++ b/testing/test_package_docs/ex/MyException/MyException.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException/hashCode.html
+++ b/testing/test_package_docs/ex/MyException/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyException/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException/operator_equals.html
+++ b/testing/test_package_docs/ex/MyException/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException/runtimeType.html
+++ b/testing/test_package_docs/ex/MyException/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyException/toString.html
+++ b/testing/test_package_docs/ex/MyException/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements-class.html
@@ -228,10 +228,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/MyExceptionImplements.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/MyExceptionImplements.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/noSuchMethod.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/toString.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
+++ b/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ParameterizedTypedef.html
+++ b/testing/test_package_docs/ex/ParameterizedTypedef.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
@@ -237,10 +237,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/PublicClassExtendsPrivateClass.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/PublicClassExtendsPrivateClass.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/test.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/test.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/toString.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -224,10 +224,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/test.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/test.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -259,10 +259,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/hashCode.html
+++ b/testing/test_package_docs/ex/ShapeType/hashCode.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/name.html
+++ b/testing/test_package_docs/ex/ShapeType/name.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ShapeType/noSuchMethod.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/operator_equals.html
+++ b/testing/test_package_docs/ex/ShapeType/operator_equals.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/rect-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/rect-constant.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/runtimeType.html
+++ b/testing/test_package_docs/ex/ShapeType/runtimeType.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ShapeType/toString.html
+++ b/testing/test_package_docs/ex/ShapeType/toString.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs/ex/SpecializedDuration-class.html
@@ -405,10 +405,6 @@ that has some operators</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/SpecializedDuration.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/SpecializedDuration.html
@@ -99,10 +99,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/abs.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/abs.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/compareTo.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/compareTo.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inDays.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inDays.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inHours.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inHours.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/noSuchMethod.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/noSuchMethod.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_equals.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_equals.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_greater.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_greater.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_greater_equal.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_greater_equal.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_less.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_less.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_less_equal.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_less_equal.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_minus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_minus.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_multiply.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_multiply.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_plus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_plus.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_truncate_divide.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_truncate_divide.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/operator_unary_minus.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/operator_unary_minus.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/SpecializedDuration/toString.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/toString.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
@@ -248,10 +248,6 @@ case right for anonymous functions.
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/TypedFunctionsWithoutTypedefs.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/TypedFunctionsWithoutTypedefs.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAComplexTypedef.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAComplexTypedef.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html
@@ -87,10 +87,6 @@ case right for anonymous functions.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/hashCode.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/noSuchMethod.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/operator_equals.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/runtimeType.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/toString.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -236,10 +236,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
+++ b/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
+++ b/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGeneric/toString.html
+++ b/testing/test_package_docs/ex/WithGeneric/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -238,10 +238,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/WithGenericSub/WithGenericSub.html
+++ b/testing/test_package_docs/ex/WithGenericSub/WithGenericSub.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aComplexTypedef.html
+++ b/testing/test_package_docs/ex/aComplexTypedef.html
@@ -124,10 +124,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo-class.html
+++ b/testing/test_package_docs/ex/aThingToDo-class.html
@@ -236,10 +236,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/aThingToDo.html
+++ b/testing/test_package_docs/ex/aThingToDo/aThingToDo.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/hashCode.html
+++ b/testing/test_package_docs/ex/aThingToDo/hashCode.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/noSuchMethod.html
+++ b/testing/test_package_docs/ex/aThingToDo/noSuchMethod.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/operator_equals.html
+++ b/testing/test_package_docs/ex/aThingToDo/operator_equals.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/runtimeType.html
+++ b/testing/test_package_docs/ex/aThingToDo/runtimeType.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/toString.html
+++ b/testing/test_package_docs/ex/aThingToDo/toString.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/what.html
+++ b/testing/test_package_docs/ex/aThingToDo/what.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/aThingToDo/who.html
+++ b/testing/test_package_docs/ex/aThingToDo/who.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/deprecatedField.html
+++ b/testing/test_package_docs/ex/deprecatedField.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/deprecatedGetter.html
@@ -125,10 +125,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/deprecatedSetter.html
@@ -126,10 +126,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -534,10 +534,6 @@ enum constants ala #1445
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/function1.html
+++ b/testing/test_package_docs/ex/function1.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/genericFunction.html
+++ b/testing/test_package_docs/ex/genericFunction.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReference-constant.html
@@ -125,10 +125,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
@@ -125,10 +125,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/number.html
+++ b/testing/test_package_docs/ex/number.html
@@ -122,10 +122,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/processMessage.html
+++ b/testing/test_package_docs/ex/processMessage.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/ex/y.html
+++ b/testing/test_package_docs/ex/y.html
@@ -125,10 +125,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -249,10 +249,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/Annotation.html
+++ b/testing/test_package_docs/fake/Annotation/Annotation.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Annotation/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/operator_equals.html
+++ b/testing/test_package_docs/fake/Annotation/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/runtimeType.html
+++ b/testing/test_package_docs/fake/Annotation/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/toString.html
+++ b/testing/test_package_docs/fake/Annotation/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Annotation/value.html
+++ b/testing/test_package_docs/fake/Annotation/value.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -251,10 +251,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface/AnotherInterface.html
+++ b/testing/test_package_docs/fake/AnotherInterface/AnotherInterface.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface/hashCode.html
+++ b/testing/test_package_docs/fake/AnotherInterface/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface/noSuchMethod.html
+++ b/testing/test_package_docs/fake/AnotherInterface/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
+++ b/testing/test_package_docs/fake/AnotherInterface/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
+++ b/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/AnotherInterface/toString.html
+++ b/testing/test_package_docs/fake/AnotherInterface/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -268,10 +268,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/BaseForDocComments.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/BaseForDocComments.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/anotherMethod.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/anotherMethod.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/doAwesomeStuff.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/doAwesomeStuff.html
@@ -101,10 +101,6 @@ the name <a href="two_exports/BaseClass-class.html">BaseClass</a> xx</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/noSuchMethod.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/noSuchMethod.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/operator_equals.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseForDocComments/toString.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/toString.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -278,10 +278,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/BaseThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy/BaseThingy.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingy.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingyField.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingyField.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingyMethod.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingyMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/hashCode.html
+++ b/testing/test_package_docs/fake/BaseThingy/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/noSuchMethod.html
+++ b/testing/test_package_docs/fake/BaseThingy/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/operator_equals.html
+++ b/testing/test_package_docs/fake/BaseThingy/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseThingy/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy/toString.html
+++ b/testing/test_package_docs/fake/BaseThingy/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -286,10 +286,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/BaseThingy2.html
+++ b/testing/test_package_docs/fake/BaseThingy2/BaseThingy2.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/aImplementingThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy2/aImplementingThingy.html
@@ -91,10 +91,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/hashCode.html
+++ b/testing/test_package_docs/fake/BaseThingy2/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/noSuchMethod.html
+++ b/testing/test_package_docs/fake/BaseThingy2/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/operator_equals.html
+++ b/testing/test_package_docs/fake/BaseThingy2/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseThingy2/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/BaseThingy2/toString.html
+++ b/testing/test_package_docs/fake/BaseThingy2/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -144,10 +144,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -143,10 +143,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -380,10 +380,6 @@ on inheritance and overrides here.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
@@ -94,10 +94,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/aMethod.html
@@ -96,10 +96,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -113,10 +113,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
@@ -101,10 +101,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -102,10 +102,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
@@ -98,10 +98,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
@@ -102,10 +102,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
@@ -95,10 +95,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -339,10 +339,6 @@ Some constants have long docs.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Color/hashCode.html
+++ b/testing/test_package_docs/fake/Color/hashCode.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Color/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Color/noSuchMethod.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Color/operator_equals.html
+++ b/testing/test_package_docs/fake/Color/operator_equals.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Color/runtimeType.html
+++ b/testing/test_package_docs/fake/Color/runtimeType.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Color/toString.html
+++ b/testing/test_package_docs/fake/Color/toString.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -271,10 +271,6 @@ Go ahead, it's fun.
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
@@ -88,10 +88,6 @@ Go ahead, it's fun.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstantClass/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstantClass/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstantClass/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/toString.html
+++ b/testing/test_package_docs/fake/ConstantClass/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ConstantClass/value.html
+++ b/testing/test_package_docs/fake/ConstantClass/value.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -249,10 +249,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/Cool.html
+++ b/testing/test_package_docs/fake/Cool/Cool.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Cool/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/operator_equals.html
+++ b/testing/test_package_docs/fake/Cool/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/returnCool.html
+++ b/testing/test_package_docs/fake/Cool/returnCool.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/runtimeType.html
+++ b/testing/test_package_docs/fake/Cool/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Cool/toString.html
+++ b/testing/test_package_docs/fake/Cool/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -266,10 +266,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/Doh.html
+++ b/testing/test_package_docs/fake/Doh/Doh.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/hashCode.html
+++ b/testing/test_package_docs/fake/Doh/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Doh/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/operator_equals.html
+++ b/testing/test_package_docs/fake/Doh/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/runtimeType.html
+++ b/testing/test_package_docs/fake/Doh/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/stackTrace.html
+++ b/testing/test_package_docs/fake/Doh/stackTrace.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Doh/toString.html
+++ b/testing/test_package_docs/fake/Doh/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -767,10 +767,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
@@ -133,10 +133,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -151,10 +151,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -280,10 +280,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/BAR-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAR-constant.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/BAZ-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAZ-constant.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/Foo2.html
+++ b/testing/test_package_docs/fake/Foo2/Foo2.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/index.html
+++ b/testing/test_package_docs/fake/Foo2/index.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Foo2/noSuchMethod.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/operator_equals.html
+++ b/testing/test_package_docs/fake/Foo2/operator_equals.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/runtimeType.html
+++ b/testing/test_package_docs/fake/Foo2/runtimeType.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Foo2/toString.html
+++ b/testing/test_package_docs/fake/Foo2/toString.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -239,10 +239,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -276,10 +276,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
+++ b/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/convertToMap.html
+++ b/testing/test_package_docs/fake/HasGenerics/convertToMap.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/doStuff.html
+++ b/testing/test_package_docs/fake/HasGenerics/doStuff.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/returnX.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnX.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/returnZ.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnZ.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -89,10 +89,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/HasGenerics/toString.html
+++ b/testing/test_package_docs/fake/HasGenerics/toString.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -283,10 +283,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy/ImplementingThingy.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/ImplementingThingy.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy/hashCode.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy/toString.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -280,10 +280,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/ImplementingThingy2.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/ImplementingThingy2.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/hashCode.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/toString.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -301,10 +301,6 @@ they are correct.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
@@ -93,10 +93,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/noSuchMethod.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/operator_equals.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -90,10 +90,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ImplicitProperties/toString.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/toString.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -251,10 +251,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface/Interface.html
+++ b/testing/test_package_docs/fake/Interface/Interface.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface/hashCode.html
+++ b/testing/test_package_docs/fake/Interface/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Interface/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface/operator_equals.html
+++ b/testing/test_package_docs/fake/Interface/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface/runtimeType.html
+++ b/testing/test_package_docs/fake/Interface/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Interface/toString.html
+++ b/testing/test_package_docs/fake/Interface/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -496,10 +496,6 @@ across... wait for it... two physical lines.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/ANSWER-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/ANSWER-constant.html
@@ -106,10 +106,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
@@ -105,10 +105,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
@@ -109,10 +109,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
@@ -108,10 +108,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
@@ -106,10 +106,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
+++ b/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
@@ -109,10 +109,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
@@ -112,10 +112,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
+++ b/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
@@ -109,10 +109,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/noParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/noParams.html
@@ -112,10 +112,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
@@ -113,10 +113,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/operator_multiply.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_multiply.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/operator_plus.html
+++ b/testing/test_package_docs/fake/LongFirstLine/operator_plus.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/optionalParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/optionalParams.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/returnString.html
+++ b/testing/test_package_docs/fake/LongFirstLine/returnString.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
@@ -109,10 +109,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/staticMethodNoParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticMethodNoParams.html
@@ -108,10 +108,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/staticMethodReturnsVoid.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticMethodReturnsVoid.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
@@ -110,10 +110,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LongFirstLine/twoParams.html
+++ b/testing/test_package_docs/fake/LongFirstLine/twoParams.html
@@ -107,10 +107,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -251,10 +251,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn/MixMeIn.html
+++ b/testing/test_package_docs/fake/MixMeIn/MixMeIn.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn/hashCode.html
+++ b/testing/test_package_docs/fake/MixMeIn/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn/noSuchMethod.html
+++ b/testing/test_package_docs/fake/MixMeIn/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn/operator_equals.html
+++ b/testing/test_package_docs/fake/MixMeIn/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn/runtimeType.html
+++ b/testing/test_package_docs/fake/MixMeIn/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/MixMeIn/toString.html
+++ b/testing/test_package_docs/fake/MixMeIn/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -144,10 +144,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -144,10 +144,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -262,10 +262,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/Oops.html
+++ b/testing/test_package_docs/fake/Oops/Oops.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/message.html
+++ b/testing/test_package_docs/fake/Oops/message.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/noSuchMethod.html
+++ b/testing/test_package_docs/fake/Oops/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/operator_equals.html
+++ b/testing/test_package_docs/fake/Oops/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/runtimeType.html
+++ b/testing/test_package_docs/fake/Oops/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/Oops/toString.html
+++ b/testing/test_package_docs/fake/Oops/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -239,10 +239,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/OperatorReferenceClass.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/OperatorReferenceClass.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/operator_equals.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/toString.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -246,10 +246,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/convert.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/convert.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/toString.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -770,10 +770,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/SpecialList.html
+++ b/testing/test_package_docs/fake/SpecialList/SpecialList.html
@@ -133,10 +133,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/add.html
+++ b/testing/test_package_docs/fake/SpecialList/add.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/addAll.html
+++ b/testing/test_package_docs/fake/SpecialList/addAll.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/any.html
+++ b/testing/test_package_docs/fake/SpecialList/any.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/asMap.html
+++ b/testing/test_package_docs/fake/SpecialList/asMap.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/clear.html
+++ b/testing/test_package_docs/fake/SpecialList/clear.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/elementAt.html
+++ b/testing/test_package_docs/fake/SpecialList/elementAt.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/every.html
+++ b/testing/test_package_docs/fake/SpecialList/every.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/expand.html
+++ b/testing/test_package_docs/fake/SpecialList/expand.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/fold.html
+++ b/testing/test_package_docs/fake/SpecialList/fold.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/forEach.html
+++ b/testing/test_package_docs/fake/SpecialList/forEach.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/indexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/indexOf.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/insert.html
+++ b/testing/test_package_docs/fake/SpecialList/insert.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/insertAll.html
+++ b/testing/test_package_docs/fake/SpecialList/insertAll.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/join.html
+++ b/testing/test_package_docs/fake/SpecialList/join.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/operator_get.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_get.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/operator_put.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_put.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/reduce.html
+++ b/testing/test_package_docs/fake/SpecialList/reduce.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/remove.html
+++ b/testing/test_package_docs/fake/SpecialList/remove.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/removeAt.html
+++ b/testing/test_package_docs/fake/SpecialList/removeAt.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/removeLast.html
+++ b/testing/test_package_docs/fake/SpecialList/removeLast.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/removeWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/removeWhere.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/retainWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/retainWhere.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/setAll.html
+++ b/testing/test_package_docs/fake/SpecialList/setAll.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/shuffle.html
+++ b/testing/test_package_docs/fake/SpecialList/shuffle.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -137,10 +137,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/singleWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/singleWhere.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/sort.html
+++ b/testing/test_package_docs/fake/SpecialList/sort.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/sublist.html
+++ b/testing/test_package_docs/fake/SpecialList/sublist.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/take.html
+++ b/testing/test_package_docs/fake/SpecialList/take.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/takeWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/takeWhile.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/toList.html
+++ b/testing/test_package_docs/fake/SpecialList/toList.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/toSet.html
+++ b/testing/test_package_docs/fake/SpecialList/toSet.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/toString.html
+++ b/testing/test_package_docs/fake/SpecialList/toString.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -132,10 +132,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -283,10 +283,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
+++ b/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SubForDocComments/localMethod.html
+++ b/testing/test_package_docs/fake/SubForDocComments/localMethod.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -285,10 +285,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
@@ -84,10 +84,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/fly.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/fly.html
@@ -87,10 +87,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/noSuchMethod.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_equals.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/operator_minus.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/operator_minus.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
@@ -88,10 +88,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/toString.html
@@ -83,10 +83,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -148,10 +148,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -143,10 +143,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -261,10 +261,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
@@ -103,10 +103,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/noSuchMethod.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/operator_equals.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/toString.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -148,10 +148,6 @@ which is a bit redundant.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -150,10 +150,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -777,10 +777,6 @@ default value.
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -151,10 +151,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -150,10 +150,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -150,10 +150,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -151,10 +151,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -144,10 +144,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -143,10 +143,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -151,10 +151,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -144,10 +144,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -162,10 +162,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -147,10 +147,6 @@ default value.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -147,10 +147,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -146,10 +146,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -161,10 +161,6 @@ It has two lines.</p>
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -177,10 +177,6 @@ with directories created by dartdoc.
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/is_deprecated/is_deprecated-library.html
+++ b/testing/test_package_docs/is_deprecated/is_deprecated-library.html
@@ -86,10 +86,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass-class.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass-class.html
@@ -166,10 +166,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/SomeOtherClass.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/SomeOtherClass.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/toString.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_one/reexport_one-library.html
+++ b/testing/test_package_docs/reexport_one/reexport_one-library.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass-class.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass-class.html
@@ -166,10 +166,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/AUnicornClass.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/AUnicornClass.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/toString.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass-class.html
+++ b/testing/test_package_docs/reexport_two/SomeClass-class.html
@@ -166,10 +166,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass/SomeClass.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/SomeClass.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/SomeClass/toString.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass-class.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass-class.html
@@ -166,10 +166,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/YetAnotherClass.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/YetAnotherClass.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/toString.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/reexport_two/reexport_two-library.html
+++ b/testing/test_package_docs/reexport_two/reexport_two-library.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
@@ -167,10 +167,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2-class.html
@@ -167,10 +167,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/Whataclass2.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/Whataclass2.html
@@ -81,10 +81,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/noSuchMethod.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/operator_equals.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
@@ -85,10 +85,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/toString.html
@@ -80,10 +80,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/test_package_imported.main/test_package_imported.main-library.html
+++ b/testing/test_package_docs/test_package_imported.main/test_package_imported.main-library.html
@@ -104,10 +104,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/two_exports/BaseClass-class.html
+++ b/testing/test_package_docs/two_exports/BaseClass-class.html
@@ -194,10 +194,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/two_exports/BaseClass/BaseClass.html
+++ b/testing/test_package_docs/two_exports/BaseClass/BaseClass.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/two_exports/ExtendingClass-class.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass-class.html
@@ -196,10 +196,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/two_exports/ExtendingClass/ExtendingClass.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass/ExtendingClass.html
@@ -82,10 +82,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/two_exports/topLevelVariable.html
+++ b/testing/test_package_docs/two_exports/topLevelVariable.html
@@ -74,10 +74,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 

--- a/testing/test_package_docs/two_exports/two_exports-library.html
+++ b/testing/test_package_docs/two_exports/two_exports-library.html
@@ -121,10 +121,6 @@
   <span class="no-break">
     test_package 0.0.1
   </span>
-  &bull;
-  <span class="copyright no-break">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-  </span>
 
 </footer>
 


### PR DESCRIPTION
- remove the creative commons footer text from normal doc generation (fix https://github.com/dart-lang/dartdoc/issues/1262)
- when generating docs for the sdk, add back in some license text

(done in separate commits to make it easier to ignore the generated file changes)

@jcollins-g 