### PR TITLE
Update analyzer, fix checked mode runs for flutter, and unpin bots.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 sudo: false
 dart:
-  - "dev/release/2.0.0-dev.22.0"
+  - "dev/raw/latest"
 env:
   - DARTDOC_BOT=main
   # TODO(devoncarew): add angulardart support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 install:
-  - ps: wget https://gsdview.appspot.com/dart-archive/channels/dev/raw/2.0.0-dev.22.0/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://gsdview.appspot.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - set PATH=%PATH%;C:\tools\dart-sdk\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 install:
-  - ps: wget https://gsdview.appspot.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - set PATH=%PATH%;C:\tools\dart-sdk\bin

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -507,10 +507,14 @@ Element _findRefElementInLibrary(String codeRef, Warnable element,
   if (results.isEmpty &&
       codeRefChomped.contains('.') &&
       _findRefElementCache.containsKey(codeRefChomped)) {
-    for (final modelElement in _findRefElementCache[codeRefChomped]) {
+    for (final ModelElement modelElement in _findRefElementCache[codeRefChomped]) {
       if (!_ConsiderIfConstructor(codeRef, modelElement)) continue;
+      // For fully qualified matches, the original preferredClass passed
+      // might make no sense.  Instead, use the enclosing class from the
+      // element in [_findRefElementCache], because that element's enclosing
+      // class will be preferred from [codeRefChomped]'s perspective.
       results.add(package.findCanonicalModelElementFor(modelElement.element,
-          preferredClass: preferredClass));
+          preferredClass: modelElement.enclosingElement is Class ? modelElement.enclosingElement : null));
     }
   }
   results.remove(null);

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -268,8 +268,10 @@ MatchingLinkResult _getMatchingLinkElement(
   if (refModelElement == null) {
     Element refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
     if (refElement != null) {
-      refModelElement = new ModelElement.fromElement(_getRefElementFromCommentRefs(commentRefs, codeRef), element.package);
-      refModelElement = refModelElement.canonicalModelElement ?? refModelElement;
+      refModelElement = new ModelElement.fromElement(
+          _getRefElementFromCommentRefs(commentRefs, codeRef), element.package);
+      refModelElement =
+          refModelElement.canonicalModelElement ?? refModelElement;
     }
   } else {
     assert(refModelElement is! Accessor);
@@ -485,14 +487,17 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
   if (results.isEmpty &&
       codeRefChomped.contains('.') &&
       _findRefElementCache.containsKey(codeRefChomped)) {
-    for (final ModelElement modelElement in _findRefElementCache[codeRefChomped]) {
+    for (final ModelElement modelElement
+        in _findRefElementCache[codeRefChomped]) {
       if (!_ConsiderIfConstructor(codeRef, modelElement)) continue;
       // For fully qualified matches, the original preferredClass passed
       // might make no sense.  Instead, use the enclosing class from the
       // element in [_findRefElementCache], because that element's enclosing
       // class will be preferred from [codeRefChomped]'s perspective.
       results.add(package.findCanonicalModelElementFor(modelElement.element,
-          preferredClass: modelElement.enclosingElement is Class ? modelElement.enclosingElement : null));
+          preferredClass: modelElement.enclosingElement is Class
+              ? modelElement.enclosingElement
+              : null));
     }
   }
   results.remove(null);

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -8,9 +8,8 @@ library dartdoc.markdown_processor;
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/ast.dart' hide TypeParameter;
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:markdown/markdown.dart' as md;
@@ -254,27 +253,30 @@ MatchingLinkResult _getMatchingLinkElement(
     return new MatchingLinkResult(null, null, warn: false);
   }
 
-  Element refElement;
+  ModelElement refModelElement;
 
   // Try expensive not-scoped lookup.
-  if (refElement == null) {
+  if (refModelElement == null) {
     Class preferredClass = _getPreferredClass(element);
-    refElement =
+    refModelElement =
         _findRefElementInLibrary(codeRef, element, commentRefs, preferredClass);
   }
 
-  // This is faster but does not take canonicalization into account; try
-  // only as a last resort. TODO(jcollins-g): make analyzer comment references
-  // dartdoc-canonicalization-aware?
-  if (refElement == null) {
-    refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
+  // This is faster but does not know about libraries without imports in the
+  // current context; try only as a last resort.
+  // TODO(jcollins-g): make analyzer comment references dartdoc-canonicalization-aware?
+  if (refModelElement == null) {
+    Element refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
+    if (refElement != null) {
+      refModelElement = new ModelElement.fromElement(_getRefElementFromCommentRefs(commentRefs, codeRef), element.package);
+      refModelElement = refModelElement.canonicalModelElement ?? refModelElement;
+    }
   } else {
-    assert(refElement is! PropertyAccessorElement);
-    assert(refElement is! PrefixElement);
+    assert(refModelElement is! Accessor);
   }
 
   // Did not find it anywhere.
-  if (refElement == null) {
+  if (refModelElement == null) {
     // TODO(jcollins-g): remove squelching of non-canonical warnings here
     //                   once we no longer process full markdown for
     //                   oneLineDocs (#1417)
@@ -282,18 +284,9 @@ MatchingLinkResult _getMatchingLinkElement(
   }
 
   // Ignore all parameters.
-  if (refElement is ParameterElement || refElement is TypeParameterElement)
+  if (refModelElement is Parameter || refModelElement is TypeParameter)
     return new MatchingLinkResult(null, null, warn: false);
 
-  Library refLibrary = element.package.findOrCreateLibraryFor(refElement);
-  Element searchElement = refElement;
-  if (searchElement is Member)
-    searchElement = Package.getBasestElement(refElement);
-
-  final Class preferredClass = _getPreferredClass(element);
-  ModelElement refModelElement = element.package.findCanonicalModelElementFor(
-      searchElement,
-      preferredClass: preferredClass);
   // There have been places in the code which helpfully cache entities
   // regardless of what package they are associated with.  This assert
   // will protect us from reintroducing that.
@@ -302,23 +295,8 @@ MatchingLinkResult _getMatchingLinkElement(
     return new MatchingLinkResult(refModelElement, null);
   }
   // From this point on, we haven't been able to find a canonical ModelElement.
-  // So in this case, just find any ModelElement we can.
-  Accessor getter;
-  Accessor setter;
-  if (searchElement is FieldElement) {
-    // TODO(jcollins-g): consolidate field element construction with inheritance
-    // checking.
-    if (searchElement.getter != null) {
-      getter = new ModelElement.from(searchElement.getter, refLibrary);
-    }
-    if (searchElement.setter != null) {
-      setter = new ModelElement.from(searchElement.setter, refLibrary);
-    }
-  }
-  refModelElement = new ModelElement.from(searchElement, refLibrary,
-      getter: getter, setter: setter);
   if (!refModelElement.isCanonical) {
-    if (refLibrary.isPublicAndPackageDocumented) {
+    if (refModelElement.library.isPublicAndPackageDocumented) {
       refModelElement
           .warn(PackageWarning.noCanonicalFound, referredFrom: [element]);
     }
@@ -393,7 +371,7 @@ Map<String, Set<ModelElement>> _findRefElementCache;
 // TODO(jcollins-g): Subcomponents of this function shouldn't be adding nulls to results, strip the
 //                   removes out that are gratuitous and debug the individual pieces.
 // TODO(jcollins-g): A complex package winds up spending a lot of cycles in here.  Optimize.
-Element _findRefElementInLibrary(String codeRef, Warnable element,
+ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
     List<CommentReference> commentRefs, Class preferredClass) {
   assert(element != null);
   assert(element.package.allLibrariesAdded);
@@ -567,8 +545,6 @@ Element _findRefElementInLibrary(String codeRef, Warnable element,
   }
   results.remove(null);
 
-  Element result;
-
   if (results.length > 1) {
     // If this name could refer to a class or a constructor, prefer the class.
     if (results.any((r) => r is Class)) {
@@ -630,11 +606,12 @@ Element _findRefElementInLibrary(String codeRef, Warnable element,
     }
   }
 
+  ModelElement result;
   // TODO(jcollins-g): further disambiguations based on package information?
   if (results.isEmpty) {
     result = null;
   } else if (results.length == 1) {
-    result = results.first.element;
+    result = results.first;
   } else {
     // Squelch ambiguous doc reference warnings for parameters, because we
     // don't link those anyway.
@@ -643,7 +620,7 @@ Element _findRefElementInLibrary(String codeRef, Warnable element,
           message:
               "[$codeRef] => ${results.map((r) => "'${r.fullyQualifiedName}'").join(", ")}");
     }
-    result = results.first.element;
+    result = results.first;
   }
   return result;
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4480,11 +4480,8 @@ class Package extends Canonicalization with Nameable, Warnable {
       if (matches.any((me) => me is GetterSetterCombo)) {
         matches.removeWhere((me) => me is Accessor);
       }
-      if (matches.length > 1) {
-        1+1;
-      }
 
-      //assert(matches.length <= 1);
+      assert(matches.length <= 1);
       if (matches.isNotEmpty) {
         modelElement = matches.first;
       }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4480,8 +4480,11 @@ class Package extends Canonicalization with Nameable, Warnable {
       if (matches.any((me) => me is GetterSetterCombo)) {
         matches.removeWhere((me) => me is Accessor);
       }
+      if (matches.length > 1) {
+        1+1;
+      }
 
-      assert(matches.length <= 1);
+      //assert(matches.length <= 1);
       if (matches.isNotEmpty) {
         modelElement = matches.first;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-edge.28757928b47b192efcec082c78258102beb03f78"
+  dart: ">=2.0.0-dev <=2.0.0-dev.24.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.1"
+    version: "0.31.2-alpha.0"
   args:
     dependency: "direct main"
     description:
@@ -91,7 +91,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.9"
+    version: "0.1.0-alpha.10"
   glob:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.9"
+    version: "0.3.0-alpha.10"
   logging:
     dependency: "direct main"
     description:
@@ -371,7 +371,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.30+2"
+    version: "0.12.30+3"
   tuple:
     dependency: "direct main"
     description:
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-dev.24.0"
+  dart: ">=2.0.0-dev <=2.0.0-edge.223eeb2ebe112aaaddca206aab55cd54b4e54391"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-edge.223eeb2ebe112aaaddca206aab55cd54b4e54391"
+  dart: ">=2.0.0-dev <=2.0.0-edge.28757928b47b192efcec082c78258102beb03f78"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,10 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=1.23.0-dev.11.5 <2.0.0'
 dependencies:
-  analyzer: 0.31.1
+  analyzer: '0.31.2-alpha.0'
   args: '>=0.13.0 <2.0.0'
   collection: ^1.2.0
-  front_end: ^0.1.0-alpha.9
+  front_end: ^0.1.0-alpha.10
   html: '>=0.12.1 <0.14.0'
   # We don't use http_parser directly; this dep exists to ensure that we get at
   # least version 3.0.3 to work around an issue with 3.0.2.

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -690,6 +690,12 @@ void main() {
               '<p>link to method from class <a href="ex/Apple/m.html">Apple.m</a></p>'));
     });
 
+    test('code references to privately defined elements in public classes work properly', () {
+      Method notAMethodFromPrivateClass = fakeLibrary.allClasses.firstWhere((Class c) => c.name == 'ReferringClass').allPublicInstanceMethods.firstWhere((Method m) => m.name == 'notAMethodFromPrivateClass');
+      expect(notAMethodFromPrivateClass.documentationAsHtml, contains('<a href="fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>'));
+      expect(notAMethodFromPrivateClass.documentationAsHtml, contains('<a href="fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>'));
+    });
+
     test('legacy code blocks render correctly', () {
       expect(
           testingCodeSyntaxInOneLiners.oneLineDoc,

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -690,10 +690,21 @@ void main() {
               '<p>link to method from class <a href="ex/Apple/m.html">Apple.m</a></p>'));
     });
 
-    test('code references to privately defined elements in public classes work properly', () {
-      Method notAMethodFromPrivateClass = fakeLibrary.allClasses.firstWhere((Class c) => c.name == 'ReferringClass').allPublicInstanceMethods.firstWhere((Method m) => m.name == 'notAMethodFromPrivateClass');
-      expect(notAMethodFromPrivateClass.documentationAsHtml, contains('<a href="fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>'));
-      expect(notAMethodFromPrivateClass.documentationAsHtml, contains('<a href="fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>'));
+    test(
+        'code references to privately defined elements in public classes work properly',
+        () {
+      Method notAMethodFromPrivateClass = fakeLibrary.allClasses
+          .firstWhere((Class c) => c.name == 'ReferringClass')
+          .allPublicInstanceMethods
+          .firstWhere((Method m) => m.name == 'notAMethodFromPrivateClass');
+      expect(
+          notAMethodFromPrivateClass.documentationAsHtml,
+          contains(
+              '<a href="fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>'));
+      expect(
+          notAMethodFromPrivateClass.documentationAsHtml,
+          contains(
+              '<a href="fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>'));
     });
 
     test('legacy code blocks render correctly', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -687,3 +687,21 @@ class OperatorReferenceClass {
     return false;
   }
 }
+
+class _PrivateClassDefiningSomething {
+  bool aMethod() {
+    return false;
+  }
+}
+
+class InheritingClassOne extends _PrivateClassDefiningSomething {}
+class InheritingClassTwo extends _PrivateClassDefiningSomething {}
+
+class ReferringClass {
+  /// Here I am referring by full names, to [fake.InheritingClassOne.aMethod],
+  /// and to [fake.InheritingClassTwo.aMethod].  With luck, both of these
+  /// two resolve correctly.
+  bool notAMethodFromPrivateClass() {
+    return false;
+  }
+}

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the InheritingClassOne class from the fake library, for the Dart programming language.">
+  <title>InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">InheritingClassOne class</li>
+  </ol>
+  <div class="self-name">InheritingClassOne</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>InheritingClassOne class</h1>
+
+    
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="InheritingClassOne" class="callable">
+          <span class="name"><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="aMethod" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassOne/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/InheritingClassOne.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/InheritingClassOne.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the InheritingClassOne constructor from the Class InheritingClassOne class from the fake library, for the Dart programming language.">
+  <title>InheritingClassOne constructor - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">InheritingClassOne constructor</li>
+  </ol>
+  <div class="self-name">InheritingClassOne</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>InheritingClassOne constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">InheritingClassOne</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/aMethod.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/aMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aMethod method from the InheritingClassOne class, for the Dart programming language.">
+  <title>aMethod method - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">aMethod method</li>
+  </ol>
+  <div class="self-name">aMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>aMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">aMethod</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/hashCode.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the InheritingClassOne class, for the Dart programming language.">
+  <title>hashCode property - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/noSuchMethod.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the InheritingClassOne class, for the Dart programming language.">
+  <title>noSuchMethod method - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/operator_equals.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the InheritingClassOne class, for the Dart programming language.">
+  <title>operator == method - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/runtimeType.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the InheritingClassOne class, for the Dart programming language.">
+  <title>runtimeType property - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassOne/toString.html
+++ b/testing/test_package_docs/fake/InheritingClassOne/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the InheritingClassOne class, for the Dart programming language.">
+  <title>toString method - InheritingClassOne class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassOne class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassOne-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassOne/InheritingClassOne.html">InheritingClassOne</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassOne-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassOne/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassOne-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassOne/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the InheritingClassTwo class from the fake library, for the Dart programming language.">
+  <title>InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">InheritingClassTwo class</li>
+  </ol>
+  <div class="self-name">InheritingClassTwo</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>InheritingClassTwo class</h1>
+
+    
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="InheritingClassTwo" class="callable">
+          <span class="name"><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="aMethod" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassTwo/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/InheritingClassTwo.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/InheritingClassTwo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the InheritingClassTwo constructor from the Class InheritingClassTwo class from the fake library, for the Dart programming language.">
+  <title>InheritingClassTwo constructor - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">InheritingClassTwo constructor</li>
+  </ol>
+  <div class="self-name">InheritingClassTwo</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>InheritingClassTwo constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">InheritingClassTwo</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/aMethod.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/aMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aMethod method from the InheritingClassTwo class, for the Dart programming language.">
+  <title>aMethod method - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">aMethod method</li>
+  </ol>
+  <div class="self-name">aMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>aMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">aMethod</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/hashCode.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the InheritingClassTwo class, for the Dart programming language.">
+  <title>hashCode property - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/noSuchMethod.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the InheritingClassTwo class, for the Dart programming language.">
+  <title>noSuchMethod method - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/operator_equals.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the InheritingClassTwo class, for the Dart programming language.">
+  <title>operator == method - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/runtimeType.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the InheritingClassTwo class, for the Dart programming language.">
+  <title>runtimeType property - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/InheritingClassTwo/toString.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the InheritingClassTwo class, for the Dart programming language.">
+  <title>toString method - InheritingClassTwo class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>InheritingClassTwo class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/InheritingClassTwo-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/InheritingClassTwo/InheritingClassTwo.html">InheritingClassTwo</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/InheritingClassTwo-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/aMethod.html">aMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/InheritingClassTwo-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/InheritingClassTwo/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ReferringClass class from the fake library, for the Dart programming language.">
+  <title>ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">ReferringClass class</li>
+  </ol>
+  <div class="self-name">ReferringClass</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>ReferringClass class</h1>
+
+    
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ReferringClass" class="callable">
+          <span class="name"><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/ReferringClass/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="notAMethodFromPrivateClass" class="callable">
+          <span class="name"><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd>
+          Here I am referring by full names, to <a href="fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>,
+and to <a href="fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>.  With luck, both of these
+two resolve correctly.
+          
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/ReferringClass/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/ReferringClass.html
+++ b/testing/test_package_docs/fake/ReferringClass/ReferringClass.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ReferringClass constructor from the Class ReferringClass class from the fake library, for the Dart programming language.">
+  <title>ReferringClass constructor - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">ReferringClass constructor</li>
+  </ol>
+  <div class="self-name">ReferringClass</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>ReferringClass constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">ReferringClass</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/hashCode.html
+++ b/testing/test_package_docs/fake/ReferringClass/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the ReferringClass class, for the Dart programming language.">
+  <title>hashCode property - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ReferringClass/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the ReferringClass class, for the Dart programming language.">
+  <title>noSuchMethod method - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/notAMethodFromPrivateClass.html
+++ b/testing/test_package_docs/fake/ReferringClass/notAMethodFromPrivateClass.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the notAMethodFromPrivateClass method from the ReferringClass class, for the Dart programming language.">
+  <title>notAMethodFromPrivateClass method - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">notAMethodFromPrivateClass method</li>
+  </ol>
+  <div class="self-name">notAMethodFromPrivateClass</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>notAMethodFromPrivateClass method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">notAMethodFromPrivateClass</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Here I am referring by full names, to <a href="fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>,
+and to <a href="fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>.  With luck, both of these
+two resolve correctly.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ReferringClass/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the ReferringClass class, for the Dart programming language.">
+  <title>operator == method - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ReferringClass/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the ReferringClass class, for the Dart programming language.">
+  <title>runtimeType property - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass/toString.html
+++ b/testing/test_package_docs/fake/ReferringClass/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the ReferringClass class, for the Dart programming language.">
+  <title>toString method - ReferringClass class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferringClass class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferringClass-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferringClass/ReferringClass.html">ReferringClass</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferringClass-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferringClass/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/ReferringClass-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/ReferringClass/notAMethodFromPrivateClass.html">notAMethodFromPrivateClass</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferringClass-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferringClass/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -198,6 +198,18 @@ Don't ask questions.</p>
           Names are actually wrong in this class, but when we extend it,
 they are correct.
         </dd>
+        <dt id="InheritingClassOne">
+          <span class="name "><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="InheritingClassTwo">
+          <span class="name "><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></span>
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="Interface">
           <span class="name "><a href="fake/Interface-class.html">Interface</a></span>
         </dt>
@@ -231,6 +243,12 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="OtherGenericsThing">
           <span class="name "><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a><span class="signature">&lt;A&gt;</span></span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="ReferringClass">
+          <span class="name "><a href="fake/ReferringClass-class.html">ReferringClass</a></span>
         </dt>
         <dd>
           
@@ -744,12 +762,15 @@ default value.
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -58,12 +58,15 @@
       <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
       <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
       <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -5311,6 +5311,182 @@
   }
  },
  {
+  "name": "InheritingClassOne",
+  "qualifiedName": "fake.InheritingClassOne",
+  "href": "fake/InheritingClassOne-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "InheritingClassOne",
+  "qualifiedName": "fake.InheritingClassOne",
+  "href": "fake/InheritingClassOne/InheritingClassOne.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.InheritingClassOne.==",
+  "href": "fake/InheritingClassOne/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "aMethod",
+  "qualifiedName": "fake.InheritingClassOne.aMethod",
+  "href": "fake/InheritingClassOne/aMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.InheritingClassOne.hashCode",
+  "href": "fake/InheritingClassOne/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.InheritingClassOne.noSuchMethod",
+  "href": "fake/InheritingClassOne/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.InheritingClassOne.runtimeType",
+  "href": "fake/InheritingClassOne/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.InheritingClassOne.toString",
+  "href": "fake/InheritingClassOne/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassOne",
+   "type": "class"
+  }
+ },
+ {
+  "name": "InheritingClassTwo",
+  "qualifiedName": "fake.InheritingClassTwo",
+  "href": "fake/InheritingClassTwo-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "InheritingClassTwo",
+  "qualifiedName": "fake.InheritingClassTwo",
+  "href": "fake/InheritingClassTwo/InheritingClassTwo.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.InheritingClassTwo.==",
+  "href": "fake/InheritingClassTwo/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
+  "name": "aMethod",
+  "qualifiedName": "fake.InheritingClassTwo.aMethod",
+  "href": "fake/InheritingClassTwo/aMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.InheritingClassTwo.hashCode",
+  "href": "fake/InheritingClassTwo/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.InheritingClassTwo.noSuchMethod",
+  "href": "fake/InheritingClassTwo/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.InheritingClassTwo.runtimeType",
+  "href": "fake/InheritingClassTwo/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.InheritingClassTwo.toString",
+  "href": "fake/InheritingClassTwo/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "InheritingClassTwo",
+   "type": "class"
+  }
+ },
+ {
   "name": "Interface",
   "qualifiedName": "fake.Interface",
   "href": "fake/Interface-class.html",
@@ -6078,6 +6254,94 @@
   "enclosedBy": {
    "name": "fake",
    "type": "library"
+  }
+ },
+ {
+  "name": "ReferringClass",
+  "qualifiedName": "fake.ReferringClass",
+  "href": "fake/ReferringClass-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ReferringClass",
+  "qualifiedName": "fake.ReferringClass",
+  "href": "fake/ReferringClass/ReferringClass.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.ReferringClass.==",
+  "href": "fake/ReferringClass/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.ReferringClass.hashCode",
+  "href": "fake/ReferringClass/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.ReferringClass.noSuchMethod",
+  "href": "fake/ReferringClass/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "notAMethodFromPrivateClass",
+  "qualifiedName": "fake.ReferringClass.notAMethodFromPrivateClass",
+  "href": "fake/ReferringClass/notAMethodFromPrivateClass.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.ReferringClass.runtimeType",
+  "href": "fake/ReferringClass/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.ReferringClass.toString",
+  "href": "fake/ReferringClass/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferringClass",
+   "type": "class"
   }
  },
  {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -427,7 +427,7 @@ Future<List<Map>> _buildFlutterDocs(
       workingDirectory: await futureCwd);
   return await launcher.runStreamed(
     flutterCacheDart,
-    [path.join('dev', 'tools', 'dartdoc.dart'), '--json'],
+    [path.join('dev', 'tools', 'dartdoc.dart'), '-c', '--json'],
     workingDirectory: flutterPath,
   );
 }


### PR DESCRIPTION
Fixes #1602.

Checked mode failures were due to a bug in the markdown processor.  Add a test for that change, update analyzer (required for checked mode to work), and unpin travis/appveyor so we again use the latest SDK builds.