### PR TITLE
Convert to using a single AnalysisDriver in place of a single AnalysisContext.

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:dartdoc/src/utils.dart';
@@ -99,14 +100,14 @@ class DartDoc extends PackageBuilder {
   Stream<String> get onCheckProgress => _onCheckProgress.stream;
 
   @override
-  void logAnalysisErrors(Set<Source> sources) {
+  void logAnalysisErrors(Set<Source> sources) async {
     List<AnalysisErrorInfo> errorInfos = [];
     // TODO(jcollins-g): figure out why sources can't contain includeExternals
     // or embedded SDK components without having spurious(?) analysis errors.
     // That seems wrong. dart-lang/dartdoc#1547
     for (Source source in sources) {
-      context.computeErrors(source);
-      AnalysisErrorInfo info = context.getErrors(source);
+      ErrorsResult errorsResult = await driver.getErrors(source.fullName);
+      AnalysisErrorInfo info = new AnalysisErrorInfoImpl(errorsResult.errors, errorsResult.lineInfo);
       List<_Error> errors = [info]
           .expand((AnalysisErrorInfo info) {
             return info.errors.map((error) =>
@@ -151,7 +152,7 @@ class DartDoc extends PackageBuilder {
   Future<DartDocResults> generateDocs() async {
     Stopwatch _stopwatch = new Stopwatch()..start();
     double seconds;
-    package = buildPackage();
+    package = await buildPackage();
     seconds = _stopwatch.elapsedMilliseconds / 1000.0;
     logInfo(
         "Initialized dartdoc with ${package.libraries.length} librar${package.libraries.length == 1 ? 'y' : 'ies'} "

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -100,7 +100,7 @@ class DartDoc extends PackageBuilder {
   Stream<String> get onCheckProgress => _onCheckProgress.stream;
 
   @override
-  void logAnalysisErrors(Set<Source> sources) async {
+  logAnalysisErrors(Set<Source> sources) async {
     List<AnalysisErrorInfo> errorInfos = [];
     // TODO(jcollins-g): figure out why sources can't contain includeExternals
     // or embedded SDK components without having spurious(?) analysis errors.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -5188,14 +5188,10 @@ class PackageBuilder {
     }
   }
 
-
   Future<List<LibraryElement>> _parseLibraries(Set<String> files) async {
     Set<LibraryElement> libraries = new Set();
     Set<Source> sources = new Set<Source>();
     files.forEach((filename) => driver.addFile(filename));
-    //for (String filename in files) {
-    //  await processLibrary(filename, libraries, sources);
-    //}
 
     await Future.wait(files.map((f) => processLibrary(f, libraries, sources)));
     await logAnalysisErrors(sources);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -5127,7 +5127,7 @@ class PackageBuilder {
 
   bool isExcluded(String name) => excludes.any((pattern) => name == pattern);
 
-  /// Parse a single library at [filePath] using the current analysis context.
+  /// Parse a single library at [filePath] using the current analysis driver.
   /// Note: [libraries] and [sources] are output parameters.  Adds a libraryElement
   /// only if it has a non-private name.
   Future processLibrary(String filePath, Set<LibraryElement> libraries,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -11,14 +11,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/dart/ast/ast.dart'
-    show
-        AnnotatedNode,
-        Declaration,
-        Expression,
-        FieldDeclaration,
-        InstanceCreationExpression,
-        VariableDeclaration,
-        VariableDeclarationList;
+    show Declaration, Expression, InstanceCreationExpression;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/file_system/file_system.dart' as fileSystem;
@@ -2753,12 +2746,10 @@ abstract class ModelElement extends Canonicalization
   // functions in package for finding elements and avoid using computeNode().
   List<String> get annotations => annotationsFromMetadata(element.metadata);
 
-  /// Returns annotations from a given metadata set, with escaping.
-  /// md is a dynamic parameter since ElementAnnotation and Annotation have no
-  /// common class for calling toSource() and element.
-  List<String> annotationsFromMetadata(List<dynamic> md) {
-    if (md == null) md = new List<dynamic>();
-    return md.map((dynamic a) {
+  /// Returns linked annotations from a given metadata set, with escaping.
+  List<String> annotationsFromMetadata(List<ElementAnnotation> md) {
+    if (md == null) return <String>[];
+    return md.map((ElementAnnotation a) {
       String annotation = (const HtmlEscape()).convert(a.toSource());
       // a.element can be null if the element can't be resolved.
       var me =

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2751,24 +2751,7 @@ abstract class ModelElement extends Canonicalization
 
   // TODO(jcollins-g): annotations should now be able to use the utility
   // functions in package for finding elements and avoid using computeNode().
-  List<String> get annotations {
-    List<dynamic> metadata;
-    if (element.computeNode() is AnnotatedNode) {
-      AnnotatedNode node = element.computeNode() as AnnotatedNode;
-
-      // Declarations are contained inside FieldDeclarations, and that is where
-      // the actual annotations are.
-      while ((node is VariableDeclaration || node is VariableDeclarationList) &&
-          node is! FieldDeclaration) {
-        assert(null != node.parent);
-        node = node.parent;
-      }
-      metadata = node.metadata;
-    } else {
-      metadata = element.metadata;
-    }
-    return annotationsFromMetadata(metadata);
-  }
+  List<String> get annotations => annotationsFromMetadata(element.metadata);
 
   /// Returns annotations from a given metadata set, with escaping.
   /// md is a dynamic parameter since ElementAnnotation and Annotation have no

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -67,6 +67,8 @@ bool isInExportedLibraries(
 
 final RegExp slashes = new RegExp('[\/]');
 bool hasPrivateName(Element e) {
+  if (e.name == null) return false;
+
   if (e.name.startsWith('_')) {
     return true;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.16.0"
+  dart: ">=1.23.0 <=2.0.0-dev.20.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -86,7 +86,7 @@ packages:
     source: hosted
     version: "0.3.1"
   front_end:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: front_end
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   analyzer: 0.31.0-alpha.2
   args: '>=0.13.0 <2.0.0'
   collection: ^1.2.0
+  front_end: ^0.1.0-alpha.7
   html: '>=0.12.1 <0.14.0'
   # We don't use http_parser directly; this dep exists to ensure that we get at
   # least version 3.0.3 to work around an issue with 3.0.2.

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -2065,7 +2065,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           aComplexTypedef.linkedReturnType,
           equals(
-              'Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="-param-"><span class="type-annotation">A3</span></span>)</span>'));
+              'Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span>'));
       expect(
           aComplexTypedef.linkedParamsLines,
           equals(

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -31,8 +31,8 @@ void main() {
   Library interceptorsLib;
   Package sdkAsPackage;
 
-  setUpAll(() {
-    utils.init();
+  setUpAll(() async {
+    await utils.init();
     package = utils.testPackage;
     ginormousPackage = utils.testPackageGinormous;
     exLibrary = package.libraries.firstWhere((lib) => lib.name == 'ex');

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -4,6 +4,7 @@
 
 library test_utils;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dartdoc/dartdoc.dart';
@@ -31,28 +32,28 @@ void delete(Directory dir) {
   if (dir.existsSync()) dir.deleteSync(recursive: true);
 }
 
-void init() {
+init() async {
   sdkDir = getSdkDir();
   sdkPackageMeta = new PackageMeta.fromSdk(sdkDir);
   setConfig();
 
-  testPackage = bootBasicPackage(
+  testPackage = await bootBasicPackage(
       'testing/test_package', ['css', 'code_in_comments', 'excluded'], false);
-  testPackageGinormous = bootBasicPackage(
+  testPackageGinormous = await bootBasicPackage(
       'testing/test_package', ['css', 'code_in_commnets', 'excluded'], true);
 
-  testPackageSmall = bootBasicPackage('testing/test_package_small', [], false);
-  testPackageSdk = bootSdkPackage();
+  testPackageSmall = await bootBasicPackage('testing/test_package_small', [], false);
+  testPackageSdk = await bootSdkPackage();
 }
 
-Package bootSdkPackage() {
+Future<Package> bootSdkPackage() {
   Directory dir = new Directory(p.current);
   return new PackageBuilder(
           dir, [], [], sdkDir, sdkPackageMeta, [], [], true, false)
       .buildPackage();
 }
 
-Package bootBasicPackage(
+Future<Package> bootBasicPackage(
     String dirPath, List<String> excludes, bool withAutoIncludedDependencies) {
   Directory dir = new Directory(dirPath);
   return new PackageBuilder(

--- a/testing/test_package_docs/ex/aComplexTypedef.html
+++ b/testing/test_package_docs/ex/aComplexTypedef.html
@@ -110,7 +110,7 @@
     <h1>aComplexTypedef&lt;A1, A2, A3&gt; typedef</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="-param-"><span class="type-annotation">A3</span></span>)</span></span>
+        <span class="returntype">Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
         <span class="name ">aComplexTypedef</span>
 (<wbr><span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">String</span></span>)
     </section>

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -112,7 +112,7 @@
     <section class="multi-line-signature">
       const <span class="name ">deprecated</span>
       =
-      <span class="constant-value">const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&quot;next release&quot;)</span>
+      <span class="constant-value">const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&#39;next release&#39;)</span>
       
     </section>
 

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -294,7 +294,7 @@ that has some operators
           
           
   <div>
-            <span class="signature"><code>const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&quot;next release&quot;)</code></span>
+            <span class="signature"><code>const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&#39;next release&#39;)</code></span>
           </div>
         </dd>
         <dt id="incorrectDocReference" class="constant">

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -436,7 +436,7 @@ enum constants ala #1445
       <dl class="callables">
         <dt id="aComplexTypedef" class="callable">
           <span class="name"><a href="ex/aComplexTypedef.html">aComplexTypedef</a></span><span class="signature">&lt;A1, A2, A3&gt;</span><span class="signature">(<wbr><span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">String</span></span>)
-            <span class="returntype parameter">&#8594; Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="-param-"><span class="type-annotation">A3</span></span>)</span></span>
+            <span class="returntype parameter">&#8594; Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_embedder_yaml/sdk/core.dart
+++ b/testing/test_package_embedder_yaml/sdk/core.dart
@@ -4,6 +4,10 @@
 
 library dart.core;
 
+// Required for analyzer for now; it assumes that all imports of dart:core
+// also import dart:async somewhere.
+import 'dart:async';
+
 external bool identical(Object a, Object b);
 
 void print(Object object) {}

--- a/testing/test_package_embedder_yaml/sdk/core.dart
+++ b/testing/test_package_embedder_yaml/sdk/core.dart
@@ -6,6 +6,7 @@ library dart.core;
 
 // Required for analyzer for now; it assumes that all imports of dart:core
 // also import dart:async somewhere.
+// ignore: unused_import
 import 'dart:async';
 
 external bool identical(Object a, Object b);


### PR DESCRIPTION
Fixes #1586.

Dartdoc has never correctly instantiated groups of AnalysisContexts, and still doesn't correctly instantiate groups of AnalysisDrivers.  But we do actually instantiate a single AnalysisDriver now instead of AnalysisContext, so that's progress.