### PR TITLE
Add a method memoizer to dartdoc

### DIFF
--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -219,7 +219,7 @@ class MethodMemoizer {
   /// returns the cached value of [f]().
   R memoized<R>(Function f) {
     _MemoKey key = new _MemoKey(f, new HashableList([]));
-    return _getOrUpdateCache(() => f(), key);
+    return _getOrUpdateCache(f, key);
   }
 
   /// Calls and caches the return value of [f]([param1]) if not in the cache, then

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -265,7 +265,8 @@ class Memoizer {
   R memoized4<R, A, B, C, D>(
       R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
     _HashableList key = new _HashableList([f, param1, param2, param3, param4]);
-    return _memoizationTable.putIfAbsent(key, () => f(param1, param2, param3, param4));
+    return _memoizationTable.putIfAbsent(
+        key, () => f(param1, param2, param3, param4));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -275,8 +276,8 @@ class Memoizer {
       C param3, D param4, E param5) {
     _HashableList key =
         new _HashableList([f, param1, param2, param3, param4, param5]);
-    return _memoizationTable.putIfAbsent(key,
-        () => f(param1, param2, param3, param4, param5));
+    return _memoizationTable.putIfAbsent(
+        key, () => f(param1, param2, param3, param4, param5));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -286,8 +287,8 @@ class Memoizer {
       B param2, C param3, D param4, E param5, F param6) {
     _HashableList key =
         new _HashableList([f, param1, param2, param3, param4, param5, param6]);
-    return _memoizationTable.putIfAbsent(key,
-        () => f(param1, param2, param3, param4, param5, param6));
+    return _memoizationTable.putIfAbsent(
+        key, () => f(param1, param2, param3, param4, param5, param6));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -298,8 +299,8 @@ class Memoizer {
       A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
     _HashableList key = new _HashableList(
         [f, param1, param2, param3, param4, param5, param6, param7]);
-    return _memoizationTable.putIfAbsent(key,
-        () => f(param1, param2, param3, param4, param5, param6, param7));
+    return _memoizationTable.putIfAbsent(
+        key, () => f(param1, param2, param3, param4, param5, param6, param7));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -318,7 +319,9 @@ class Memoizer {
       H param8) {
     _HashableList key = new _HashableList(
         [f, param1, param2, param3, param4, param5, param6, param7, param8]);
-    return _memoizationTable.putIfAbsent(key,
-        () => f(param1, param2, param3, param4, param5, param6, param7, param8));
+    return _memoizationTable.putIfAbsent(
+        key,
+        () =>
+            f(param1, param2, param3, param4, param5, param6, param7, param8));
   }
 }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -176,7 +176,7 @@ class HashableList extends UnmodifiableListView<dynamic> {
   HashableList(Iterable<dynamic> iterable) : super(iterable);
 
   @override
-  bool operator==(other) {
+  bool operator ==(other) {
     if (this.length == other.length) {
       for (var index = 0; index < length; ++index) {
         if (this[index] != other[index]) return false;
@@ -205,7 +205,9 @@ class MethodMemoizer {
   }
 
   /// Reset the memoization table, forcing calls of the underlying functions.
-  void invalidateMemos() { _memoizationTable = new Map(); }
+  void invalidateMemos() {
+    _memoizationTable = new Map();
+  }
 
   // Never write this if statement again.
   R _getOrUpdateCache<R>(R Function() f, _MemoKey key) {
@@ -247,42 +249,69 @@ class MethodMemoizer {
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4]) if not in the cache, then returns the cached value of
   /// [f]([param1], [param2], [param3], [param4]).
-  R memoized4<R, A, B, C, D>(R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
-    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4]));
+  R memoized4<R, A, B, C, D>(
+      R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
+    _MemoKey key =
+        new _MemoKey(f, new HashableList([param1, param2, param3, param4]));
     return _getOrUpdateCache(() => f(param1, param2, param3, param4), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4], [param5]) if not in the cache, then returns the cached value of [f](
   /// [param1], [param2], [param3], [param4], [param5]).
-  R memoized5<R, A, B, C, D, E>(R Function(A, B, C, D, E) f, A param1, B param2, C param3, D param4, E param5) {
-    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5]));
-    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5), key);
+  R memoized5<R, A, B, C, D, E>(R Function(A, B, C, D, E) f, A param1, B param2,
+      C param3, D param4, E param5) {
+    _MemoKey key = new _MemoKey(
+        f, new HashableList([param1, param2, param3, param4, param5]));
+    return _getOrUpdateCache(
+        () => f(param1, param2, param3, param4, param5), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4], [param5], [param6]) if not in the cache, then returns the cached
   /// value of [f]([param1], [param2], [param3], [param4], [param5], [param6]).
-  R memoized6<R, A, B, C, D, E, F>(R Function(A, B, C, D, E, F) f, A param1, B param2, C param3, D param4, E param5, F param6) {
-    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5, param6]));
-    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5, param6), key);
+  R memoized6<R, A, B, C, D, E, F>(R Function(A, B, C, D, E, F) f, A param1,
+      B param2, C param3, D param4, E param5, F param6) {
+    _MemoKey key = new _MemoKey(
+        f, new HashableList([param1, param2, param3, param4, param5, param6]));
+    return _getOrUpdateCache(
+        () => f(param1, param2, param3, param4, param5, param6), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4], [param5], [param6], [param7]) if not in the cache, then returns
   /// the cached value of [f]([param1], [param2], [param3], [param4], [param5],
   /// [param6], [param7]).
-  R memoized7<R, A, B, C, D, E, F, G>(R Function(A, B, C, D, E, F, G) f, A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
-    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5, param6, param7]));
-    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5, param6, param7), key);
+  R memoized7<R, A, B, C, D, E, F, G>(R Function(A, B, C, D, E, F, G) f,
+      A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
+    _MemoKey key = new _MemoKey(
+        f,
+        new HashableList(
+            [param1, param2, param3, param4, param5, param6, param7]));
+    return _getOrUpdateCache(
+        () => f(param1, param2, param3, param4, param5, param6, param7), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4], [param5], [param6], [param7], [param8]) if not in the cache,
   /// then returns the cached value of [f]([param1], [param2], [param3],
   /// [param4], [param5], [param6], [param7], [param8]).
-  R memoized8<R, A, B, C, D, E, F, G, H>(R Function(A, B, C, D, E, F, G, H) f, A param1, B param2, C param3, D param4, E param5, F param6, G param7, H param8) {
-    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5, param6, param7, param8]));
-    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5, param6, param7, param8), key);
+  R memoized8<R, A, B, C, D, E, F, G, H>(
+      R Function(A, B, C, D, E, F, G, H) f,
+      A param1,
+      B param2,
+      C param3,
+      D param4,
+      E param5,
+      F param6,
+      G param7,
+      H param8) {
+    _MemoKey key = new _MemoKey(
+        f,
+        new HashableList(
+            [param1, param2, param3, param4, param5, param6, param7, param8]));
+    return _getOrUpdateCache(
+        () => f(param1, param2, param3, param4, param5, param6, param7, param8),
+        key);
   }
 }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -190,17 +190,18 @@ class HashableList extends UnmodifiableListView<dynamic> {
   get hashCode => hashObjects(this);
 }
 
+/// A type alias for [Tuple2]`<Function, HashableList>`.
 class _MemoKey extends Tuple2<Function, HashableList> {
   _MemoKey(Function f, HashableList l) : super(f, l) {}
 }
 
 /// Extend or use as a mixin to track object-specific cached values, or
 /// instantiate directly to track other values.
-class MethodMemoizer {
+class Memoizer {
   /// Map of a function and its positional parameters (if any), to a value.
   Map<_MemoKey, dynamic> _memoizationTable;
 
-  MethodMemoizer() {
+  Memoizer() {
     invalidateMemos();
   }
 

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -190,11 +190,15 @@ class HashableList extends UnmodifiableListView<dynamic> {
   get hashCode => hashObjects(this);
 }
 
+class _MemoKey extends Tuple2<Function, HashableList> {
+  _MemoKey(Function f, HashableList l) : super(f, l) {}
+}
+
 /// Extend or use as a mixin to track object-specific cached values, or
 /// instantiate directly to track other values.
 class MethodMemoizer {
   /// Map of a function and its positional parameters (if any), to a value.
-  Map<Tuple2<Function, HashableList>, dynamic> _memoizationTable;
+  Map<_MemoKey, dynamic> _memoizationTable;
 
   MethodMemoizer() {
     invalidateMemos();
@@ -203,78 +207,65 @@ class MethodMemoizer {
   /// Reset the memoization table, forcing calls of the underlying functions.
   void invalidateMemos() { _memoizationTable = new Map(); }
 
-  /// Calls and caches the return value of [f]() if not in the cache, then
-  /// returns the cached value of [f]().
-  R memoized<R>(Function f) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([]));
+  // Never write this if statement again.
+  R _getOrUpdateCache<R>(R Function() f, _MemoKey key) {
     if (!_memoizationTable.containsKey(key)) {
       _memoizationTable[key] = f();
     }
     return _memoizationTable[key];
   }
 
+  /// Calls and caches the return value of [f]() if not in the cache, then
+  /// returns the cached value of [f]().
+  R memoized<R>(Function f) {
+    _MemoKey key = new _MemoKey(f, new HashableList([]));
+    return _getOrUpdateCache(() => f(), key);
+  }
+
   /// Calls and caches the return value of [f]([param1]) if not in the cache, then
   /// returns the cached value of [f]([param1]).
   R memoized1<R, A>(R Function(A) f, A param1) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1]));
-     if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1]));
+    return _getOrUpdateCache(() => f(param1), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2]) if not in the
   /// cache, then returns the cached value of [f]([param1], [param2]).
   R memoized2<R, A, B>(R Function(A, B) f, A param1, B param2) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2]));
+    return _getOrUpdateCache(() => f(param1, param2), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3]) if
   /// not in the cache, then returns the cached value of [f]([param1],
   /// [param2], [param3]).
   R memoized3<R, A, B, C>(R Function(A, B, C) f, A param1, B param2, C param3) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2, param3);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3]));
+    return _getOrUpdateCache(() => f(param1, param2, param3), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4]) if not in the cache, then returns the cached value of
   /// [f]([param1], [param2], [param3], [param4]).
   R memoized4<R, A, B, C, D>(R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2, param3, param4);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4]));
+    return _getOrUpdateCache(() => f(param1, param2, param3, param4), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4], [param5]) if not in the cache, then returns the cached value of [f](
   /// [param1], [param2], [param3], [param4], [param5]).
   R memoized5<R, A, B, C, D, E>(R Function(A, B, C, D, E) f, A param1, B param2, C param3, D param4, E param5) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2, param3, param4, param5);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5]));
+    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
   /// [param4], [param5], [param6]) if not in the cache, then returns the cached
   /// value of [f]([param1], [param2], [param3], [param4], [param5], [param6]).
   R memoized6<R, A, B, C, D, E, F>(R Function(A, B, C, D, E, F) f, A param1, B param2, C param3, D param4, E param5, F param6) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5, param6]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2, param3, param4, param5, param6);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5, param6]));
+    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5, param6), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -282,11 +273,8 @@ class MethodMemoizer {
   /// the cached value of [f]([param1], [param2], [param3], [param4], [param5],
   /// [param6], [param7]).
   R memoized7<R, A, B, C, D, E, F, G>(R Function(A, B, C, D, E, F, G) f, A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5, param6, param7]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2, param3, param4, param5, param6, param7);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5, param6, param7]));
+    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5, param6, param7), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -294,10 +282,7 @@ class MethodMemoizer {
   /// then returns the cached value of [f]([param1], [param2], [param3],
   /// [param4], [param5], [param6], [param7], [param8]).
   R memoized8<R, A, B, C, D, E, F, G, H>(R Function(A, B, C, D, E, F, G, H) f, A param1, B param2, C param3, D param4, E param5, F param6, G param7, H param8) {
-    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5, param6, param7, param8]));
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f(param1, param2, param3, param4, param5, param6, param7, param8);
-    }
-    return _memoizationTable[key];
+    _MemoKey key = new _MemoKey(f, new HashableList([param1, param2, param3, param4, param5, param6, param7, param8]));
+    return _getOrUpdateCache(() => f(param1, param2, param3, param4, param5, param6, param7, param8), key);
   }
 }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -243,21 +243,21 @@ class Memoizer {
   ///
 
   R memoized<R>(Function f) {
-    _HashableList key =  new _HashableList([f]);
+    _HashableList key = new _HashableList([f]);
     return _getOrUpdateCache(f, key);
   }
 
   /// Calls and caches the return value of [f]([param1]) if not in the cache, then
   /// returns the cached value of [f]([param1]).
   R memoized1<R, A>(R Function(A) f, A param1) {
-    _HashableList key =  new _HashableList([f, param1]);
+    _HashableList key = new _HashableList([f, param1]);
     return _getOrUpdateCache(() => f(param1), key);
   }
 
   /// Calls and caches the return value of [f]([param1], [param2]) if not in the
   /// cache, then returns the cached value of [f]([param1], [param2]).
   R memoized2<R, A, B>(R Function(A, B) f, A param1, B param2) {
-    _HashableList key =  new _HashableList([f, param1, param2]);
+    _HashableList key = new _HashableList([f, param1, param2]);
     return _getOrUpdateCache(() => f(param1, param2), key);
   }
 
@@ -265,7 +265,7 @@ class Memoizer {
   /// not in the cache, then returns the cached value of [f]([param1],
   /// [param2], [param3]).
   R memoized3<R, A, B, C>(R Function(A, B, C) f, A param1, B param2, C param3) {
-    _HashableList key =  new _HashableList([f, param1, param2, param3]);
+    _HashableList key = new _HashableList([f, param1, param2, param3]);
     return _getOrUpdateCache(() => f(param1, param2, param3), key);
   }
 
@@ -274,8 +274,7 @@ class Memoizer {
   /// [f]([param1], [param2], [param3], [param4]).
   R memoized4<R, A, B, C, D>(
       R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
-    _HashableList key =
-         new _HashableList([f, param1, param2, param3, param4]);
+    _HashableList key = new _HashableList([f, param1, param2, param3, param4]);
     return _getOrUpdateCache(() => f(param1, param2, param3, param4), key);
   }
 
@@ -284,7 +283,8 @@ class Memoizer {
   /// [param1], [param2], [param3], [param4], [param5]).
   R memoized5<R, A, B, C, D, E>(R Function(A, B, C, D, E) f, A param1, B param2,
       C param3, D param4, E param5) {
-    _HashableList key = new _HashableList([f, param1, param2, param3, param4, param5]);
+    _HashableList key =
+        new _HashableList([f, param1, param2, param3, param4, param5]);
     return _getOrUpdateCache(
         () => f(param1, param2, param3, param4, param5), key);
   }
@@ -294,7 +294,8 @@ class Memoizer {
   /// value of [f]([param1], [param2], [param3], [param4], [param5], [param6]).
   R memoized6<R, A, B, C, D, E, F>(R Function(A, B, C, D, E, F) f, A param1,
       B param2, C param3, D param4, E param5, F param6) {
-    _HashableList key = new _HashableList([f, param1, param2, param3, param4, param5, param6]);
+    _HashableList key =
+        new _HashableList([f, param1, param2, param3, param4, param5, param6]);
     return _getOrUpdateCache(
         () => f(param1, param2, param3, param4, param5, param6), key);
   }
@@ -306,7 +307,7 @@ class Memoizer {
   R memoized7<R, A, B, C, D, E, F, G>(R Function(A, B, C, D, E, F, G) f,
       A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
     _HashableList key = new _HashableList(
-            [f, param1, param2, param3, param4, param5, param6, param7]);
+        [f, param1, param2, param3, param4, param5, param6, param7]);
     return _getOrUpdateCache(
         () => f(param1, param2, param3, param4, param5, param6, param7), key);
   }
@@ -326,7 +327,7 @@ class Memoizer {
       G param7,
       H param8) {
     _HashableList key = new _HashableList(
-            [f, param1, param2, param3, param4, param5, param6, param7, param8]);
+        [f, param1, param2, param3, param4, param5, param6, param7, param8]);
     return _getOrUpdateCache(
         () => f(param1, param2, param3, param4, param5, param6, param7, param8),
         key);

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -4,6 +4,7 @@
 
 library dartdoc.model_utils;
 
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -12,6 +13,8 @@ import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source_io.dart';
 import 'package:dartdoc/src/model.dart';
+import 'package:quiver_hashcode/hashcode.dart';
+import 'package:tuple/tuple.dart';
 
 import 'config.dart';
 
@@ -165,4 +168,136 @@ String crossdartifySource(
     newSource = sanitizer.convert(source);
   }
   return newSource;
+}
+
+/// An UnmodifiableListView that computes equality and hashCode based on the
+/// equality and hashCode of its contained objects.
+class HashableList extends UnmodifiableListView<dynamic> {
+  HashableList(Iterable<dynamic> iterable) : super(iterable);
+
+  @override
+  bool operator==(other) {
+    if (this.length == other.length) {
+      for (var index = 0; index < length; ++index) {
+        if (this[index] != other[index]) return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  get hashCode => hashObjects(this);
+}
+
+/// Extend or use as a mixin to track object-specific cached values, or
+/// instantiate directly to track other values.
+class MethodMemoizer {
+  /// Map of a function and its positional parameters (if any), to a value.
+  Map<Tuple2<Function, HashableList>, dynamic> _memoizationTable;
+
+  MethodMemoizer() {
+    invalidateMemos();
+  }
+
+  /// Reset the memoization table, forcing calls of the underlying functions.
+  void invalidateMemos() { _memoizationTable = new Map(); }
+
+  /// Calls and caches the return value of [f]() if not in the cache, then
+  /// returns the cached value of [f]().
+  R memoized<R>(Function f) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f();
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1]) if not in the cache, then
+  /// returns the cached value of [f]([param1]).
+  R memoized1<R, A>(R Function(A) f, A param1) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1]));
+     if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2]) if not in the
+  /// cache, then returns the cached value of [f]([param1], [param2]).
+  R memoized2<R, A, B>(R Function(A, B) f, A param1, B param2) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2], [param3]) if
+  /// not in the cache, then returns the cached value of [f]([param1],
+  /// [param2], [param3]).
+  R memoized3<R, A, B, C>(R Function(A, B, C) f, A param1, B param2, C param3) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2, param3);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2], [param3],
+  /// [param4]) if not in the cache, then returns the cached value of
+  /// [f]([param1], [param2], [param3], [param4]).
+  R memoized4<R, A, B, C, D>(R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2, param3, param4);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2], [param3],
+  /// [param4], [param5]) if not in the cache, then returns the cached value of [f](
+  /// [param1], [param2], [param3], [param4], [param5]).
+  R memoized5<R, A, B, C, D, E>(R Function(A, B, C, D, E) f, A param1, B param2, C param3, D param4, E param5) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2, param3, param4, param5);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2], [param3],
+  /// [param4], [param5], [param6]) if not in the cache, then returns the cached
+  /// value of [f]([param1], [param2], [param3], [param4], [param5], [param6]).
+  R memoized6<R, A, B, C, D, E, F>(R Function(A, B, C, D, E, F) f, A param1, B param2, C param3, D param4, E param5, F param6) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5, param6]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2, param3, param4, param5, param6);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2], [param3],
+  /// [param4], [param5], [param6], [param7]) if not in the cache, then returns
+  /// the cached value of [f]([param1], [param2], [param3], [param4], [param5],
+  /// [param6], [param7]).
+  R memoized7<R, A, B, C, D, E, F, G>(R Function(A, B, C, D, E, F, G) f, A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5, param6, param7]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2, param3, param4, param5, param6, param7);
+    }
+    return _memoizationTable[key];
+  }
+
+  /// Calls and caches the return value of [f]([param1], [param2], [param3],
+  /// [param4], [param5], [param6], [param7], [param8]) if not in the cache,
+  /// then returns the cached value of [f]([param1], [param2], [param3],
+  /// [param4], [param5], [param6], [param7], [param8]).
+  R memoized8<R, A, B, C, D, E, F, G, H>(R Function(A, B, C, D, E, F, G, H) f, A param1, B param2, C param3, D param4, E param5, F param6, G param7, H param8) {
+    Tuple2<Function, HashableList> key = new Tuple2(f, new HashableList([param1, param2, param3, param4, param5, param6, param7, param8]));
+    if (!_memoizationTable.containsKey(key)) {
+      _memoizationTable[key] = f(param1, param2, param3, param4, param5, param6, param7, param8);
+    }
+    return _memoizationTable[key];
+  }
 }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -230,35 +230,25 @@ class Memoizer {
     _memoizationTable = new Map();
   }
 
-  // Never write this if statement again.
-  R _getOrUpdateCache<R>(R Function() f, _HashableList key) {
-    if (!_memoizationTable.containsKey(key)) {
-      _memoizationTable[key] = f();
-    }
-    return _memoizationTable[key];
-  }
-
   /// Calls and caches the return value of [f]() if not in the cache, then
   /// returns the cached value of [f]().
-  ///
-
   R memoized<R>(Function f) {
     _HashableList key = new _HashableList([f]);
-    return _getOrUpdateCache(f, key);
+    return _memoizationTable.putIfAbsent(key, f);
   }
 
   /// Calls and caches the return value of [f]([param1]) if not in the cache, then
   /// returns the cached value of [f]([param1]).
   R memoized1<R, A>(R Function(A) f, A param1) {
     _HashableList key = new _HashableList([f, param1]);
-    return _getOrUpdateCache(() => f(param1), key);
+    return _memoizationTable.putIfAbsent(key, () => f(param1));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2]) if not in the
   /// cache, then returns the cached value of [f]([param1], [param2]).
   R memoized2<R, A, B>(R Function(A, B) f, A param1, B param2) {
     _HashableList key = new _HashableList([f, param1, param2]);
-    return _getOrUpdateCache(() => f(param1, param2), key);
+    return _memoizationTable.putIfAbsent(key, () => f(param1, param2));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3]) if
@@ -266,7 +256,7 @@ class Memoizer {
   /// [param2], [param3]).
   R memoized3<R, A, B, C>(R Function(A, B, C) f, A param1, B param2, C param3) {
     _HashableList key = new _HashableList([f, param1, param2, param3]);
-    return _getOrUpdateCache(() => f(param1, param2, param3), key);
+    return _memoizationTable.putIfAbsent(key, () => f(param1, param2, param3));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -275,7 +265,7 @@ class Memoizer {
   R memoized4<R, A, B, C, D>(
       R Function(A, B, C, D) f, A param1, B param2, C param3, D param4) {
     _HashableList key = new _HashableList([f, param1, param2, param3, param4]);
-    return _getOrUpdateCache(() => f(param1, param2, param3, param4), key);
+    return _memoizationTable.putIfAbsent(key, () => f(param1, param2, param3, param4));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -285,8 +275,8 @@ class Memoizer {
       C param3, D param4, E param5) {
     _HashableList key =
         new _HashableList([f, param1, param2, param3, param4, param5]);
-    return _getOrUpdateCache(
-        () => f(param1, param2, param3, param4, param5), key);
+    return _memoizationTable.putIfAbsent(key,
+        () => f(param1, param2, param3, param4, param5));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -296,8 +286,8 @@ class Memoizer {
       B param2, C param3, D param4, E param5, F param6) {
     _HashableList key =
         new _HashableList([f, param1, param2, param3, param4, param5, param6]);
-    return _getOrUpdateCache(
-        () => f(param1, param2, param3, param4, param5, param6), key);
+    return _memoizationTable.putIfAbsent(key,
+        () => f(param1, param2, param3, param4, param5, param6));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -308,8 +298,8 @@ class Memoizer {
       A param1, B param2, C param3, D param4, E param5, F param6, G param7) {
     _HashableList key = new _HashableList(
         [f, param1, param2, param3, param4, param5, param6, param7]);
-    return _getOrUpdateCache(
-        () => f(param1, param2, param3, param4, param5, param6, param7), key);
+    return _memoizationTable.putIfAbsent(key,
+        () => f(param1, param2, param3, param4, param5, param6, param7));
   }
 
   /// Calls and caches the return value of [f]([param1], [param2], [param3],
@@ -328,8 +318,7 @@ class Memoizer {
       H param8) {
     _HashableList key = new _HashableList(
         [f, param1, param2, param3, param4, param5, param6, param7, param8]);
-    return _getOrUpdateCache(
-        () => f(param1, param2, param3, param4, param5, param6, param7, param8),
-        key);
+    return _memoizationTable.putIfAbsent(key,
+        () => f(param1, param2, param3, param4, param5, param6, param7, param8));
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -374,4 +374,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.10.0"
+  dart: ">=1.23.0 <=2.0.0-dev.12.0"

--- a/test/model_utils_test.dart
+++ b/test/model_utils_test.dart
@@ -11,32 +11,77 @@ class MemoizerUser extends MethodMemoizer {
   int foo = 0;
   // These are actually not things you would ordinarily memoize, because
   // they change.  But they are useful for testing.
-  int _toMemoize() { return foo++; }
+  int _toMemoize() {
+    return foo++;
+  }
+
   int get toMemoize => memoized(_toMemoize);
 
   String _memoizedParameter1(String param) => "${foo++} ${param}";
-  String memoizedParameter1(String param) => memoized1(_memoizedParameter1, param);
+  String memoizedParameter1(String param) =>
+      memoized1(_memoizedParameter1, param);
 
-  String _memoizedParameter2(String param, String param2) => "${foo++} ${param} ${param2}";
-  String memoizedParameter2(String param, String param2) => memoized2(_memoizedParameter2, param, param2);
+  String _memoizedParameter2(String param, String param2) =>
+      "${foo++} ${param} ${param2}";
+  String memoizedParameter2(String param, String param2) =>
+      memoized2(_memoizedParameter2, param, param2);
 
-  String _memoizedParameter3(String param, String param2, String param3) => "${foo++} ${param} ${param2} ${param3}";
-  String memoizedParameter3(String param, String param2, String param3) => memoized3(_memoizedParameter3, param, param2, param3);
+  String _memoizedParameter3(String param, String param2, String param3) =>
+      "${foo++} ${param} ${param2} ${param3}";
+  String memoizedParameter3(String param, String param2, String param3) =>
+      memoized3(_memoizedParameter3, param, param2, param3);
 
-  String _memoizedParameter4(String param, String param2, String param3, String param4) => "${foo++} ${param} ${param2} ${param3} ${param4}";
-  String memoizedParameter4(String param, String param2, String param3, String param4) => memoized4(_memoizedParameter4, param, param2, param3, param4);
+  String _memoizedParameter4(
+          String param, String param2, String param3, String param4) =>
+      "${foo++} ${param} ${param2} ${param3} ${param4}";
+  String memoizedParameter4(
+          String param, String param2, String param3, String param4) =>
+      memoized4(_memoizedParameter4, param, param2, param3, param4);
 
-  String _memoizedParameter5(String param, String param2, String param3, String param4, String param5) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5}";
-  String memoizedParameter5(String param, String param2, String param3, String param4, String param5) => memoized5(_memoizedParameter5, param, param2, param3, param4, param5);
+  String _memoizedParameter5(String param, String param2, String param3,
+          String param4, String param5) =>
+      "${foo++} ${param} ${param2} ${param3} ${param4} ${param5}";
+  String memoizedParameter5(String param, String param2, String param3,
+          String param4, String param5) =>
+      memoized5(_memoizedParameter5, param, param2, param3, param4, param5);
 
-  String _memoizedParameter6(String param, String param2, String param3, String param4, String param5, String param6) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6}";
-  String memoizedParameter6(String param, String param2, String param3, String param4, String param5, String param6) => memoized6(_memoizedParameter6, param, param2, param3, param4, param5, param6);
+  String _memoizedParameter6(String param, String param2, String param3,
+          String param4, String param5, String param6) =>
+      "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6}";
+  String memoizedParameter6(String param, String param2, String param3,
+          String param4, String param5, String param6) =>
+      memoized6(
+          _memoizedParameter6, param, param2, param3, param4, param5, param6);
 
-  String _memoizedParameter7(String param, String param2, String param3, String param4, String param5, String param6, String param7) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6} ${param7}";
-  String memoizedParameter7(String param, String param2, String param3, String param4, String param5, String param6, String param7) => memoized7(_memoizedParameter7, param, param2, param3, param4, param5, param6, param7);
+  String _memoizedParameter7(String param, String param2, String param3,
+          String param4, String param5, String param6, String param7) =>
+      "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6} ${param7}";
+  String memoizedParameter7(String param, String param2, String param3,
+          String param4, String param5, String param6, String param7) =>
+      memoized7(_memoizedParameter7, param, param2, param3, param4, param5,
+          param6, param7);
 
-  String _memoizedParameter8(String param, String param2, String param3, String param4, String param5, String param6, String param7, String param8) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6} ${param7} ${param8}";
-  String memoizedParameter8(String param, String param2, String param3, String param4, String param5, String param6, String param7, String param8) => memoized8(_memoizedParameter8, param, param2, param3, param4, param5, param6, param7, param8);
+  String _memoizedParameter8(
+          String param,
+          String param2,
+          String param3,
+          String param4,
+          String param5,
+          String param6,
+          String param7,
+          String param8) =>
+      "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6} ${param7} ${param8}";
+  String memoizedParameter8(
+          String param,
+          String param2,
+          String param3,
+          String param4,
+          String param5,
+          String param6,
+          String param7,
+          String param8) =>
+      memoized8(_memoizedParameter8, param, param2, param3, param4, param5,
+          param6, param7, param8);
 }
 
 void main() {
@@ -96,32 +141,55 @@ void main() {
 
     test('memoization of a method with parameter', () {
       var m = new MemoizerUser();
-      expect(m.memoizedParameter1("hello"), equals("0 hello"), reason: "initialization problem");
-      expect(m.memoizedParameter1("hello"), equals("0 hello"), reason: "failed to memoize");
+      expect(m.memoizedParameter1("hello"), equals("0 hello"),
+          reason: "initialization problem");
+      expect(m.memoizedParameter1("hello"), equals("0 hello"),
+          reason: "failed to memoize");
       expect(m.memoizedParameter1("goodbye"), equals("1 goodbye"));
       expect(m.memoizedParameter1("something"), equals("2 something"));
       m.invalidateMemos();
-      expect(m.memoizedParameter1("hello"), equals("3 hello"), reason: "failed to invalidate");
+      expect(m.memoizedParameter1("hello"), equals("3 hello"),
+          reason: "failed to invalidate");
     });
 
     test('memoization of many parameters', () {
       var m = new MemoizerUser();
       expect(m.memoizedParameter1("hello"), equals("0 hello"));
       expect(m.memoizedParameter2("hello", "obi"), equals("1 hello obi"));
-      expect(m.memoizedParameter3("hello", "obi", "wan"), equals("2 hello obi wan"));
-      expect(m.memoizedParameter4("hello", "obi", "wan", "how"), equals("3 hello obi wan how"));
-      expect(m.memoizedParameter5("hello", "obi", "wan", "how", "are"), equals("4 hello obi wan how are"));
-      expect(m.memoizedParameter6("hello", "obi", "wan", "how", "are", "you"), equals("5 hello obi wan how are you"));
-      expect(m.memoizedParameter7("hello", "obi", "wan", "how", "are", "you", "doing"), equals("6 hello obi wan how are you doing"));
-      expect(m.memoizedParameter8("hello", "obi", "wan", "how", "are", "you", "doing", "today"), equals("7 hello obi wan how are you doing today"));
+      expect(m.memoizedParameter3("hello", "obi", "wan"),
+          equals("2 hello obi wan"));
+      expect(m.memoizedParameter4("hello", "obi", "wan", "how"),
+          equals("3 hello obi wan how"));
+      expect(m.memoizedParameter5("hello", "obi", "wan", "how", "are"),
+          equals("4 hello obi wan how are"));
+      expect(m.memoizedParameter6("hello", "obi", "wan", "how", "are", "you"),
+          equals("5 hello obi wan how are you"));
+      expect(
+          m.memoizedParameter7(
+              "hello", "obi", "wan", "how", "are", "you", "doing"),
+          equals("6 hello obi wan how are you doing"));
+      expect(
+          m.memoizedParameter8(
+              "hello", "obi", "wan", "how", "are", "you", "doing", "today"),
+          equals("7 hello obi wan how are you doing today"));
       expect(m.memoizedParameter1("hello"), equals("0 hello"));
       expect(m.memoizedParameter2("hello", "obi"), equals("1 hello obi"));
-      expect(m.memoizedParameter3("hello", "obi", "wan"), equals("2 hello obi wan"));
-      expect(m.memoizedParameter4("hello", "obi", "wan", "how"), equals("3 hello obi wan how"));
-      expect(m.memoizedParameter5("hello", "obi", "wan", "how", "are"), equals("4 hello obi wan how are"));
-      expect(m.memoizedParameter6("hello", "obi", "wan", "how", "are", "you"), equals("5 hello obi wan how are you"));
-      expect(m.memoizedParameter7("hello", "obi", "wan", "how", "are", "you", "doing"), equals("6 hello obi wan how are you doing"));
-      expect(m.memoizedParameter8("hello", "obi", "wan", "how", "are", "you", "doing", "today"), equals("7 hello obi wan how are you doing today"));
+      expect(m.memoizedParameter3("hello", "obi", "wan"),
+          equals("2 hello obi wan"));
+      expect(m.memoizedParameter4("hello", "obi", "wan", "how"),
+          equals("3 hello obi wan how"));
+      expect(m.memoizedParameter5("hello", "obi", "wan", "how", "are"),
+          equals("4 hello obi wan how are"));
+      expect(m.memoizedParameter6("hello", "obi", "wan", "how", "are", "you"),
+          equals("5 hello obi wan how are you"));
+      expect(
+          m.memoizedParameter7(
+              "hello", "obi", "wan", "how", "are", "you", "doing"),
+          equals("6 hello obi wan how are you doing"));
+      expect(
+          m.memoizedParameter8(
+              "hello", "obi", "wan", "how", "are", "you", "doing", "today"),
+          equals("7 hello obi wan how are you doing today"));
     });
   });
 }

--- a/test/model_utils_test.dart
+++ b/test/model_utils_test.dart
@@ -7,6 +7,38 @@ library dartdoc.model_utils_test;
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:test/test.dart';
 
+class MemoizerUser extends MethodMemoizer {
+  int foo = 0;
+  // These are actually not things you would ordinarily memoize, because
+  // they change.  But they are useful for testing.
+  int _toMemoize() { return foo++; }
+  int get toMemoize => memoized(_toMemoize);
+
+  String _memoizedParameter1(String param) => "${foo++} ${param}";
+  String memoizedParameter1(String param) => memoized1(_memoizedParameter1, param);
+
+  String _memoizedParameter2(String param, String param2) => "${foo++} ${param} ${param2}";
+  String memoizedParameter2(String param, String param2) => memoized2(_memoizedParameter2, param, param2);
+
+  String _memoizedParameter3(String param, String param2, String param3) => "${foo++} ${param} ${param2} ${param3}";
+  String memoizedParameter3(String param, String param2, String param3) => memoized3(_memoizedParameter3, param, param2, param3);
+
+  String _memoizedParameter4(String param, String param2, String param3, String param4) => "${foo++} ${param} ${param2} ${param3} ${param4}";
+  String memoizedParameter4(String param, String param2, String param3, String param4) => memoized4(_memoizedParameter4, param, param2, param3, param4);
+
+  String _memoizedParameter5(String param, String param2, String param3, String param4, String param5) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5}";
+  String memoizedParameter5(String param, String param2, String param3, String param4, String param5) => memoized5(_memoizedParameter5, param, param2, param3, param4, param5);
+
+  String _memoizedParameter6(String param, String param2, String param3, String param4, String param5, String param6) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6}";
+  String memoizedParameter6(String param, String param2, String param3, String param4, String param5, String param6) => memoized6(_memoizedParameter6, param, param2, param3, param4, param5, param6);
+
+  String _memoizedParameter7(String param, String param2, String param3, String param4, String param5, String param6, String param7) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6} ${param7}";
+  String memoizedParameter7(String param, String param2, String param3, String param4, String param5, String param6, String param7) => memoized7(_memoizedParameter7, param, param2, param3, param4, param5, param6, param7);
+
+  String _memoizedParameter8(String param, String param2, String param3, String param4, String param5, String param6, String param7, String param8) => "${foo++} ${param} ${param2} ${param3} ${param4} ${param5} ${param6} ${param7} ${param8}";
+  String memoizedParameter8(String param, String param2, String param3, String param4, String param5, String param6, String param7, String param8) => memoized8(_memoizedParameter8, param, param2, param3, param4, param5, param6, param7, param8);
+}
+
 void main() {
   group('model_utils stripIndentFromSource', () {
     test('no indent', () {
@@ -50,6 +82,46 @@ void main() {
           stripDartdocCommentsFromSource(
               '/**\n * foo comment\n */\nvoid foo() {\n  print(1);\n}\n'),
           'void foo() {\n  print(1);\n}\n');
+    });
+  });
+
+  group('model_utils MethodMemoizer', () {
+    test('basic memoization and invalidation', () {
+      var m = new MemoizerUser();
+      expect(m.toMemoize, equals(0), reason: "initialization problem");
+      expect(m.toMemoize, equals(0), reason: "failed to memoize");
+      m.invalidateMemos();
+      expect(m.toMemoize, equals(1), reason: "failed to invalidate");
+    });
+
+    test('memoization of a method with parameter', () {
+      var m = new MemoizerUser();
+      expect(m.memoizedParameter1("hello"), equals("0 hello"), reason: "initialization problem");
+      expect(m.memoizedParameter1("hello"), equals("0 hello"), reason: "failed to memoize");
+      expect(m.memoizedParameter1("goodbye"), equals("1 goodbye"));
+      expect(m.memoizedParameter1("something"), equals("2 something"));
+      m.invalidateMemos();
+      expect(m.memoizedParameter1("hello"), equals("3 hello"), reason: "failed to invalidate");
+    });
+
+    test('memoization of many parameters', () {
+      var m = new MemoizerUser();
+      expect(m.memoizedParameter1("hello"), equals("0 hello"));
+      expect(m.memoizedParameter2("hello", "obi"), equals("1 hello obi"));
+      expect(m.memoizedParameter3("hello", "obi", "wan"), equals("2 hello obi wan"));
+      expect(m.memoizedParameter4("hello", "obi", "wan", "how"), equals("3 hello obi wan how"));
+      expect(m.memoizedParameter5("hello", "obi", "wan", "how", "are"), equals("4 hello obi wan how are"));
+      expect(m.memoizedParameter6("hello", "obi", "wan", "how", "are", "you"), equals("5 hello obi wan how are you"));
+      expect(m.memoizedParameter7("hello", "obi", "wan", "how", "are", "you", "doing"), equals("6 hello obi wan how are you doing"));
+      expect(m.memoizedParameter8("hello", "obi", "wan", "how", "are", "you", "doing", "today"), equals("7 hello obi wan how are you doing today"));
+      expect(m.memoizedParameter1("hello"), equals("0 hello"));
+      expect(m.memoizedParameter2("hello", "obi"), equals("1 hello obi"));
+      expect(m.memoizedParameter3("hello", "obi", "wan"), equals("2 hello obi wan"));
+      expect(m.memoizedParameter4("hello", "obi", "wan", "how"), equals("3 hello obi wan how"));
+      expect(m.memoizedParameter5("hello", "obi", "wan", "how", "are"), equals("4 hello obi wan how are"));
+      expect(m.memoizedParameter6("hello", "obi", "wan", "how", "are", "you"), equals("5 hello obi wan how are you"));
+      expect(m.memoizedParameter7("hello", "obi", "wan", "how", "are", "you", "doing"), equals("6 hello obi wan how are you doing"));
+      expect(m.memoizedParameter8("hello", "obi", "wan", "how", "are", "you", "doing", "today"), equals("7 hello obi wan how are you doing today"));
     });
   });
 }

--- a/test/model_utils_test.dart
+++ b/test/model_utils_test.dart
@@ -7,7 +7,7 @@ library dartdoc.model_utils_test;
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:test/test.dart';
 
-class MemoizerUser extends MethodMemoizer {
+class MemoizerUser extends Memoizer {
   int foo = 0;
   // These are actually not things you would ordinarily memoize, because
   // they change.  But they are useful for testing.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -132,8 +132,6 @@ analyze() async {
 @Depends(analyze, test, testDartdoc)
 buildbot() => null;
 
-void anOrdinaryFunction() {}
-
 @Task('Generate docs for the Dart SDK')
 Future buildSdkDocs() async {
   log('building SDK docs');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -14,14 +14,16 @@ import 'package:yaml/yaml.dart' as yaml;
 
 main([List<String> args]) => grind(args);
 
+// Directory.systemTemp is not a constant.  So wrap it.
+Directory createTempSync(String prefix) =>
+    Directory.systemTemp.createTempSync(prefix);
+
 final Memoizer tempdirsCache = new Memoizer();
 
 Directory get dartdocDocsDir =>
-    tempdirsCache.memoized1(Directory.systemTemp.createTempSync, 'dartdoc');
-Directory get sdkDocsDir =>
-    tempdirsCache.memoized1(Directory.systemTemp.createTempSync, 'sdkdocs');
-Directory get flutterDir =>
-    tempdirsCache.memoized1(Directory.systemTemp.createTempSync, 'flutter');
+    tempdirsCache.memoized1(createTempSync, 'dartdoc');
+Directory get sdkDocsDir => tempdirsCache.memoized1(createTempSync, 'sdkdocs');
+Directory get flutterDir => tempdirsCache.memoized1(createTempSync, 'flutter');
 
 final Directory flutterDirDevTools =
     new Directory(path.join(flutterDir.path, 'dev', 'tools'));
@@ -129,6 +131,8 @@ analyze() async {
 @Task('analyze, test, and self-test dartdoc')
 @Depends(analyze, test, testDartdoc)
 buildbot() => null;
+
+void anOrdinaryFunction() {}
 
 @Task('Generate docs for the Dart SDK')
 Future buildSdkDocs() async {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -7,35 +7,21 @@ import 'dart:convert';
 import 'dart:io' hide ProcessException;
 
 import 'package:dartdoc/src/io_utils.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:grinder/grinder.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart' as yaml;
 
 main([List<String> args]) => grind(args);
 
-Directory _dartdocDocsDir;
-Directory get dartdocDocsDir {
-  if (_dartdocDocsDir == null) {
-    _dartdocDocsDir = Directory.systemTemp.createTempSync('dartdoc');
-  }
-  return _dartdocDocsDir;
-}
+final Memoizer tempdirsCache = new Memoizer();
 
-Directory _sdkDocsDir;
-Directory get sdkDocsDir {
-  if (_sdkDocsDir == null) {
-    _sdkDocsDir = Directory.systemTemp.createTempSync('sdkdocs');
-  }
-  return _sdkDocsDir;
-}
-
-Directory _flutterDir;
-Directory get flutterDir {
-  if (_flutterDir == null) {
-    _flutterDir = Directory.systemTemp.createTempSync('flutter');
-  }
-  return _flutterDir;
-}
+Directory get dartdocDocsDir =>
+    tempdirsCache.memoized1(Directory.systemTemp.createTempSync, 'dartdoc');
+Directory get sdkDocsDir =>
+    tempdirsCache.memoized1(Directory.systemTemp.createTempSync, 'sdkdocs');
+Directory get flutterDir =>
+    tempdirsCache.memoized1(Directory.systemTemp.createTempSync, 'flutter');
 
 final Directory flutterDirDevTools =
     new Directory(path.join(flutterDir.path, 'dev', 'tools'));


### PR DESCRIPTION
First version of a memoizer to eliminate code of the form:

```dart
class GinormousClass extends GinormousInterface {
  Thing _foo;
  Thing foo {
    if (_foo == null) {
      _foo = doExpensiveThing();
    }
    return _foo;
  }
}
```

and replace it with
```dart

class GinormousClass extends GinormousInterface {
  Memoizer _memoizer = new Memoizer();

  Thing foo => _memoizer.memoize(doExpensiveThing);
}
```
The cache gets declared once, and from that point on you don't have to worry about it.  The class can also handle a variety of other "cache the result of this" tasks that dartdoc currently implements separately, over and over again.

Alternatively, it could conceivably be used as a mixin:

```dart

class GinormousClass extends GinormousInterface with Memoizer {
  Thing foo => memoize(doExpensiveThing);
}
```

This has some disadvantages, including polluting the namespace.  Probably the former is what I will go with to update dartdoc.

I am building this differently from [package memoize](https://pub.dartlang.org/packages/memoize) because Dartdoc needs a per-object cache, and in the future dartdoc will need cache invalidation and possibly serialization of cached entities.  Some elements of this work might eventually make it to that package, though.
