### PR TITLE
Improve the rendering of inline <code>

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -237,6 +237,7 @@ pre.prettyprint {
 pre code {
   white-space: pre;
   word-wrap: initial;
+  font-size: 100%
 }
 
 .fixed {
@@ -253,7 +254,10 @@ code {
   font-family: 'Source Code Pro', monospace;
   /* overriding bootstrap */
   color: inherit;
-  background-color: #eee;
+  padding: 0.2em 0.4em;
+  font-size: 85%;
+  background-color: rgba(27,31,35,0.05);
+  border-radius: 3px;
 }
 
 h2 .crossdart {

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -237,6 +237,7 @@ pre.prettyprint {
 pre code {
   white-space: pre;
   word-wrap: initial;
+  font-size: 100%
 }
 
 .fixed {
@@ -253,7 +254,10 @@ code {
   font-family: 'Source Code Pro', monospace;
   /* overriding bootstrap */
   color: inherit;
-  background-color: #eee;
+  padding: 0.2em 0.4em;
+  font-size: 85%;
+  background-color: rgba(27,31,35,0.05);
+  border-radius: 3px;
 }
 
 h2 .crossdart {


### PR DESCRIPTION
Taking inspiration from GitHub

Before
<img width="604" alt="before" src="https://user-images.githubusercontent.com/17034/34056291-49e992e2-e187-11e7-8086-5bc9c0f5dfdf.png">

After
<img width="600" alt="after" src="https://user-images.githubusercontent.com/17034/34056290-49d6a6a0-e187-11e7-82f8-4791510ee000.png">
