### PR TITLE
Make link validation optional

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -262,7 +262,8 @@ main(List<String> arguments) async {
           double.parse(args['ambiguous-reexport-scorer-min-confidence']),
       verboseWarnings: args['verbose-warnings'],
       excludePackages: args['exclude-packages'],
-      dropTextFrom: dropTextFrom);
+      dropTextFrom: dropTextFrom,
+      validateLinks: args['validate-links']);
 
   DartDoc dartdoc = new DartDoc(inputDir, excludeLibraries, sdkDir, generators,
       outputDir, packageMeta, includeLibraries, includeExternals);
@@ -382,13 +383,15 @@ ArgParser _createArgsParser() {
         "Drop all text for SDK components.  Helpful for integration tests for dartdoc, probably not useful for anything else.",
     negatable: true,
     defaultsTo: false,
-    hide: true,
-  );
+    hide: true);
   parser.addFlag('json',
       help: 'Prints out progress JSON maps. One entry per line.',
       defaultsTo: false,
       negatable: true);
-
+  parser.addFlag('validate-links',
+       help: 'Runs the built-in link checker to display Dart context aware warnings for broken links (slow)',
+       negatable: true,
+       defaultsTo: true);
   return parser;
 }
 

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -377,21 +377,21 @@ ArgParser _createArgsParser() {
       help: 'Display extra debugging information and help with warnings.',
       negatable: true,
       defaultsTo: true);
-  parser.addFlag(
-    'hide-sdk-text',
-    help:
-        "Drop all text for SDK components.  Helpful for integration tests for dartdoc, probably not useful for anything else.",
-    negatable: true,
-    defaultsTo: false,
-    hide: true);
+  parser.addFlag('hide-sdk-text',
+      help:
+          "Drop all text for SDK components.  Helpful for integration tests for dartdoc, probably not useful for anything else.",
+      negatable: true,
+      defaultsTo: false,
+      hide: true);
   parser.addFlag('json',
       help: 'Prints out progress JSON maps. One entry per line.',
       defaultsTo: false,
       negatable: true);
   parser.addFlag('validate-links',
-       help: 'Runs the built-in link checker to display Dart context aware warnings for broken links (slow)',
-       negatable: true,
-       defaultsTo: true);
+      help:
+          'Runs the built-in link checker to display Dart context aware warnings for broken links (slow)',
+      negatable: true,
+      defaultsTo: true);
   return parser;
 }
 

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -171,8 +171,7 @@ class DartDoc extends PackageBuilder {
       await generator.generate(package, outputDir.path);
       writtenFiles.addAll(generator.writtenFiles.map(path.normalize));
     }
-
-    verifyLinks(package, outputDir.path);
+    if (config.validateLinks) validateLinks(package, outputDir.path);
     int warnings = package.packageWarningCounter.warningCount;
     int errors = package.packageWarningCounter.errorCount;
     if (warnings == 0 && errors == 0) {
@@ -398,7 +397,7 @@ class DartDoc extends PackageBuilder {
 
   /// Don't call this method more than once, and only after you've
   /// generated all docs for the Package.
-  void verifyLinks(Package package, String origin) {
+  void validateLinks(Package package, String origin) {
     assert(_hrefs == null);
     _hrefs = package.allHrefs;
 

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -19,6 +19,7 @@ class Config {
   final bool verboseWarnings;
   final List<String> dropTextFrom;
   final List<String> excludePackages;
+  final bool validateLinks;
   Config._(
       this.inputDir,
       this.showWarnings,
@@ -31,7 +32,8 @@ class Config {
       this.reexportMinConfidence,
       this.verboseWarnings,
       this.dropTextFrom,
-      this.excludePackages);
+      this.excludePackages,
+      this.validateLinks);
 }
 
 Config _config;
@@ -49,7 +51,8 @@ void setConfig(
     double reexportMinConfidence: 0.1,
     bool verboseWarnings: true,
     List<String> dropTextFrom,
-    List<String> excludePackages}) {
+    List<String> excludePackages,
+    bool validateLinks: true}) {
   _config = new Config._(
       inputDir,
       showWarnings,
@@ -62,5 +65,6 @@ void setConfig(
       reexportMinConfidence,
       verboseWarnings,
       dropTextFrom ?? const <String>[],
-      excludePackages ?? const <String>[]);
+      excludePackages ?? const <String>[],
+      validateLinks);
 }


### PR DESCRIPTION
Link validation takes a very long time (close to half the doc build time).  This is a lot of compute time, for warnings that aren't usually acted on.

Make this optional, so that unless someone is actively chasing bad links they don't have to pay the penalty.