### PR TITLE
New resolver to untangle embedder SDK problem

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-dev.22.0"
+  dart: ">=2.0.0-dev <=2.0.0-dev.24.0"


### PR DESCRIPTION
Fixes #1601.  AnalysisDriver seems to haave some different resolver setup requirements that are challenging to replicate without either reimplementing ContextBuilder or porting over dartdoc to use ContextBuilder (thus requiring a second port when the new API is ready).

So, for now, just duct-tape and bailing wire the thing together with a custom resolver that behaves the way the analyzer expects for cases where embedded SDK components might also be part of a package, while continuing to bypass the more complex setup in ContextBuilder.