### PR TITLE
Fix navigation and constructor docs to include class generics

### DIFF
--- a/lib/src/html/template_data.dart
+++ b/lib/src/html/template_data.dart
@@ -36,7 +36,13 @@ abstract class TemplateData<T extends Documentable> {
   String get kind => self is ModelElement ? (self as ModelElement).kind : null;
 
   List get navLinks;
-  Documentable get parent => navLinks.isNotEmpty ? navLinks.last : null;
+  List get navLinksWithGenerics => [];
+  Documentable get parent {
+    if (navLinksWithGenerics.isEmpty) {
+      return navLinks.isNotEmpty ? navLinks.last : null;
+    }
+    return navLinksWithGenerics.last;
+  }
 
   bool get includeVersion => false;
 
@@ -236,7 +242,9 @@ class ConstructorTemplateData extends TemplateData<Constructor> {
   String get layoutTitle => _layoutTitle(
       constructor.name, constructor.fullKind, constructor.isDeprecated);
   @override
-  List get navLinks => [package, library, clazz];
+  List get navLinks => [package, library];
+  @override
+  List get navLinksWithGenerics => [clazz];
   @override
   Iterable<Subnav> getSubNavItems() => _gatherSubnavForInvokable(constructor);
   @override

--- a/lib/src/html/template_data.dart
+++ b/lib/src/html/template_data.dart
@@ -339,7 +339,9 @@ class MethodTemplateData extends TemplateData<Method> {
       'API docs for the ${method.name} method from the ${clazz.name} class, '
       'for the Dart programming language.';
   @override
-  List get navLinks => [package, library, clazz];
+  List get navLinks => [package, library];
+  @override
+  List get navLinksWithGenerics => [clazz];
   @override
   Iterable<Subnav> getSubNavItems() => _gatherSubnavForInvokable(method);
   @override
@@ -369,7 +371,9 @@ class PropertyTemplateData extends TemplateData<Field> {
       'API docs for the ${property.name} $type from the ${clazz.name} class, '
       'for the Dart programming language.';
   @override
-  List get navLinks => [package, library, clazz];
+  List get navLinks => [package, library];
+  @override
+  List get navLinksWithGenerics => [clazz];
   @override
   String get htmlBase => '../..';
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1126,10 +1126,14 @@ class Class extends ModelElement
 }
 
 class Constructor extends ModelElement
-    with SourceCodeMixin
+    with SourceCodeMixin, TypeParameters
     implements EnclosedElement {
   Constructor(ConstructorElement element, Library library)
       : super(element, library, null);
+
+  @override
+  // TODO(jcollins-g): Revisit this when dart-lang/sdk#31517 is implemented.
+  List<TypeParameter> get typeParameters => (enclosingElement as Class).typeParameters;
 
   @override
   ModelElement get enclosingElement =>
@@ -1170,6 +1174,20 @@ class Constructor extends ModelElement
       }
     }
     return _name;
+  }
+
+  String _nameWithGenerics;
+  @override
+  String get nameWithGenerics {
+    if (_nameWithGenerics == null) {
+      String constructorName = element.name;
+      if (constructorName.isEmpty) {
+        _nameWithGenerics = '${enclosingElement.name}${genericParameters}';
+      } else {
+        _nameWithGenerics = '${enclosingElement.name}${genericParameters}.$constructorName';
+      }
+    }
+    return _nameWithGenerics;
   }
 
   String get shortName {
@@ -4689,8 +4707,6 @@ abstract class SourceCodeMixin {
 }
 
 abstract class TypeParameters implements Nameable {
-  Element get element;
-
   String get nameWithGenerics => '$name$genericParameters';
 
   String get genericParameters {

--- a/lib/templates/_head.html
+++ b/lib/templates/_head.html
@@ -37,6 +37,9 @@
     {{#navLinks}}
     <li><a href="{{href}}">{{name}}</a></li>
     {{/navLinks}}
+    {{#navLinksWithGenerics}}
+    <li><a href="{{href}}">{{name}}{{{genericParameters}}}</a></li>
+    {{/navLinksWithGenerics}}
     {{^hasHomepage}}
     <li class="self-crumb">{{{ layoutTitle }}}</li>
     {{/hasHomepage}}

--- a/lib/templates/constructor.html
+++ b/lib/templates/constructor.html
@@ -8,8 +8,17 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     {{#constructor}}
     <section class="multi-line-signature">
+      {{#hasAnnotations}}
+      <div>
+        <ol class="annotation-list">
+          {{#annotations}}
+          <li>{{{.}}}</li>
+          {{/annotations}}
+        </ol>
+      </div>
+      {{/hasAnnotations}}
       {{#isConst}}const{{/isConst}}
-      {{>name_summary}}(<wbr>{{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}})
+      <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{nameWithGenerics}}}</span>(<wbr>{{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}})
     </section>
 
     {{>documentation}}

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1915,15 +1915,26 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
   group('Constructor', () {
     Constructor appleDefaultConstructor, constCatConstructor;
     Constructor appleConstructorFromString;
-    Class apple, constCat;
+    Constructor constructorTesterDefault, constructorTesterFromSomething;
+    Class apple, constCat, constructorTester;
     setUp(() {
       apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
       constCat = exLibrary.classes.firstWhere((c) => c.name == 'ConstantCat');
+      constructorTester = fakeLibrary.classes.firstWhere((c) => c.name == 'ConstructorTester');
       constCatConstructor = constCat.constructors[0];
       appleDefaultConstructor =
           apple.constructors.firstWhere((c) => c.name == 'Apple');
       appleConstructorFromString =
           apple.constructors.firstWhere((c) => c.name == 'Apple.fromString');
+      constructorTesterDefault =
+          constructorTester.constructors.firstWhere((c) => c.name == 'ConstructorTester');
+      constructorTesterFromSomething =
+          constructorTester.constructors.firstWhere((c) => c.name == 'ConstructorTester.fromSomething');
+    });
+
+    test('displays generic parameters correctly', () {
+      expect(constructorTesterDefault.nameWithGenerics, 'ConstructorTester&lt;A, B&gt;');
+      expect(constructorTesterFromSomething.nameWithGenerics, 'ConstructorTester&lt;A, B&gt;.fromSomething');
     });
 
     test('has a fully qualified name', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -74,6 +74,11 @@ abstract class BaseThingy2 implements BaseThingy {
   ImplementingThingy2 get aImplementingThingy;
 }
 
+class ConstructorTester<A, B> {
+  ConstructorTester(String param1) {}
+  ConstructorTester.fromSomething(A foo) {}
+}
+
 class HasGenerics<X, Y, Z> {
   HasGenerics(X x, Y y, Z z) {}
 

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/AnotherParameterizedClass.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/AnotherParameterizedClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass&lt;B&gt;</a></li>
     <li class="self-crumb">constructor AnotherParameterizedClass</li>
   </ol>
   <div class="self-name">AnotherParameterizedClass</div>
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">AnotherParameterizedClass</span>(<wbr>)
+      <span class="name ">AnotherParameterizedClass&lt;B&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/hashCode.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass&lt;B&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass&lt;B&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/operator_equals.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass&lt;B&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/runtimeType.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass&lt;B&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/toString.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass&lt;B&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/Apple/Apple.fromString.html
+++ b/testing/test_package_docs/ex/Apple/Apple.fromString.html
@@ -78,7 +78,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Apple.fromString</span>(<wbr><span class="parameter" id="fromString-param-s"><span class="type-annotation">String</span> <span class="parameter-name">s</span></span>)
+      <span class="name ">Apple.fromString</span>(<wbr><span class="parameter" id="fromString-param-s"><span class="type-annotation">String</span> <span class="parameter-name">s</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Apple/Apple.html
+++ b/testing/test_package_docs/ex/Apple/Apple.html
@@ -78,7 +78,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Apple</span>(<wbr>)
+      <span class="name ">Apple</span>(<wbr>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/ex/B/B.html
+++ b/testing/test_package_docs/ex/B/B.html
@@ -79,7 +79,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">B</span>(<wbr>)
+      <span class="name ">B</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Cat/Cat.html
+++ b/testing/test_package_docs/ex/Cat/Cat.html
@@ -65,7 +65,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Cat</span>(<wbr>)
+      <span class="name ">Cat</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/CatString/CatString.html
+++ b/testing/test_package_docs/ex/CatString/CatString.html
@@ -71,7 +71,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">CatString</span>(<wbr>)
+      <span class="name ">CatString</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
+++ b/testing/test_package_docs/ex/ConstantCat/ConstantCat.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">ConstantCat</span>(<wbr><span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span></span>)
+      <span class="name ">ConstantCat</span>(<wbr><span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)
+      <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -88,8 +88,13 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
+      <div>
+        <ol class="annotation-list">
+          <li>@deprecated</li>
+        </ol>
+      </div>
       
-            <span class="name deprecated">Dog.deprecatedCreate</span>(<wbr><span class="parameter" id="deprecatedCreate-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span></span>)
+      <span class="name deprecated">Dog.deprecatedCreate</span>(<wbr><span class="parameter" id="deprecatedCreate-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -89,7 +89,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Dog</span>(<wbr>)
+      <span class="name ">Dog</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/E/E.html
+++ b/testing/test_package_docs/ex/E/E.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">E</span>(<wbr>)
+      <span class="name ">E</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/ExtendedShortName/ExtendedShortName.html
+++ b/testing/test_package_docs/ex/ExtendedShortName/ExtendedShortName.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">ExtendedShortName</span>(<wbr><span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)
+      <span class="name ">ExtendedShortName</span>(<wbr><span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/F-class.html">F</a></li>
+    <li><a href="ex/F-class.html">F&lt;T extends String&gt;</a></li>
     <li class="self-crumb">constructor F</li>
   </ol>
   <div class="self-name">F</div>
@@ -82,7 +82,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">F</span>(<wbr>)
+      <span class="name ">F&lt;T extends String&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/F-class.html">F</a></li>
+    <li><a href="ex/F-class.html">F&lt;T extends String&gt;</a></li>
     <li class="self-crumb">method methodWithGenericParam</li>
   </ol>
   <div class="self-name">methodWithGenericParam</div>

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/F-class.html">F</a></li>
+    <li><a href="ex/F-class.html">F&lt;T extends String&gt;</a></li>
     <li class="self-crumb">method test</li>
   </ol>
   <div class="self-name">test</div>

--- a/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
+++ b/testing/test_package_docs/ex/ForAnnotation/ForAnnotation.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">ForAnnotation</span>(<wbr><span class="parameter" id="-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
+      <span class="name ">ForAnnotation</span>(<wbr><span class="parameter" id="-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/HasAnnotation/HasAnnotation.html
+++ b/testing/test_package_docs/ex/HasAnnotation/HasAnnotation.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">HasAnnotation</span>(<wbr>)
+      <span class="name ">HasAnnotation</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Helper/Helper.html
+++ b/testing/test_package_docs/ex/Helper/Helper.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Helper</span>(<wbr>)
+      <span class="name ">Helper</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Klass/Klass.html
+++ b/testing/test_package_docs/ex/Klass/Klass.html
@@ -68,7 +68,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Klass</span>(<wbr>)
+      <span class="name ">Klass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/MyError/MyError.html
+++ b/testing/test_package_docs/ex/MyError/MyError.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">MyError</span>(<wbr>)
+      <span class="name ">MyError</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
+++ b/testing/test_package_docs/ex/MyErrorImplements/MyErrorImplements.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">MyErrorImplements</span>(<wbr>)
+      <span class="name ">MyErrorImplements</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/MyException/MyException.html
+++ b/testing/test_package_docs/ex/MyException/MyException.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">MyException</span>(<wbr>)
+      <span class="name ">MyException</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/MyExceptionImplements/MyExceptionImplements.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements/MyExceptionImplements.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">MyExceptionImplements</span>(<wbr>)
+      <span class="name ">MyExceptionImplements</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/ParameterizedClass/ParameterizedClass.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/ParameterizedClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">constructor ParameterizedClass</li>
   </ol>
   <div class="self-name">ParameterizedClass</div>
@@ -69,7 +69,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ParameterizedClass</span>(<wbr>)
+      <span class="name ">ParameterizedClass&lt;T&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedField.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedField.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">property aInheritedField</li>
   </ol>
   <div class="self-name">aInheritedField</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedGetter.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedGetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">property aInheritedGetter</li>
   </ol>
   <div class="self-name">aInheritedGetter</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedMethod.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">abstract method aInheritedMethod</li>
   </ol>
   <div class="self-name">aInheritedMethod</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedSetter.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedSetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">property aInheritedSetter</li>
   </ol>
   <div class="self-name">aInheritedSetter</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedTypedefReturningMethod.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedTypedefReturningMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">abstract method aInheritedTypedefReturningMethod</li>
   </ol>
   <div class="self-name">aInheritedTypedefReturningMethod</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/hashCode.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/operator_equals.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/operator_plus.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/operator_plus.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">abstract method operator +</li>
   </ol>
   <div class="self-name">operator +</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/runtimeType.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/toString.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass&lt;T&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/PublicClassExtendsPrivateClass.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass/PublicClassExtendsPrivateClass.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">PublicClassExtendsPrivateClass</span>(<wbr>)
+      <span class="name ">PublicClassExtendsPrivateClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface/PublicClassImplementsPrivateInterface.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">PublicClassImplementsPrivateInterface</span>(<wbr>)
+      <span class="name ">PublicClassImplementsPrivateInterface</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/ShortName/ShortName.html
+++ b/testing/test_package_docs/ex/ShortName/ShortName.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">ShortName</span>(<wbr><span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)
+      <span class="name ">ShortName</span>(<wbr><span class="parameter" id="-param-aParameter"><span class="type-annotation">String</span> <span class="parameter-name">aParameter</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/SpecializedDuration/SpecializedDuration.html
+++ b/testing/test_package_docs/ex/SpecializedDuration/SpecializedDuration.html
@@ -81,7 +81,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">SpecializedDuration</span>(<wbr>)
+      <span class="name ">SpecializedDuration</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/TemplatedClass/TemplatedClass.html
+++ b/testing/test_package_docs/ex/TemplatedClass/TemplatedClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">constructor TemplatedClass</li>
   </ol>
   <div class="self-name">TemplatedClass</div>
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">TemplatedClass</span>(<wbr>)
+      <span class="name ">TemplatedClass&lt;X&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/TemplatedClass/aMethod.html
+++ b/testing/test_package_docs/ex/TemplatedClass/aMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">method aMethod</li>
   </ol>
   <div class="self-name">aMethod</div>

--- a/testing/test_package_docs/ex/TemplatedClass/hashCode.html
+++ b/testing/test_package_docs/ex/TemplatedClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/TemplatedClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/TemplatedClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/TemplatedClass/operator_equals.html
+++ b/testing/test_package_docs/ex/TemplatedClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/TemplatedClass/runtimeType.html
+++ b/testing/test_package_docs/ex/TemplatedClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/TemplatedClass/toString.html
+++ b/testing/test_package_docs/ex/TemplatedClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass</a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass&lt;X&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/TemplatedInterface/TemplatedInterface.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/TemplatedInterface.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface&lt;A&gt;</a></li>
     <li class="self-crumb">constructor TemplatedInterface</li>
   </ol>
   <div class="self-name">TemplatedInterface</div>
@@ -74,7 +74,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">TemplatedInterface</span>(<wbr>)
+      <span class="name ">TemplatedInterface&lt;A&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/TemplatedInterface/aField.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aField.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface&lt;A&gt;</a></li>
     <li class="self-crumb">property aField</li>
   </ol>
   <div class="self-name">aField</div>

--- a/testing/test_package_docs/ex/TemplatedInterface/aGetter.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aGetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface&lt;A&gt;</a></li>
     <li class="self-crumb">property aGetter</li>
   </ol>
   <div class="self-name">aGetter</div>

--- a/testing/test_package_docs/ex/TemplatedInterface/aMethodInterface.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aMethodInterface.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface&lt;A&gt;</a></li>
     <li class="self-crumb">abstract method aMethodInterface</li>
   </ol>
   <div class="self-name">aMethodInterface</div>

--- a/testing/test_package_docs/ex/TemplatedInterface/aSetter.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aSetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface&lt;A&gt;</a></li>
     <li class="self-crumb">property aSetter</li>
   </ol>
   <div class="self-name">aSetter</div>

--- a/testing/test_package_docs/ex/TemplatedInterface/aTypedefReturningMethodInterface.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aTypedefReturningMethodInterface.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface&lt;A&gt;</a></li>
     <li class="self-crumb">abstract method aTypedefReturningMethodInterface</li>
   </ol>
   <div class="self-name">aTypedefReturningMethodInterface</div>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/TypedFunctionsWithoutTypedefs.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/TypedFunctionsWithoutTypedefs.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">TypedFunctionsWithoutTypedefs</span>(<wbr>)
+      <span class="name ">TypedFunctionsWithoutTypedefs</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
+++ b/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">constructor WithGeneric</li>
   </ol>
   <div class="self-name">WithGeneric</div>
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">WithGeneric</span>(<wbr><span class="parameter" id="-param-prop"><span class="type-annotation">T</span> <span class="parameter-name">prop</span></span>)
+      <span class="name ">WithGeneric&lt;T&gt;</span>(<wbr><span class="parameter" id="-param-prop"><span class="type-annotation">T</span> <span class="parameter-name">prop</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
+++ b/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">property prop</li>
   </ol>
   <div class="self-name">prop</div>

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/WithGeneric/toString.html
+++ b/testing/test_package_docs/ex/WithGeneric/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric</a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric&lt;T&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/WithGenericSub/WithGenericSub.html
+++ b/testing/test_package_docs/ex/WithGenericSub/WithGenericSub.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">WithGenericSub</span>(<wbr><span class="parameter" id="-param-prop"><span class="type-annotation"><a href="ex/Apple-class.html">Apple</a></span> <span class="parameter-name">prop</span></span>)
+      <span class="name ">WithGenericSub</span>(<wbr><span class="parameter" id="-param-prop"><span class="type-annotation"><a href="ex/Apple-class.html">Apple</a></span> <span class="parameter-name">prop</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/aThingToDo/aThingToDo.html
+++ b/testing/test_package_docs/ex/aThingToDo/aThingToDo.html
@@ -65,7 +65,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">aThingToDo</span>(<wbr><span class="parameter" id="-param-who"><span class="type-annotation">String</span> <span class="parameter-name">who</span>, </span> <span class="parameter" id="-param-what"><span class="type-annotation">String</span> <span class="parameter-name">what</span></span>)
+      <span class="name ">aThingToDo</span>(<wbr><span class="parameter" id="-param-who"><span class="type-annotation">String</span> <span class="parameter-name">who</span>, </span> <span class="parameter" id="-param-what"><span class="type-annotation">String</span> <span class="parameter-name">what</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -48,6 +48,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin/AClassUsingASuperMixin.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin/AClassUsingASuperMixin.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">AClassUsingASuperMixin</span>(<wbr>)
+      <span class="name ">AClassUsingASuperMixin</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -48,6 +48,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper/AMixinCallingSuper.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper/AMixinCallingSuper.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">AMixinCallingSuper</span>(<wbr>)
+      <span class="name ">AMixinCallingSuper</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Annotation/Annotation.html
+++ b/testing/test_package_docs/fake/Annotation/Annotation.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">Annotation</span>(<wbr><span class="parameter" id="-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
+      <span class="name ">Annotation</span>(<wbr><span class="parameter" id="-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface/AnotherInterface.html
+++ b/testing/test_package_docs/fake/AnotherInterface/AnotherInterface.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">AnotherInterface</span>(<wbr>)
+      <span class="name ">AnotherInterface</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments/BaseForDocComments.html
+++ b/testing/test_package_docs/fake/BaseForDocComments/BaseForDocComments.html
@@ -65,7 +65,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">BaseForDocComments</span>(<wbr>)
+      <span class="name ">BaseForDocComments</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/BaseThingy/BaseThingy.html
+++ b/testing/test_package_docs/fake/BaseThingy/BaseThingy.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">BaseThingy</span>(<wbr>)
+      <span class="name ">BaseThingy</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2/BaseThingy2.html
+++ b/testing/test_package_docs/fake/BaseThingy2/BaseThingy2.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">BaseThingy2</span>(<wbr>)
+      <span class="name ">BaseThingy2</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/ClassWithUnusualProperties.html
@@ -76,7 +76,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ClassWithUnusualProperties</span>(<wbr>)
+      <span class="name ">ClassWithUnusualProperties</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">ConstantClass</span>(<wbr><span class="parameter" id="-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
+      <span class="name ">ConstantClass</span>(<wbr><span class="parameter" id="-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.isVeryConstant.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">ConstantClass.isVeryConstant</span>(<wbr><span class="parameter" id="isVeryConstant-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
+      <span class="name ">ConstantClass.isVeryConstant</span>(<wbr><span class="parameter" id="isVeryConstant-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
+++ b/testing/test_package_docs/fake/ConstantClass/ConstantClass.notConstant.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ConstantClass.notConstant</span>(<wbr><span class="parameter" id="notConstant-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
+      <span class="name ">ConstantClass.notConstant</span>(<wbr><span class="parameter" id="notConstant-param-value"><span class="type-annotation">String</span> <span class="parameter-name">value</span></span>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -39,6 +39,8 @@
     <h5>library fake</h5>
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
       <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
@@ -58,6 +60,7 @@
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ConstructorTester class from the fake library, for the Dart programming language.">
+  <title>ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">class ConstructorTester&lt;A, B&gt;</li>
+  </ol>
+  <div class="self-name">ConstructorTester</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>library fake</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+    
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ConstructorTester" class="callable">
+          <span class="name"><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></span><span class="signature">(<span class="parameter" id="-param-param1"><span class="type-annotation">String</span> <span class="parameter-name">param1</span></span>)</span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="ConstructorTester.fromSomething" class="callable">
+          <span class="name"><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">ConstructorTester.fromSomething</a></span><span class="signature">(<span class="parameter" id="fromSomething-param-foo"><span class="type-annotation">A</span> <span class="parameter-name">foo</span></span>)</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/ConstructorTester/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.fromSomething.html
+++ b/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.fromSomething.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ConstructorTester.fromSomething constructor from the Class ConstructorTester class from the fake library, for the Dart programming language.">
+  <title>ConstructorTester.fromSomething constructor - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
+    <li class="self-crumb">constructor ConstructorTester.fromSomething</li>
+  </ol>
+  <div class="self-name">ConstructorTester.fromSomething</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      
+      <span class="name ">ConstructorTester&lt;A, B&gt;.fromSomething</span>(<wbr><span class="parameter" id="fromSomething-param-foo"><span class="type-annotation">A</span> <span class="parameter-name">foo</span></span>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>constructor ConstructorTester.fromSomething</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.html
+++ b/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ConstructorTester constructor from the Class ConstructorTester class from the fake library, for the Dart programming language.">
+  <title>ConstructorTester constructor - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
+    <li class="self-crumb">constructor ConstructorTester</li>
+  </ol>
+  <div class="self-name">ConstructorTester</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      
+      <span class="name ">ConstructorTester&lt;A, B&gt;</span>(<wbr><span class="parameter" id="-param-param1"><span class="type-annotation">String</span> <span class="parameter-name">param1</span></span>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>constructor ConstructorTester</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/hashCode.html
+++ b/testing/test_package_docs/fake/ConstructorTester/hashCode.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the ConstructorTester class, for the Dart programming language.">
+  <title>hashCode property - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li class="self-crumb">property hashCode</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>property hashCode</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/hashCode.html
+++ b/testing/test_package_docs/fake/ConstructorTester/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/ConstructorTester/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstructorTester/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/ConstructorTester/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstructorTester/noSuchMethod.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the ConstructorTester class, for the Dart programming language.">
+  <title>noSuchMethod method - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li class="self-crumb">method noSuchMethod</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>method noSuchMethod</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstructorTester/operator_equals.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the ConstructorTester class, for the Dart programming language.">
+  <title>operator == method - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li class="self-crumb">method operator ==</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>method operator ==</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstructorTester/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/ConstructorTester/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstructorTester/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/ConstructorTester/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstructorTester/runtimeType.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the ConstructorTester class, for the Dart programming language.">
+  <title>runtimeType property - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li class="self-crumb">property runtimeType</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>property runtimeType</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ConstructorTester/toString.html
+++ b/testing/test_package_docs/fake/ConstructorTester/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester&lt;A, B&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/ConstructorTester/toString.html
+++ b/testing/test_package_docs/fake/ConstructorTester/toString.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the ConstructorTester class, for the Dart programming language.">
+  <title>toString method - ConstructorTester class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+    <li class="self-crumb">method toString</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>class ConstructorTester</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ConstructorTester-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.html">ConstructorTester</a></li>
+      <li><a href="fake/ConstructorTester/ConstructorTester.fromSomething.html">fromSomething</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ConstructorTester-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ConstructorTester/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ConstructorTester-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ConstructorTester/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <h5>method toString</h5>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Cool/Cool.html
+++ b/testing/test_package_docs/fake/Cool/Cool.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Cool</span>(<wbr>)
+      <span class="name ">Cool</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Doh/Doh.html
+++ b/testing/test_package_docs/fake/Doh/Doh.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Doh</span>(<wbr>)
+      <span class="name ">Doh</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+    <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">constructor ExtraSpecialList</li>
   </ol>
   <div class="self-name">ExtraSpecialList</div>
@@ -115,7 +115,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ExtraSpecialList</span>(<wbr>)
+      <span class="name ">ExtraSpecialList&lt;E&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Foo2/Foo2.html
+++ b/testing/test_package_docs/fake/Foo2/Foo2.html
@@ -67,7 +67,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       const
-            <span class="name ">Foo2</span>(<wbr><span class="parameter" id="-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span></span>)
+      <span class="name ">Foo2</span>(<wbr><span class="parameter" id="-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends&lt;T extends Foo2&gt;</a></li>
     <li class="self-crumb">constructor HasGenericWithExtends</li>
   </ol>
   <div class="self-name">HasGenericWithExtends</div>
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">HasGenericWithExtends</span>(<wbr>)
+      <span class="name ">HasGenericWithExtends&lt;T extends Foo2&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends&lt;T extends Foo2&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends&lt;T extends Foo2&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends&lt;T extends Foo2&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends&lt;T extends Foo2&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends&lt;T extends Foo2&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
+++ b/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">constructor HasGenerics</li>
   </ol>
   <div class="self-name">HasGenerics</div>
@@ -67,7 +67,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">HasGenerics</span>(<wbr><span class="parameter" id="-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="-param-y"><span class="type-annotation">Y</span> <span class="parameter-name">y</span>, </span> <span class="parameter" id="-param-z"><span class="type-annotation">Z</span> <span class="parameter-name">z</span></span>)
+      <span class="name ">HasGenerics&lt;X, Y, Z&gt;</span>(<wbr><span class="parameter" id="-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="-param-y"><span class="type-annotation">Y</span> <span class="parameter-name">y</span>, </span> <span class="parameter" id="-param-z"><span class="type-annotation">Z</span> <span class="parameter-name">z</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/HasGenerics/convertToMap.html
+++ b/testing/test_package_docs/fake/HasGenerics/convertToMap.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method convertToMap</li>
   </ol>
   <div class="self-name">convertToMap</div>

--- a/testing/test_package_docs/fake/HasGenerics/doStuff.html
+++ b/testing/test_package_docs/fake/HasGenerics/doStuff.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method doStuff</li>
   </ol>
   <div class="self-name">doStuff</div>

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/HasGenerics/returnX.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnX.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method returnX</li>
   </ol>
   <div class="self-name">returnX</div>

--- a/testing/test_package_docs/fake/HasGenerics/returnZ.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnZ.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method returnZ</li>
   </ol>
   <div class="self-name">returnZ</div>

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/HasGenerics/toString.html
+++ b/testing/test_package_docs/fake/HasGenerics/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics&lt;X, Y, Z&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy/ImplementingThingy.html
+++ b/testing/test_package_docs/fake/ImplementingThingy/ImplementingThingy.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ImplementingThingy</span>(<wbr>)
+      <span class="name ">ImplementingThingy</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2/ImplementingThingy2.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2/ImplementingThingy2.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ImplementingThingy2</span>(<wbr>)
+      <span class="name ">ImplementingThingy2</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/ImplicitProperties.html
@@ -68,7 +68,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ImplicitProperties</span>(<wbr>)
+      <span class="name ">ImplicitProperties</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Interface/Interface.html
+++ b/testing/test_package_docs/fake/Interface/Interface.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Interface</span>(<wbr>)
+      <span class="name ">Interface</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromHasGenerics.html
@@ -87,7 +87,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">LongFirstLine.fromHasGenerics</span>(<wbr><span class="parameter" id="fromHasGenerics-param-hg"><span class="type-annotation"><a href="fake/HasGenerics-class.html">HasGenerics</a></span> <span class="parameter-name">hg</span></span>)
+      <span class="name ">LongFirstLine.fromHasGenerics</span>(<wbr><span class="parameter" id="fromHasGenerics-param-hg"><span class="type-annotation"><a href="fake/HasGenerics-class.html">HasGenerics</a></span> <span class="parameter-name">hg</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.fromMap.html
@@ -87,7 +87,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">LongFirstLine.fromMap</span>(<wbr><span class="parameter" id="fromMap-param-data"><span class="type-annotation">Map</span> <span class="parameter-name">data</span></span>)
+      <span class="name ">LongFirstLine.fromMap</span>(<wbr><span class="parameter" id="fromMap-param-data"><span class="type-annotation">Map</span> <span class="parameter-name">data</span></span>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
+++ b/testing/test_package_docs/fake/LongFirstLine/LongFirstLine.html
@@ -86,8 +86,13 @@
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
+      <div>
+        <ol class="annotation-list">
+          <li>@deprecated</li>
+        </ol>
+      </div>
       
-            <span class="name deprecated">LongFirstLine</span>(<wbr>)
+      <span class="name deprecated">LongFirstLine</span>(<wbr>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/MixMeIn/MixMeIn.html
+++ b/testing/test_package_docs/fake/MixMeIn/MixMeIn.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">MixMeIn</span>(<wbr>)
+      <span class="name ">MixMeIn</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -48,6 +48,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/NotAMixin/NotAMixin.html
+++ b/testing/test_package_docs/fake/NotAMixin/NotAMixin.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">NotAMixin</span>(<wbr>)
+      <span class="name ">NotAMixin</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/Oops/Oops.html
+++ b/testing/test_package_docs/fake/Oops/Oops.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Oops</span>(<wbr><span class="parameter" id="-param-message"><span class="type-annotation">String</span> <span class="parameter-name">message</span></span>)
+      <span class="name ">Oops</span>(<wbr><span class="parameter" id="-param-message"><span class="type-annotation">String</span> <span class="parameter-name">message</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass/OperatorReferenceClass.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass/OperatorReferenceClass.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">OperatorReferenceClass</span>(<wbr>)
+      <span class="name ">OperatorReferenceClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">constructor OtherGenericsThing</li>
   </ol>
   <div class="self-name">OtherGenericsThing</div>
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">OtherGenericsThing</span>(<wbr>)
+      <span class="name ">OtherGenericsThing&lt;A&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/OtherGenericsThing/convert.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/convert.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">method convert</li>
   </ol>
   <div class="self-name">convert</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/toString.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing&lt;A&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/SpecialList/SpecialList.html
+++ b/testing/test_package_docs/fake/SpecialList/SpecialList.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">constructor SpecialList</li>
   </ol>
   <div class="self-name">SpecialList</div>
@@ -115,7 +115,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">SpecialList</span>(<wbr>)
+      <span class="name ">SpecialList&lt;E&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/SpecialList/add.html
+++ b/testing/test_package_docs/fake/SpecialList/add.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method add</li>
   </ol>
   <div class="self-name">add</div>

--- a/testing/test_package_docs/fake/SpecialList/addAll.html
+++ b/testing/test_package_docs/fake/SpecialList/addAll.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method addAll</li>
   </ol>
   <div class="self-name">addAll</div>

--- a/testing/test_package_docs/fake/SpecialList/any.html
+++ b/testing/test_package_docs/fake/SpecialList/any.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method any</li>
   </ol>
   <div class="self-name">any</div>

--- a/testing/test_package_docs/fake/SpecialList/asMap.html
+++ b/testing/test_package_docs/fake/SpecialList/asMap.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method asMap</li>
   </ol>
   <div class="self-name">asMap</div>

--- a/testing/test_package_docs/fake/SpecialList/clear.html
+++ b/testing/test_package_docs/fake/SpecialList/clear.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method clear</li>
   </ol>
   <div class="self-name">clear</div>

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method contains</li>
   </ol>
   <div class="self-name">contains</div>

--- a/testing/test_package_docs/fake/SpecialList/elementAt.html
+++ b/testing/test_package_docs/fake/SpecialList/elementAt.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method elementAt</li>
   </ol>
   <div class="self-name">elementAt</div>

--- a/testing/test_package_docs/fake/SpecialList/every.html
+++ b/testing/test_package_docs/fake/SpecialList/every.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method every</li>
   </ol>
   <div class="self-name">every</div>

--- a/testing/test_package_docs/fake/SpecialList/expand.html
+++ b/testing/test_package_docs/fake/SpecialList/expand.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method expand&lt;T&gt;</li>
   </ol>
   <div class="self-name">expand</div>

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method fillRange</li>
   </ol>
   <div class="self-name">fillRange</div>

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property first</li>
   </ol>
   <div class="self-name">first</div>

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method firstWhere</li>
   </ol>
   <div class="self-name">firstWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/fold.html
+++ b/testing/test_package_docs/fake/SpecialList/fold.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method fold&lt;T&gt;</li>
   </ol>
   <div class="self-name">fold</div>

--- a/testing/test_package_docs/fake/SpecialList/forEach.html
+++ b/testing/test_package_docs/fake/SpecialList/forEach.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method forEach</li>
   </ol>
   <div class="self-name">forEach</div>

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method getRange</li>
   </ol>
   <div class="self-name">getRange</div>

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/SpecialList/indexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/indexOf.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method indexOf</li>
   </ol>
   <div class="self-name">indexOf</div>

--- a/testing/test_package_docs/fake/SpecialList/insert.html
+++ b/testing/test_package_docs/fake/SpecialList/insert.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method insert</li>
   </ol>
   <div class="self-name">insert</div>

--- a/testing/test_package_docs/fake/SpecialList/insertAll.html
+++ b/testing/test_package_docs/fake/SpecialList/insertAll.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method insertAll</li>
   </ol>
   <div class="self-name">insertAll</div>

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property isEmpty</li>
   </ol>
   <div class="self-name">isEmpty</div>

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property isNotEmpty</li>
   </ol>
   <div class="self-name">isNotEmpty</div>

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property iterator</li>
   </ol>
   <div class="self-name">iterator</div>

--- a/testing/test_package_docs/fake/SpecialList/join.html
+++ b/testing/test_package_docs/fake/SpecialList/join.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method join</li>
   </ol>
   <div class="self-name">join</div>

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property last</li>
   </ol>
   <div class="self-name">last</div>

--- a/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method lastIndexOf</li>
   </ol>
   <div class="self-name">lastIndexOf</div>

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method lastWhere</li>
   </ol>
   <div class="self-name">lastWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property length</li>
   </ol>
   <div class="self-name">length</div>

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method map&lt;T&gt;</li>
   </ol>
   <div class="self-name">map</div>

--- a/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/SpecialList/operator_get.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_get.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method operator []</li>
   </ol>
   <div class="self-name">operator []</div>

--- a/testing/test_package_docs/fake/SpecialList/operator_put.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_put.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method operator []=</li>
   </ol>
   <div class="self-name">operator []=</div>

--- a/testing/test_package_docs/fake/SpecialList/reduce.html
+++ b/testing/test_package_docs/fake/SpecialList/reduce.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method reduce</li>
   </ol>
   <div class="self-name">reduce</div>

--- a/testing/test_package_docs/fake/SpecialList/remove.html
+++ b/testing/test_package_docs/fake/SpecialList/remove.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method remove</li>
   </ol>
   <div class="self-name">remove</div>

--- a/testing/test_package_docs/fake/SpecialList/removeAt.html
+++ b/testing/test_package_docs/fake/SpecialList/removeAt.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method removeAt</li>
   </ol>
   <div class="self-name">removeAt</div>

--- a/testing/test_package_docs/fake/SpecialList/removeLast.html
+++ b/testing/test_package_docs/fake/SpecialList/removeLast.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method removeLast</li>
   </ol>
   <div class="self-name">removeLast</div>

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method removeRange</li>
   </ol>
   <div class="self-name">removeRange</div>

--- a/testing/test_package_docs/fake/SpecialList/removeWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/removeWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method removeWhere</li>
   </ol>
   <div class="self-name">removeWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method replaceRange</li>
   </ol>
   <div class="self-name">replaceRange</div>

--- a/testing/test_package_docs/fake/SpecialList/retainWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/retainWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method retainWhere</li>
   </ol>
   <div class="self-name">retainWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property reversed</li>
   </ol>
   <div class="self-name">reversed</div>

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/SpecialList/setAll.html
+++ b/testing/test_package_docs/fake/SpecialList/setAll.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method setAll</li>
   </ol>
   <div class="self-name">setAll</div>

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method setRange</li>
   </ol>
   <div class="self-name">setRange</div>

--- a/testing/test_package_docs/fake/SpecialList/shuffle.html
+++ b/testing/test_package_docs/fake/SpecialList/shuffle.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method shuffle</li>
   </ol>
   <div class="self-name">shuffle</div>

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">property single</li>
   </ol>
   <div class="self-name">single</div>

--- a/testing/test_package_docs/fake/SpecialList/singleWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/singleWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method singleWhere</li>
   </ol>
   <div class="self-name">singleWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method skip</li>
   </ol>
   <div class="self-name">skip</div>

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method skipWhile</li>
   </ol>
   <div class="self-name">skipWhile</div>

--- a/testing/test_package_docs/fake/SpecialList/sort.html
+++ b/testing/test_package_docs/fake/SpecialList/sort.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method sort</li>
   </ol>
   <div class="self-name">sort</div>

--- a/testing/test_package_docs/fake/SpecialList/sublist.html
+++ b/testing/test_package_docs/fake/SpecialList/sublist.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method sublist</li>
   </ol>
   <div class="self-name">sublist</div>

--- a/testing/test_package_docs/fake/SpecialList/take.html
+++ b/testing/test_package_docs/fake/SpecialList/take.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method take</li>
   </ol>
   <div class="self-name">take</div>

--- a/testing/test_package_docs/fake/SpecialList/takeWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/takeWhile.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method takeWhile</li>
   </ol>
   <div class="self-name">takeWhile</div>

--- a/testing/test_package_docs/fake/SpecialList/toList.html
+++ b/testing/test_package_docs/fake/SpecialList/toList.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method toList</li>
   </ol>
   <div class="self-name">toList</div>

--- a/testing/test_package_docs/fake/SpecialList/toSet.html
+++ b/testing/test_package_docs/fake/SpecialList/toSet.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method toSet</li>
   </ol>
   <div class="self-name">toSet</div>

--- a/testing/test_package_docs/fake/SpecialList/toString.html
+++ b/testing/test_package_docs/fake/SpecialList/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList&lt;E&gt;</a></li>
     <li class="self-crumb">method where</li>
   </ol>
   <div class="self-name">where</div>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
+++ b/testing/test_package_docs/fake/SubForDocComments/SubForDocComments.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">SubForDocComments</span>(<wbr>)
+      <span class="name ">SubForDocComments</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/SuperAwesomeClass.html
@@ -66,7 +66,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">SuperAwesomeClass</span>(<wbr>)
+      <span class="name ">SuperAwesomeClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter/WithGetterAndSetter.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">WithGetterAndSetter</span>(<wbr>)
+      <span class="name ">WithGetterAndSetter</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -124,6 +124,12 @@ Don't ask questions.</p>
         <dd>
           For make-better testing of constants. <a href="fake/ConstantClass-class.html">[...]</a>
         </dd>
+        <dt id="ConstructorTester">
+          <span class="name "><a href="fake/ConstructorTester-class.html">ConstructorTester</a></span>
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="Cool">
           <span class="name "><a href="fake/Cool-class.html">Cool</a></span>
         </dt>
@@ -690,6 +696,7 @@ default value.
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -46,6 +46,7 @@
       <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
       <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
       <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
       <li><a href="fake/Cool-class.html">Cool</a></li>
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -4310,6 +4310,94 @@
   }
  },
  {
+  "name": "ConstructorTester",
+  "qualifiedName": "fake.ConstructorTester",
+  "href": "fake/ConstructorTester-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ConstructorTester",
+  "qualifiedName": "fake.ConstructorTester",
+  "href": "fake/ConstructorTester/ConstructorTester.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.ConstructorTester.==",
+  "href": "fake/ConstructorTester/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
+  "name": "ConstructorTester.fromSomething",
+  "qualifiedName": "fake.ConstructorTester.fromSomething",
+  "href": "fake/ConstructorTester/ConstructorTester.fromSomething.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.ConstructorTester.hashCode",
+  "href": "fake/ConstructorTester/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.ConstructorTester.noSuchMethod",
+  "href": "fake/ConstructorTester/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.ConstructorTester.runtimeType",
+  "href": "fake/ConstructorTester/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.ConstructorTester.toString",
+  "href": "fake/ConstructorTester/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ConstructorTester",
+   "type": "class"
+  }
+ },
+ {
   "name": "Cool",
   "qualifiedName": "fake.Cool",
   "href": "fake/Cool-class.html",

--- a/testing/test_package_docs/reexport_one/SomeOtherClass/SomeOtherClass.html
+++ b/testing/test_package_docs/reexport_one/SomeOtherClass/SomeOtherClass.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">SomeOtherClass</span>(<wbr>)
+      <span class="name ">SomeOtherClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/reexport_two/AUnicornClass/AUnicornClass.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass/AUnicornClass.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">AUnicornClass</span>(<wbr>)
+      <span class="name ">AUnicornClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/reexport_two/SomeClass/SomeClass.html
+++ b/testing/test_package_docs/reexport_two/SomeClass/SomeClass.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">SomeClass</span>(<wbr>)
+      <span class="name ">SomeClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/reexport_two/YetAnotherClass/YetAnotherClass.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass/YetAnotherClass.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">YetAnotherClass</span>(<wbr>)
+      <span class="name ">YetAnotherClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass&lt;T&gt;</a></li>
     <li class="self-crumb">constructor Whataclass</li>
   </ol>
   <div class="self-name">Whataclass</div>
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Whataclass</span>(<wbr>)
+      <span class="name ">Whataclass&lt;T&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass&lt;T&gt;</a></li>
     <li class="self-crumb">property hashCode</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass&lt;T&gt;</a></li>
     <li class="self-crumb">method noSuchMethod</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass&lt;T&gt;</a></li>
     <li class="self-crumb">method operator ==</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass&lt;T&gt;</a></li>
     <li class="self-crumb">property runtimeType</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass&lt;T&gt;</a></li>
     <li class="self-crumb">method toString</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass2/Whataclass2.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass2/Whataclass2.html
@@ -63,7 +63,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">Whataclass2</span>(<wbr>)
+      <span class="name ">Whataclass2</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/two_exports/BaseClass/BaseClass.html
+++ b/testing/test_package_docs/two_exports/BaseClass/BaseClass.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">BaseClass</span>(<wbr>)
+      <span class="name ">BaseClass</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/two_exports/ExtendingClass/ExtendingClass.html
+++ b/testing/test_package_docs/two_exports/ExtendingClass/ExtendingClass.html
@@ -64,7 +64,7 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <section class="multi-line-signature">
       
-            <span class="name ">ExtendingClass</span>(<wbr>)
+      <span class="name ">ExtendingClass</span>(<wbr>)
     </section>
 
     


### PR DESCRIPTION
Fixes #1027.  Make generic arguments for constructors show up in navigation and in the constructor documentation itself so it is easier to understand how to call them.

The new version's LinkedListEntry constructor:
![screenshot from 2017-12-01 14 58 19](https://user-images.githubusercontent.com/14116827/33507318-eefa1458-d6a8-11e7-8770-2f790bcd49e9.png)

I've also adjusted navigation for other pages too:

![screenshot from 2017-12-01 14 57 01](https://user-images.githubusercontent.com/14116827/33507335-0b081c1c-d6a9-11e7-9f2b-3198edf1890e.png)


And finally, an example of a named constructor with type arguments:

![screenshot from 2017-12-01 14 52 19](https://user-images.githubusercontent.com/14116827/33507313-e8391de4-d6a8-11e7-836f-fabc74110265.png)
