### PR TITLE
upgrade the version of grinder used

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,12 +7,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.31.0-alpha.2"
-  ansicolor:
-    description:
-      name: ansicolor
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.9"
   args:
     description:
       name: args
@@ -96,7 +90,7 @@ packages:
       name: grinder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0+3"
+    version: "0.8.1"
   html:
     description:
       name: html
@@ -175,12 +169,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.4"
-  mockable_filesystem:
-    description:
-      name: mockable_filesystem
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.3"
   multi_server_socket:
     description:
       name: multi_server_socket
@@ -313,12 +301,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
-  supports_color:
-    description:
-      name: supports_color
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
   term_glyph:
     description:
       name: term_glyph
@@ -343,12 +325,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
-  unscripted:
-    description:
-      name: unscripted
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.2"
   utf:
     description:
       name: utf
@@ -374,4 +350,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.12.0"
+  dart: ">=1.23.0 <=2.0.0-dev.6.0"

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -30,15 +30,17 @@ final Directory flutterDirDevTools =
 
 final RegExp quotables = new RegExp(r'[ "\r\n\$]');
 // from flutter:dev/tools/dartdoc.dart, modified
-void _printStream(Stream<List<int>> stream, Stdout output,
-    {String prefix: ''}) {
+void _printStream(
+  Stream<List<int>> stream,
+  Stdout output, {
+  String prefix: '',
+}) {
   assert(prefix != null);
   stream
       .transform(UTF8.decoder)
       .transform(const LineSplitter())
       .listen((String line) {
-    output.write('$prefix$line'.trim());
-    output.write('\n');
+    output.write('  $prefix${line.trim()}\n');
   });
 }
 
@@ -76,7 +78,7 @@ class _SubprocessLauncher {
   /// TODO(jcollins-g): move this to grinder?
   Future runStreamed(String executable, List<String> arguments,
       {String workingDirectory}) async {
-    stderr.write('$prefix+ ');
+    stderr.write('  $prefix+ ');
     if (workingDirectory != null) stderr.write('cd "$workingDirectory" && ');
     if (environment != null) {
       stderr.write(environment.keys.map((String key) {


### PR DESCRIPTION
- upgrade package:grinder to 0.8.1 (this version removes deps on a few packages, including package:unscripted, which was not strong and unlikely to ever be so
- tweak the output of the streaming process output in dartdoc's build (to indent the output so it lines up better with grinder's task output)

@jcollins-g 
