### PR TITLE
Update mustache4dart and clean up templates

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -15,7 +15,9 @@ class ElementType {
   final ModelElement element;
   String _linkedName;
 
-  ElementType(this._type, this.element);
+  ElementType(this._type, this.element) {
+    assert(element != null);
+  }
 
   bool get isDynamic => _type.isDynamic;
 
@@ -82,7 +84,9 @@ class ElementType {
       } else {
         typeArguments = type.typeFormals.map((f) => f.type);
       }
-      return typeArguments.map(_getElementTypeFrom).toList();
+      return typeArguments
+          .map(_getElementTypeFrom)
+          .toList();
     } else {
       return (_type as ParameterizedType)
           .typeArguments
@@ -129,6 +133,11 @@ class ElementType {
     // can happen if element is dynamic
     if (f.element.library != null) {
       lib = new ModelElement.from(f.element.library, element.library);
+    } else {
+      // TODO(jcollins-g): Assigning libraries to dynamics doesn't make sense,
+      // really, but is needed for .package.
+      assert(f.element.kind == ElementKind.DYNAMIC);
+      lib = element.library;
     }
     return new ElementType(f, new ModelElement.from(f.element, lib));
   }

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -313,8 +313,6 @@ class HtmlGeneratorInstance implements HtmlOptions {
   void _writeFile(String filename, Object content) {
     // If you see this assert, we're probably being called to build non-canonical
     // docs somehow.  Check data.self.isCanonical and callers for bugs.
-    if (writtenFiles.contains(filename))
-      1+1;
     assert(!writtenFiles.contains(filename));
 
     File file = new File(filename);

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -53,6 +53,9 @@ class HtmlGeneratorInstance implements HtmlOptions {
     await _copyResources();
     if (faviconPath != null) {
       var bytes = new File(faviconPath).readAsBytesSync();
+      // Allow overwrite of favicon.
+      String filename = path.join(out.path, 'static-assets', 'favicon.png');
+      writtenFiles.remove(filename);
       _writeFile(path.join(out.path, 'static-assets', 'favicon.png'), bytes);
     }
   }
@@ -310,6 +313,8 @@ class HtmlGeneratorInstance implements HtmlOptions {
   void _writeFile(String filename, Object content) {
     // If you see this assert, we're probably being called to build non-canonical
     // docs somehow.  Check data.self.isCanonical and callers for bugs.
+    if (writtenFiles.contains(filename))
+      1+1;
     assert(!writtenFiles.contains(filename));
 
     File file = new File(filename);

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -28,6 +28,8 @@ const _partials = const <String>[
   'sidebar_for_enum',
   'source_code',
   'sidebar_for_library',
+  'accessor_getter',
+  'accessor_setter'
 ];
 
 Future<Map<String, String>> _loadPartials(List<String> headerPaths,

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -28,8 +28,6 @@ const _partials = const <String>[
   'sidebar_for_enum',
   'source_code',
   'sidebar_for_library',
-  'accessor_getter',
-  'accessor_setter'
 ];
 
 Future<Map<String, String>> _loadPartials(List<String> headerPaths,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -206,6 +206,13 @@ class InheritableAccessor extends Accessor with Inheritable {
     }
     return _enclosingElement;
   }
+
+  @override
+  Set<String> get features {
+    Set<String> all_features = super.features;
+    if (isInherited) all_features.add('inherited');
+    return all_features;
+  }
 }
 
 /// Getters and setters.
@@ -217,18 +224,72 @@ class Accessor extends ModelElement
   Accessor(PropertyAccessorElement element, Library library)
       : super(element, library);
 
-  ModelElement get enclosingCombo => _enclosingCombo;
+  get linkedReturnType {
+    assert(isGetter);
+    return modelType.createLinkedReturnTypeName();
+  }
+
+  GetterSetterCombo get enclosingCombo {
+    if (_enclosingCombo == null) {
+      if (enclosingElement is Class) {
+        // TODO(jcollins-g): this side effect is rather hacky.  Make sure
+        // enclosingCombo always gets set at accessor creation time, somehow, to
+        // avoid this.
+        // TODO(jcollins-g): This also doesn't work for private accessors sometimes.
+        (enclosingElement as Class).allFields;
+      }
+      assert(_enclosingCombo != null);
+    }
+    return _enclosingCombo;
+  }
 
   /// Call exactly once to set the enclosing combo for this Accessor.
-  void set enclosingCombo(GetterSetterCombo combo) {
-    assert(_enclosingCombo == null || combo == _enclosingCombo);
-    _enclosingCombo = combo;
+  set enclosingCombo(GetterSetterCombo combo) {
+      assert(_enclosingCombo == null || combo == _enclosingCombo);
+        assert(combo != null);
+      _enclosingCombo = combo;
+  }
+
+  bool get isSynthetic => element.isSynthetic;
+
+  @override
+  String get sourceCode {
+    if (_sourceCodeCache == null) {
+      if (isSynthetic) {
+        _sourceCodeCache =
+            sourceCodeFor((element as PropertyAccessorElement).variable);
+      } else {
+        _sourceCodeCache = super.sourceCode;
+      }
+    }
+    return _sourceCodeCache;
+  }
+
+  @override
+  List<ModelElement> get computeDocumentationFrom {
+    if (isSynthetic) return [this];
+    return super.computeDocumentationFrom;
   }
 
   @override
   String get computeDocumentationComment {
-    if (element.isSynthetic) {
-      return (element as PropertyAccessorElement).variable.documentationComment;
+    if (isSynthetic) {
+      String docComment = (element as PropertyAccessorElement).variable.documentationComment;
+      // If we're a setter, only display something if we have something different than the getter.
+      // TODO(jcollins-g): modify analyzer to do this itself?
+      if (isGetter ||
+          // TODO(jcollins-g): @nodoc reading from comments is at the wrong abstraction level here.
+          (docComment != null &&
+              (docComment.contains('<nodoc>') ||
+                  docComment.contains('@nodoc'))) ||
+          (isSetter &&
+              enclosingCombo.hasGetter &&
+              enclosingCombo.getter.computeDocumentationComment !=
+                  docComment)) {
+        return stripComments(docComment);
+      } else {
+        return '';
+      }
     }
     return stripComments(super.computeDocumentationComment);
   }
@@ -272,6 +333,7 @@ class Accessor extends ModelElement
   }
 
   bool get isGetter => _accessor.isGetter;
+  bool get isSetter => _accessor.isSetter;
 
   bool _overriddenElementIsSet = false;
   ModelElement _overriddenElement;
@@ -422,6 +484,15 @@ class Class extends ModelElement implements EnclosedElement {
   bool get allInstancePropertiesInherited =>
       instanceProperties.every((f) => f.isInherited);
 
+  Iterable<Accessor> get allAccessors {
+    return allInstanceProperties.expand((f) {
+      List<Accessor> getterSetters = [];
+      if (f.hasGetter) getterSetters.add(f.getter);
+      if (f.hasSetter) getterSetters.add(f.setter);
+      return getterSetters;
+    });
+  }
+
   List<Operator> get allOperators {
     if (_allOperators != null) return _allOperators;
     _allOperators = []
@@ -438,7 +509,7 @@ class Class extends ModelElement implements EnclosedElement {
 
   List<Field> get constants {
     if (_constants != null) return _constants;
-    _constants = _allFields.where((f) => f.isConst).toList(growable: false)
+    _constants = allFields.where((f) => f.isConst).toList(growable: false)
       ..sort(byName);
 
     return _constants;
@@ -466,6 +537,7 @@ class Class extends ModelElement implements EnclosedElement {
       _allModelElements
         ..addAll(allInstanceMethods)
         ..addAll(allInstanceProperties)
+        ..addAll(allAccessors)
         ..addAll(allOperators)
         ..addAll(constants)
         ..addAll(constructors)
@@ -684,7 +756,7 @@ class Class extends ModelElement implements EnclosedElement {
 
   List<Field> get inheritedProperties {
     if (_inheritedProperties == null) {
-      _inheritedProperties = _allFields.where((f) => f.isInherited).toList()
+      _inheritedProperties = allFields.where((f) => f.isInherited).toList()
         ..sort(byName);
     }
     return _inheritedProperties;
@@ -704,7 +776,7 @@ class Class extends ModelElement implements EnclosedElement {
 
   List<Field> get instanceProperties {
     if (_instanceFields != null) return _instanceFields;
-    _instanceFields = _allFields
+    _instanceFields = allFields
         .where((f) => !f.isStatic && !f.isInherited && !f.isConst)
         .toList(growable: false)
           ..sort(byName);
@@ -814,7 +886,7 @@ class Class extends ModelElement implements EnclosedElement {
 
   List<Field> get staticProperties {
     if (_staticFields != null) return _staticFields;
-    _staticFields = _allFields
+    _staticFields = allFields
         .where((f) => f.isStatic)
         .where((f) => !f.isConst)
         .toList(growable: false)
@@ -857,7 +929,7 @@ class Class extends ModelElement implements EnclosedElement {
 
   ElementType get supertype => _supertype;
 
-  List<Field> get _allFields {
+  List<Field> get allFields {
     if (_fields != null) return _fields;
     _fields = [];
     Map<String, ExecutableElement> cmap =
@@ -1231,7 +1303,7 @@ class Field extends ModelElement
     var v = _field.computeNode().toSource();
     if (v == null) return null;
     var string = v.substring(v.indexOf('=') + 1, v.length).trim();
-    _constantValue = string.replaceAll(modelType.name, modelType.linkedName);
+    _constantValue = string.replaceAll("${modelType.name}", "${modelType.linkedName}");
 
     return _constantValue;
   }
@@ -1297,13 +1369,7 @@ class Field extends ModelElement
 
   @override
   Set<String> get features {
-    Set<String> all_features = super.features;
-    all_features.addAll(annotations);
-
-    /// final/const implies read-only, so don't display both strings.
-    if (readOnly && !isFinal && !isConst) all_features.add('read-only');
-    if (writeOnly) all_features.add('write-only');
-    if (readWrite) all_features.add('read / write');
+    Set<String> all_features = super.features..addAll(comboFeatures);
     if (hasPublicGetter && hasPublicSetter) {
       if (getter.isInherited && setter.isInherited) {
         all_features.add('inherited');
@@ -1356,11 +1422,7 @@ class Field extends ModelElement
 
   void _setModelType() {
     if (hasGetter) {
-      var t = (getter.element as PropertyAccessorElement).returnType;
-      _modelType = new ElementType(
-          t,
-          new ModelElement.from(
-              t.element, _findOrCreateEnclosingLibraryFor(t.element)));
+      _modelType = getter.modelType;
     }
   }
 }
@@ -1368,6 +1430,17 @@ class Field extends ModelElement
 /// Mixin for top-level variables and fields (aka properties)
 abstract class GetterSetterCombo implements ModelElement {
   Accessor get getter;
+
+  Set<String> get comboFeatures {
+    Set<String> all_features = new Set();
+    if (hasExplicitGetter) all_features.addAll(getter.features);
+    if (hasExplicitSetter) all_features.addAll(setter.features);
+    if (readOnly && !isFinal && !isConst) all_features.add('read-only');
+    if (writeOnly) all_features.add('write-only');
+    if (readWrite) all_features.add('read / write');
+    return all_features;
+  }
+
 
   @override
   ModelElement enclosingElement;
@@ -1393,12 +1466,10 @@ abstract class GetterSetterCombo implements ModelElement {
     if (_documentationFrom == null) {
       _documentationFrom = [];
       if (hasPublicGetter) {
-        _documentationFrom.addAll(getter.documentationFrom.where((e) =>
-            e.computeDocumentationComment != computeDocumentationComment));
+        _documentationFrom.addAll(getter.documentationFrom);
+      } else if (hasPublicSetter) {
+        _documentationFrom.addAll(setter.documentationFrom);
       }
-      if (hasPublicSetter)
-        _documentationFrom.addAll(setter.documentationFrom.where((e) =>
-            e.computeDocumentationComment != computeDocumentationComment));
       if (_documentationFrom.length == 0 ||
           _documentationFrom.every((e) => e.documentation == ''))
         _documentationFrom = computeDocumentationFrom;
@@ -1406,24 +1477,22 @@ abstract class GetterSetterCombo implements ModelElement {
     return _documentationFrom;
   }
 
+  bool get hasAccessorsWithDocs =>
+      (hasPublicGetter && getter.documentation.isNotEmpty ||
+          hasPublicSetter && setter.documentation.isNotEmpty);
+  bool get getterSetterBothAvailable => (hasPublicGetter &&
+      getter.documentation.isNotEmpty &&
+      hasPublicSetter &&
+      setter.documentation.isNotEmpty);
+
   String _oneLineDoc;
   @override
   String get oneLineDoc {
     if (_oneLineDoc == null) {
-      bool hasAccessorsWithDocs =
-          (hasPublicGetter && getter.oneLineDoc.isNotEmpty ||
-              hasPublicSetter && setter.oneLineDoc.isNotEmpty);
       if (!hasAccessorsWithDocs) {
         _oneLineDoc = _documentation.asOneLiner;
       } else {
         StringBuffer buffer = new StringBuffer();
-        bool getterSetterBothAvailable = false;
-        if (hasPublicGetter &&
-            getter.oneLineDoc.isNotEmpty &&
-            hasPublicSetter &&
-            setter.oneLineDoc.isNotEmpty) {
-          getterSetterBothAvailable = true;
-        }
         if (hasPublicGetter && getter.oneLineDoc.isNotEmpty) {
           buffer.write('${getter.oneLineDoc}');
         }
@@ -1439,7 +1508,7 @@ abstract class GetterSetterCombo implements ModelElement {
   String get getterSetterDocumentationComment {
     var buffer = new StringBuffer();
 
-    if (hasPublicGetter && !getter.element.isSynthetic) {
+    if (hasPublicGetter && !getter.isSynthetic) {
       assert(getter.documentationFrom.length == 1);
       // We have to check against dropTextFrom here since documentationFrom
       // doesn't yield the real elements for GetterSetterCombos.
@@ -1451,7 +1520,7 @@ abstract class GetterSetterCombo implements ModelElement {
       }
     }
 
-    if (hasPublicSetter && !setter.element.isSynthetic) {
+    if (hasPublicSetter && !setter.isSynthetic) {
       assert(setter.documentationFrom.length == 1);
       if (!config.dropTextFrom
           .contains(setter.documentationFrom.first.element.library.name)) {
@@ -1467,8 +1536,11 @@ abstract class GetterSetterCombo implements ModelElement {
   }
 
   String get linkedReturnType {
-    if (hasGetter) return modelType.linkedName;
-    return null;
+    if (hasGetter) {
+      return getter.linkedReturnType;
+    } else {
+      return setter.linkedParamsNoMetadataOrNames;
+    }
   }
 
   @override
@@ -1489,14 +1561,16 @@ abstract class GetterSetterCombo implements ModelElement {
     return null;
   }
 
-  bool get hasExplicitGetter => hasPublicGetter && !getter.element.isSynthetic;
+  bool get hasExplicitGetter => hasPublicGetter && !getter.isSynthetic;
 
-  bool get hasExplicitSetter => hasPublicSetter && !setter.element.isSynthetic;
-  bool get hasImplicitSetter => hasPublicSetter && setter.element.isSynthetic;
+  bool get hasExplicitSetter => hasPublicSetter && !setter.isSynthetic;
+  bool get hasImplicitSetter => hasPublicSetter && setter.isSynthetic;
+  bool get hasImplicitGetter => hasPublicGetter && getter.isSynthetic;
 
   bool get hasGetter => getter != null;
 
-  bool get hasNoGetterSetter => !hasExplicitGetter && !hasExplicitSetter;
+  bool get hasNoGetterSetter => !hasGetterOrSetter;
+  bool get hasGetterOrSetter => hasExplicitGetter || hasExplicitSetter;
 
   bool get hasSetter => setter != null;
 
@@ -2791,7 +2865,25 @@ abstract class ModelElement extends Nameable
     return linkedParams(showMetadata: false, showNames: false);
   }
 
-  ElementType get modelType => _modelType;
+  ElementType get modelType {
+    if (_modelType == null) {
+      if (element is ExecutableElement ||
+          element is FunctionTypedElement ||
+          element is ParameterElement ||
+          element is TypeDefiningElement ||
+          element is PropertyInducingElement) {
+        Library lib;
+        // TODO(jcollins-g): get rid of dynamic special casing
+        if (element.kind != ElementKind.DYNAMIC) {
+          lib = _findOrCreateEnclosingLibraryFor((element as dynamic).type.element);
+        }
+        _modelType = new ElementType(
+            (element as dynamic).type, new ModelElement.from((element as dynamic).type.element, lib));
+      }
+    }
+    return _modelType;
+  }
+
 
   @override
   String get name => element.name;
@@ -3758,6 +3850,7 @@ class Package extends Nameable implements Documentable {
       // only here, but since the warnings that depend on this debug
       // canonicalization problems, don't limit ourselves in case an href is
       // generated for something non-canonical.
+      if (modelElement is Dynamic) continue;
       if (modelElement.href == null) continue;
       hrefMap.putIfAbsent(modelElement.href, () => new Set());
       hrefMap[modelElement.href].add(modelElement);
@@ -4283,22 +4376,14 @@ class TopLevelVariable extends ModelElement
   TopLevelVariable(TopLevelVariableElement element, Library library,
       this.getter, this.setter)
       : super(element, library) {
-    if (hasGetter) {
-      var t = _variable.getter.returnType;
-
-      _modelType = new ElementType(
-          t,
-          new ModelElement.from(
-              t.element, package.findOrCreateLibraryFor(t.element)));
-    } else {
-      var s = _variable.setter.parameters.first.type;
-      _modelType = new ElementType(
-          s,
-          new ModelElement.from(
-              s.element, package.findOrCreateLibraryFor(s.element)));
+    if (getter != null) {
+      getter.enclosingCombo = this;
+      assert(getter.enclosingCombo != null);
     }
-    if (getter != null) getter.enclosingCombo = this;
-    if (setter != null) setter.enclosingCombo = this;
+    if (setter != null) {
+      setter.enclosingCombo = this;
+      assert(setter.enclosingCombo != null);
+    }
   }
 
   @override
@@ -4348,15 +4433,7 @@ class TopLevelVariable extends ModelElement
   String get kind => 'top-level property';
 
   @override
-  Set<String> get features {
-    Set<String> all_features = super.features;
-
-    /// final/const implies read-only, so don't display both strings.
-    if (readOnly && !isFinal && !isConst) all_features.add('read-only');
-    if (writeOnly) all_features.add('write-only');
-    if (readWrite) all_features.add('read / write');
-    return all_features;
-  }
+  Set<String> get features => super.features..addAll(comboFeatures);
 
   @override
   String get computeDocumentationComment {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -209,9 +209,9 @@ class InheritableAccessor extends Accessor with Inheritable {
 
   @override
   Set<String> get features {
-    Set<String> all_features = super.features;
-    if (isInherited) all_features.add('inherited');
-    return all_features;
+    Set<String> allFeatures = super.features;
+    if (isInherited) allFeatures.add('inherited');
+    return allFeatures;
   }
 }
 
@@ -1369,18 +1369,18 @@ class Field extends ModelElement
 
   @override
   Set<String> get features {
-    Set<String> all_features = super.features..addAll(comboFeatures);
+    Set<String> allFeatures = super.features..addAll(comboFeatures);
     if (hasPublicGetter && hasPublicSetter) {
       if (getter.isInherited && setter.isInherited) {
-        all_features.add('inherited');
+        allFeatures.add('inherited');
       } else {
-        if (getter.isInherited) all_features.add('inherited-getter');
-        if (setter.isInherited) all_features.add('inherited-setter');
+        if (getter.isInherited) allFeatures.add('inherited-getter');
+        if (setter.isInherited) allFeatures.add('inherited-setter');
       }
     } else {
-      if (isInherited) all_features.add('inherited');
+      if (isInherited) allFeatures.add('inherited');
     }
-    return all_features;
+    return allFeatures;
   }
 
   @override
@@ -1432,13 +1432,13 @@ abstract class GetterSetterCombo implements ModelElement {
   Accessor get getter;
 
   Set<String> get comboFeatures {
-    Set<String> all_features = new Set();
-    if (hasExplicitGetter) all_features.addAll(getter.features);
-    if (hasExplicitSetter) all_features.addAll(setter.features);
-    if (readOnly && !isFinal && !isConst) all_features.add('read-only');
-    if (writeOnly) all_features.add('write-only');
-    if (readWrite) all_features.add('read / write');
-    return all_features;
+    Set<String> allFeatures = new Set();
+    if (hasExplicitGetter) allFeatures.addAll(getter.features);
+    if (hasExplicitSetter) allFeatures.addAll(setter.features);
+    if (readOnly && !isFinal && !isConst) allFeatures.add('read-only');
+    if (writeOnly) allFeatures.add('write-only');
+    if (readWrite) allFeatures.add('read / write');
+    return allFeatures;
   }
 
 
@@ -2122,9 +2122,9 @@ class Method extends ModelElement
 
   @override
   Set<String> get features {
-    Set<String> all_features = super.features;
-    if (isInherited) all_features.add('inherited');
-    return all_features;
+    Set<String> allFeatures = super.features;
+    if (isInherited) allFeatures.add('inherited');
+    return allFeatures;
   }
 
   @override
@@ -2526,25 +2526,25 @@ abstract class ModelElement extends Nameable
   }
 
   Set<String> get features {
-    Set<String> all_features = new Set<String>();
-    all_features.addAll(annotations);
+    Set<String> allFeatures = new Set<String>();
+    allFeatures.addAll(annotations);
 
     // override as an annotation should be replaced with direct information
     // from the analyzer if we decide to display it at this level.
-    all_features.remove('@override');
+    allFeatures.remove('@override');
 
     // Drop the plain "deprecated" annotation, that's indicated via
     // strikethroughs. Custom @Deprecated() will still appear.
-    all_features.remove('@deprecated');
+    allFeatures.remove('@deprecated');
     // const and static are not needed here because const/static elements get
     // their own sections in the doc.
-    if (isFinal) all_features.add('final');
-    return all_features;
+    if (isFinal) allFeatures.add('final');
+    return allFeatures;
   }
 
   String get featuresAsString {
-    List<String> all_features = features.toList()..sort(byFeatureOrdering);
-    return all_features.join(', ');
+    List<String> allFeatures = features.toList()..sort(byFeatureOrdering);
+    return allFeatures.join(', ');
   }
 
   bool get canHaveParameters =>

--- a/lib/templates/_accessor_getter.html
+++ b/lib/templates/_accessor_getter.html
@@ -1,0 +1,13 @@
+{{#getter}}
+<section id="getter">
+
+<section class="multi-line-signature">
+  <span class="returntype">{{{ linkedReturnType }}}</span>
+  {{>name_summary}}
+  {{>features}}
+</section>
+
+{{>documentation}}
+{{>source_code}}
+</section>
+{{/getter}}

--- a/lib/templates/_accessor_getter.html
+++ b/lib/templates/_accessor_getter.html
@@ -1,9 +1,0 @@
-<section id="getter">
-
-<section class="multi-line-signature">
-  <span class="returntype">{{{ linkedReturnType }}}</span>
-  {{>name_summary}}
-</section>
-
-{{>documentation}}
-</section>

--- a/lib/templates/_accessor_setter.html
+++ b/lib/templates/_accessor_setter.html
@@ -1,0 +1,13 @@
+{{#setter}}
+<section id="setter">
+
+<section class="multi-line-signature">
+  <span class="returntype">void</span>
+  {{>name_summary}}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
+  {{>features}}
+</section>
+
+{{>documentation}}
+{{>source_code}}
+</section>
+{{/setter}}

--- a/lib/templates/_accessor_setter.html
+++ b/lib/templates/_accessor_setter.html
@@ -1,9 +1,0 @@
-<section id="setter">
-
-<section class="multi-line-signature">
-  <span class="returntype">void</span>
-  {{>name_summary}}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
-</section>
-
-{{>documentation}}
-</section>

--- a/lib/templates/_property.html
+++ b/lib/templates/_property.html
@@ -1,16 +1,7 @@
-{{ #hasPublicSetter }}
-<dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
-  <span class="name{{#isDeprecated}} deprecated{{/isDeprecated}}">{{{linkedName}}}</span><span class="signature">{{{genericParameters}}}
-    <span class="returntype parameter">{{{ arrow }}} {{ #hasExplicitSetter }} {{{ linkedParamsNoMetadata }}} {{/hasExplicitSetter}} {{#hasImplicitSetter}} {{{linkedParamsNoMetadataOrNames}}} {{/hasImplicitSetter}}</span>
-  </span>
-</dt>
-{{ /hasPublicSetter }}
-{{ #hasPublicGetterNoSetter }}
 <dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
   <span class="name">{{{linkedName}}}</span>
   <span class="signature">{{{ arrow }}} {{{ linkedReturnType }}}</span>
 </dt>
-{{ /hasPublicGetterNoSetter }}
 <dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
   {{{ oneLineDoc }}}
   {{>features}}

--- a/lib/templates/_source_code.html
+++ b/lib/templates/_source_code.html
@@ -1,5 +1,5 @@
 {{#hasSourceCode}}
 <section class="summary source-code" id="source">
   <h2><span>Source</span> {{{crossdartHtmlTag}}}</h2>
-  <pre class="prettyprint language-dart">{{{ sourceCode }}}</pre>
+  <pre class="language-dart"><code class="language-dart">{{{ sourceCode }}}</code></pre>
 </section>{{/hasSourceCode}}

--- a/lib/templates/property.html
+++ b/lib/templates/property.html
@@ -7,30 +7,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    {{#property.hasNoGetterSetter}}
+    {{#self}}
     <section class="multi-line-signature">
       <span class="returntype">{{{ linkedReturnType }}}</span>
-        {{>name_summary}}
-        {{>features}}
+      {{>name_summary}}
+      {{>features}}
     </section>
 
     {{>documentation}}
-    {{/property.hasNoGetterSetter}}
-
-    {{#property.hasExplicitGetter}}
-    {{#property.getter}}
-      {{>accessor_getter}}
-      {{>source_code}}
-    {{/property.getter}}
-    {{/property.hasExplicitGetter}}
-
-    {{#property.hasExplicitSetter}}
-    {{#property.setter}}
-      {{>accessor_setter}}
-      {{>source_code}}
-    {{/property.setter}}
-    {{/property.hasExplicitSetter}}
-
+    {{>source_code}}
+    {{/self}}
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/lib/templates/property.html
+++ b/lib/templates/property.html
@@ -6,16 +6,26 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     {{#self}}
-    <section class="multi-line-signature">
-      <span class="returntype">{{{ linkedReturnType }}}</span>
-      {{>name_summary}}
-      {{>features}}
-    </section>
+      {{#hasNoGetterSetter}}
+        <section class="multi-line-signature">
+          <span class="returntype">{{{ linkedReturnType }}}</span>
+          {{>name_summary}}
+          {{>features}}
+        </section>
+        {{>documentation}}
+        {{>source_code}}
+      {{/hasNoGetterSetter}}
 
-    {{>documentation}}
-    {{>source_code}}
+      {{#hasGetterOrSetter}}
+        {{#hasGetter}}
+        {{>accessor_getter}}
+        {{/hasGetter}}
+
+        {{#hasSetter}}
+        {{>accessor_setter}}
+        {{/hasSetter}}
+      {{/hasGetterOrSetter}}
     {{/self}}
   </div> <!-- /.main-content -->
 

--- a/lib/templates/top_level_constant.html
+++ b/lib/templates/top_level_constant.html
@@ -7,19 +7,17 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    {{#self}}
     <section class="multi-line-signature">
-      {{#property}}
-        {{>name_summary}}
-        =
-        <span class="constant-value">{{{ constantValue }}}</span>
-        {{>features}}
-      {{/property}}
+      {{>name_summary}}
+      =
+      <span class="constant-value">{{{ constantValue }}}</span>
+      {{>features}}
     </section>
 
-    {{#property}}
-      {{>documentation}}
-      {{>source_code}}
-    {{/property}}
+    {{>documentation}}
+    {{>source_code}}
+    {{/self}}
 
   </div> <!-- /.main-content -->
 

--- a/lib/templates/top_level_property.html
+++ b/lib/templates/top_level_property.html
@@ -6,18 +6,25 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     {{#self}}
+    {{#hasNoGetterSetter}}
     <section class="multi-line-signature">
       <span class="returntype">{{{ linkedReturnType }}}</span>
       {{>name_summary}}
       {{>features}}
     </section>
-
     {{>documentation}}
     {{>source_code}}
-    {{/self}}
+    {{/hasNoGetterSetter}}
 
+    {{#hasExplicitGetter}}
+    {{>accessor_getter}}
+    {{/hasExplicitGetter}}
+
+    {{#hasExplicitSetter}}
+    {{>accessor_setter}}
+    {{/hasExplicitSetter}}
+    {{/self}}
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/lib/templates/top_level_property.html
+++ b/lib/templates/top_level_property.html
@@ -7,29 +7,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    {{#property.hasNoGetterSetter}}
-      <section class="multi-line-signature">
-        <span class="returntype">{{{ linkedReturnType }}}</span>
-        {{>name_summary}}
-        {{>features}}
-      </section>
+    {{#self}}
+    <section class="multi-line-signature">
+      <span class="returntype">{{{ linkedReturnType }}}</span>
+      {{>name_summary}}
+      {{>features}}
+    </section>
 
-      {{>documentation}}
-    {{/property.hasNoGetterSetter}}
-
-    {{#property.hasExplicitGetter}}
-    {{#property.getter}}
-      {{>accessor_getter}}
-      {{>source_code}}
-    {{/property.getter}}
-    {{/property.hasExplicitGetter}}
-
-    {{#property.hasExplicitSetter}}
-    {{#property.setter}}
-      {{>accessor_setter}}
-      {{>source_code}}
-    {{/property.setter}}
-    {{/property.hasExplicitSetter}}
+    {{>documentation}}
+    {{>source_code}}
+    {{/self}}
 
   </div> <!-- /.main-content -->
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,4 +350,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.6.0"
+  dart: ">=1.23.0 <=2.0.0-dev.7.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,7 +174,7 @@ packages:
       name: mustache4dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   node_preamble:
     description:
       name: node_preamble

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http_parser: '>=3.0.3 <4.0.0'
   logging: ^0.11.3+1
   markdown: ^0.11.2
-  mustache4dart: ^1.1.0
+  mustache4dart: ^2.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
   resource: ^1.1.0

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1297,6 +1297,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     Field sFromApple, mFromApple, mInB, autoCompress;
     Field isEmpty;
     Field implicitGetterExplicitSetter, explicitGetterImplicitSetter;
+    Field explicitGetterSetter;
     Field explicitNonDocumentedInBaseClassGetter;
     Field documentedPartialFieldInSubclassOnly;
     Field ExtraSpecialListLength;
@@ -1316,6 +1317,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((e) => e.name == 'implicitGetterExplicitSetter');
       explicitGetterImplicitSetter = UnusualProperties.allModelElements
           .firstWhere((e) => e.name == 'explicitGetterImplicitSetter');
+      explicitGetterSetter = UnusualProperties.allModelElements
+          .firstWhere((e) => e.name == 'explicitGetterSetter');
       explicitNonDocumentedInBaseClassGetter =
           UnusualProperties.allModelElements.firstWhere(
               (e) => e.name == 'explicitNonDocumentedInBaseClassGetter');
@@ -1354,6 +1357,20 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((c) => c.name == 'SpecialList')
           .allInstanceProperties
           .firstWhere((f) => f.name == 'length');
+    });
+
+    test('annotations from getters and setters are accumulated in Fields', () {
+      expect(
+          explicitGetterSetter.featuresAsString.contains('a Getter Annotation'),
+          isTrue);
+      expect(
+          explicitGetterSetter.featuresAsString.contains('a Setter Annotation'),
+          isTrue);
+    });
+
+    test('Docs from inherited implicit accessors are preserved', () {
+      expect(explicitGetterImplicitSetter.setter.computeDocumentationComment,
+          isNot(''));
     });
 
     test('@nodoc on simple property works', () {
@@ -1428,10 +1445,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(explicitGetterImplicitSetter.oneLineDoc,
           equals('Getter doc for explicitGetterImplicitSetter'));
       // Even though we have some new setter docs, getter still takes priority.
-      expect(
-          explicitGetterImplicitSetter.documentation,
-          equals(
-              'Getter doc for explicitGetterImplicitSetter'));
+      expect(explicitGetterImplicitSetter.documentation,
+          equals('Getter doc for explicitGetterImplicitSetter'));
     });
 
     test('has a fully qualified name', () {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1431,7 +1431,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           explicitGetterImplicitSetter.documentation,
           equals(
-              'Docs for explicitGetterImplicitSetter from ImplicitProperties.'));
+              'Getter doc for explicitGetterImplicitSetter'));
     });
 
     test('has a fully qualified name', () {
@@ -1500,11 +1500,6 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('setter documentation', () {
       expect(onlySetter.documentation,
           equals('Only a setter, with a single param, of type double.'));
-    });
-
-    test('explicit getter and setter docs are unified', () {
-      expect(lengthX.documentation, contains('Sets the length.'));
-      expect(lengthX.documentation, contains('Returns a length.'));
     });
 
     test('Field with no explicit getter/setter has documentation', () {
@@ -1681,11 +1676,6 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('just a setter has documentation', () {
       expect(justSetter.documentation,
           equals('Just a setter. No partner getter.'));
-    });
-
-    test('a distinct getter and setters docs appear in the propertys docs', () {
-      expect(setAndGet.documentation, contains('The getter for setAndGet.'));
-      expect(setAndGet.documentation, contains('The setter for setAndGet.'));
     });
 
     test('has a getter accessor', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -255,6 +255,7 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   String get explicitNonDocumentedInBaseClassGetter => "something else";
 
   /// Getter doc for explicitGetterSetter.
+  @Annotation('a Getter Annotation')
   myCoolTypedef get explicitGetterSetter {
     return _aFunction;
   }
@@ -269,6 +270,7 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   String get explicitNodocGetterSetter => "something";
 
   /// This property is not synthetic, so it might reference [f] -- display it.
+  @Annotation('a Setter Annotation')
   set explicitGetterSetter(myCoolTypedef f) => _aFunction = f;
 
   /// This property only has a getter and no setter; no parameters to print.

--- a/testing/test_package_docs/css/css-library.html
+++ b/testing/test_package_docs/css/css-library.html
@@ -67,9 +67,8 @@ with directories created by dartdoc.</p>
 
       <dl class="properties">
         <dt id="theOnlyThingInTheLibrary" class="property">
-          <span class="name"><a href="css/theOnlyThingInTheLibrary.html">theOnlyThingInTheLibrary</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="theOnlyThingInTheLibrary=-param-_theOnlyThingInTheLibrary"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="css/theOnlyThingInTheLibrary.html">theOnlyThingInTheLibrary</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
+++ b/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
@@ -51,13 +51,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">theOnlyThingInTheLibrary</span>        <div class="features">read / write</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">theOnlyThingInTheLibrary</span>      <div class="features">read / write</div>
+    </section>
 
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
+++ b/testing/test_package_docs/css/theOnlyThingInTheLibrary.html
@@ -50,13 +50,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">String</span>
       <span class="name ">theOnlyThingInTheLibrary</span>      <div class="features">read / write</div>
     </section>
-
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Animal/hashCode.html
+++ b/testing/test_package_docs/ex/Animal/hashCode.html
@@ -66,11 +66,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Animal/hashCode.html
+++ b/testing/test_package_docs/ex/Animal/hashCode.html
@@ -66,17 +66,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Animal/runtimeType.html
+++ b/testing/test_package_docs/ex/Animal/runtimeType.html
@@ -66,11 +66,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Animal/runtimeType.html
+++ b/testing/test_package_docs/ex/Animal/runtimeType.html
@@ -66,17 +66,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -154,18 +154,16 @@
           <div class="features">final</div>
 </dd>
         <dt id="m" class="property">
-          <span class="name"><a href="ex/Apple/m.html">m</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="m=-param-_m"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/Apple/m.html">m</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           The read-write field <code>m</code>.
           <div class="features">read / write</div>
 </dd>
         <dt id="s" class="property">
-          <span class="name"><a href="ex/Apple/s.html">s</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>  </span>
-          </span>
+          <span class="name"><a href="ex/Apple/s.html">s</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           The getter for <code>s</code>
@@ -297,9 +295,8 @@
 
       <dl class="properties">
         <dt id="string" class="property">
-          <span class="name"><a href="ex/Apple/string.html">string</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="string=-param-_string"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/Apple/string.html">string</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
+++ b/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
@@ -79,15 +79,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a>&lt;bool&gt;</span>
-        <span class="name ">fieldWithTypedef</span>        <div class="features">final</div>
+      <span class="name ">fieldWithTypedef</span>      <div class="features">final</div>
     </section>
 
     <section class="desc markdown">
       <p>fieldWithTypedef docs here</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
+++ b/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
@@ -76,16 +76,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a>&lt;bool&gt;</span>
+          <span class="name ">fieldWithTypedef</span>          <div class="features">final</div>
+        </section>
+        <section class="desc markdown">
+          <p>fieldWithTypedef docs here</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a>&lt;bool&gt;</span>
-      <span class="name ">fieldWithTypedef</span>      <div class="features">final</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>fieldWithTypedef docs here</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -77,11 +77,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Apple/hashCode.html
+++ b/testing/test_package_docs/ex/Apple/hashCode.html
@@ -77,17 +77,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/m.html
+++ b/testing/test_package_docs/ex/Apple/m.html
@@ -76,16 +76,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">m</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>The read-write field <code>m</code>.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">m</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>The read-write field <code>m</code>.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/m.html
+++ b/testing/test_package_docs/ex/Apple/m.html
@@ -79,15 +79,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">m</span>        <div class="features">read / write</div>
+      <span class="name ">m</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>The read-write field <code>m</code>.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/runtimeType.html
+++ b/testing/test_package_docs/ex/Apple/runtimeType.html
@@ -77,11 +77,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Apple/runtimeType.html
+++ b/testing/test_package_docs/ex/Apple/runtimeType.html
@@ -77,17 +77,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/s.html
+++ b/testing/test_package_docs/ex/Apple/s.html
@@ -77,32 +77,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">s</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">s</span></section>
-      
-      <section class="desc markdown">
-  <p>The getter for <code>s</code></p>
-</section>
-</section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">s=</span><span class="signature">(<wbr><span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>The setter for <code>s</code></p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>The getter for <code>s</code>
+The setter for <code>s</code></p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/s.html
+++ b/testing/test_package_docs/ex/Apple/s.html
@@ -77,17 +77,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">s</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>The getter for <code>s</code>
-The setter for <code>s</code></p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">s</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>The getter for <code>s</code></p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">s=</span><span class="signature">(<wbr><span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>The setter for <code>s</code></p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property s</h5>

--- a/testing/test_package_docs/ex/Apple/string.html
+++ b/testing/test_package_docs/ex/Apple/string.html
@@ -76,13 +76,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">string</span>          <div class="features">read / write</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">string</span>      <div class="features">read / write</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Apple/string.html
+++ b/testing/test_package_docs/ex/Apple/string.html
@@ -79,12 +79,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">string</span>        <div class="features">read / write</div>
+      <span class="name ">string</span>      <div class="features">read / write</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -159,7 +159,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
         </dt>
         <dd>
           
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="list" class="property">
           <span class="name"><a href="ex/B/list.html">list</a></span>
@@ -175,7 +175,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
         </dt>
         <dd>
           The getter for <code>s</code>
-          <div class="features">@override, inherited-setter, read / write</div>
+          <div class="features">inherited-setter, read / write, inherited</div>
 </dd>
         <dt id="fieldWithTypedef" class="property inherited">
           <span class="name"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></span>

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -145,9 +145,8 @@
 
       <dl class="properties">
         <dt id="autoCompress" class="property">
-          <span class="name"><a href="ex/B/autoCompress.html">autoCompress</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="autoCompress=-param-_autoCompress"><span class="type-annotation">bool</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/B/autoCompress.html">autoCompress</a></span>
+          <span class="signature">&#8596; bool</span>
         </dt>
         <dd>
           The default value is <code>false</code> (compression disabled).
@@ -163,18 +162,16 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           <div class="features">@override, read-only</div>
 </dd>
         <dt id="list" class="property">
-          <span class="name"><a href="ex/B/list.html">list</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="list=-param-_list"><span class="type-annotation">List&lt;String&gt;</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/B/list.html">list</a></span>
+          <span class="signature">&#8596; List&lt;String&gt;</span>
         </dt>
         <dd>
           A list of Strings
           <div class="features">read / write</div>
 </dd>
         <dt id="s" class="property">
-          <span class="name"><a href="ex/B/s.html">s</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>  </span>
-          </span>
+          <span class="name"><a href="ex/B/s.html">s</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           The getter for <code>s</code>
@@ -197,9 +194,8 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="m" class="property inherited">
-          <span class="name"><a href="ex/Apple/m.html">m</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="m=-param-_m"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/Apple/m.html">m</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           The read-write field <code>m</code>.

--- a/testing/test_package_docs/ex/B/autoCompress.html
+++ b/testing/test_package_docs/ex/B/autoCompress.html
@@ -77,17 +77,16 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">autoCompress</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>The default value is <code>false</code> (compression disabled).
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">autoCompress</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>The default value is <code>false</code> (compression disabled).
 To enable, set <code>autoCompress</code> to <code>true</code>.</p>
-    </section>
-        
+        </section>
+                
+
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B/autoCompress.html
+++ b/testing/test_package_docs/ex/B/autoCompress.html
@@ -80,16 +80,14 @@
 
     <section class="multi-line-signature">
       <span class="returntype">bool</span>
-        <span class="name ">autoCompress</span>        <div class="features">read / write</div>
+      <span class="name ">autoCompress</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>The default value is <code>false</code> (compression disabled).
 To enable, set <code>autoCompress</code> to <code>true</code>.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B/isImplemented.html
+++ b/testing/test_package_docs/ex/B/isImplemented.html
@@ -78,11 +78,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isImplemented</span>      <div class="features">@override, read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isImplemented</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/B/isImplemented.html
+++ b/testing/test_package_docs/ex/B/isImplemented.html
@@ -78,17 +78,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isImplemented</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isImplemented</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B/list.html
+++ b/testing/test_package_docs/ex/B/list.html
@@ -77,16 +77,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">List&lt;String&gt;</span>
+          <span class="name ">list</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>A list of Strings</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">List&lt;String&gt;</span>
-      <span class="name ">list</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>A list of Strings</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B/list.html
+++ b/testing/test_package_docs/ex/B/list.html
@@ -80,15 +80,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">List&lt;String&gt;</span>
-        <span class="name ">list</span>        <div class="features">read / write</div>
+      <span class="name ">list</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>A list of Strings</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B/s.html
+++ b/testing/test_package_docs/ex/B/s.html
@@ -78,32 +78,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">s</span>      <div class="features">@override, inherited-setter, read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">s</span></section>
-      
-      <section class="desc markdown">
-  <p>The getter for <code>s</code></p>
-</section>
-</section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">s=</span><span class="signature">(<wbr><span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>The setter for <code>s</code></p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>The getter for <code>s</code>
+The setter for <code>s</code></p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/B/s.html
+++ b/testing/test_package_docs/ex/B/s.html
@@ -78,17 +78,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">s</span>      <div class="features">@override, inherited-setter, read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>The getter for <code>s</code>
-The setter for <code>s</code></p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">s</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>The getter for <code>s</code></p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">s=</span><span class="signature">(<wbr><span class="parameter" id="s=-param-something"><span class="type-annotation">String</span> <span class="parameter-name">something</span></span>)</span>
+          <div class="features">inherited</div>
+</section>
+        
+        <section class="desc markdown">
+  <p>The setter for <code>s</code></p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property s</h5>

--- a/testing/test_package_docs/ex/COLOR-constant.html
+++ b/testing/test_package_docs/ex/COLOR-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">COLOR</span>        =
-        <span class="constant-value">&#39;red&#39;</span>
-        
+      <span class="name ">COLOR</span>      =
+      <span class="constant-value">&#39;red&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/COLOR_GREEN-constant.html
+++ b/testing/test_package_docs/ex/COLOR_GREEN-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">COLOR_GREEN</span>        =
-        <span class="constant-value">&#39;green&#39;</span>
-        
+      <span class="name ">COLOR_GREEN</span>      =
+      <span class="constant-value">&#39;green&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
+++ b/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">COLOR_ORANGE</span>        =
-        <span class="constant-value">&#39;orange&#39;</span>
-        
+      <span class="name ">COLOR_ORANGE</span>      =
+      <span class="constant-value">&#39;orange&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
+++ b/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">COMPLEX_COLOR</span>        =
-        <span class="constant-value">&#39;red&#39; + &#39;-&#39; + &#39;green&#39; + &#39;-&#39; + &#39;blue&#39;</span>
-        
+      <span class="name ">COMPLEX_COLOR</span>      =
+      <span class="constant-value">&#39;red&#39; + &#39;-&#39; + &#39;green&#39; + &#39;-&#39; + &#39;blue&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Cat/hashCode.html
+++ b/testing/test_package_docs/ex/Cat/hashCode.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Cat/isImplemented.html
+++ b/testing/test_package_docs/ex/Cat/isImplemented.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isImplemented</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isImplemented</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Cat/isImplemented.html
+++ b/testing/test_package_docs/ex/Cat/isImplemented.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isImplemented</span>      <div class="features">read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isImplemented</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Cat/runtimeType.html
+++ b/testing/test_package_docs/ex/Cat/runtimeType.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Cat/runtimeType.html
+++ b/testing/test_package_docs/ex/Cat/runtimeType.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/CatString/hashCode.html
+++ b/testing/test_package_docs/ex/CatString/hashCode.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/CatString/hashCode.html
+++ b/testing/test_package_docs/ex/CatString/hashCode.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/CatString/isEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isEmpty.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isEmpty</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isEmpty</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/CatString/isEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isEmpty.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isEmpty</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isEmpty</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/CatString/isNotEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isNotEmpty.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isNotEmpty</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isNotEmpty</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/CatString/isNotEmpty.html
+++ b/testing/test_package_docs/ex/CatString/isNotEmpty.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isNotEmpty</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isNotEmpty</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/CatString/length.html
+++ b/testing/test_package_docs/ex/CatString/length.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">length</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">length</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/CatString/length.html
+++ b/testing/test_package_docs/ex/CatString/length.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">length</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">length</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/CatString/runtimeType.html
+++ b/testing/test_package_docs/ex/CatString/runtimeType.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/CatString/runtimeType.html
+++ b/testing/test_package_docs/ex/CatString/runtimeType.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -142,7 +142,7 @@
         </dt>
         <dd>
           
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="ex/ConstantCat/name.html">name</a></span>

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ConstantCat/hashCode.html
+++ b/testing/test_package_docs/ex/ConstantCat/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ConstantCat/isImplemented.html
+++ b/testing/test_package_docs/ex/ConstantCat/isImplemented.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isImplemented</span>      <div class="features">@override, read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isImplemented</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ConstantCat/isImplemented.html
+++ b/testing/test_package_docs/ex/ConstantCat/isImplemented.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isImplemented</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isImplemented</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ConstantCat/name.html
+++ b/testing/test_package_docs/ex/ConstantCat/name.html
@@ -67,12 +67,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">name</span>        <div class="features">final</div>
+      <span class="name ">name</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ConstantCat/name.html
+++ b/testing/test_package_docs/ex/ConstantCat/name.html
@@ -64,13 +64,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">name</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">name</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ConstantCat/runtimeType.html
+++ b/testing/test_package_docs/ex/ConstantCat/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ConstantCat/runtimeType.html
+++ b/testing/test_package_docs/ex/ConstantCat/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -65,12 +65,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">expires</span>        <div class="features">final</div>
+      <span class="name ">expires</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -62,13 +62,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">expires</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">expires</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -182,9 +182,8 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <div class="features">@protected, final</div>
 </dd>
         <dt id="deprecatedField" class="property">
-          <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="deprecatedField=-param-_deprecatedField"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           
@@ -199,9 +198,8 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <div class="features">@deprecated, read-only</div>
 </dd>
         <dt id="deprecatedSetter" class="property">
-          <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
-          </span>
+          <span class="name"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd>
           
@@ -216,9 +214,8 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <div class="features">@override, read-only</div>
 </dd>
         <dt id="name" class="property">
-          <span class="name"><a href="ex/Dog/name.html">name</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="name=-param-_name"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/Dog/name.html">name</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           
@@ -376,9 +373,8 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           <div class="features">final</div>
 </dd>
         <dt id="staticGetterSetter" class="property">
-          <span class="name"><a href="ex/Dog/staticGetterSetter.html">staticGetterSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="staticGetterSetter=-param-x"><span class="parameter-name">x</span></span>  </span>
-          </span>
+          <span class="name"><a href="ex/Dog/staticGetterSetter.html">staticGetterSetter</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -187,7 +187,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         </dt>
         <dd>
           
-          <div class="features">@deprecated, read / write</div>
+          <div class="features">read / write</div>
 </dd>
         <dt id="deprecatedGetter" class="property">
           <span class="name"><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></span>
@@ -195,15 +195,15 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         </dt>
         <dd>
           
-          <div class="features">@deprecated, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="deprecatedSetter" class="property">
           <span class="name"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span></span></span>
         </dt>
         <dd>
           
-          <div class="features">@deprecated, write-only</div>
+          <div class="features">write-only</div>
 </dd>
         <dt id="isImplemented" class="property">
           <span class="name"><a href="ex/Dog/isImplemented.html">isImplemented</a></span>
@@ -211,7 +211,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         </dt>
         <dd>
           
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="ex/Dog/name.html">name</a></span>

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -89,12 +89,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">aFinalField</span>        <div class="features">final</div>
+      <span class="name ">aFinalField</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -86,13 +86,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">aFinalField</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">aFinalField</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -87,17 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">aGetterReturningRandomThings</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">aGetterReturningRandomThings</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -87,11 +87,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">aGetterReturningRandomThings</span>      <div class="features">read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">aGetterReturningRandomThings</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -86,13 +86,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">aProtectedFinalField</span>          <div class="features">@protected, final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">aProtectedFinalField</span>      <div class="features">@protected, final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -89,12 +89,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">aProtectedFinalField</span>        <div class="features">@protected, final</div>
+      <span class="name ">aProtectedFinalField</span>      <div class="features">@protected, final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -86,13 +86,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name deprecated">deprecatedField</span>          <div class="features">read / write</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name deprecated">deprecatedField</span>      <div class="features">@deprecated, read / write</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -89,12 +89,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name deprecated">deprecatedField</span>        <div class="features">@deprecated, read / write</div>
+      <span class="name deprecated">deprecatedField</span>      <div class="features">@deprecated, read / write</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -87,11 +87,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name deprecated">deprecatedGetter</span>      <div class="features">@deprecated, read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name deprecated">deprecatedGetter</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -87,17 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name deprecated">deprecatedGetter</span>      <div class="features">@deprecated, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name deprecated">deprecatedGetter</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -87,13 +87,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"></span>
-      <span class="name deprecated">deprecatedSetter</span>      <div class="features">@deprecated, write-only</div>
-    </section>
 
+        <section id="setter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name deprecated">deprecatedSetter=</span><span class="signature">(<wbr><span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
+          
+</section>
+        
+        
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property deprecatedSetter</h5>

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -87,18 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"></span>
+      <span class="name deprecated">deprecatedSetter</span>      <div class="features">@deprecated, write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name deprecated">deprecatedSetter=</span><span class="signature">(<wbr><span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
-      </section>
-      
-      </section>
-      
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -87,11 +87,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -87,17 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -87,17 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isImplemented</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isImplemented</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -87,11 +87,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isImplemented</span>      <div class="features">@override, read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isImplemented</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -86,13 +86,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">name</span>          <div class="features">read / write</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">name</span>      <div class="features">read / write</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -89,12 +89,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">name</span>        <div class="features">read / write</div>
+      <span class="name ">name</span>      <div class="features">read / write</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -87,17 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -87,11 +87,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -86,16 +86,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">somethingTasty</span>          <div class="features">final</div>
+        </section>
+        <section class="desc markdown">
+          <p>A tasty static + final property.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">somethingTasty</span>      <div class="features">final</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>A tasty static + final property.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -89,15 +89,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">somethingTasty</span>        <div class="features">final</div>
+      <span class="name ">somethingTasty</span>      <div class="features">final</div>
     </section>
 
     <section class="desc markdown">
       <p>A tasty static + final property.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -87,26 +87,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">staticGetterSetter</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">staticGetterSetter</span></section>
-      
-      </section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">staticGetterSetter=</span><span class="signature">(<wbr><span class="parameter" id="staticGetterSetter=-param-x"><span class="parameter-name">x</span></span>)</span>
-      </section>
-      
-      </section>
-      
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -87,13 +87,27 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">staticGetterSetter</span>      <div class="features">read / write</div>
-    </section>
-
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">staticGetterSetter</span>  
+</section>
+        
+        
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">staticGetterSetter=</span><span class="signature">(<wbr><span class="parameter" id="staticGetterSetter=-param-x"><span class="parameter-name">x</span></span>)</span>
+          
+</section>
+        
+        
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property staticGetterSetter</h5>

--- a/testing/test_package_docs/ex/E/hashCode.html
+++ b/testing/test_package_docs/ex/E/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/E/hashCode.html
+++ b/testing/test_package_docs/ex/E/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/E/runtimeType.html
+++ b/testing/test_package_docs/ex/E/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/E/runtimeType.html
+++ b/testing/test_package_docs/ex/E/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -160,9 +160,8 @@
           <div class="features">@protected, final, inherited</div>
 </dd>
         <dt id="deprecatedField" class="property inherited">
-          <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="deprecatedField=-param-_deprecatedField"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           
@@ -177,9 +176,8 @@
           <div class="features">@deprecated, read-only, inherited</div>
 </dd>
         <dt id="deprecatedSetter" class="property inherited">
-          <span class="name deprecated"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
-          </span>
+          <span class="name"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd class="inherited">
           
@@ -202,9 +200,8 @@
           <div class="features">@override, read-only, inherited</div>
 </dd>
         <dt id="name" class="property inherited">
-          <span class="name"><a href="ex/Dog/name.html">name</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="name=-param-_name"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/Dog/name.html">name</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd class="inherited">
           

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -165,7 +165,7 @@
         </dt>
         <dd class="inherited">
           
-          <div class="features">@deprecated, read / write, inherited</div>
+          <div class="features">read / write, inherited</div>
 </dd>
         <dt id="deprecatedGetter" class="property inherited">
           <span class="name"><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></span>
@@ -173,15 +173,15 @@
         </dt>
         <dd class="inherited">
           
-          <div class="features">@deprecated, read-only, inherited</div>
+          <div class="features">read-only, inherited</div>
 </dd>
         <dt id="deprecatedSetter" class="property inherited">
           <span class="name"><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span></span></span>
         </dt>
         <dd class="inherited">
           
-          <div class="features">@deprecated, write-only, inherited</div>
+          <div class="features">write-only, inherited</div>
 </dd>
         <dt id="hashCode" class="property inherited">
           <span class="name"><a href="ex/Dog/hashCode.html">hashCode</a></span>
@@ -197,7 +197,7 @@
         </dt>
         <dd class="inherited">
           
-          <div class="features">@override, read-only, inherited</div>
+          <div class="features">read-only, inherited</div>
 </dd>
         <dt id="name" class="property inherited">
           <span class="name"><a href="ex/Dog/name.html">name</a></span>

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ForAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/ForAnnotation/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/ForAnnotation/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ForAnnotation/value.html
+++ b/testing/test_package_docs/ex/ForAnnotation/value.html
@@ -62,13 +62,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">value</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">value</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ForAnnotation/value.html
+++ b/testing/test_package_docs/ex/ForAnnotation/value.html
@@ -65,12 +65,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">value</span>        <div class="features">final</div>
+      <span class="name ">value</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/HasAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/HasAnnotation/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/HasAnnotation/hashCode.html
+++ b/testing/test_package_docs/ex/HasAnnotation/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
+++ b/testing/test_package_docs/ex/HasAnnotation/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Helper/hashCode.html
+++ b/testing/test_package_docs/ex/Helper/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Helper/hashCode.html
+++ b/testing/test_package_docs/ex/Helper/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Helper/runtimeType.html
+++ b/testing/test_package_docs/ex/Helper/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Helper/runtimeType.html
+++ b/testing/test_package_docs/ex/Helper/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -67,11 +67,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Klass/hashCode.html
+++ b/testing/test_package_docs/ex/Klass/hashCode.html
@@ -67,17 +67,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Klass/runtimeType.html
+++ b/testing/test_package_docs/ex/Klass/runtimeType.html
@@ -67,17 +67,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Klass/runtimeType.html
+++ b/testing/test_package_docs/ex/Klass/runtimeType.html
@@ -67,11 +67,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MY_CAT-constant.html
+++ b/testing/test_package_docs/ex/MY_CAT-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">MY_CAT</span>        =
-        <span class="constant-value">const <a href="ex/ConstantCat-class.html">ConstantCat</a>(&#39;tabby&#39;)</span>
-        
+      <span class="name ">MY_CAT</span>      =
+      <span class="constant-value">const <a href="ex/ConstantCat-class.html">ConstantCat</a>(&#39;tabby&#39;)</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyError/hashCode.html
+++ b/testing/test_package_docs/ex/MyError/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyError/hashCode.html
+++ b/testing/test_package_docs/ex/MyError/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyError/runtimeType.html
+++ b/testing/test_package_docs/ex/MyError/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyError/runtimeType.html
+++ b/testing/test_package_docs/ex/MyError/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyError/stackTrace.html
+++ b/testing/test_package_docs/ex/MyError/stackTrace.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">StackTrace</span>
+      <span class="name ">stackTrace</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">StackTrace</span>
-        <span class="name ">stackTrace</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyError/stackTrace.html
+++ b/testing/test_package_docs/ex/MyError/stackTrace.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">StackTrace</span>
-      <span class="name ">stackTrace</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">StackTrace</span>
+          <span class="name ">stackTrace</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -141,7 +141,7 @@
         </dt>
         <dd>
           
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="hashCode" class="property inherited">
           <span class="name"><a href="ex/MyErrorImplements/hashCode.html">hashCode</a></span>

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">StackTrace</span>
+      <span class="name ">stackTrace</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">StackTrace</span>
-        <span class="name ">stackTrace</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/stackTrace.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">StackTrace</span>
-      <span class="name ">stackTrace</span>      <div class="features">@override, read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">StackTrace</span>
+          <span class="name ">stackTrace</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyException/hashCode.html
+++ b/testing/test_package_docs/ex/MyException/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyException/hashCode.html
+++ b/testing/test_package_docs/ex/MyException/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyException/runtimeType.html
+++ b/testing/test_package_docs/ex/MyException/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyException/runtimeType.html
+++ b/testing/test_package_docs/ex/MyException/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
+++ b/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">PRETTY_COLORS</span>        =
-        <span class="constant-value">const &lt;String&gt; [COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;]</span>
-        
+      <span class="name ">PRETTY_COLORS</span>      =
+      <span class="constant-value">const &lt;String&gt; [COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;]</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -208,7 +208,7 @@
           
           
   <div>
-            <span class="signature"><code>const <a href="ex/ShapeType-class.html">ShapeType</a>._internal("Ellipse")</code></span>
+            <span class="signature"><code>const ShapeType._internal("Ellipse")</code></span>
           </div>
         </dd>
         <dt id="rect" class="constant">
@@ -219,7 +219,7 @@
           
           
   <div>
-            <span class="signature"><code>const <a href="ex/ShapeType-class.html">ShapeType</a>._internal("Rect")</code></span>
+            <span class="signature"><code>const ShapeType._internal("Rect")</code></span>
           </div>
         </dd>
       </dl>

--- a/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
@@ -67,7 +67,7 @@
     <section class="multi-line-signature">
         <span class="returntype"><a href="ex/ShapeType-class.html">ShapeType</a></span>
         <span class="name ">ellipse</span>        =
-        <span class="constant-value">const <a href="ex/ShapeType-class.html">ShapeType</a>._internal("Ellipse")</span>
+        <span class="constant-value">const ShapeType._internal("Ellipse")</span>
     </section>
 
         

--- a/testing/test_package_docs/ex/ShapeType/hashCode.html
+++ b/testing/test_package_docs/ex/ShapeType/hashCode.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ShapeType/hashCode.html
+++ b/testing/test_package_docs/ex/ShapeType/hashCode.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ShapeType/name.html
+++ b/testing/test_package_docs/ex/ShapeType/name.html
@@ -63,13 +63,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">name</span>          <div class="features">final, inherited</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">name</span>      <div class="features">final, inherited</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ShapeType/name.html
+++ b/testing/test_package_docs/ex/ShapeType/name.html
@@ -66,12 +66,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">name</span>        <div class="features">final, inherited</div>
+      <span class="name ">name</span>      <div class="features">final, inherited</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ShapeType/rect-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/rect-constant.html
@@ -67,7 +67,7 @@
     <section class="multi-line-signature">
         <span class="returntype"><a href="ex/ShapeType-class.html">ShapeType</a></span>
         <span class="name ">rect</span>        =
-        <span class="constant-value">const <a href="ex/ShapeType-class.html">ShapeType</a>._internal("Rect")</span>
+        <span class="constant-value">const ShapeType._internal("Rect")</span>
     </section>
 
         

--- a/testing/test_package_docs/ex/ShapeType/runtimeType.html
+++ b/testing/test_package_docs/ex/ShapeType/runtimeType.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/ShapeType/runtimeType.html
+++ b/testing/test_package_docs/ex/ShapeType/runtimeType.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/hashCode.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inDays.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inDays.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">inDays</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">inDays</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inDays.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inDays.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">inDays</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">inDays</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/inHours.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inHours.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">inHours</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">inHours</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/inHours.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inHours.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">inHours</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">inHours</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">inMicroseconds</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">inMicroseconds</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMicroseconds.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">inMicroseconds</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">inMicroseconds</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">inMilliseconds</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">inMilliseconds</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMilliseconds.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">inMilliseconds</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">inMilliseconds</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">inMinutes</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">inMinutes</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inMinutes.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">inMinutes</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">inMinutes</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">inSeconds</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">inSeconds</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/inSeconds.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">inSeconds</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">inSeconds</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isNegative</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isNegative</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/isNegative.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isNegative</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isNegative</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
@@ -80,11 +80,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/runtimeType.html
@@ -80,17 +80,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/hashCode.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/hashCode.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/runtimeType.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/runtimeType.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -134,9 +134,8 @@
 
       <dl class="properties">
         <dt id="prop" class="property">
-          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="prop=-param-_prop"><span class="type-annotation">T</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span>
+          <span class="signature">&#8596; T</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -65,12 +65,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">T</span>
-        <span class="name ">prop</span>        <div class="features">read / write</div>
+      <span class="name ">prop</span>      <div class="features">read / write</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -62,13 +62,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">T</span>
+          <span class="name ">prop</span>          <div class="features">read / write</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">T</span>
-      <span class="name ">prop</span>      <div class="features">read / write</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -144,9 +144,8 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="prop" class="property inherited">
-          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="prop=-param-_prop"><span class="type-annotation">T</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/WithGeneric/prop.html">prop</a></span>
+          <span class="signature">&#8596; T</span>
         </dt>
         <dd class="inherited">
           

--- a/testing/test_package_docs/ex/aThingToDo/hashCode.html
+++ b/testing/test_package_docs/ex/aThingToDo/hashCode.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/aThingToDo/hashCode.html
+++ b/testing/test_package_docs/ex/aThingToDo/hashCode.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/aThingToDo/runtimeType.html
+++ b/testing/test_package_docs/ex/aThingToDo/runtimeType.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/aThingToDo/runtimeType.html
+++ b/testing/test_package_docs/ex/aThingToDo/runtimeType.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/aThingToDo/what.html
+++ b/testing/test_package_docs/ex/aThingToDo/what.html
@@ -66,12 +66,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">what</span>        <div class="features">final</div>
+      <span class="name ">what</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/aThingToDo/what.html
+++ b/testing/test_package_docs/ex/aThingToDo/what.html
@@ -63,13 +63,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">what</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">what</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/aThingToDo/who.html
+++ b/testing/test_package_docs/ex/aThingToDo/who.html
@@ -66,12 +66,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">who</span>        <div class="features">final</div>
+      <span class="name ">who</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/aThingToDo/who.html
+++ b/testing/test_package_docs/ex/aThingToDo/who.html
@@ -63,13 +63,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">who</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">who</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -103,12 +103,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">deprecated</span>        =
-        <span class="constant-value">const <a href="ex/Deprecated-class.html">Deprecated</a>(&quot;next release&quot;)</span>
-        
+      <span class="name ">deprecated</span>      =
+      <span class="constant-value">const <a href="ex/Deprecated-class.html">Deprecated</a>(&quot;next release&quot;)</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/deprecatedField.html
+++ b/testing/test_package_docs/ex/deprecatedField.html
@@ -102,13 +102,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name deprecated">deprecatedField</span>        <div class="features">read / write</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name deprecated">deprecatedField</span>      <div class="features">read / write</div>
+    </section>
 
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/deprecatedField.html
+++ b/testing/test_package_docs/ex/deprecatedField.html
@@ -101,13 +101,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">int</span>
       <span class="name deprecated">deprecatedField</span>      <div class="features">read / write</div>
     </section>
-
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/deprecatedGetter.html
@@ -102,16 +102,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name deprecated">deprecatedGetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name deprecated">deprecatedGetter</span></section>
-      
-      </section>
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/deprecatedGetter.html
@@ -102,13 +102,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section id="getter">
+    
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-      <span class="name deprecated">deprecatedGetter</span>      <div class="features">read-only</div>
-    </section>
-
-        
-
+      <span class="name deprecated">deprecatedGetter</span>  
+</section>
+    
+    
+</section>
+    
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/deprecatedSetter.html
@@ -102,14 +102,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+
+    <section id="setter">
+    
     <section class="multi-line-signature">
-      <span class="returntype"></span>
-      <span class="name deprecated">deprecatedSetter</span>      <div class="features">write-only</div>
-    </section>
-
-        
-
-  </div> <!-- /.main-content -->
+      <span class="returntype">void</span>
+        <span class="name deprecated">deprecatedSetter=</span><span class="signature">(<wbr><span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
+      
+</section>
+    
+    
+</section>
+      </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>top-level property deprecatedSetter</h5>

--- a/testing/test_package_docs/ex/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/deprecatedSetter.html
@@ -102,17 +102,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"></span>
+      <span class="name deprecated">deprecatedSetter</span>      <div class="features">write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name deprecated">deprecatedSetter=</span><span class="signature">(<wbr><span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
-      </section>
-      
-      </section>
-      
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -312,9 +312,8 @@ that has some operators
 
       <dl class="properties">
         <dt id="deprecatedField" class="property">
-          <span class="name deprecated"><a class="deprecated" href="ex/deprecatedField.html">deprecatedField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="deprecatedField=-param-_deprecatedField"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a class="deprecated" href="ex/deprecatedField.html">deprecatedField</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           
@@ -329,18 +328,16 @@ that has some operators
           <div class="features">read-only</div>
 </dd>
         <dt id="deprecatedSetter" class="property">
-          <span class="name deprecated"><a class="deprecated" href="ex/deprecatedSetter.html">deprecatedSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
-          </span>
+          <span class="name"><a class="deprecated" href="ex/deprecatedSetter.html">deprecatedSetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd>
           
           <div class="features">write-only</div>
 </dd>
         <dt id="number" class="property">
-          <span class="name"><a href="ex/number.html">number</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="number=-param-_number"><span class="type-annotation">double</span></span> </span>
-          </span>
+          <span class="name"><a href="ex/number.html">number</a></span>
+          <span class="signature">&#8596; double</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -329,7 +329,7 @@ that has some operators
 </dd>
         <dt id="deprecatedSetter" class="property">
           <span class="name"><a class="deprecated" href="ex/deprecatedSetter.html">deprecatedSetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="deprecatedSetter=-param-value"><span class="type-annotation">int</span></span></span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/ex/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReference-constant.html
@@ -103,15 +103,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">incorrectDocReference</span>        =
-        <span class="constant-value">&#39;same name as const from fake&#39;</span>
-        
+      <span class="name ">incorrectDocReference</span>      =
+      <span class="constant-value">&#39;same name as const from fake&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>This is the same name as a top-level const from the fake lib.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>This is the same name as a top-level const from the fake lib.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
@@ -103,15 +103,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">incorrectDocReferenceFromEx</span>        =
-        <span class="constant-value">&#39;doh&#39;</span>
-        
+      <span class="name ">incorrectDocReferenceFromEx</span>      =
+      <span class="constant-value">&#39;doh&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>This should <code>not work</code>.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>This should <code>not work</code>.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/number.html
+++ b/testing/test_package_docs/ex/number.html
@@ -101,13 +101,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">double</span>
       <span class="name ">number</span>      <div class="features">read / write</div>
     </section>
-
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/number.html
+++ b/testing/test_package_docs/ex/number.html
@@ -102,13 +102,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">double</span>
-        <span class="name ">number</span>        <div class="features">read / write</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">double</span>
+      <span class="name ">number</span>      <div class="features">read / write</div>
+    </section>
 
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/y.html
+++ b/testing/test_package_docs/ex/y.html
@@ -102,13 +102,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section id="getter">
+    
     <section class="multi-line-signature">
       <span class="returntype">dynamic</span>
-      <span class="name ">y</span>      <div class="features">read-only</div>
-    </section>
-
-        
-
+      <span class="name ">y</span>  
+</section>
+    
+    
+</section>
+    
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/y.html
+++ b/testing/test_package_docs/ex/y.html
@@ -102,16 +102,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">y</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">dynamic</span>
-        <span class="name ">y</span></section>
-      
-      </section>
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Annotation/hashCode.html
+++ b/testing/test_package_docs/fake/Annotation/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Annotation/runtimeType.html
+++ b/testing/test_package_docs/fake/Annotation/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Annotation/runtimeType.html
+++ b/testing/test_package_docs/fake/Annotation/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Annotation/value.html
+++ b/testing/test_package_docs/fake/Annotation/value.html
@@ -62,13 +62,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">value</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">value</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Annotation/value.html
+++ b/testing/test_package_docs/fake/Annotation/value.html
@@ -65,12 +65,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">value</span>        <div class="features">final</div>
+      <span class="name ">value</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/AnotherInterface/hashCode.html
+++ b/testing/test_package_docs/fake/AnotherInterface/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/AnotherInterface/hashCode.html
+++ b/testing/test_package_docs/fake/AnotherInterface/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
+++ b/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
+++ b/testing/test_package_docs/fake/AnotherInterface/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/hashCode.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
@@ -64,17 +64,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/runtimeType.html
@@ -64,11 +64,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -165,9 +165,8 @@
           <div class="features">read-only</div>
 </dd>
         <dt id="aImplementingThingyField" class="property">
-          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="aImplementingThingyField=-param-_aImplementingThingyField"><span class="type-annotation"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span></span> </span>
-          </span>
+          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>
+          <span class="signature">&#8596; <a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingy.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
-      <span class="name ">aImplementingThingy</span>      <div class="features">read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
+          <span class="name ">aImplementingThingy</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingy.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
+      <span class="name ">aImplementingThingy</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
-        <span class="name ">aImplementingThingy</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingyField.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingyField.html
@@ -64,13 +64,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
+          <span class="name ">aImplementingThingyField</span>          <div class="features">read / write</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
-      <span class="name ">aImplementingThingyField</span>      <div class="features">read / write</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy/aImplementingThingyField.html
+++ b/testing/test_package_docs/fake/BaseThingy/aImplementingThingyField.html
@@ -67,12 +67,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
-        <span class="name ">aImplementingThingyField</span>        <div class="features">read / write</div>
+      <span class="name ">aImplementingThingyField</span>      <div class="features">read / write</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy/hashCode.html
+++ b/testing/test_package_docs/fake/BaseThingy/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseThingy/hashCode.html
+++ b/testing/test_package_docs/fake/BaseThingy/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseThingy/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseThingy/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -173,9 +173,8 @@
           <div class="features">@override, read-only</div>
 </dd>
         <dt id="aImplementingThingyField" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="aImplementingThingyField=-param-_aImplementingThingyField"><span class="type-annotation"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span></span> </span>
-          </span>
+          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>
+          <span class="signature">&#8596; <a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
         </dt>
         <dd class="inherited">
           

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -170,7 +170,7 @@
         </dt>
         <dd>
           BaseThingy2's doc for aImplementingThingy.
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="aImplementingThingyField" class="property inherited">
           <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>

--- a/testing/test_package_docs/fake/BaseThingy2/aImplementingThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy2/aImplementingThingy.html
@@ -65,14 +65,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></span>
-      <span class="name ">aImplementingThingy</span>      <div class="features">@override, read-only</div>
-    </section>
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype"><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></span>
+          <span class="name ">aImplementingThingy</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>BaseThingy2's doc for aImplementingThingy.</p>
+</section>
 
-    <section class="desc markdown">
-      <p>BaseThingy2's doc for aImplementingThingy.</p>
-    </section>
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseThingy2/aImplementingThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy2/aImplementingThingy.html
@@ -65,20 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></span>
+      <span class="name ">aImplementingThingy</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype"><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></span>
-        <span class="name ">aImplementingThingy</span></section>
-      
-      <section class="desc markdown">
-  <p>BaseThingy2's doc for aImplementingThingy.</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>BaseThingy2's doc for aImplementingThingy.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy2/hashCode.html
+++ b/testing/test_package_docs/fake/BaseThingy2/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/BaseThingy2/hashCode.html
+++ b/testing/test_package_docs/fake/BaseThingy2/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy2/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseThingy2/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/BaseThingy2/runtimeType.html
+++ b/testing/test_package_docs/fake/BaseThingy2/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -125,12 +125,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">CUSTOM_CLASS</span>        =
-        <span class="constant-value">const <a href="fake/ConstantClass-class.html">ConstantClass</a>(&#39;custom&#39;)</span>
-        
+      <span class="name ">CUSTOM_CLASS</span>      =
+      <span class="constant-value">const <a href="fake/ConstantClass-class.html">ConstantClass</a>(&#39;custom&#39;)</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -168,7 +168,7 @@ on inheritance and overrides here.</p>
         </dt>
         <dd>
           This getter is documented, so we should see a read-only property here.
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="explicitGetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetter.html">explicitGetter</a></span>
@@ -184,7 +184,7 @@ on inheritance and overrides here.</p>
         </dt>
         <dd>
           Getter doc for explicitGetterImplicitSetter
-          <div class="features">@override, inherited-setter, read / write</div>
+          <div class="features">inherited-setter, read / write</div>
 </dd>
         <dt id="explicitGetterSetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></span>
@@ -200,11 +200,11 @@ on inheritance and overrides here.</p>
         </dt>
         <dd>
           Since I have a different doc, I should be documented.
-          <div class="features">@override, read-only</div>
+          <div class="features">read-only</div>
 </dd>
         <dt id="explicitSetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List&lt;int&gt;</span></span>)</span></span>
         </dt>
         <dd>
           Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.
@@ -224,7 +224,7 @@ on inheritance and overrides here.</p>
         </dt>
         <dd>
           Docs for implicitGetterExplicitSetter from ImplicitProperties.
-          <div class="features">@override, inherited-getter, read / write</div>
+          <div class="features">inherited-getter, read / write</div>
 </dd>
         <dt id="implicitReadWrite" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></span>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -192,7 +192,7 @@ on inheritance and overrides here.</p>
         </dt>
         <dd>
           Getter doc for explicitGetterSetter.
-          <div class="features">read / write</div>
+          <div class="features">@<a href="fake/Annotation-class.html">Annotation</a>(&#39;a Getter Annotation&#39;), @<a href="fake/Annotation-class.html">Annotation</a>(&#39;a Setter Annotation&#39;), read / write</div>
 </dd>
         <dt id="explicitNonDocumentedInBaseClassGetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html">explicitNonDocumentedInBaseClassGetter</a></span>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -179,18 +179,16 @@ on inheritance and overrides here.</p>
           <div class="features">read-only</div>
 </dd>
         <dt id="explicitGetterImplicitSetter" class="property">
-          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="explicitGetterImplicitSetter=-param-_explicitGetterImplicitSetter"><span class="type-annotation">List&lt;int&gt;</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span>
+          <span class="signature">&#8596; List&lt;int&gt;</span>
         </dt>
         <dd>
           Getter doc for explicitGetterImplicitSetter
           <div class="features">@override, inherited-setter, read / write</div>
 </dd>
         <dt id="explicitGetterSetter" class="property">
-          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="explicitGetterSetter=-param-f"><span class="type-annotation"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span> <span class="parameter-name">f</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterSetter.html">explicitGetterSetter</a></span>
+          <span class="signature">&#8596; <a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
         </dt>
         <dd>
           Getter doc for explicitGetterSetter.
@@ -205,9 +203,8 @@ on inheritance and overrides here.</p>
           <div class="features">@override, read-only</div>
 </dd>
         <dt id="explicitSetter" class="property">
-          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List&lt;int&gt;</span> <span class="parameter-name">macTruck</span></span>)</span>  </span>
-          </span>
+          <span class="name"><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd>
           Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.
@@ -222,27 +219,24 @@ on inheritance and overrides here.</p>
           <div class="features">final</div>
 </dd>
         <dt id="implicitGetterExplicitSetter" class="property">
-          <span class="name"><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="implicitGetterExplicitSetter=-param-x"><span class="type-annotation">String</span> <span class="parameter-name">x</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           Docs for implicitGetterExplicitSetter from ImplicitProperties.
           <div class="features">@override, inherited-getter, read / write</div>
 </dd>
         <dt id="implicitReadWrite" class="property">
-          <span class="name"><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="implicitReadWrite=-param-_implicitReadWrite"><span class="type-annotation">Map</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/ClassWithUnusualProperties/implicitReadWrite.html">implicitReadWrite</a></span>
+          <span class="signature">&#8596; Map</span>
         </dt>
         <dd>
           
           <div class="features">read / write</div>
 </dd>
         <dt id="explicitGetterSetterForInheriting" class="property inherited">
-          <span class="name"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="explicitGetterSetterForInheriting=-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           Explicit getter for inheriting.
@@ -257,9 +251,8 @@ on inheritance and overrides here.</p>
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="forInheriting" class="property inherited">
-          <span class="name"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="forInheriting=-param-_forInheriting"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           A simple property to inherit.

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
@@ -75,16 +75,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">documentedPartialFieldInSubclassOnly</span>      <div class="features">@override, read-only</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>This getter is documented, so we should see a read-only property here.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">documentedPartialFieldInSubclassOnly</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>This getter is documented, so we should see a read-only property here.</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">documentedPartialFieldInSubclassOnly=</span><span class="signature">(<wbr><span class="parameter" id="documentedPartialFieldInSubclassOnly=-param-_documentedPartialFieldInSubclassOnly"><span class="type-annotation">String</span> <span class="parameter-name">_documentedPartialFieldInSubclassOnly</span></span>)</span>
+          <div class="features">inherited</div>
+</section>
+        
+        <section class="desc markdown">
+  <p>@nodoc here, you should never see this</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property documentedPartialFieldInSubclassOnly</h5>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/documentedPartialFieldInSubclassOnly.html
@@ -75,20 +75,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">documentedPartialFieldInSubclassOnly</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">documentedPartialFieldInSubclassOnly</span></section>
-      
-      <section class="desc markdown">
-  <p>This getter is documented, so we should see a read-only property here.</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>This getter is documented, so we should see a read-only property here.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
@@ -75,20 +75,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+      <span class="name ">explicitGetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-        <span class="name ">explicitGetter</span></section>
-      
-      <section class="desc markdown">
-  <p>This property only has a getter and no setter; no parameters to print.</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>This property only has a getter and no setter; no parameters to print.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetter.html
@@ -75,14 +75,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-      <span class="name ">explicitGetter</span>      <div class="features">read-only</div>
-    </section>
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+          <span class="name ">explicitGetter</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>This property only has a getter and no setter; no parameters to print.</p>
+</section>
 
-    <section class="desc markdown">
-      <p>This property only has a getter and no setter; no parameters to print.</p>
-    </section>
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -75,20 +75,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">List&lt;int&gt;</span>
+      <span class="name ">explicitGetterImplicitSetter</span>      <div class="features">@override, inherited-setter, read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">List&lt;int&gt;</span>
-        <span class="name ">explicitGetterImplicitSetter</span></section>
-      
-      <section class="desc markdown">
-  <p>Getter doc for explicitGetterImplicitSetter</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>Docs for explicitGetterImplicitSetter from ImplicitProperties.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -75,16 +75,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">List&lt;int&gt;</span>
-      <span class="name ">explicitGetterImplicitSetter</span>      <div class="features">@override, inherited-setter, read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Docs for explicitGetterImplicitSetter from ImplicitProperties.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">List&lt;int&gt;</span>
+          <span class="name ">explicitGetterImplicitSetter</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>Getter doc for explicitGetterImplicitSetter</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">explicitGetterImplicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterImplicitSetter=-param-_explicitGetterImplicitSetter"><span class="type-annotation">List&lt;int&gt;</span> <span class="parameter-name">_explicitGetterImplicitSetter</span></span>)</span>
+          <div class="features">inherited</div>
+</section>
+        
+        <section class="desc markdown">
+  <p>Docs for explicitGetterImplicitSetter from ImplicitProperties.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property explicitGetterImplicitSetter</h5>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -79,7 +79,7 @@
         
         <section class="multi-line-signature">
           <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-          <span class="name ">explicitGetterSetter</span>  
+          <span class="name ">explicitGetterSetter</span>  <div class="features">@<a href="fake/Annotation-class.html">Annotation</a>(&#39;a Getter Annotation&#39;)</div>
 </section>
         
         <section class="desc markdown">
@@ -93,7 +93,7 @@
         <section class="multi-line-signature">
           <span class="returntype">void</span>
             <span class="name ">explicitGetterSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterSetter=-param-f"><span class="type-annotation"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span> <span class="parameter-name">f</span></span>)</span>
-          
+          <div class="features">@<a href="fake/Annotation-class.html">Annotation</a>(&#39;a Setter Annotation&#39;)</div>
 </section>
         
         <section class="desc markdown">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -75,17 +75,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-      <span class="name ">explicitGetterSetter</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Getter doc for explicitGetterSetter.
-This property is not synthetic, so it might reference <code>f</code> -- display it.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+          <span class="name ">explicitGetterSetter</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>Getter doc for explicitGetterSetter.</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">explicitGetterSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterSetter=-param-f"><span class="type-annotation"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span> <span class="parameter-name">f</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>This property is not synthetic, so it might reference <code>f</code> -- display it.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property explicitGetterSetter</h5>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterSetter.html
@@ -75,32 +75,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
+      <span class="name ">explicitGetterSetter</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span>
-        <span class="name ">explicitGetterSetter</span></section>
-      
-      <section class="desc markdown">
-  <p>Getter doc for explicitGetterSetter.</p>
-</section>
-</section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">explicitGetterSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterSetter=-param-f"><span class="type-annotation"><a href="fake/myCoolTypedef.html">myCoolTypedef</a></span> <span class="parameter-name">f</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>This property is not synthetic, so it might reference <code>f</code> -- display it.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Getter doc for explicitGetterSetter.
+This property is not synthetic, so it might reference <code>f</code> -- display it.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
@@ -75,20 +75,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">explicitNonDocumentedInBaseClassGetter</span>      <div class="features">@override, read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">explicitNonDocumentedInBaseClassGetter</span></section>
-      
-      <section class="desc markdown">
-  <p>Since I have a different doc, I should be documented.</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>Since I have a different doc, I should be documented.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitNonDocumentedInBaseClassGetter.html
@@ -75,14 +75,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">explicitNonDocumentedInBaseClassGetter</span>      <div class="features">@override, read-only</div>
-    </section>
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">explicitNonDocumentedInBaseClassGetter</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>Since I have a different doc, I should be documented.</p>
+</section>
 
-    <section class="desc markdown">
-      <p>Since I have a different doc, I should be documented.</p>
-    </section>
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -75,16 +75,21 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"></span>
-      <span class="name ">explicitSetter</span>      <div class="features">write-only</div>
-    </section>
 
-    <section class="desc markdown">
-      <p>Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.</p>
-    </section>
+        <section id="setter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">explicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List&lt;int&gt;</span> <span class="parameter-name">macTruck</span></span>)</span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property explicitSetter</h5>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -75,21 +75,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"></span>
+      <span class="name ">explicitSetter</span>      <div class="features">write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">explicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List&lt;int&gt;</span> <span class="parameter-name">macTruck</span></span>)</span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
@@ -74,16 +74,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">Set</span>
+          <span class="name ">finalProperty</span>          <div class="features">final</div>
+        </section>
+        <section class="desc markdown">
+          <p>This property has some docs, too.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">Set</span>
-      <span class="name ">finalProperty</span>      <div class="features">final</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>This property has some docs, too.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/finalProperty.html
@@ -77,15 +77,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">Set</span>
-        <span class="name ">finalProperty</span>        <div class="features">final</div>
+      <span class="name ">finalProperty</span>      <div class="features">final</div>
     </section>
 
     <section class="desc markdown">
       <p>This property has some docs, too.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
@@ -75,21 +75,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">implicitGetterExplicitSetter</span>      <div class="features">@override, inherited-getter, read / write</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">implicitGetterExplicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="implicitGetterExplicitSetter=-param-x"><span class="type-annotation">String</span> <span class="parameter-name">x</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitGetterExplicitSetter.html
@@ -75,16 +75,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">implicitGetterExplicitSetter</span>      <div class="features">@override, inherited-getter, read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">implicitGetterExplicitSetter</span>  <div class="features">inherited</div>
+</section>
+        
+        <section class="desc markdown">
+  <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">implicitGetterExplicitSetter=</span><span class="signature">(<wbr><span class="parameter" id="implicitGetterExplicitSetter=-param-x"><span class="type-annotation">String</span> <span class="parameter-name">x</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property implicitGetterExplicitSetter</h5>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
@@ -74,13 +74,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">Map</span>
+          <span class="name ">implicitReadWrite</span>          <div class="features">read / write</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">Map</span>
-      <span class="name ">implicitReadWrite</span>      <div class="features">read / write</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/implicitReadWrite.html
@@ -77,12 +77,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">Map</span>
-        <span class="name ">implicitReadWrite</span>        <div class="features">read / write</div>
+      <span class="name ">implicitReadWrite</span>      <div class="features">read / write</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Color/hashCode.html
+++ b/testing/test_package_docs/fake/Color/hashCode.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Color/hashCode.html
+++ b/testing/test_package_docs/fake/Color/hashCode.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Color/runtimeType.html
+++ b/testing/test_package_docs/fake/Color/runtimeType.html
@@ -70,17 +70,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Color/runtimeType.html
+++ b/testing/test_package_docs/fake/Color/runtimeType.html
@@ -70,11 +70,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ConstantClass/hashCode.html
+++ b/testing/test_package_docs/fake/ConstantClass/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ConstantClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstantClass/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ConstantClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstantClass/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ConstantClass/value.html
+++ b/testing/test_package_docs/fake/ConstantClass/value.html
@@ -67,12 +67,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">value</span>        <div class="features">final</div>
+      <span class="name ">value</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ConstantClass/value.html
+++ b/testing/test_package_docs/fake/ConstantClass/value.html
@@ -64,13 +64,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">value</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">value</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Cool/hashCode.html
+++ b/testing/test_package_docs/fake/Cool/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Cool/runtimeType.html
+++ b/testing/test_package_docs/fake/Cool/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Cool/runtimeType.html
+++ b/testing/test_package_docs/fake/Cool/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -125,15 +125,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name deprecated">DOWN</span>        =
-        <span class="constant-value">&#39;down&#39;</span>
-        
+      <span class="name deprecated">DOWN</span>      =
+      <span class="constant-value">&#39;down&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>Dynamic-typed down.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>Dynamic-typed down.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Doh/hashCode.html
+++ b/testing/test_package_docs/fake/Doh/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Doh/hashCode.html
+++ b/testing/test_package_docs/fake/Doh/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Doh/runtimeType.html
+++ b/testing/test_package_docs/fake/Doh/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Doh/runtimeType.html
+++ b/testing/test_package_docs/fake/Doh/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Doh/stackTrace.html
+++ b/testing/test_package_docs/fake/Doh/stackTrace.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">StackTrace</span>
+      <span class="name ">stackTrace</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">StackTrace</span>
-        <span class="name ">stackTrace</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Doh/stackTrace.html
+++ b/testing/test_package_docs/fake/Doh/stackTrace.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">StackTrace</span>
-      <span class="name ">stackTrace</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">StackTrace</span>
+          <span class="name ">stackTrace</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -210,9 +210,8 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="length" class="property inherited">
-          <span class="name"><a href="fake/SpecialList/length.html">length</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/SpecialList/length.html">length</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -227,7 +227,7 @@
           
           
   <div>
-            <span class="signature"><code>const <a href="fake/Foo2-class.html">Foo2</a>(0)</code></span>
+            <span class="signature"><code>const Foo2(0)</code></span>
           </div>
         </dd>
         <dt id="BAZ" class="constant">
@@ -238,7 +238,7 @@
           
           
   <div>
-            <span class="signature"><code>const <a href="fake/Foo2-class.html">Foo2</a>(1)</code></span>
+            <span class="signature"><code>const Foo2(1)</code></span>
           </div>
         </dd>
       </dl>

--- a/testing/test_package_docs/fake/Foo2/BAR-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAR-constant.html
@@ -69,7 +69,7 @@
     <section class="multi-line-signature">
         <span class="returntype"><a href="fake/Foo2-class.html">Foo2</a></span>
         <span class="name ">BAR</span>        =
-        <span class="constant-value">const <a href="fake/Foo2-class.html">Foo2</a>(0)</span>
+        <span class="constant-value">const Foo2(0)</span>
     </section>
 
         

--- a/testing/test_package_docs/fake/Foo2/BAZ-constant.html
+++ b/testing/test_package_docs/fake/Foo2/BAZ-constant.html
@@ -69,7 +69,7 @@
     <section class="multi-line-signature">
         <span class="returntype"><a href="fake/Foo2-class.html">Foo2</a></span>
         <span class="name ">BAZ</span>        =
-        <span class="constant-value">const <a href="fake/Foo2-class.html">Foo2</a>(1)</span>
+        <span class="constant-value">const Foo2(1)</span>
     </section>
 
         

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -66,11 +66,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Foo2/hashCode.html
+++ b/testing/test_package_docs/fake/Foo2/hashCode.html
@@ -66,17 +66,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Foo2/index.html
+++ b/testing/test_package_docs/fake/Foo2/index.html
@@ -65,13 +65,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">index</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">index</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Foo2/index.html
+++ b/testing/test_package_docs/fake/Foo2/index.html
@@ -68,12 +68,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">index</span>        <div class="features">final</div>
+      <span class="name ">index</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Foo2/runtimeType.html
+++ b/testing/test_package_docs/fake/Foo2/runtimeType.html
@@ -66,11 +66,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Foo2/runtimeType.html
+++ b/testing/test_package_docs/fake/Foo2/runtimeType.html
@@ -66,17 +66,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -66,11 +66,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -66,17 +66,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -66,11 +66,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -66,17 +66,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -170,9 +170,8 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="aImplementingThingyField" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="aImplementingThingyField=-param-_aImplementingThingyField"><span class="type-annotation"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span></span> </span>
-          </span>
+          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>
+          <span class="signature">&#8596; <a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
         </dt>
         <dd class="inherited">
           

--- a/testing/test_package_docs/fake/ImplementingThingy/hashCode.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ImplementingThingy/hashCode.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplementingThingy/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplementingThingy/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -167,9 +167,8 @@
           <div class="features">@override, read-only, inherited</div>
 </dd>
         <dt id="aImplementingThingyField" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="aImplementingThingyField=-param-_aImplementingThingyField"><span class="type-annotation"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span></span> </span>
-          </span>
+          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>
+          <span class="signature">&#8596; <a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
         </dt>
         <dd class="inherited">
           

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -164,7 +164,7 @@
         </dt>
         <dd class="inherited">
           BaseThingy2's doc for aImplementingThingy.
-          <div class="features">@override, read-only, inherited</div>
+          <div class="features">read-only, inherited</div>
 </dd>
         <dt id="aImplementingThingyField" class="property inherited">
           <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>

--- a/testing/test_package_docs/fake/ImplementingThingy2/hashCode.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ImplementingThingy2/hashCode.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplementingThingy2/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplementingThingy2/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -160,18 +160,16 @@ they are correct.</p>
 
       <dl class="properties">
         <dt id="explicitGetterImplicitSetter" class="property">
-          <span class="name"><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="explicitGetterImplicitSetter=-param-_explicitGetterImplicitSetter"><span class="type-annotation">List&lt;int&gt;</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span>
+          <span class="signature">&#8596; List&lt;int&gt;</span>
         </dt>
         <dd>
           Docs for explicitGetterImplicitSetter from ImplicitProperties.
           <div class="features">read / write</div>
 </dd>
         <dt id="explicitGetterSetterForInheriting" class="property">
-          <span class="name"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="explicitGetterSetterForInheriting=-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/ImplicitProperties/explicitGetterSetterForInheriting.html">explicitGetterSetterForInheriting</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           Explicit getter for inheriting.
@@ -186,18 +184,16 @@ they are correct.</p>
           <div class="features">read-only</div>
 </dd>
         <dt id="forInheriting" class="property">
-          <span class="name"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="forInheriting=-param-_forInheriting"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/ImplicitProperties/forInheriting.html">forInheriting</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           A simple property to inherit.
           <div class="features">read / write</div>
 </dd>
         <dt id="implicitGetterExplicitSetter" class="property">
-          <span class="name"><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="implicitGetterExplicitSetter=-param-_implicitGetterExplicitSetter"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/ImplicitProperties/implicitGetterExplicitSetter.html">implicitGetterExplicitSetter</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           Docs for implicitGetterExplicitSetter from ImplicitProperties.

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -69,15 +69,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">List&lt;int&gt;</span>
-        <span class="name ">explicitGetterImplicitSetter</span>        <div class="features">read / write</div>
+      <span class="name ">explicitGetterImplicitSetter</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>Docs for explicitGetterImplicitSetter from ImplicitProperties.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -66,16 +66,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">List&lt;int&gt;</span>
+          <span class="name ">explicitGetterImplicitSetter</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>Docs for explicitGetterImplicitSetter from ImplicitProperties.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">List&lt;int&gt;</span>
-      <span class="name ">explicitGetterImplicitSetter</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Docs for explicitGetterImplicitSetter from ImplicitProperties.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
@@ -67,32 +67,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">explicitGetterSetterForInheriting</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">explicitGetterSetterForInheriting</span></section>
-      
-      <section class="desc markdown">
-  <p>Explicit getter for inheriting.</p>
-</section>
-</section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">explicitGetterSetterForInheriting=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterSetterForInheriting=-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Explicit setter for inheriting.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Explicit getter for inheriting.
+Explicit setter for inheriting.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterSetterForInheriting.html
@@ -67,17 +67,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">explicitGetterSetterForInheriting</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Explicit getter for inheriting.
-Explicit setter for inheriting.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">explicitGetterSetterForInheriting</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>Explicit getter for inheriting.</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">explicitGetterSetterForInheriting=</span><span class="signature">(<wbr><span class="parameter" id="explicitGetterSetterForInheriting=-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>Explicit setter for inheriting.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property explicitGetterSetterForInheriting</h5>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
@@ -67,16 +67,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">double</span>
-      <span class="name ">explicitPartiallyDocumentedField</span>      <div class="features">read-only</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>but documented here.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">double</span>
+          <span class="name ">explicitPartiallyDocumentedField</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>but documented here.</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">explicitPartiallyDocumentedField=</span><span class="signature">(<wbr><span class="parameter" id="explicitPartiallyDocumentedField=-param-foo"><span class="type-annotation">double</span> <span class="parameter-name">foo</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>@nodoc here, you should never see this</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property explicitPartiallyDocumentedField</h5>

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitPartiallyDocumentedField.html
@@ -67,20 +67,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">double</span>
+      <span class="name ">explicitPartiallyDocumentedField</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">double</span>
-        <span class="name ">explicitPartiallyDocumentedField</span></section>
-      
-      <section class="desc markdown">
-  <p>but documented here.</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>but documented here.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
@@ -66,16 +66,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">forInheriting</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>A simple property to inherit.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">forInheriting</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>A simple property to inherit.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/forInheriting.html
@@ -69,15 +69,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">forInheriting</span>        <div class="features">read / write</div>
+      <span class="name ">forInheriting</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>A simple property to inherit.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
@@ -67,11 +67,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/hashCode.html
@@ -67,17 +67,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
@@ -69,15 +69,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">implicitGetterExplicitSetter</span>        <div class="features">read / write</div>
+      <span class="name ">implicitGetterExplicitSetter</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/implicitGetterExplicitSetter.html
@@ -66,16 +66,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">implicitGetterExplicitSetter</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">implicitGetterExplicitSetter</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Docs for implicitGetterExplicitSetter from ImplicitProperties.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -67,17 +67,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/runtimeType.html
@@ -67,11 +67,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Interface/hashCode.html
+++ b/testing/test_package_docs/fake/Interface/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Interface/hashCode.html
+++ b/testing/test_package_docs/fake/Interface/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Interface/runtimeType.html
+++ b/testing/test_package_docs/fake/Interface/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Interface/runtimeType.html
+++ b/testing/test_package_docs/fake/Interface/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -190,9 +190,8 @@ across... wait for it... two physical lines.</p>
 
       <dl class="properties">
         <dt id="aStringProperty" class="property">
-          <span class="name"><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="aStringProperty=-param-_aStringProperty"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/LongFirstLine/aStringProperty.html">aStringProperty</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           An instance string property. Readable and writable.
@@ -207,9 +206,8 @@ across... wait for it... two physical lines.</p>
           <div class="features">read-only</div>
 </dd>
         <dt id="onlySetter" class="property">
-          <span class="name"><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="onlySetter=-param-d"><span class="type-annotation">double</span> <span class="parameter-name">d</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd>
           Only a setter, with a single param, of type double.
@@ -224,9 +222,8 @@ across... wait for it... two physical lines.</p>
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="powers" class="property inherited">
-          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="powers=-param-_powers"><span class="type-annotation">List&lt;String&gt;</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
+          <span class="signature">&#8596; List&lt;String&gt;</span>
         </dt>
         <dd class="inherited">
           In the super class.
@@ -359,9 +356,8 @@ across... wait for it... two physical lines.</p>
 
       <dl class="properties">
         <dt id="meaningOfLife" class="property">
-          <span class="name"><a href="fake/LongFirstLine/meaningOfLife.html">meaningOfLife</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="meaningOfLife=-param-_meaningOfLife"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/LongFirstLine/meaningOfLife.html">meaningOfLife</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           A static int property.
@@ -376,9 +372,8 @@ across... wait for it... two physical lines.</p>
           <div class="features">read-only</div>
 </dd>
         <dt id="staticOnlySetter" class="property">
-          <span class="name"><a href="fake/LongFirstLine/staticOnlySetter.html">staticOnlySetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="staticOnlySetter=-param-thing"><span class="type-annotation">bool</span> <span class="parameter-name">thing</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/LongFirstLine/staticOnlySetter.html">staticOnlySetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -207,7 +207,7 @@ across... wait for it... two physical lines.</p>
 </dd>
         <dt id="onlySetter" class="property">
           <span class="name"><a href="fake/LongFirstLine/onlySetter.html">onlySetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="onlySetter=-param-d"><span class="type-annotation">double</span></span></span>
         </dt>
         <dd>
           Only a setter, with a single param, of type double.
@@ -373,7 +373,7 @@ across... wait for it... two physical lines.</p>
 </dd>
         <dt id="staticOnlySetter" class="property">
           <span class="name"><a href="fake/LongFirstLine/staticOnlySetter.html">staticOnlySetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="staticOnlySetter=-param-thing"><span class="type-annotation">bool</span></span></span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
+++ b/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
@@ -85,16 +85,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">aStringProperty</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>An instance string property. Readable and writable.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">aStringProperty</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>An instance string property. Readable and writable.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
+++ b/testing/test_package_docs/fake/LongFirstLine/aStringProperty.html
@@ -88,15 +88,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">aStringProperty</span>        <div class="features">read / write</div>
+      <span class="name ">aStringProperty</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>An instance string property. Readable and writable.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
@@ -86,20 +86,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">dynamicGetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">dynamic</span>
-        <span class="name ">dynamicGetter</span></section>
-      
-      <section class="desc markdown">
-  <p>Dynamic getter. Readable only.</p>
-</section>
-</section>
-      
-
-
+    <section class="desc markdown">
+      <p>Dynamic getter. Readable only.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/dynamicGetter.html
@@ -86,14 +86,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">dynamic</span>
-      <span class="name ">dynamicGetter</span>      <div class="features">read-only</div>
-    </section>
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">dynamic</span>
+          <span class="name ">dynamicGetter</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>Dynamic getter. Readable only.</p>
+</section>
 
-    <section class="desc markdown">
-      <p>Dynamic getter. Readable only.</p>
-    </section>
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
+++ b/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
@@ -85,16 +85,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">meaningOfLife</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>A static int property.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">meaningOfLife</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>A static int property.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
+++ b/testing/test_package_docs/fake/LongFirstLine/meaningOfLife.html
@@ -88,15 +88,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-        <span class="name ">meaningOfLife</span>        <div class="features">read / write</div>
+      <span class="name ">meaningOfLife</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>A static int property.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
@@ -86,16 +86,21 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"></span>
-      <span class="name ">onlySetter</span>      <div class="features">write-only</div>
-    </section>
 
-    <section class="desc markdown">
-      <p>Only a setter, with a single param, of type double.</p>
-    </section>
+        <section id="setter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">onlySetter=</span><span class="signature">(<wbr><span class="parameter" id="onlySetter=-param-d"><span class="type-annotation">double</span> <span class="parameter-name">d</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>Only a setter, with a single param, of type double.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property onlySetter</h5>

--- a/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/onlySetter.html
@@ -86,21 +86,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"></span>
+      <span class="name ">onlySetter</span>      <div class="features">write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">onlySetter=</span><span class="signature">(<wbr><span class="parameter" id="onlySetter=-param-d"><span class="type-annotation">double</span> <span class="parameter-name">d</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Only a setter, with a single param, of type double.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Only a setter, with a single param, of type double.</p>
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
@@ -86,17 +86,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">staticGetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">staticGetter</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticGetter.html
@@ -86,11 +86,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">staticGetter</span>      <div class="features">read-only</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">staticGetter</span>  
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
@@ -86,18 +86,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"></span>
+      <span class="name ">staticOnlySetter</span>      <div class="features">write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">staticOnlySetter=</span><span class="signature">(<wbr><span class="parameter" id="staticOnlySetter=-param-thing"><span class="type-annotation">bool</span> <span class="parameter-name">thing</span></span>)</span>
-      </section>
-      
-      </section>
-      
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
+++ b/testing/test_package_docs/fake/LongFirstLine/staticOnlySetter.html
@@ -86,13 +86,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype"></span>
-      <span class="name ">staticOnlySetter</span>      <div class="features">write-only</div>
-    </section>
 
+        <section id="setter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">staticOnlySetter=</span><span class="signature">(<wbr><span class="parameter" id="staticOnlySetter=-param-thing"><span class="type-annotation">bool</span> <span class="parameter-name">thing</span></span>)</span>
+          
+</section>
+        
+        
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property staticOnlySetter</h5>

--- a/testing/test_package_docs/fake/MixMeIn/hashCode.html
+++ b/testing/test_package_docs/fake/MixMeIn/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/MixMeIn/hashCode.html
+++ b/testing/test_package_docs/fake/MixMeIn/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/MixMeIn/runtimeType.html
+++ b/testing/test_package_docs/fake/MixMeIn/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/MixMeIn/runtimeType.html
+++ b/testing/test_package_docs/fake/MixMeIn/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -125,12 +125,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">NAME_SINGLEUNDERSCORE</span>        =
-        <span class="constant-value">&#39;yay bug hunting&#39;</span>
-        
+      <span class="name ">NAME_SINGLEUNDERSCORE</span>      =
+      <span class="constant-value">&#39;yay bug hunting&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -125,12 +125,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">NAME_WITH_TWO_UNDERSCORES</span>        =
-        <span class="constant-value">&#39;episode seven better be good; episode seven better be good; episode seven better be good; episode seven better be good&#39;</span>
-        
+      <span class="name ">NAME_WITH_TWO_UNDERSCORES</span>      =
+      <span class="constant-value">&#39;episode seven better be good; episode seven better be good; episode seven better be good; episode seven better be good&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Oops/hashCode.html
+++ b/testing/test_package_docs/fake/Oops/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Oops/message.html
+++ b/testing/test_package_docs/fake/Oops/message.html
@@ -65,12 +65,10 @@
 
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-        <span class="name ">message</span>        <div class="features">final</div>
+      <span class="name ">message</span>      <div class="features">final</div>
     </section>
 
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Oops/message.html
+++ b/testing/test_package_docs/fake/Oops/message.html
@@ -62,13 +62,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">message</span>          <div class="features">final</div>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">String</span>
-      <span class="name ">message</span>      <div class="features">final</div>
-    </section>
-
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/Oops/runtimeType.html
+++ b/testing/test_package_docs/fake/Oops/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/Oops/runtimeType.html
+++ b/testing/test_package_docs/fake/Oops/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -125,15 +125,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">PI</span>        =
-        <span class="constant-value">3.14159</span>
-        
+      <span class="name ">PI</span>      =
+      <span class="constant-value">3.14159</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>Constant property.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>Constant property.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -165,9 +165,8 @@
 
       <dl class="properties">
         <dt id="length" class="property">
-          <span class="name"><a href="fake/SpecialList/length.html">length</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/SpecialList/length.html">length</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">E</span>
-      <span class="name ">first</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">E</span>
+          <span class="name ">first</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">E</span>
+      <span class="name ">first</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">E</span>
-        <span class="name ">first</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isEmpty</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isEmpty</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isEmpty</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isEmpty</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">bool</span>
-      <span class="name ">isNotEmpty</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">bool</span>
+          <span class="name ">isNotEmpty</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">isNotEmpty</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">isNotEmpty</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Iterator&lt;E&gt;</span>
+      <span class="name ">iterator</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Iterator&lt;E&gt;</span>
-        <span class="name ">iterator</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Iterator&lt;E&gt;</span>
-      <span class="name ">iterator</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Iterator&lt;E&gt;</span>
+          <span class="name ">iterator</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">E</span>
+      <span class="name ">last</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">E</span>
-        <span class="name ">last</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">E</span>
-      <span class="name ">last</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">E</span>
+          <span class="name ">last</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -114,13 +114,27 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">length</span>      <div class="features">read / write</div>
-    </section>
-
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">length</span>  
+</section>
+        
+        
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">length=</span><span class="signature">(<wbr><span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span>)</span>
+          
+</section>
+        
+        
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property length</h5>

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -114,26 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">length</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">length</span></section>
-      
-      </section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">length=</span><span class="signature">(<wbr><span class="parameter" id="length=-param-length"><span class="type-annotation">int</span> <span class="parameter-name">length</span></span>)</span>
-      </section>
-      
-      </section>
-      
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Iterable&lt;E&gt;</span>
+      <span class="name ">reversed</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Iterable&lt;E&gt;</span>
-        <span class="name ">reversed</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Iterable&lt;E&gt;</span>
-      <span class="name ">reversed</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Iterable&lt;E&gt;</span>
+          <span class="name ">reversed</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -114,17 +114,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">E</span>
+      <span class="name ">single</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">E</span>
-        <span class="name ">single</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -114,11 +114,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">E</span>
-      <span class="name ">single</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">E</span>
+          <span class="name ">single</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -163,9 +163,8 @@
 
       <dl class="properties">
         <dt id="powers" class="property">
-          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="powers=-param-_powers"><span class="type-annotation">List&lt;String&gt;</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
+          <span class="signature">&#8596; List&lt;String&gt;</span>
         </dt>
         <dd>
           In the super class.

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/hashCode.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
@@ -64,16 +64,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">List&lt;String&gt;</span>
+          <span class="name ">powers</span>          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>In the super class.</p>
+        </section>
+                
 
-    <section class="multi-line-signature">
-      <span class="returntype">List&lt;String&gt;</span>
-      <span class="name ">powers</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>In the super class.</p>
-    </section>
-        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
@@ -67,15 +67,13 @@
 
     <section class="multi-line-signature">
       <span class="returntype">List&lt;String&gt;</span>
-        <span class="name ">powers</span>        <div class="features">read / write</div>
+      <span class="name ">powers</span>      <div class="features">read / write</div>
     </section>
 
     <section class="desc markdown">
       <p>In the super class.</p>
     </section>
-    
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
@@ -65,17 +65,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/runtimeType.html
@@ -65,11 +65,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -125,16 +125,16 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">UP</span>        =
-        <span class="constant-value">&#39;up&#39;</span>
-        
+      <span class="name ">UP</span>      =
+      <span class="constant-value">&#39;up&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>Up is a direction.</p>
+    <section class="desc markdown">
+      <p>Up is a direction.</p>
 <p>Getting up in the morning can be hard.</p>
-      </section>
-            
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -159,9 +159,8 @@
 
       <dl class="properties">
         <dt id="lengthX" class="property">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           Returns a length. <a href="fake/WithGetterAndSetter/lengthX.html">[...]</a>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/hashCode.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
@@ -63,34 +63,18 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">lengthX</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">lengthX</span></section>
-      
-      <section class="desc markdown">
-  <p>Returns a length.</p>
-<p>Throws some exception if used in the fourth dimension.</p>
-</section>
-</section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">lengthX=</span><span class="signature">(<wbr><span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Sets the length.</p>
+    <section class="desc markdown">
+      <p>Returns a length.</p>
+<p>Throws some exception if used in the fourth dimension.
+Sets the length.</p>
 <p>Throws if set to an imaginary number.</p>
-</section>
-</section>
-      
-
+    </section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/lengthX.html
@@ -63,19 +63,35 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">lengthX</span>      <div class="features">read / write</div>
-    </section>
-
-    <section class="desc markdown">
-      <p>Returns a length.</p>
-<p>Throws some exception if used in the fourth dimension.
-Sets the length.</p>
-<p>Throws if set to an imaginary number.</p>
-    </section>
+        <section id="getter">
         
-  </div> <!-- /.main-content -->
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">lengthX</span>  
+</section>
+        
+        <section class="desc markdown">
+  <p>Returns a length.</p>
+<p>Throws some exception if used in the fourth dimension.</p>
+</section>
+
+</section>
+        
+        <section id="setter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">void</span>
+            <span class="name ">lengthX=</span><span class="signature">(<wbr><span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>)</span>
+          
+</section>
+        
+        <section class="desc markdown">
+  <p>Sets the length.</p>
+<p>Throws if set to an imaginary number.</p>
+</section>
+
+</section>
+          </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>property lengthX</h5>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
@@ -63,11 +63,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/runtimeType.html
@@ -63,17 +63,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -125,16 +125,16 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">ZERO</span>        =
-        <span class="constant-value">0</span>
-        
+      <span class="name ">ZERO</span>      =
+      <span class="constant-value">0</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>A constant integer value,
+    <section class="desc markdown">
+      <p>A constant integer value,
 which is a bit redundant.</p>
-      </section>
-            
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -124,19 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">dynamicGetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">dynamic</span>
-        <span class="name ">dynamicGetter</span></section>
-      
-      <section class="desc markdown">
-  <p>A dynamic getter.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>A dynamic getter.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -124,16 +124,19 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section id="getter">
+    
     <section class="multi-line-signature">
       <span class="returntype">dynamic</span>
-      <span class="name ">dynamicGetter</span>      <div class="features">read-only</div>
-    </section>
-
+      <span class="name ">dynamicGetter</span>  
+</section>
+    
     <section class="desc markdown">
-      <p>A dynamic getter.</p>
-    </section>
-        
+  <p>A dynamic getter.</p>
+</section>
 
+</section>
+    
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -409,7 +409,7 @@ which is a bit redundant.
 </dd>
         <dt id="justSetter" class="property">
           <span class="name"><a href="fake/justSetter.html">justSetter</a></span>
-          <span class="signature">&#8592; </span>
+          <span class="signature">&#8592; <span class="parameter" id="justSetter=-param-value"><span class="type-annotation">int</span></span></span>
         </dt>
         <dd>
           Just a setter. No partner getter.

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -384,9 +384,8 @@ which is a bit redundant.
           <div class="features">read-only</div>
 </dd>
         <dt id="getterSetterNodocGetter" class="property">
-          <span class="name"><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="getterSetterNodocGetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></span>
+          <span class="signature">&#8592; int</span>
         </dt>
         <dd>
           Setter docs should be shown.
@@ -409,18 +408,16 @@ which is a bit redundant.
           <div class="features">read-only</div>
 </dd>
         <dt id="justSetter" class="property">
-          <span class="name"><a href="fake/justSetter.html">justSetter</a></span><span class="signature">
-            <span class="returntype parameter">&#8592;  <span class="parameter" id="justSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/justSetter.html">justSetter</a></span>
+          <span class="signature">&#8592; </span>
         </dt>
         <dd>
           Just a setter. No partner getter.
           <div class="features">write-only</div>
 </dd>
         <dt id="mapWithDynamicKeys" class="property">
-          <span class="name"><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="mapWithDynamicKeys=-param-_mapWithDynamicKeys"><span class="type-annotation">Map&lt;dynamic, String&gt;</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></span>
+          <span class="signature">&#8596; Map&lt;dynamic, String&gt;</span>
         </dt>
         <dd>
           
@@ -435,18 +432,16 @@ which is a bit redundant.
           <div class="features">final</div>
 </dd>
         <dt id="setAndGet" class="property">
-          <span class="name"><a href="fake/setAndGet.html">setAndGet</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="setAndGet=-param-thing"><span class="type-annotation">String</span> <span class="parameter-name">thing</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/setAndGet.html">setAndGet</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           The getter for setAndGet.
           <div class="features">read / write</div>
 </dd>
         <dt id="simpleProperty" class="property">
-          <span class="name"><a href="fake/simpleProperty.html">simpleProperty</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="simpleProperty=-param-_simpleProperty"><span class="type-annotation">String</span></span> </span>
-          </span>
+          <span class="name"><a href="fake/simpleProperty.html">simpleProperty</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
           Simple property

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -124,20 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">getterSetterNodocGetter</span>      <div class="features">write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">getterSetterNodocGetter=</span><span class="signature">(<wbr><span class="parameter" id="getterSetterNodocGetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Setter docs should be shown.</p>
-</section>
-</section>
-      
+    <section class="desc markdown">
+      <p>Setter docs should be shown.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -124,17 +124,21 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+
+    <section id="setter">
+    
     <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">getterSetterNodocGetter</span>      <div class="features">write-only</div>
-    </section>
-
+      <span class="returntype">void</span>
+        <span class="name ">getterSetterNodocGetter=</span><span class="signature">(<wbr><span class="parameter" id="getterSetterNodocGetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
+      
+</section>
+    
     <section class="desc markdown">
-      <p>Setter docs should be shown.</p>
-    </section>
-        
+  <p>Setter docs should be shown.</p>
+</section>
 
-  </div> <!-- /.main-content -->
+</section>
+      </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>top-level property getterSetterNodocGetter</h5>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -124,19 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">getterSetterNodocSetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">getterSetterNodocSetter</span></section>
-      
-      <section class="desc markdown">
-  <p>Getter docs should be shown.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Getter docs should be shown.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -124,16 +124,19 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section id="getter">
+    
     <section class="multi-line-signature">
       <span class="returntype">int</span>
-      <span class="name ">getterSetterNodocSetter</span>      <div class="features">read-only</div>
-    </section>
-
+      <span class="name ">getterSetterNodocSetter</span>  
+</section>
+    
     <section class="desc markdown">
-      <p>Getter docs should be shown.</p>
-    </section>
-        
+  <p>Getter docs should be shown.</p>
+</section>
 
+</section>
+    
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -125,15 +125,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">greatAnnotation</span>        =
-        <span class="constant-value">&#39;great&#39;</span>
-        
+      <span class="name ">greatAnnotation</span>      =
+      <span class="constant-value">&#39;great&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>This is a great thing.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>This is a great thing.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -125,15 +125,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">greatestAnnotation</span>        =
-        <span class="constant-value">&#39;greatest&#39;</span>
-        
+      <span class="name ">greatestAnnotation</span>      =
+      <span class="constant-value">&#39;greatest&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>This is the greatest thing.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>This is the greatest thing.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -125,15 +125,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">incorrectDocReference</span>        =
-        <span class="constant-value">&#39;doh&#39;</span>
-        
+      <span class="name ">incorrectDocReference</span>      =
+      <span class="constant-value">&#39;doh&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>Referencing something that <code>doesn't exist</code>.</p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>Referencing something that <code>doesn't exist</code>.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -124,16 +124,19 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section id="getter">
+    
     <section class="multi-line-signature">
       <span class="returntype">bool</span>
-      <span class="name ">justGetter</span>      <div class="features">read-only</div>
-    </section>
-
+      <span class="name ">justGetter</span>  
+</section>
+    
     <section class="desc markdown">
-      <p>Just a getter. No partner setter.</p>
-    </section>
-        
+  <p>Just a getter. No partner setter.</p>
+</section>
 
+</section>
+    
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -124,19 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">justGetter</span>      <div class="features">read-only</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">bool</span>
-        <span class="name ">justGetter</span></section>
-      
-      <section class="desc markdown">
-  <p>Just a getter. No partner setter.</p>
-</section>
-</section>
-      
-
+    <section class="desc markdown">
+      <p>Just a getter. No partner setter.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -124,20 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype"></span>
+      <span class="name ">justSetter</span>      <div class="features">write-only</div>
+    </section>
 
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">justSetter=</span><span class="signature">(<wbr><span class="parameter" id="justSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>Just a setter. No partner getter.</p>
-</section>
-</section>
-      
+    <section class="desc markdown">
+      <p>Just a setter. No partner getter.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -124,17 +124,21 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+
+    <section id="setter">
+    
     <section class="multi-line-signature">
-      <span class="returntype"></span>
-      <span class="name ">justSetter</span>      <div class="features">write-only</div>
-    </section>
-
+      <span class="returntype">void</span>
+        <span class="name ">justSetter=</span><span class="signature">(<wbr><span class="parameter" id="justSetter=-param-value"><span class="type-annotation">int</span> <span class="parameter-name">value</span></span>)</span>
+      
+</section>
+    
     <section class="desc markdown">
-      <p>Just a setter. No partner getter.</p>
-    </section>
-        
+  <p>Just a setter. No partner getter.</p>
+</section>
 
-  </div> <!-- /.main-content -->
+</section>
+      </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>top-level property justSetter</h5>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -124,13 +124,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">Map&lt;dynamic, String&gt;</span>
-        <span class="name ">mapWithDynamicKeys</span>        <div class="features">read / write</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">Map&lt;dynamic, String&gt;</span>
+      <span class="name ">mapWithDynamicKeys</span>      <div class="features">read / write</div>
+    </section>
 
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -123,13 +123,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">Map&lt;dynamic, String&gt;</span>
       <span class="name ">mapWithDynamicKeys</span>      <div class="features">read / write</div>
     </section>
-
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -124,16 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name deprecated">meaningOfLife</span>        <div class="features">final</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name deprecated">meaningOfLife</span>      <div class="features">final</div>
+    </section>
 
-      <section class="desc markdown">
-        <p>Final property.</p>
-      </section>
-      
-
+    <section class="desc markdown">
+      <p>Final property.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -123,16 +123,15 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">int</span>
       <span class="name deprecated">meaningOfLife</span>      <div class="features">final</div>
     </section>
-
     <section class="desc markdown">
       <p>Final property.</p>
     </section>
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -125,12 +125,12 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">required</span>        =
-        <span class="constant-value">&#39;required&#39;</span>
-        
+      <span class="name ">required</span>      =
+      <span class="constant-value">&#39;required&#39;</span>
+      
     </section>
 
-            
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -124,18 +124,33 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section id="getter">
+    
     <section class="multi-line-signature">
       <span class="returntype">String</span>
-      <span class="name ">setAndGet</span>      <div class="features">read / write</div>
-    </section>
-
+      <span class="name ">setAndGet</span>  
+</section>
+    
     <section class="desc markdown">
-      <p>The getter for setAndGet.
-The setter for setAndGet.</p>
-    </section>
-        
+  <p>The getter for setAndGet.</p>
+</section>
 
-  </div> <!-- /.main-content -->
+</section>
+    
+    <section id="setter">
+    
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+        <span class="name ">setAndGet=</span><span class="signature">(<wbr><span class="parameter" id="setAndGet=-param-thing"><span class="type-annotation">String</span> <span class="parameter-name">thing</span></span>)</span>
+      
+</section>
+    
+    <section class="desc markdown">
+  <p>The setter for setAndGet.</p>
+</section>
+
+</section>
+      </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <h5>top-level property setAndGet</h5>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -124,31 +124,16 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">setAndGet</span>      <div class="features">read / write</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">setAndGet</span></section>
-      
-      <section class="desc markdown">
-  <p>The getter for setAndGet.</p>
-</section>
-</section>
-      
-
-      <section id="setter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">void</span>
-          <span class="name ">setAndGet=</span><span class="signature">(<wbr><span class="parameter" id="setAndGet=-param-thing"><span class="type-annotation">String</span> <span class="parameter-name">thing</span></span>)</span>
-      </section>
-      
-      <section class="desc markdown">
-  <p>The setter for setAndGet.</p>
-</section>
-</section>
-      
+    <section class="desc markdown">
+      <p>The getter for setAndGet.
+The setter for setAndGet.</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -124,16 +124,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">String</span>
-        <span class="name ">simpleProperty</span>        <div class="features">read / write</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">simpleProperty</span>      <div class="features">read / write</div>
+    </section>
 
-      <section class="desc markdown">
-        <p>Simple property</p>
-      </section>
-      
-
+    <section class="desc markdown">
+      <p>Simple property</p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -123,16 +123,15 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">String</span>
       <span class="name ">simpleProperty</span>      <div class="features">read / write</div>
     </section>
-
     <section class="desc markdown">
       <p>Simple property</p>
     </section>
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -125,15 +125,15 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
     <section class="multi-line-signature">
-        <span class="name ">testingCodeSyntaxInOneLiners</span>        =
-        <span class="constant-value">&#39;fantastic&#39;</span>
-        
+      <span class="name ">testingCodeSyntaxInOneLiners</span>      =
+      <span class="constant-value">&#39;fantastic&#39;</span>
+      
     </section>
 
-      <section class="desc markdown">
-        <p>These are code syntaxes: <code>true</code> and <code>false</code></p>
-      </section>
-            
+    <section class="desc markdown">
+      <p>These are code syntaxes: <code>true</code> and <code>false</code></p>
+    </section>
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">int</span>
-      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/hashCode.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">hashCode</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">hashCode</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
@@ -62,11 +62,15 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-    <section class="multi-line-signature">
-      <span class="returntype">Type</span>
-      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
-    </section>
-
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
         
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/runtimeType.html
@@ -62,17 +62,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
+    <section class="multi-line-signature">
+      <span class="returntype">Type</span>
+      <span class="name ">runtimeType</span>      <div class="features">read-only, inherited</div>
+    </section>
 
-      <section id="getter">
-      
-      <section class="multi-line-signature">
-        <span class="returntype">Type</span>
-        <span class="name ">runtimeType</span></section>
-      
-      </section>
-      
-
-
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/two_exports/BaseClass-class.html
+++ b/testing/test_package_docs/two_exports/BaseClass-class.html
@@ -100,9 +100,8 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="lengthX" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           Returns a length. <a href="fake/WithGetterAndSetter/lengthX.html">[...]</a>

--- a/testing/test_package_docs/two_exports/ExtendingClass-class.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass-class.html
@@ -102,9 +102,8 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="lengthX" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;  <span class="parameter" id="lengthX=-param-_length"><span class="type-annotation">int</span> <span class="parameter-name">_length</span></span>  </span>
-          </span>
+          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd class="inherited">
           Returns a length. <a href="fake/WithGetterAndSetter/lengthX.html">[...]</a>

--- a/testing/test_package_docs/two_exports/topLevelVariable.html
+++ b/testing/test_package_docs/two_exports/topLevelVariable.html
@@ -53,13 +53,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-
     <section class="multi-line-signature">
       <span class="returntype">int</span>
       <span class="name ">topLevelVariable</span>      <div class="features">read / write</div>
     </section>
-
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/two_exports/topLevelVariable.html
+++ b/testing/test_package_docs/two_exports/topLevelVariable.html
@@ -54,13 +54,12 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
 
-      <section class="multi-line-signature">
-        <span class="returntype">int</span>
-        <span class="name ">topLevelVariable</span>        <div class="features">read / write</div>
-      </section>
+    <section class="multi-line-signature">
+      <span class="returntype">int</span>
+      <span class="name ">topLevelVariable</span>      <div class="features">read / write</div>
+    </section>
 
-      
-
+        
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/two_exports/two_exports-library.html
+++ b/testing/test_package_docs/two_exports/two_exports-library.html
@@ -81,9 +81,8 @@
 
       <dl class="properties">
         <dt id="topLevelVariable" class="property">
-          <span class="name"><a href="two_exports/topLevelVariable.html">topLevelVariable</a></span><span class="signature">
-            <span class="returntype parameter">&#8596;   <span class="parameter" id="topLevelVariable=-param-_topLevelVariable"><span class="type-annotation">int</span></span> </span>
-          </span>
+          <span class="name"><a href="two_exports/topLevelVariable.html">topLevelVariable</a></span>
+          <span class="signature">&#8596; int</span>
         </dt>
         <dd>
           


### PR DESCRIPTION
Fixes #1525, #1286.  This is the second breakout from #1524.

The public/private refactoring in #1524 required a large number of renames to methods used by the templates.  It was extremely difficult to change those without the verification provided by a new version of mustache4dart that will raise an exception on a missing method, so updated that.  That in turn revealed more bugs and problems with the use of templates, as well as some inconsistencies in output.  These are fixed here.

To make reviewing the output changes easier I have the old and new versions of the test package docs serving.  I suggest comparing the members of "ClassWithUnusualProperties" as properties have the most significant changes here -- most others are whitespace or HTML metadata.

old:
http://jcollins1.pdx.corp.google.com:8000/fake/ClassWithUnusualProperties-class.html
new:
http://jcollins1.pdx.corp.google.com:8001/fake/ClassWithUnusualProperties-class.html


