### PR TITLE
Warnings enhancements from #1524

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -174,7 +174,7 @@ main(List<String> arguments) async {
       assert(message.isNotEmpty);
 
       if (record.level < logging.Level.WARNING) {
-        if (message.endsWith('...')) {
+        if (showProgress && message.endsWith('...')) {
           // Assume there may be more progress to print, so omit the trailing
           // newline
           writingProgress = true;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2151,7 +2151,8 @@ ModelElement resolveMultiplyInheritedElement(
 /// helps prevent subtle bugs as generated output for a non-canonical
 /// ModelElement will reference itself as part of the "wrong" [Library]
 /// from the public interface perspective.
-abstract class ModelElement extends Nameable with Warnable
+abstract class ModelElement extends Nameable
+    with Warnable
     implements Comparable, Documentable {
   final Element _element;
   final Library _library;
@@ -3479,8 +3480,8 @@ class Package extends Nameable with Documentable, Warnable {
       new Set();
   void warnOnElement(Warnable warnable, PackageWarning kind,
       {String message,
-        Iterable<Locatable> referredFrom,
-        Iterable<String> extendedDebug}) {
+      Iterable<Locatable> referredFrom,
+      Iterable<String> extendedDebug}) {
     var newEntry = new Tuple3(warnable?.element, kind, message);
     if (_warnAlreadySeen.contains(newEntry)) {
       return;
@@ -3497,8 +3498,8 @@ class Package extends Nameable with Documentable, Warnable {
 
   void _warnOnElement(Warnable warnable, PackageWarning kind,
       {String message,
-        Iterable<Locatable> referredFrom,
-        Iterable<String> extendedDebug}) {
+      Iterable<Locatable> referredFrom,
+      Iterable<String> extendedDebug}) {
     if (warnable != null) {
       // This sort of warning is only applicable to top level elements.
       if (kind == PackageWarning.ambiguousReexport) {

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -90,11 +90,10 @@ abstract class Warnable implements Locatable {
   Warnable get enclosingElement;
 
   Set<String> get locationPieces {
-    return new Set()
-      ..addAll(element.location
-          .toString()
-          .split(locationSplitter)
-          .where((s) => s.isNotEmpty));
+    return new Set.from(element.location
+        .toString()
+        .split(locationSplitter)
+        .where((s) => s.isNotEmpty));
   }
 }
 

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:dartdoc/src/model.dart';
 import 'package:tuple/tuple.dart';
 
 import 'config.dart';
@@ -82,10 +83,19 @@ final Map<PackageWarning, PackageWarningHelpText> packageWarningText = const {
 };
 
 /// Something that package warnings can be called on.
+/// TODO(jcollins-g): Complete object model refactoring for #1524.
 abstract class Warnable implements Locatable {
   void warn(PackageWarning warning,
       {String message, Iterable<Locatable> referredFrom});
   Warnable get enclosingElement;
+
+  Set<String> get locationPieces {
+    return new Set()
+      ..addAll(element.location
+          .toString()
+          .split(locationSplitter)
+          .where((s) => s.isNotEmpty));
+  }
 }
 
 /// Something that can be located for warning purposes.
@@ -240,7 +250,7 @@ class PackageWarningCounter {
   int get errorCount {
     return _warningCounts.keys
         .map((w) => options.asErrors.contains(w) ? _warningCounts[w] : 0)
-        .reduce((a, b) => a + b);
+        .fold(0, (a, b) => a + b);
   }
 
   int get warningCount {
@@ -249,7 +259,7 @@ class PackageWarningCounter {
             options.asWarnings.contains(w) && !options.asErrors.contains(w)
                 ? _warningCounts[w]
                 : 0)
-        .reduce((a, b) => a + b);
+        .fold(0, (a, b) => a + b);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,4 +350,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.6.0"
+  dart: ">=1.23.0 <=2.0.0-dev.7.0"


### PR DESCRIPTION
This is the first breakout piece from canonicalization overhaul part 3 (#1524).  Mostly minor changes here.

- Clean up output when --show-progress isn't given
- Move location splitting into the Warnable class
- Allow for warnings that generate more warnings when calculating warning text (required for the rest of the overhaul)
- Avoid a crash if no warnings or errors are generated (use fold instead of reduce)
