### PR TITLE
Move to alpha version of analyzer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 install:
-  - ps: wget https://gsdview.appspot.com/dart-archive/channels/stable/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://gsdview.appspot.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - set PATH=%PATH%;C:\tools\dart-sdk\bin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+4"
+    version: "0.31.0-alpha.1"
   ansicolor:
     description:
       name: ansicolor
@@ -78,7 +78,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4.1"
+    version: "0.1.0-alpha.6"
   glob:
     description:
       name: glob
@@ -132,7 +132,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1.1"
+    version: "0.3.0-alpha.3"
   logging:
     description:
       name: logging

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.0-alpha.1"
+    version: "0.31.0-alpha.2"
   ansicolor:
     description:
       name: ansicolor
@@ -78,7 +78,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.6"
+    version: "0.1.0-alpha.7"
   glob:
     description:
       name: glob
@@ -132,7 +132,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.3"
+    version: "0.3.0-alpha.4"
   logging:
     description:
       name: logging

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=1.23.0-dev.11.5 <2.0.0'
 dependencies:
-  analyzer: ^0.30.0
+  analyzer: 0.31.0-alpha.1
   args: ^0.13.0
   collection: ^1.2.0
   html: '>=0.12.1 <0.14.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,8 @@ version: 0.14.2-dev
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
+# For development, recommend 1.25.0-dev.0.0 or higher to allow
+# dartanalyzer to work on dartdoc itself.
 environment:
   sdk: '>=1.23.0-dev.11.5 <2.0.0'
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=1.23.0-dev.11.5 <2.0.0'
 dependencies:
-  analyzer: 0.31.0-alpha.1
+  analyzer: 0.31.0-alpha.2
   args: ^0.13.0
   collection: ^1.2.0
   html: '>=0.12.1 <0.14.0'

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1414,7 +1414,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
               'dart.core',
           isTrue);
       expect(ExtraSpecialListLength.oneLineDoc == '', isFalse);
-    }, skip: 'Passes on Analyzer 0.31.0+');
+    });
 
     test('split inheritance with explicit setter works', () {
       expect(implicitGetterExplicitSetter.getter.isInherited, isTrue);

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -5623,7 +5623,7 @@
   "qualifiedName": "fake.SpecialList.[]",
   "href": "fake/SpecialList/operator_get.html",
   "type": "method",
-  "overriddenDepth": 0,
+  "overriddenDepth": 1,
   "enclosedBy": {
    "name": "SpecialList",
    "type": "class"
@@ -5634,7 +5634,7 @@
   "qualifiedName": "fake.SpecialList.[]=",
   "href": "fake/SpecialList/operator_put.html",
   "type": "method",
-  "overriddenDepth": 0,
+  "overriddenDepth": 1,
   "enclosedBy": {
    "name": "SpecialList",
    "type": "class"


### PR DESCRIPTION
Some fixes for generic functions are unlikely to be backported to 0.30, so move to the newest version available, even though it is marked "alpha".

This unfortunately fails to work on stable due to a crash when dartdoc tries to document itself:

```
~/dart/dartdoc
$ grind test-dartdoc
grinder running [test-dartdoc]

[test-dartdoc]
  running dartdoc
  /usr/local/google/home/jcollins/dart/all_sdks/1.24.2/bin/dart --checked bin/dartdoc.dart --output /tmp/doc/api
  Generating documentation for 'dartdoc' into /tmp/doc/api/
  parsing lib/dartdoc.dart...
  
  Generation failed: Stack Overflow
  package:analyzer/src/context/cache.dart 127:17  AnalysisCache.get
  package:analyzer/src/context/cache.dart 810:34  CacheEntry._setErrorState.<fn>
  dart:collection                                 _HashFieldBase&_HashBase&_OperatorEqualsAndHashCode&SetMixin.forEach
  package:analyzer/src/context/cache.dart 807:31  CacheEntry._setErrorState
  package:analyzer/src/context/cache.dart 812:17  CacheEntry._setErrorState.<fn>
  dart:collection                                 _HashFieldBase&_HashBase&_OperatorEqualsAndHashCode&SetMixin.forEach
  package:analyzer/src/context/cache.dart 807:31  CacheEntry._setErrorState
  package:analyzer/src/context/cache.dart 812:17  CacheEntry._setErrorState.<fn>
  dart:collection                                 _HashFieldBase&_HashBase&_OperatorEqualsAndHashCode&SetMixin.forEach
  package:analyzer/src/context/cache.dart 807:31  CacheEntry._setErrorState
  package:analyzer/src/context/cache.dart 812:17  CacheEntry._setErrorState.<fn>
  .                                               ...
  .                                               ...
  ===== asynchronous gap ===========================
  dart:async                                      _Completer.completeError
  package:dartdoc/dartdoc.dart 217:3              DartDoc.generateDocs
  ===== asynchronous gap ===========================
  dart:async                                      new Future.microtask
  package:dartdoc/dartdoc.dart 129:47             DartDoc.generateDocs
  bin/dartdoc.dart 273:46                         main.<fn>.<fn>
  ===== asynchronous gap ===========================
  dart:async                                      new Future.microtask
  bin/dartdoc.dart 272:29                         main.<fn>.<fn>
  dart:async                                      runZoned
  bin/dartdoc.dart 272:11                         main.<fn>
  ===== asynchronous gap ===========================
  dart:async                                      new Future.microtask
  bin/dartdoc.dart 271:32                         main.<fn>
  package:stack_trace                             Chain.capture
  bin/dartdoc.dart 271:15                         main

failed with exit code 255
#0      run (package:grinder/src/run.dart:48:5)
#1      Dart.run (package:grinder/grinder_sdk.dart:75:12)
#2      testDartdoc (file:///usr/local/google/home/jcollins/dart/dartdoc/tool/grind.dart:193:10)
```