### PR TITLE
Pin bots to 2.0.0-dev.16.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 install:
-  - ps: wget https://gsdview.appspot.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://gsdview.appspot.com/dart-archive/channels/dev/raw/2.0.0-dev.16.0/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - set PATH=%PATH%;C:\tools\dart-sdk\bin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.15.0"
+  dart: ">=1.23.0 <=2.0.0-dev.16.0"


### PR DESCRIPTION
Fixes #1592.  Force appveyor to use the previous version for now.