### PR TITLE
Fix truncation in middle of links for constants

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -84,9 +84,7 @@ class ElementType {
       } else {
         typeArguments = type.typeFormals.map((f) => f.type);
       }
-      return typeArguments
-          .map(_getElementTypeFrom)
-          .toList();
+      return typeArguments.map(_getElementTypeFrom).toList();
     } else {
       return (_type as ParameterizedType)
           .typeArguments

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -245,9 +245,9 @@ class Accessor extends ModelElement
 
   /// Call exactly once to set the enclosing combo for this Accessor.
   set enclosingCombo(GetterSetterCombo combo) {
-      assert(_enclosingCombo == null || combo == _enclosingCombo);
-        assert(combo != null);
-      _enclosingCombo = combo;
+    assert(_enclosingCombo == null || combo == _enclosingCombo);
+    assert(combo != null);
+    _enclosingCombo = combo;
   }
 
   bool get isSynthetic => element.isSynthetic;
@@ -274,7 +274,8 @@ class Accessor extends ModelElement
   @override
   String get computeDocumentationComment {
     if (isSynthetic) {
-      String docComment = (element as PropertyAccessorElement).variable.documentationComment;
+      String docComment =
+          (element as PropertyAccessorElement).variable.documentationComment;
       // If we're a setter, only display something if we have something different than the getter.
       // TODO(jcollins-g): modify analyzer to do this itself?
       if (isGetter ||
@@ -1452,7 +1453,7 @@ abstract class GetterSetterCombo implements ModelElement {
   String get constantValue => linkifyWithModelType(constantValueBase);
 
   String get constantValueTruncated =>
-       linkifyWithModelType(truncateString(constantValueBase, 200));
+      linkifyWithModelType(truncateString(constantValueBase, 200));
 
   /// Returns true if both accessors are synthetic.
   bool get hasSyntheticAccessors {
@@ -2876,15 +2877,15 @@ abstract class ModelElement extends Nameable
         Library lib;
         // TODO(jcollins-g): get rid of dynamic special casing
         if (element.kind != ElementKind.DYNAMIC) {
-          lib = _findOrCreateEnclosingLibraryFor((element as dynamic).type.element);
+          lib = _findOrCreateEnclosingLibraryFor(
+              (element as dynamic).type.element);
         }
-        _modelType = new ElementType(
-            (element as dynamic).type, new ModelElement.from((element as dynamic).type.element, lib));
+        _modelType = new ElementType((element as dynamic).type,
+            new ModelElement.from((element as dynamic).type.element, lib));
       }
     }
     return _modelType;
   }
-
 
   @override
   String get name => element.name;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1454,7 +1454,6 @@ abstract class GetterSetterCombo implements ModelElement {
   String get constantValueTruncated =>
        linkifyWithModelType(truncateString(constantValueBase, 200));
 
-
   /// Returns true if both accessors are synthetic.
   bool get hasSyntheticAccessors {
     if ((hasPublicGetter && getter.element.isSynthetic) ||

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -44,10 +44,11 @@ String stripComments(String str) {
 
 String truncateString(String str, int length) {
   if (str != null && str.length > length) {
-    return str.substring(0, length) + '…';
-  } else {
-    return str;
+    // Do not call this on unsanitized HTML.
+    assert(!str.contains("<"));
+    return '${str.substring(0, length)}…';
   }
+  return str;
 }
 
 String pluralize(String word, int count) => count == 1 ? word : '${word}s';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,4 +350,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.7.0"
+  dart: ">=1.23.0 <=2.0.0-dev.8.0"

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -697,7 +697,7 @@ void main() {
     });
 
     test('correctly finds all the classes', () {
-      expect(classes, hasLength(22));
+      expect(classes, hasLength(24));
     });
 
     test('abstract', () {
@@ -1711,7 +1711,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
         prettyColorsConstant,
         deprecated;
 
-    Field aStaticConstField;
+    Field aStaticConstField, aName;
 
     setUp(() {
       greenConstant =
@@ -1723,9 +1723,15 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       cat = exLibrary.constants.firstWhere((c) => c.name == 'MY_CAT');
       deprecated =
           exLibrary.constants.firstWhere((c) => c.name == 'deprecated');
+      Class Dog = exLibrary.allClasses.firstWhere((c) => c.name == 'Dog');
       aStaticConstField =
-          exLibrary.allClasses.firstWhere((c) => c.name == 'Dog')
-              .allFields.firstWhere((f) => f.name == 'aStaticConstField');
+          Dog.allFields.firstWhere((f) => f.name == 'aStaticConstField');
+      aName = Dog.allFields.firstWhere((f) => f.name == 'aName');
+    });
+
+    test('substrings of the constant values type are not linked (#1535)', () {
+      expect(aName.constantValue,
+          'const ExtendedShortName(&quot;hello there&quot;)');
     });
 
     test('constant field values are escaped', () {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1711,6 +1711,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
         prettyColorsConstant,
         deprecated;
 
+    Field aStaticConstField;
+
     setUp(() {
       greenConstant =
           exLibrary.constants.firstWhere((c) => c.name == 'COLOR_GREEN');
@@ -1721,6 +1723,13 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       cat = exLibrary.constants.firstWhere((c) => c.name == 'MY_CAT');
       deprecated =
           exLibrary.constants.firstWhere((c) => c.name == 'deprecated');
+      aStaticConstField =
+          exLibrary.allClasses.firstWhere((c) => c.name == 'Dog')
+              .allFields.firstWhere((f) => f.name == 'aStaticConstField');
+    });
+
+    test('constant field values are escaped', () {
+      expect(aStaticConstField.constantValue, '&quot;A Constant Dog&quot;');
     });
 
     test('has a fully qualified name', () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -67,6 +67,15 @@ typedef String processMessage<T>(String msg);
 
 typedef String ParameterizedTypedef<T>(T msg, int foo);
 
+class ShortName {
+  final String aParameter;
+  const ShortName(this.aParameter);
+}
+
+class ExtendedShortName extends ShortName {
+  const ExtendedShortName(String aParameter) : super(aParameter);
+}
+
 /// Referencing [processMessage] (or other things) here should not break
 /// enum constants ala #1445
 enum Animal {
@@ -245,6 +254,9 @@ class Dog implements Cat, E {
 
   final int aFinalField;
   static const String aStaticConstField = "A Constant Dog";
+
+  /// Verify link substitution in constants (#1535)
+  static const ShortName aName = const ExtendedShortName("hello there");
 
   @protected
   final int aProtectedFinalField;

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/COLOR-constant.html
+++ b/testing/test_package_docs/ex/COLOR-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/COLOR_GREEN-constant.html
+++ b/testing/test_package_docs/ex/COLOR_GREEN-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
+++ b/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
+++ b/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/Cat-class.html
+++ b/testing/test_package_docs/ex/Cat-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/CatString-class.html
+++ b/testing/test_package_docs/ex/CatString-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -410,7 +410,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           
           
   <div>
-            <span class="signature"><code>"A Constant Dog"</code></span>
+            <span class="signature"><code>&quot;A Constant Dog&quot;</code></span>
           </div>
         </dd>
       </dl>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
@@ -402,6 +404,17 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <h2>Constants</h2>
 
       <dl class="properties">
+        <dt id="aName" class="constant">
+          <span class="name "><a href="ex/Dog/aName-constant.html">aName</a></span>
+          <span class="signature">&#8594; <a href="ex/ShortName-class.html">ShortName</a></span>
+        </dt>
+        <dd>
+          Verify link substitution in constants (#1535)
+          
+  <div>
+            <span class="signature"><code>const ExtendedShortName(&quot;hello there&quot;)</code></span>
+          </div>
+        </dd>
         <dt id="aStaticConstField" class="constant">
           <span class="name "><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></span>
           <span class="signature">&#8594; String</span>
@@ -463,6 +476,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/aName-constant.html
+++ b/testing/test_package_docs/ex/Dog/aName-constant.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aName constant from the Dog class, for the Dart programming language.">
+  <title>aName constant - Dog class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/Dog-class.html">Dog</a></li>
+    <li class="self-crumb">constant aName</li>
+  </ol>
+  <div class="self-name">aName</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class Dog</h5>
+    <ol>
+      <li class="section-title"><a href="ex/Dog-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/Dog/Dog.html">Dog</a></li>
+      <li><a class="deprecated" href="ex/Dog/Dog.deprecatedCreate.html">deprecatedCreate</a></li>
+    
+      <li class="section-title">
+        <a href="ex/Dog-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/Dog/aFinalField.html">aFinalField</a></li>
+      <li><a href="ex/Dog/aGetterReturningRandomThings.html">aGetterReturningRandomThings</a></li>
+      <li><a href="ex/Dog/aProtectedFinalField.html">aProtectedFinalField</a></li>
+      <li><a class="deprecated" href="ex/Dog/deprecatedField.html">deprecatedField</a></li>
+      <li><a class="deprecated" href="ex/Dog/deprecatedGetter.html">deprecatedGetter</a></li>
+      <li><a class="deprecated" href="ex/Dog/deprecatedSetter.html">deprecatedSetter</a></li>
+      <li><a href="ex/Dog/isImplemented.html">isImplemented</a></li>
+      <li><a href="ex/Dog/name.html">name</a></li>
+      <li class="inherited"><a href="ex/Dog/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Dog/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/Dog-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/Dog/abstractMethod.html">abstractMethod</a></li>
+      <li><a href="ex/Dog/foo.html">foo</a></li>
+      <li><a class="deprecated" href="ex/Dog/getAnotherClassD.html">getAnotherClassD</a></li>
+      <li><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></li>
+      <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
+      <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
+      <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
+      <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/Dog/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="ex/Dog-class.html#operators">Operators</a></li>
+      <li><a href="ex/Dog/operator_equals.html">operator ==</a></li>
+    
+      <li class="section-title"><a href="ex/Dog-class.html#static-properties">Static properties</a></li>
+      <li><a href="ex/Dog/somethingTasty.html">somethingTasty</a></li>
+      <li><a href="ex/Dog/staticGetterSetter.html">staticGetterSetter</a></li>
+    
+      <li class="section-title"><a href="ex/Dog-class.html#static-methods">Static methods</a></li>
+      <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
+    
+      <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
+      <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    <section class="multi-line-signature">
+        <span class="returntype"><a href="ex/ShortName-class.html">ShortName</a></span>
+        <span class="name ">aName</span>        =
+        <span class="constant-value">const ExtendedShortName(&quot;hello there&quot;)</span>
+    </section>
+
+    <section class="desc markdown">
+      <p>Verify link substitution in constants (#1535)</p>
+    </section>
+        
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>property aName</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -90,7 +90,7 @@
     <section class="multi-line-signature">
         <span class="returntype">String</span>
         <span class="name ">aStaticConstField</span>        =
-        <span class="constant-value">"A Constant Dog"</span>
+        <span class="constant-value">&quot;A Constant Dog&quot;</span>
     </section>
 
         

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-left-->

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/hashCode.html
+++ b/testing/test_package_docs/ex/Dog/hashCode.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Dog/noSuchMethod.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/runtimeType.html
+++ b/testing/test_package_docs/ex/Dog/runtimeType.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/toString.html
+++ b/testing/test_package_docs/ex/Dog/toString.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/withMacro.html
+++ b/testing/test_package_docs/ex/Dog/withMacro.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -81,6 +81,7 @@
       <li><a class="deprecated" href="ex/Dog/createDog.html">createDog</a></li>
     
       <li class="section-title"><a href="ex/Dog-class.html#constants">Constants</a></li>
+      <li><a href="ex/Dog/aName-constant.html">aName</a></li>
       <li><a href="ex/Dog/aStaticConstField-constant.html">aStaticConstField</a></li>
     </ol>
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_docs/ex/E-class.html
+++ b/testing/test_package_docs/ex/E-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ExtendedShortName-class.html
+++ b/testing/test_package_docs/ex/ExtendedShortName-class.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ExtendedShortName class from the ex library, for the Dart programming language.">
+  <title>ExtendedShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li class="self-crumb">class ExtendedShortName</li>
+  </ol>
+  <div class="self-name">ExtendedShortName</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>library ex</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ex-library.html#classes">Classes</a></li>
+      <li><a href="ex/Apple-class.html">Apple</a></li>
+      <li><a href="ex/aThingToDo-class.html">aThingToDo</a></li>
+      <li><a href="ex/B-class.html">B</a></li>
+      <li><a href="ex/Cat-class.html">Cat</a></li>
+      <li><a href="ex/CatString-class.html">CatString</a></li>
+      <li><a href="ex/ConstantCat-class.html">ConstantCat</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
+      <li><a href="ex/Dog-class.html">Dog</a></li>
+      <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
+      <li><a href="ex/F-class.html">F</a></li>
+      <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
+      <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
+      <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/Klass-class.html">Klass</a></li>
+      <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
+      <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
+      <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
+      <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
+      <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
+      <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+      <li><a href="ex/WithGenericSub-class.html">WithGenericSub</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#constants">Constants</a></li>
+      <li><a href="ex/COLOR-constant.html">COLOR</a></li>
+      <li><a href="ex/COLOR_GREEN-constant.html">COLOR_GREEN</a></li>
+      <li><a href="ex/COLOR_ORANGE-constant.html">COLOR_ORANGE</a></li>
+      <li><a href="ex/COMPLEX_COLOR-constant.html">COMPLEX_COLOR</a></li>
+      <li><a href="ex/deprecated-constant.html">deprecated</a></li>
+      <li><a href="ex/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="ex/incorrectDocReferenceFromEx-constant.html">incorrectDocReferenceFromEx</a></li>
+      <li><a href="ex/MY_CAT-constant.html">MY_CAT</a></li>
+      <li><a href="ex/PRETTY_COLORS-constant.html">PRETTY_COLORS</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#properties">Properties</a></li>
+      <li><a class="deprecated" href="ex/deprecatedField.html">deprecatedField</a></li>
+      <li><a class="deprecated" href="ex/deprecatedGetter.html">deprecatedGetter</a></li>
+      <li><a class="deprecated" href="ex/deprecatedSetter.html">deprecatedSetter</a></li>
+      <li><a href="ex/number.html">number</a></li>
+      <li><a href="ex/y.html">y</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#functions">Functions</a></li>
+      <li><a href="ex/function1.html">function1</a></li>
+      <li><a href="ex/genericFunction.html">genericFunction</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#enums">Enums</a></li>
+      <li><a href="ex/Animal-class.html">Animal</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#typedefs">Typedefs</a></li>
+      <li><a href="ex/aComplexTypedef.html">aComplexTypedef</a></li>
+      <li><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a></li>
+      <li><a href="ex/processMessage.html">processMessage</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#exceptions">Exceptions</a></li>
+      <li><a href="ex/MyError-class.html">MyError</a></li>
+      <li><a href="ex/MyErrorImplements-class.html">MyErrorImplements</a></li>
+      <li><a href="ex/MyException-class.html">MyException</a></li>
+      <li><a href="ex/MyExceptionImplements-class.html">MyExceptionImplements</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    
+    <section>
+      <dl class="dl-horizontal">
+        <dt>Inheritance</dt>
+        <dd><ul class="gt-separated dark clazz-relationships">
+          <li>Object</li>
+          <li><a href="ex/ShortName-class.html">ShortName</a></li>
+          <li>ExtendedShortName</li>
+        </ul></dd>
+
+
+
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ExtendedShortName" class="callable">
+          <span class="name"><a href="ex/ExtendedShortName/ExtendedShortName.html">ExtendedShortName</a></span><span class="signature">(<span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)</span>
+        </dt>
+        <dd>
+          
+          <div class="constructor-modifier features">const</div>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="aParameter" class="property inherited">
+          <span class="name"><a href="ex/ShortName/aParameter.html">aParameter</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">final, inherited</div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/ShortName/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="ex/ShortName/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="ex/ShortName/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="ex/ShortName/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>class ExtendedShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ExtendedShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ExtendedShortName/ExtendedShortName.html">ExtendedShortName</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/ExtendedShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ExtendedShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ExtendedShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ExtendedShortName/ExtendedShortName.html
+++ b/testing/test_package_docs/ex/ExtendedShortName/ExtendedShortName.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ExtendedShortName constructor from the Class ExtendedShortName class from the ex library, for the Dart programming language.">
+  <title>ExtendedShortName constructor - ExtendedShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
+    <li class="self-crumb">const constructor ExtendedShortName</li>
+  </ol>
+  <div class="self-name">ExtendedShortName</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ExtendedShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ExtendedShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ExtendedShortName/ExtendedShortName.html">ExtendedShortName</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/ExtendedShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ExtendedShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ExtendedShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      const
+            <span class="name ">ExtendedShortName</span>(<wbr><span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>constructor ExtendedShortName</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs/ex/HasAnnotation-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/Helper-class.html
+++ b/testing/test_package_docs/ex/Helper-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/MY_CAT-constant.html
+++ b/testing/test_package_docs/ex/MY_CAT-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/MyError-class.html
+++ b/testing/test_package_docs/ex/MyError-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/MyException-class.html
+++ b/testing/test_package_docs/ex/MyException-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
+++ b/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ParameterizedTypedef.html
+++ b/testing/test_package_docs/ex/ParameterizedTypedef.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -208,7 +208,7 @@
           
           
   <div>
-            <span class="signature"><code>const ShapeType._internal("Ellipse")</code></span>
+            <span class="signature"><code>const ShapeType._internal(&quot;Ellipse&quot;)</code></span>
           </div>
         </dd>
         <dt id="rect" class="constant">
@@ -219,7 +219,7 @@
           
           
   <div>
-            <span class="signature"><code>const ShapeType._internal("Rect")</code></span>
+            <span class="signature"><code>const ShapeType._internal(&quot;Rect&quot;)</code></span>
           </div>
         </dd>
       </dl>

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/ellipse-constant.html
@@ -67,7 +67,7 @@
     <section class="multi-line-signature">
         <span class="returntype"><a href="ex/ShapeType-class.html">ShapeType</a></span>
         <span class="name ">ellipse</span>        =
-        <span class="constant-value">const ShapeType._internal("Ellipse")</span>
+        <span class="constant-value">const ShapeType._internal(&quot;Ellipse&quot;)</span>
     </section>
 
         

--- a/testing/test_package_docs/ex/ShapeType/rect-constant.html
+++ b/testing/test_package_docs/ex/ShapeType/rect-constant.html
@@ -67,7 +67,7 @@
     <section class="multi-line-signature">
         <span class="returntype"><a href="ex/ShapeType-class.html">ShapeType</a></span>
         <span class="name ">rect</span>        =
-        <span class="constant-value">const ShapeType._internal("Rect")</span>
+        <span class="constant-value">const ShapeType._internal(&quot;Rect&quot;)</span>
     </section>
 
         

--- a/testing/test_package_docs/ex/ShortName-class.html
+++ b/testing/test_package_docs/ex/ShortName-class.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ShortName class from the ex library, for the Dart programming language.">
+  <title>ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li class="self-crumb">class ShortName</li>
+  </ol>
+  <div class="self-name">ShortName</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>library ex</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ex-library.html#classes">Classes</a></li>
+      <li><a href="ex/Apple-class.html">Apple</a></li>
+      <li><a href="ex/aThingToDo-class.html">aThingToDo</a></li>
+      <li><a href="ex/B-class.html">B</a></li>
+      <li><a href="ex/Cat-class.html">Cat</a></li>
+      <li><a href="ex/CatString-class.html">CatString</a></li>
+      <li><a href="ex/ConstantCat-class.html">ConstantCat</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
+      <li><a href="ex/Dog-class.html">Dog</a></li>
+      <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
+      <li><a href="ex/F-class.html">F</a></li>
+      <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
+      <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
+      <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/Klass-class.html">Klass</a></li>
+      <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
+      <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
+      <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
+      <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
+      <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
+      <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+      <li><a href="ex/WithGenericSub-class.html">WithGenericSub</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#constants">Constants</a></li>
+      <li><a href="ex/COLOR-constant.html">COLOR</a></li>
+      <li><a href="ex/COLOR_GREEN-constant.html">COLOR_GREEN</a></li>
+      <li><a href="ex/COLOR_ORANGE-constant.html">COLOR_ORANGE</a></li>
+      <li><a href="ex/COMPLEX_COLOR-constant.html">COMPLEX_COLOR</a></li>
+      <li><a href="ex/deprecated-constant.html">deprecated</a></li>
+      <li><a href="ex/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="ex/incorrectDocReferenceFromEx-constant.html">incorrectDocReferenceFromEx</a></li>
+      <li><a href="ex/MY_CAT-constant.html">MY_CAT</a></li>
+      <li><a href="ex/PRETTY_COLORS-constant.html">PRETTY_COLORS</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#properties">Properties</a></li>
+      <li><a class="deprecated" href="ex/deprecatedField.html">deprecatedField</a></li>
+      <li><a class="deprecated" href="ex/deprecatedGetter.html">deprecatedGetter</a></li>
+      <li><a class="deprecated" href="ex/deprecatedSetter.html">deprecatedSetter</a></li>
+      <li><a href="ex/number.html">number</a></li>
+      <li><a href="ex/y.html">y</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#functions">Functions</a></li>
+      <li><a href="ex/function1.html">function1</a></li>
+      <li><a href="ex/genericFunction.html">genericFunction</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#enums">Enums</a></li>
+      <li><a href="ex/Animal-class.html">Animal</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#typedefs">Typedefs</a></li>
+      <li><a href="ex/aComplexTypedef.html">aComplexTypedef</a></li>
+      <li><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a></li>
+      <li><a href="ex/processMessage.html">processMessage</a></li>
+    
+      <li class="section-title"><a href="ex/ex-library.html#exceptions">Exceptions</a></li>
+      <li><a href="ex/MyError-class.html">MyError</a></li>
+      <li><a href="ex/MyErrorImplements-class.html">MyErrorImplements</a></li>
+      <li><a href="ex/MyException-class.html">MyException</a></li>
+      <li><a href="ex/MyExceptionImplements-class.html">MyExceptionImplements</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ShortName" class="callable">
+          <span class="name"><a href="ex/ShortName/ShortName.html">ShortName</a></span><span class="signature">(<span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)</span>
+        </dt>
+        <dd>
+          
+          <div class="constructor-modifier features">const</div>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="aParameter" class="property">
+          <span class="name"><a href="ex/ShortName/aParameter.html">aParameter</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">final</div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="ex/ShortName/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="ex/ShortName/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="ex/ShortName/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="ex/ShortName/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/ShortName.html
+++ b/testing/test_package_docs/ex/ShortName/ShortName.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ShortName constructor from the Class ShortName class from the ex library, for the Dart programming language.">
+  <title>ShortName constructor - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">const constructor ShortName</li>
+  </ol>
+  <div class="self-name">ShortName</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      const
+            <span class="name ">ShortName</span>(<wbr><span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>constructor ShortName</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/aParameter.html
+++ b/testing/test_package_docs/ex/ShortName/aParameter.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aParameter property from the ShortName class, for the Dart programming language.">
+  <title>aParameter property - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">property aParameter</li>
+  </ol>
+  <div class="self-name">aParameter</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">aParameter</span>          <div class="features">final</div>
+        </section>
+                
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>property aParameter</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/hashCode.html
+++ b/testing/test_package_docs/ex/ShortName/hashCode.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the ShortName class, for the Dart programming language.">
+  <title>hashCode property - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">property hashCode</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>property hashCode</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ShortName/noSuchMethod.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the ShortName class, for the Dart programming language.">
+  <title>noSuchMethod method - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">method noSuchMethod</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>method noSuchMethod</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/operator_equals.html
+++ b/testing/test_package_docs/ex/ShortName/operator_equals.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the ShortName class, for the Dart programming language.">
+  <title>operator == method - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">method operator ==</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>method operator ==</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/runtimeType.html
+++ b/testing/test_package_docs/ex/ShortName/runtimeType.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the ShortName class, for the Dart programming language.">
+  <title>runtimeType property - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">property runtimeType</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>property runtimeType</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/ShortName/toString.html
+++ b/testing/test_package_docs/ex/ShortName/toString.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the ShortName class, for the Dart programming language.">
+  <title>toString method - ShortName class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/ShortName-class.html">ShortName</a></li>
+    <li class="self-crumb">method toString</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ShortName</h5>
+    <ol>
+      <li class="section-title"><a href="ex/ShortName-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/ShortName/ShortName.html">ShortName</a></li>
+    
+      <li class="section-title">
+        <a href="ex/ShortName-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="ex/ShortName/aParameter.html">aParameter</a></li>
+      <li class="inherited"><a href="ex/ShortName/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/ShortName/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="ex/ShortName/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/ShortName/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/ShortName-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/ShortName/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>method toString</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs/ex/SpecializedDuration-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/aComplexTypedef.html
+++ b/testing/test_package_docs/ex/aComplexTypedef.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/aThingToDo-class.html
+++ b/testing/test_package_docs/ex/aThingToDo-class.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/deprecatedField.html
+++ b/testing/test_package_docs/ex/deprecatedField.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/deprecatedGetter.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/deprecatedSetter.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -123,6 +123,12 @@
         <dd>
           
         </dd>
+        <dt id="ExtendedShortName">
+          <span class="name "><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></span>
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="F">
           <span class="name "><a href="ex/F-class.html">F</a></span>
         </dt>
@@ -172,6 +178,12 @@
         </dt>
         <dd>
           Foo bar. <a href="ex/ShapeType-class.html">[...]</a>
+        </dd>
+        <dt id="ShortName">
+          <span class="name "><a href="ex/ShortName-class.html">ShortName</a></span>
+        </dt>
+        <dd>
+          
         </dd>
         <dt id="SpecializedDuration">
           <span class="name "><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></span>
@@ -474,6 +486,7 @@ enum constants ala #1445
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -482,6 +495,7 @@ enum constants ala #1445
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/function1.html
+++ b/testing/test_package_docs/ex/function1.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/genericFunction.html
+++ b/testing/test_package_docs/ex/genericFunction.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReference-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/number.html
+++ b/testing/test_package_docs/ex/number.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/processMessage.html
+++ b/testing/test_package_docs/ex/processMessage.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/ex/y.html
+++ b/testing/test_package_docs/ex/y.html
@@ -49,6 +49,7 @@
       <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
       <li><a href="ex/Dog-class.html">Dog</a></li>
       <li><a href="ex/E-class.html">E</a></li>
+      <li><a href="ex/ExtendedShortName-class.html">ExtendedShortName</a></li>
       <li><a href="ex/F-class.html">F</a></li>
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
@@ -57,6 +58,7 @@
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>
       <li><a href="ex/PublicClassImplementsPrivateInterface-class.html">PublicClassImplementsPrivateInterface</a></li>
       <li><a href="ex/ShapeType-class.html">ShapeType</a></li>
+      <li><a href="ex/ShortName-class.html">ShortName</a></li>
       <li><a href="ex/SpecializedDuration-class.html">SpecializedDuration</a></li>
       <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
       <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -429,7 +429,7 @@ across... wait for it... two physical lines.</p>
           
           
   <div>
-            <span class="signature"><code>'yup'</code></span>
+            <span class="signature"><code>&#39;yup&#39;</code></span>
           </div>
         </dd>
       </dl>

--- a/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
@@ -89,7 +89,7 @@
     <section class="multi-line-signature">
         <span class="returntype">dynamic</span>
         <span class="name ">THING</span>        =
-        <span class="constant-value">'yup'</span>
+        <span class="constant-value">&#39;yup&#39;</span>
     </section>
 
         

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1025,6 +1025,17 @@
   }
  },
  {
+  "name": "aName",
+  "qualifiedName": "ex.Dog.aName",
+  "href": "ex/Dog/aName-constant.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
   "name": "aProtectedFinalField",
   "qualifiedName": "ex.Dog.aProtectedFinalField",
   "href": "ex/Dog/aProtectedFinalField.html",
@@ -1362,6 +1373,28 @@
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "E",
+   "type": "class"
+  }
+ },
+ {
+  "name": "ExtendedShortName",
+  "qualifiedName": "ex.ExtendedShortName",
+  "href": "ex/ExtendedShortName-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ExtendedShortName",
+  "qualifiedName": "ex.ExtendedShortName",
+  "href": "ex/ExtendedShortName/ExtendedShortName.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ExtendedShortName",
    "type": "class"
   }
  },
@@ -2429,6 +2462,94 @@
   "overriddenDepth": 1,
   "enclosedBy": {
    "name": "ShapeType",
+   "type": "class"
+  }
+ },
+ {
+  "name": "ShortName",
+  "qualifiedName": "ex.ShortName",
+  "href": "ex/ShortName-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ShortName",
+  "qualifiedName": "ex.ShortName",
+  "href": "ex/ShortName/ShortName.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "ex.ShortName.==",
+  "href": "ex/ShortName/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
+   "type": "class"
+  }
+ },
+ {
+  "name": "aParameter",
+  "qualifiedName": "ex.ShortName.aParameter",
+  "href": "ex/ShortName/aParameter.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "ex.ShortName.hashCode",
+  "href": "ex/ShortName/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "ex.ShortName.noSuchMethod",
+  "href": "ex/ShortName/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "ex.ShortName.runtimeType",
+  "href": "ex/ShortName/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "ex.ShortName.toString",
+  "href": "ex/ShortName/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ShortName",
    "type": "class"
   }
  },


### PR DESCRIPTION
Fixes #1535.  Third breakout from #1524 -- necessary because #1535 becomes much worse with the overhaul as more classes are made linkable.  Without this change #1535 would become a P1 post-overhaul as Flutter docs would begin generating broken links and warning about them.

Rearranges how constantValue is calculated, factoring it out into GetterSetterCombo and substituting any links in after truncating and escaping, rather than before.