### PR TITLE
Remove unused field and no-op value set

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -35,7 +35,7 @@ export 'src/sdk.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String version = '0.15.0+1';
+const String version = '0.15.1-dev';
 
 final String defaultOutDir = path.join('doc', 'api');
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4882,7 +4882,6 @@ class TypeParameter extends ModelElement {
 
   @override
   String get name {
-    var bound = _typeParameter.bound;
     return _typeParameter.bound != null
         ? '${_typeParameter.name} extends ${boundType.nameWithGenerics}'
         : _typeParameter.name;
@@ -5011,7 +5010,6 @@ class PackageBuilder {
     if (_context == null) {
       // TODO(jcollins-g): fix this so it actually obeys analyzer options files.
       var options = new AnalysisOptionsImpl();
-      options.enableAssertInitializer = true;
       options.enableSuperMixins = true;
       AnalysisEngine.instance.processRequiredPlugins();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.15.0+1
+version: 0.15.1-dev
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.15.0+1">
+  <meta name="generator" content="made with love by dartdoc 0.15.1-dev">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
With the current version of pkg/analyzer (0.31.0-alpha.2),
enableAssertInitializer setter does nothing