### PR TITLE
Prevent private or non-canonical elements from ever generating links

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -21,6 +21,8 @@ class ElementType extends Privacy {
 
   DartType get type => _type;
 
+  Library get library => element.library;
+
   bool get isDynamic => _type.isDynamic;
 
   bool get isFunctionType => (_type is FunctionType);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -128,7 +128,12 @@ abstract class Inheritable implements ModelElement {
   ModelElement get definingEnclosingElement =>
       _memoizer.memoized(_definingEnclosingElement);
 
-  ModelElement _canonicalEnclosingElement() {
+  @override
+  ModelElement _canonicalModelElement() {
+    return canonicalEnclosingElement?.allCanonicalModelElements?.firstWhere((m) => m.name == name, orElse: () => null);
+  }
+
+  Class _canonicalEnclosingElement() {
     Class canonicalEnclosingClass;
     Element searchElement = element;
     if (isInherited) {
@@ -180,7 +185,7 @@ abstract class Inheritable implements ModelElement {
     return canonicalEnclosingClass;
   }
 
-  ModelElement get canonicalEnclosingElement =>
+  Class get canonicalEnclosingElement =>
       _memoizer.memoized(_canonicalEnclosingElement);
 
   List<Class> get inheritance {
@@ -654,8 +659,12 @@ class Class extends ModelElement
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/$fileName';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (canonicalLibrary != library)
+      1+1;
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
   }
 
   /// Returns all the implementors of this class.
@@ -1132,8 +1141,10 @@ class Constructor extends ModelElement
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/${_constructor.enclosingElement.name}/$name.html';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name.html';
   }
 
   @override
@@ -1346,9 +1357,11 @@ class EnumField extends Field {
 
   @override
   String get href {
-    if (canonicalLibrary == null || canonicalEnclosingElement == null)
-      return null;
-    return '${canonicalEnclosingElement.library.dirName}/${(canonicalEnclosingElement as Class).fileName}';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(!(canonicalLibrary == null || canonicalEnclosingElement == null));
+    assert(canonicalLibrary == library);
+    assert(canonicalEnclosingElement == enclosingElement);
+    return '${enclosingElement.library.dirName}/${(enclosingElement as Class).fileName}';
   }
 
   @override
@@ -1422,19 +1435,11 @@ class Field extends ModelElement
 
   @override
   String get href {
-    String retval;
-    if (canonicalLibrary == null) return null;
-    if (enclosingElement is Class) {
-      if (canonicalEnclosingElement == null) return null;
-      retval =
-          '${canonicalEnclosingElement.canonicalLibrary.dirName}/${canonicalEnclosingElement.name}/$_fileName';
-    } else if (enclosingElement is Library) {
-      retval = '${canonicalLibrary.dirName}/$_fileName';
-    } else {
-      throw new StateError(
-          '$name is not in a class or library, instead it is a ${enclosingElement.element}');
-    }
-    return retval;
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(canonicalLibrary != null);
+    assert(canonicalEnclosingElement == enclosingElement);
+    assert(canonicalLibrary == library);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
   }
 
   @override
@@ -1494,7 +1499,7 @@ class Field extends ModelElement
 
   FieldElement get _field => (element as FieldElement);
 
-  String get _fileName => isConst ? '$name-constant.html' : '$name.html';
+  String get fileName => isConst ? '$name-constant.html' : '$name.html';
 
   String _sourceCode() {
     // We could use a set to figure the dupes out, but that would lose ordering.
@@ -1943,8 +1948,8 @@ class Library extends ModelElement {
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/$fileName';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    return '${library.dirName}/$fileName';
   }
 
   InheritanceManager _inheritanceManager() => new InheritanceManager(element);
@@ -2284,9 +2289,11 @@ class Method extends ModelElement
 
   @override
   String get href {
-    if (canonicalLibrary == null || canonicalEnclosingElement == null)
-      return null;
-    return '${canonicalEnclosingElement.canonicalLibrary.dirName}/${canonicalEnclosingElement.name}/${fileName}';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(!(canonicalLibrary == null || canonicalEnclosingElement == null));
+    assert(canonicalLibrary == library);
+    assert(canonicalEnclosingElement == enclosingElement);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/${fileName}';
   }
 
   @override
@@ -2692,6 +2699,18 @@ abstract class ModelElement extends Canonicalization
 
   bool get canHaveParameters =>
       element is ExecutableElement || element is FunctionTypedElement;
+
+  ModelElement _canonicalModelElement() {
+    Class preferredClass;
+    if (enclosingElement is Class) {
+      preferredClass = enclosingElement;
+    }
+    return package.findCanonicalModelElementFor(element, preferredClass: preferredClass);
+  }
+
+  // Returns the canonical ModelElement for this ModelElement, or null
+  // if there isn't one.
+  ModelElement get canonicalModelElement => _memoizer.memoized(_canonicalModelElement);
 
   // TODO(jcollins-g): untangle when mixins can call super
   @override
@@ -3561,8 +3580,10 @@ class ModelFunctionTyped extends ModelElement
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/$fileName';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
   }
 
   @override
@@ -4180,6 +4201,9 @@ class Package extends Canonicalization with Nameable, Warnable, Memoizeable {
     if (e is PropertyAccessorElement) {
       searchElement = e.variable;
     }
+    if (e is GenericFunctionTypeElement) {
+      searchElement = e.enclosingElement;
+    }
 
     for (Library library in publicLibraries) {
       if (library.modelElementsMap.containsKey(searchElement)) {
@@ -4209,6 +4233,10 @@ class Package extends Canonicalization with Nameable, Warnable, Memoizeable {
   /// Tries to find a canonical ModelElement for this element.  If we know
   /// this element is related to a particular class, pass preferredClass to
   /// disambiguate.
+  ///
+  /// This doesn't know anything about [Package.inheritThrough] and probably
+  /// shouldn't, so using it with [Inheritable]s without special casing is
+  /// not advised.
   ModelElement findCanonicalModelElementFor(Element e, {Class preferredClass}) {
     assert(allLibrariesAdded);
     Library lib = findCanonicalLibraryFor(e);
@@ -4293,7 +4321,9 @@ class Package extends Canonicalization with Nameable, Warnable, Memoizeable {
       }
 
       assert(matches.length <= 1);
-      if (!matches.isEmpty) modelElement = matches.first;
+      if (matches.isNotEmpty) {
+        modelElement = matches.first;
+      }
     } else {
       if (lib != null) {
         Accessor getter;
@@ -4429,19 +4459,7 @@ class Parameter extends ModelElement implements EnclosedElement {
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    var p = _parameter.enclosingElement;
-
-    if (p is FunctionElement) {
-      return '${canonicalLibrary.dirName}/${p.name}.html';
-    } else {
-      // TODO: why is this logic here?
-      var name = Operator.friendlyNames.containsKey(p.name)
-          ? Operator.friendlyNames[p.name]
-          : p.name;
-      return '${canonicalLibrary.dirName}/${p.enclosingElement.name}/' +
-          '${name}.html#${htmlId}';
-    }
+    throw new StateError('href not implemented for parameters');
   }
 
   @override
@@ -4634,8 +4652,10 @@ class TopLevelVariable extends ModelElement
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/$_fileName';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
   }
 
   @override
@@ -4662,7 +4682,7 @@ class TopLevelVariable extends ModelElement
     return docs;
   }
 
-  String get _fileName => isConst ? '$name-constant.html' : '$name.html';
+  String get fileName => isConst ? '$name-constant.html' : '$name.html';
 
   TopLevelVariableElement get _variable => (element as TopLevelVariableElement);
 }
@@ -4695,8 +4715,10 @@ class Typedef extends ModelElement
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/$fileName';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
   }
 
   // Food for mustache.
@@ -4728,8 +4750,10 @@ class TypeParameter extends ModelElement {
 
   @override
   String get href {
-    if (canonicalLibrary == null) return null;
-    return '${canonicalLibrary.dirName}/${_typeParameter.enclosingElement.name}/$name';
+    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name';
   }
 
   @override

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -130,7 +130,8 @@ abstract class Inheritable implements ModelElement {
 
   @override
   ModelElement _canonicalModelElement() {
-    return canonicalEnclosingElement?.allCanonicalModelElements?.firstWhere((m) => m.name == name, orElse: () => null);
+    return canonicalEnclosingElement?.allCanonicalModelElements
+        ?.firstWhere((m) => m.name == name, orElse: () => null);
   }
 
   Class _canonicalEnclosingElement() {
@@ -613,6 +614,7 @@ class Class extends ModelElement
   @override
   ModelElement get enclosingElement => library;
 
+  @override
   String get fileName => "${name}-class.html";
 
   String get fullkind {
@@ -659,9 +661,8 @@ class Class extends ModelElement
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
-    if (canonicalLibrary != library)
-      1+1;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
     return '${library.dirName}/$fileName';
@@ -1141,7 +1142,8 @@ class Constructor extends ModelElement
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
     return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name.html';
@@ -1357,7 +1359,8 @@ class EnumField extends Field {
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(!(canonicalLibrary == null || canonicalEnclosingElement == null));
     assert(canonicalLibrary == library);
     assert(canonicalEnclosingElement == enclosingElement);
@@ -1435,7 +1438,8 @@ class Field extends ModelElement
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalEnclosingElement == enclosingElement);
     assert(canonicalLibrary == library);
@@ -1499,6 +1503,7 @@ class Field extends ModelElement
 
   FieldElement get _field => (element as FieldElement);
 
+  @override
   String get fileName => isConst ? '$name-constant.html' : '$name.html';
 
   String _sourceCode() {
@@ -1565,8 +1570,8 @@ abstract class GetterSetterCombo implements ModelElement {
     if (targetClass.name == target.name) {
       return original.replaceAll(constructorName, "${target.linkedName}");
     }
-    return original.replaceAll(
-        "${targetClass.name}.${target.name}", "${targetClass.linkedName}.${target.linkedName}");
+    return original.replaceAll("${targetClass.name}.${target.name}",
+        "${targetClass.linkedName}.${target.linkedName}");
   }
 
   String _constantValueBase() {
@@ -1911,6 +1916,7 @@ class Library extends ModelElement {
 
   Iterable<Class> get publicExceptions => filterNonPublic(exceptions);
 
+  @override
   String get fileName => '$dirName-library.html';
 
   List<ModelFunction> _functions() {
@@ -1948,7 +1954,8 @@ class Library extends ModelElement {
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     return '${library.dirName}/$fileName';
   }
 
@@ -2280,8 +2287,6 @@ class Method extends ModelElement
     return _enclosingClass;
   }
 
-  String get fileName => "${name}.html";
-
   String get fullkind {
     if (_method.isAbstract) return 'abstract $kind';
     return kind;
@@ -2289,7 +2294,8 @@ class Method extends ModelElement
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(!(canonicalLibrary == null || canonicalEnclosingElement == null));
     assert(canonicalLibrary == library);
     assert(canonicalEnclosingElement == enclosingElement);
@@ -2705,12 +2711,14 @@ abstract class ModelElement extends Canonicalization
     if (enclosingElement is Class) {
       preferredClass = enclosingElement;
     }
-    return package.findCanonicalModelElementFor(element, preferredClass: preferredClass);
+    return package.findCanonicalModelElementFor(element,
+        preferredClass: preferredClass);
   }
 
   // Returns the canonical ModelElement for this ModelElement, or null
   // if there isn't one.
-  ModelElement get canonicalModelElement => _memoizer.memoized(_canonicalModelElement);
+  ModelElement get canonicalModelElement =>
+      _memoizer.memoized(_canonicalModelElement);
 
   // TODO(jcollins-g): untangle when mixins can call super
   @override
@@ -2906,6 +2914,8 @@ abstract class ModelElement extends Canonicalization
     }
     return '';
   }
+
+  String get fileName => "${name}.html";
 
   /// Returns the fully qualified name.
   ///
@@ -3576,11 +3586,10 @@ class ModelFunctionTyped extends ModelElement
   @override
   ModelElement get enclosingElement => library;
 
-  String get fileName => "$name.html";
-
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
     return '${library.dirName}/$fileName';
@@ -4652,7 +4661,8 @@ class TopLevelVariable extends ModelElement
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
     return '${library.dirName}/$fileName';
@@ -4682,6 +4692,7 @@ class TopLevelVariable extends ModelElement
     return docs;
   }
 
+  @override
   String get fileName => isConst ? '$name-constant.html' : '$name.html';
 
   TopLevelVariableElement get _variable => (element as TopLevelVariableElement);
@@ -4695,8 +4706,6 @@ class Typedef extends ModelElement
 
   @override
   ModelElement get enclosingElement => library;
-
-  String get fileName => '$name.html';
 
   @override
   String get nameWithGenerics => '$name${super.genericParameters}';
@@ -4715,7 +4724,8 @@ class Typedef extends ModelElement
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
     return '${library.dirName}/$fileName';
@@ -4750,7 +4760,8 @@ class TypeParameter extends ModelElement {
 
   @override
   String get href {
-    if (!identical(canonicalModelElement, this)) return canonicalModelElement?.href;
+    if (!identical(canonicalModelElement, this))
+      return canonicalModelElement?.href;
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
     return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name';

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -70,6 +70,13 @@ bool hasPrivateName(Element e) {
   if (e.name.startsWith('_')) {
     return true;
   }
+  // GenericFunctionTypeElements have the name we care about in the enclosing
+  // element.
+  if (e is GenericFunctionTypeElement) {
+    if (e.enclosingElement.name.startsWith('_')) {
+      return true;
+    }
+  }
   if (e is LibraryElement &&
       (e.identifier.startsWith('dart:_') ||
           ['dart:nativewrappers'].contains(e.identifier))) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.15.0"
+  dart: ">=1.23.0 <=2.0.0-dev.16.0"

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1889,6 +1889,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
   group('Constant', () {
     TopLevelVariable greenConstant,
         cat,
+        customClassPrivate,
         orangeConstant,
         prettyColorsConstant,
         deprecated;
@@ -1906,6 +1907,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       deprecated =
           exLibrary.constants.firstWhere((c) => c.name == 'deprecated');
       Class Dog = exLibrary.allClasses.firstWhere((c) => c.name == 'Dog');
+      customClassPrivate = fakeLibrary.constants.firstWhere((c) => c.name == 'CUSTOM_CLASS_PRIVATE');
       aStaticConstField =
           Dog.allFields.firstWhere((f) => f.name == 'aStaticConstField');
       aName = Dog.allFields.firstWhere((f) => f.name == 'aName');
@@ -1918,6 +1920,10 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('constant field values are escaped', () {
       expect(aStaticConstField.constantValue, '&quot;A Constant Dog&quot;');
+    });
+
+    test('privately constructed constants are unlinked', () {
+      expect(customClassPrivate.constantValue, 'const _APrivateConstClass()');
     });
 
     test('has a fully qualified name', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -160,6 +160,12 @@ class ConstantClass {
   ConstantClass.notConstant(this.value);
 }
 
+class _APrivateConstClass {
+  const _APrivateConstClass();
+}
+
+const _APrivateConstClass CUSTOM_CLASS_PRIVATE = const _APrivateConstClass();
+
 // No dart docs on purpose. Also, a non-primitive const class.
 const ConstantClass CUSTOM_CLASS = const ConstantClass('custom');
 

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the OtherGenericsThing class from the fake library, for the Dart programming language.">
-  <title>OtherGenericsThing class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the CUSTOM_CLASS_PRIVATE constant from the fake library, for the Dart programming language.">
+  <title>CUSTOM_CLASS_PRIVATE constant - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">OtherGenericsThing<span class="signature">&lt;A&gt;</span> class</li>
+    <li class="self-crumb">CUSTOM_CLASS_PRIVATE constant</li>
   </ol>
-  <div class="self-name">OtherGenericsThing</div>
+  <div class="self-name">CUSTOM_CLASS_PRIVATE</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -126,124 +126,23 @@
       <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
       <li><a href="fake/Oops-class.html">Oops</a></li>
     </ol>
-  </div>
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>OtherGenericsThing&lt;A&gt; class</h1>
+    <h1>CUSTOM_CLASS_PRIVATE top-level constant</h1>
 
-    
-
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">
-        <dt id="OtherGenericsThing" class="callable">
-          <span class="name"><a href="fake/OtherGenericsThing/OtherGenericsThing.html">OtherGenericsThing</a></span><span class="signature">()</span>
-        </dt>
-        <dd>
-          
-        </dd>
-      </dl>
+    <section class="multi-line-signature">
+      const <span class="name ">CUSTOM_CLASS_PRIVATE</span>
+      =
+      <span class="constant-value">const _APrivateConstClass()</span>
+      
     </section>
 
-    <section class="summary offset-anchor inherited" id="instance-properties">
-      <h2>Properties</h2>
-
-      <dl class="properties">
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/OtherGenericsThing/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-        <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="fake/OtherGenericsThing/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor" id="instance-methods">
-      <h2>Methods</h2>
-      <dl class="callables">
-        <dt id="convert" class="callable">
-          <span class="name"><a href="fake/OtherGenericsThing/convert.html">convert</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; <a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;A, <a href="fake/Cool-class.html">Cool</a>, String&gt;</span></span>
-          </span>
-        </dt>
-        <dd>
-          
-          
-</dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/OtherGenericsThing/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-        <dt id="toString" class="callable inherited">
-          <span class="name"><a href="fake/OtherGenericsThing/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="operators">
-      <h2>Operators</h2>
-      <dl class="callables">
-        <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="fake/OtherGenericsThing/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-
-
+        
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <ol>
-      <li class="section-title"><a href="fake/OtherGenericsThing-class.html#constructors">Constructors</a></li>
-      <li><a href="fake/OtherGenericsThing/OtherGenericsThing.html">OtherGenericsThing</a></li>
-    
-      <li class="section-title inherited">
-        <a href="fake/OtherGenericsThing-class.html#instance-properties">Properties</a>
-      </li>
-      <li class="inherited"><a href="fake/OtherGenericsThing/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="fake/OtherGenericsThing/runtimeType.html">runtimeType</a></li>
-    
-      <li class="section-title"><a href="fake/OtherGenericsThing-class.html#instance-methods">Methods</a></li>
-      <li><a href="fake/OtherGenericsThing/convert.html">convert</a></li>
-      <li class="inherited"><a href="fake/OtherGenericsThing/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="fake/OtherGenericsThing/toString.html">toString</a></li>
-    
-      <li class="section-title inherited"><a href="fake/OtherGenericsThing-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/OtherGenericsThing/operator_equals.html">operator ==</a></li>
-    
-    
-    
-    </ol>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -277,6 +277,17 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
             <span class="signature"><code>const <a href="fake/ConstantClass/ConstantClass.html">ConstantClass</a>(&#39;custom&#39;)</code></span>
           </div>
         </dd>
+        <dt id="CUSTOM_CLASS_PRIVATE" class="constant">
+          <span class="name "><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></span>
+          <span class="signature">&#8594; const _APrivateConstClass</span>
+        </dt>
+        <dd>
+          
+          
+  <div>
+            <span class="signature"><code>const _APrivateConstClass()</code></span>
+          </div>
+        </dd>
         <dt id="DOWN" class="constant">
           <span class="name deprecated"><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></span>
           <span class="signature">&#8594; const dynamic</span>
@@ -746,6 +757,7 @@ default value.
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -71,6 +71,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
       <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
       <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -4068,6 +4068,17 @@
   }
  },
  {
+  "name": "CUSTOM_CLASS_PRIVATE",
+  "qualifiedName": "fake.CUSTOM_CLASS_PRIVATE",
+  "href": "fake/CUSTOM_CLASS_PRIVATE-constant.html",
+  "type": "top-level constant",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
   "name": "Callback2",
   "qualifiedName": "fake.Callback2",
   "href": "fake/Callback2.html",


### PR DESCRIPTION
Fixes #1588.  First part of a long awaited refactor to rationalize how we calculate links, but moved up to fix a regression.