### PR TITLE
Make all markdown content render at 700px

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -79,10 +79,6 @@ main {
   padding: 20px 15px 0 30px;
 }
 
-.main-content p {
-  max-width: 700px;
-}
-
 .sidebar,
 .main-content {
   margin: 20px 0;
@@ -414,6 +410,10 @@ footer .container-fluid {
 
 footer a, footer a:hover {
   color: #fff;
+}
+
+.markdown.desc {
+  max-width: 700px;
 }
 
 .markdown h1 {

--- a/testing/test_package/README.md
+++ b/testing/test_package/README.md
@@ -14,6 +14,11 @@ It also has some awesome code
 void main() {
   // in Dart!
 }
+
+/*
+80-characters: to ensure default styles accommodate Dart line length convention.
+01234567890123456789012345678901234567890123456789012345678901234567890123456789
+*/
 ```
 
 ```yaml

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -60,6 +60,11 @@
 <pre class="language-dart"><code class="language-dart">void main() {
   // in Dart!
 }
+
+/*
+80-characters: to ensure default styles accommodate Dart line length convention.
+01234567890123456789012345678901234567890123456789012345678901234567890123456789
+*/
 </code></pre>
 <pre class="language-yaml"><code class="language-yaml">and_yaml:
   - value

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -79,10 +79,6 @@ main {
   padding: 20px 15px 0 30px;
 }
 
-.main-content p {
-  max-width: 700px;
-}
-
 .sidebar,
 .main-content {
   margin: 20px 0;
@@ -414,6 +410,10 @@ footer .container-fluid {
 
 footer a, footer a:hover {
   color: #fff;
+}
+
+.markdown.desc {
+  max-width: 700px;
 }
 
 .markdown h1 {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/1522

Also add test content to validate 80-char code blocks