### PR TITLE
Add arbitrary pub package serving to grinder and ignore URI_HAS_NOT_BEEN_GENERATED

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,31 @@ yet in the issue tracker, start by opening an issue. Thanks!
 1. `grind` is needed to run dartdoc integration tests, see installed via `pub global activate grinder`.
 2. When a change is user-facing, please add a new entry to the [changelog](https://github.com/dart-lang/dartdoc/blob/master/CHANGELOG.md)
 3. Please include a test for your change.  `dartdoc` has both `package:test`-style unittests as well as integration tests.  To run the unittests, use `dart test/all.dart`.  Most changes can be tested via a unittest, but some require modifying the [test_package](https://github.com/dart-lang/dartdoc/tree/master/testing/test_package) and regenerating its docs via `grind update-test-package-docs`.
-4.  Be sure to format your Dart code using `dartfmt -w`, otherwise travis will complain.
-5.  Post your change via a pull request for review and integration!
+4. For major changes, run `grind compare-sdk-warnings` and include the summary results in your pull request.
+5.  Be sure to format your Dart code using `dartfmt -w`, otherwise travis will complain.
+6.  Post your change via a pull request for review and integration!
+
+## Testing
+
+dartdoc has a number of grinder utility methods that can be used to check for behavior changes
+or try out your change on arbitrary packages. 
+
+```bash
+# Serve the latest version of the given package locally on port 9000.
+PACKAGE_NAME=angular_components grind serve-pub-package
+
+# Build the SDK docs with the head version and compare its warning
+# output and (rough) performance to the main version.
+grind compare-sdk-warnings
+
+# Serve the flutter docs built with the head version on port 8001.
+grind serve-flutter-docs
+
+# Serve the test package (testing/test_package) on port 8002
+grind serve-test-package-docs
+```
+
+There are more added all the time -- run `grind --help` to see them all.
 
 ## License
 

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -131,6 +131,8 @@ class DartDoc extends PackageBuilder {
               new _Error(error, info.lineInfo, packageMeta.dir.path));
         })
         .where((_Error error) => error.isError)
+        // TODO(jcollins-g): remove after conversion to analysis driver
+        .where((_Error error) => error.error.errorCode != CompileTimeErrorCode.URI_HAS_NOT_BEEN_GENERATED)
         .toList()
           ..sort();
 

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -91,7 +91,11 @@ class SubprocessLauncher {
   }
 
   SubprocessLauncher(this.context, [Map<String, String> environment]) {
-    if (environment == null) this._environment = new Map();
+    if (environment == null) {
+      this._environment = new Map();
+    } else {
+      this._environment = environment;
+    }
   }
 
   /// A wrapper around start/await process.exitCode that will display the

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -67,9 +67,7 @@ final RegExp quotables = new RegExp(r'[ "\r\n\$]');
 
 class SubprocessLauncher {
   final String context;
-  Map<String, String> _environment;
-
-  Map<String, String> get environment => _environment;
+  final Map<String, String> environment;
 
   String get prefix => context.isNotEmpty ? '$context: ' : '';
 
@@ -90,13 +88,8 @@ class SubprocessLauncher {
     });
   }
 
-  SubprocessLauncher(this.context, [Map<String, String> environment]) {
-    if (environment == null) {
-      this._environment = new Map();
-    } else {
-      this._environment = environment;
-    }
-  }
+  SubprocessLauncher(this.context, [Map<String, String> environment]) :
+      this.environment = environment ?? <String, String>{};
 
   /// A wrapper around start/await process.exitCode that will display the
   /// output of the executable continuously and fail on non-zero exit codes.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.16.0"
+  dart: ">=1.23.0 <=2.0.0-dev.20.0"

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -23,7 +23,6 @@ Directory get dartdocDocsDir =>
     tempdirsCache.memoized1(createTempSync, 'dartdoc');
 Directory get sdkDocsDir => tempdirsCache.memoized1(createTempSync, 'sdkdocs');
 Directory get flutterDir => tempdirsCache.memoized1(createTempSync, 'flutter');
-Directory get angularComponentsDir => tempdirsCache.memoized1(createTempSync, 'angular2');
 Directory get testPackage =>
     new Directory(path.joinAll(['testing', 'test_package']));
 Directory get testPackageDocsDir =>
@@ -291,25 +290,6 @@ Future _buildFlutterDocs(String flutterPath, [String label]) async {
     [path.join('dev', 'tools', 'dartdoc.dart')],
     workingDirectory: flutterPath,
   );
-}
-
-Future _buildAngularComponentsDocs(String angularComponentsPath, [String label]) async {
-  var launcher = new SubprocessLauncher(
-      'build-angular-components-docs${label == null ? "" :"-$label"}');
-  await launcher.runStreamed('git',
-      ['clone', '--depth', '1', 'https://github.com/dart-lang/angular_components.git', '.'],
-      workingDirectory: angularComponentsPath);
-  String cwd = Directory.current.absolute.path;
-  await launcher.runStreamed(sdkBin('pub'), ['get'], workingDirectory: cwd);
-  return await launcher.runStreamed(
-      Platform.resolvedExecutable,
-      [
-        '--checked',
-        path.join(cwd, 'bin', 'dartdoc.dart'),
-        '--json',
-        '--show-progress',
-      ],
-      workingDirectory: angularComponentsPath);
 }
 
 /// Returns the directory in which we generated documentation.


### PR DESCRIPTION
Fixes #1595.

Dartdoc will now always ignore this error message.  To make testing this sort of thing easier, added grinder support for downloading and serving docs for an arbitrary pub package, and documented some of the
new grinder tools in CONTRIBUTING.md.  They're just too useful not to use on a regular basis by regular contributors.
