### PR TITLE
Enable strong mode in Dartdoc

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -702,8 +702,12 @@ class Class extends ModelElement
       _inheritedMethods = new List<Method>();
       Set<String> methodNames = _methods.map((m) => m.element.name).toSet();
 
-      Set<ExecutableElement> inheritedMethodElements = _inheritedElements.where((e) {
-        return (e is MethodElement && !e.isOperator && e is! PropertyAccessorElement && !methodNames.contains(e.name));
+      Set<ExecutableElement> inheritedMethodElements =
+          _inheritedElements.where((e) {
+        return (e is MethodElement &&
+            !e.isOperator &&
+            e is! PropertyAccessorElement &&
+            !methodNames.contains(e.name));
       }).toSet();
 
       for (ExecutableElement e in inheritedMethodElements) {
@@ -725,8 +729,11 @@ class Class extends ModelElement
       _inheritedOperators = [];
       Set<String> operatorNames = _operators.map((o) => o.element.name).toSet();
 
-      Set<ExecutableElement> inheritedOperatorElements = _inheritedElements.where((e) {
-        return (e is MethodElement && e.isOperator && !operatorNames.contains(e.name));
+      Set<ExecutableElement> inheritedOperatorElements =
+          _inheritedElements.where((e) {
+        return (e is MethodElement &&
+            e.isOperator &&
+            !operatorNames.contains(e.name));
       }).toSet();
       for (ExecutableElement e in inheritedOperatorElements) {
         Operator o = new ModelElement.from(e, library, enclosingClass: this);
@@ -926,10 +933,13 @@ class Class extends ModelElement
   List<ExecutableElement> get _inheritedElements {
     if (__inheritedElements == null) {
       __inheritedElements = [];
-      Map<String, ExecutableElement> cmap = library.inheritanceManager.getMembersInheritedFromClasses(element);
-      Map<String, ExecutableElement> imap = library.inheritanceManager.getMembersInheritedFromInterfaces(element);
+      Map<String, ExecutableElement> cmap =
+          library.inheritanceManager.getMembersInheritedFromClasses(element);
+      Map<String, ExecutableElement> imap =
+          library.inheritanceManager.getMembersInheritedFromInterfaces(element);
       __inheritedElements.addAll(cmap.values);
-      __inheritedElements.addAll(imap.values.where((e) => !cmap.containsKey(e.name)));
+      __inheritedElements
+          .addAll(imap.values.where((e) => !cmap.containsKey(e.name)));
     }
     return __inheritedElements;
   }
@@ -937,7 +947,8 @@ class Class extends ModelElement
   List<Field> get allFields {
     if (_fields != null) return _fields;
     _fields = [];
-    Set<PropertyAccessorElement> inheritedAccessors = new Set()..addAll(_inheritedElements.where((e) => e is PropertyAccessorElement));
+    Set<PropertyAccessorElement> inheritedAccessors = new Set()
+      ..addAll(_inheritedElements.where((e) => e is PropertyAccessorElement));
 
     // This structure keeps track of inherited accessors, allowing lookup
     // by field name (stripping the '=' from setters).

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -698,60 +698,21 @@ class Class extends ModelElement
   }
 
   List<Method> get inheritedMethods {
-    if (_inheritedMethods != null) return _inheritedMethods;
+    if (_inheritedMethods == null) {
+      _inheritedMethods = new List<Method>();
+      Set<String> methodNames = _methods.map((m) => m.element.name).toSet();
 
-    Map<String, ExecutableElement> cmap =
-        library.inheritanceManager.getMembersInheritedFromClasses(element);
-    Map<String, ExecutableElement> imap =
-        library.inheritanceManager.getMembersInheritedFromInterfaces(element);
+      Set<ExecutableElement> inheritedMethodElements = _inheritedElements.where((e) {
+        return (e is MethodElement && !e.isOperator && e is! PropertyAccessorElement && !methodNames.contains(e.name));
+      }).toSet();
 
-    // remove methods that exist on this class
-    _methods.forEach((method) {
-      cmap.remove(method.name);
-      imap.remove(method.name);
-    });
-
-    _inheritedMethods = [];
-    List<ExecutableElement> values = [];
-    Set<String> uniqueNames = new Set();
-
-    instanceProperties.forEach((f) {
-      if (f.setter != null) uniqueNames.add(f.setter.element.name);
-      if (f.getter != null) uniqueNames.add(f.getter.element.name);
-    });
-
-    for (String key in cmap.keys) {
-      // XXX: if we care about showing a hierarchy with our inherited methods,
-      // then don't do this
-      if (uniqueNames.contains(key)) continue;
-
-      uniqueNames.add(key);
-      values.add(cmap[key]);
-    }
-
-    for (String key in imap.keys) {
-      // XXX: if we care about showing a hierarchy with our inherited methods,
-      // then don't do this
-      if (uniqueNames.contains(key)) continue;
-
-      uniqueNames.add(key);
-      values.add(imap[key]);
-    }
-
-    for (ExecutableElement value in values) {
-      if (value != null &&
-          value is MethodElement &&
-          !value.isOperator &&
-          value.enclosingElement != null) {
-        Method m;
-        m = new ModelElement.from(value, library, enclosingClass: this);
+      for (ExecutableElement e in inheritedMethodElements) {
+        Method m = new ModelElement.from(e, library, enclosingClass: this);
         _inheritedMethods.add(m);
         _genPageMethods.add(m);
       }
+      _inheritedMethods.sort(byName);
     }
-
-    _inheritedMethods.sort(byName);
-
     return _inheritedMethods;
   }
 
@@ -759,53 +720,21 @@ class Class extends ModelElement
 
   bool get hasPublicInheritedMethods => publicInheritedMethods.isNotEmpty;
 
-  // TODO(jcollins-g): this is very copy-paste from inheritedMethods now that the
-  // constructor is always [ModelElement.from].  Fix this.
   List<Operator> get inheritedOperators {
-    if (_inheritedOperators != null) return _inheritedOperators;
-    Map<String, ExecutableElement> cmap =
-        library.inheritanceManager.getMembersInheritedFromClasses(element);
-    Map<String, ExecutableElement> imap =
-        library.inheritanceManager.getMembersInheritedFromInterfaces(element);
-    operators.forEach((operator) {
-      cmap.remove(operator.element.name);
-      imap.remove(operator.element.name);
-    });
-    _inheritedOperators = [];
-    Map<String, ExecutableElement> values = {};
+    if (_inheritedOperators == null) {
+      _inheritedOperators = [];
+      Set<String> operatorNames = _operators.map((o) => o.element.name).toSet();
 
-    bool _isInheritedOperator(ExecutableElement value) {
-      if (value != null &&
-          value is MethodElement &&
-          value.isOperator &&
-          value.enclosingElement != null) {
-        return true;
+      Set<ExecutableElement> inheritedOperatorElements = _inheritedElements.where((e) {
+        return (e is MethodElement && e.isOperator && !operatorNames.contains(e.name));
+      }).toSet();
+      for (ExecutableElement e in inheritedOperatorElements) {
+        Operator o = new ModelElement.from(e, library, enclosingClass: this);
+        _inheritedOperators.add(o);
+        _genPageOperators.add(o);
       }
-      return false;
+      _inheritedOperators.sort(byName);
     }
-
-    for (String key in cmap.keys) {
-      ExecutableElement value = cmap[key];
-      if (_isInheritedOperator(value)) {
-        values.putIfAbsent(value.name, () => value);
-      }
-    }
-
-    for (String key in imap.keys) {
-      ExecutableElement value = imap[key];
-      if (_isInheritedOperator(value)) {
-        values.putIfAbsent(value.name, () => value);
-      }
-    }
-
-    for (ExecutableElement value in values.values) {
-      Operator o = new ModelElement.from(value, library, enclosingClass: this);
-      _inheritedOperators.add(o);
-      _genPageOperators.add(o);
-    }
-
-    _inheritedOperators.sort(byName);
-
     return _inheritedOperators;
   }
 
@@ -993,22 +922,22 @@ class Class extends ModelElement
 
   ElementType get supertype => _supertype;
 
+  List<ExecutableElement> __inheritedElements;
+  List<ExecutableElement> get _inheritedElements {
+    if (__inheritedElements == null) {
+      __inheritedElements = [];
+      Map<String, ExecutableElement> cmap = library.inheritanceManager.getMembersInheritedFromClasses(element);
+      Map<String, ExecutableElement> imap = library.inheritanceManager.getMembersInheritedFromInterfaces(element);
+      __inheritedElements.addAll(cmap.values);
+      __inheritedElements.addAll(imap.values.where((e) => !cmap.containsKey(e.name)));
+    }
+    return __inheritedElements;
+  }
+
   List<Field> get allFields {
     if (_fields != null) return _fields;
     _fields = [];
-    Map<String, ExecutableElement> cmap =
-        library.inheritanceManager.getMembersInheritedFromClasses(element);
-    Map<String, ExecutableElement> imap =
-        library.inheritanceManager.getMembersInheritedFromInterfaces(element);
-
-    Set<PropertyAccessorElement> inheritedAccessors = new Set();
-    inheritedAccessors
-        .addAll(cmap.values.where((e) => e is PropertyAccessorElement));
-
-    // Interfaces are subordinate to members inherited from classes, so don't
-    // add this to our accessor set if we already have something inherited from classes.
-    inheritedAccessors.addAll(imap.values.where(
-        (e) => e is PropertyAccessorElement && !cmap.containsKey(e.name)));
+    Set<PropertyAccessorElement> inheritedAccessors = new Set()..addAll(_inheritedElements.where((e) => e is PropertyAccessorElement));
 
     // This structure keeps track of inherited accessors, allowing lookup
     // by field name (stripping the '=' from setters).

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -777,7 +777,6 @@ class Class extends ModelElement
     bool _isInheritedOperator(ExecutableElement value) {
       if (value != null &&
           value is MethodElement &&
-          !value.isPrivate &&
           value.isOperator &&
           value.enclosingElement != null) {
         return true;
@@ -785,15 +784,15 @@ class Class extends ModelElement
       return false;
     }
 
-    for (String key in imap.keys) {
-      ExecutableElement value = imap[key];
+    for (String key in cmap.keys) {
+      ExecutableElement value = cmap[key];
       if (_isInheritedOperator(value)) {
         values.putIfAbsent(value.name, () => value);
       }
     }
 
-    for (String key in cmap.keys) {
-      ExecutableElement value = cmap[key];
+    for (String key in imap.keys) {
+      ExecutableElement value = imap[key];
       if (_isInheritedOperator(value)) {
         values.putIfAbsent(value.name, () => value);
       }
@@ -5091,6 +5090,7 @@ class PackageBuilder {
       PerformanceLog log = new PerformanceLog(null);
       AnalysisDriverScheduler scheduler = new AnalysisDriverScheduler(log);
       AnalysisOptionsImpl options = new AnalysisOptionsImpl();
+      options.strongMode = true;
       options.enableSuperMixins = true;
 
       // TODO(jcollins-g): Make use of currently not existing API for managing

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-dev.24.0"
+  dart: ">=2.0.0-dev <=2.0.0-edge.0d5cf900b021bf5c9fa593ffa12b15bcd1cc5fe0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-edge.0d5cf900b021bf5c9fa593ffa12b15bcd1cc5fe0"
+  dart: ">=2.0.0-dev <=2.0.0-dev.30.0"

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -6,6 +6,7 @@ library dartdoc.model_test;
 
 import 'dart:io';
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/warnings.dart';
@@ -729,6 +730,15 @@ void main() {
       Iterable<Match> matches = new RegExp('In the super class')
           .allMatches(powers.documentationAsHtml);
       expect(matches, hasLength(1));
+    });
+  });
+
+  group('Class edge cases', () {
+    test('ExecutableElements from private classes and from public interfaces (#1561)', () {
+      Class MIEEMixinWithOverride = fakeLibrary.publicClasses.firstWhere((c) => c.name == 'MIEEMixinWithOverride');
+      Operator problematicOperator = MIEEMixinWithOverride.inheritedOperators.firstWhere((o) => o.name == 'operator []=');
+      expect(problematicOperator.element.enclosingElement.name, equals('_MIEEPrivateOverride'));
+      expect(problematicOperator.canonicalModelElement.enclosingElement.name, equals('MIEEMixinWithOverride'));
     });
   });
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -705,3 +705,24 @@ class ReferringClass {
     return false;
   }
 }
+
+/// Test an edge case for cases where inherited ExecutableElements can come
+/// both from private classes and public interfaces.  The test makes sure the
+/// class still takes precedence (#1561).
+abstract class MIEEMixinWithOverride<K, V> = MIEEBase<K, V> with _MIEEPrivateOverride<K, V>;
+
+abstract class _MIEEPrivateOverride<K, V> implements MIEEThing<K, V> {
+  void operator[]=(K key, V value) {
+    throw new UnsupportedError("Never use this");
+  }
+}
+
+abstract class MIEEBase<K, V> extends MIEEMixin<K, V> {}
+
+abstract class MIEEMixin<K, V> implements MIEEThing<K, V> {
+  operator []=(K key, V value);
+}
+
+abstract class MIEEThing<K, V> {
+  void operator[]=(K key, V value);
+}

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -375,7 +375,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <dl class="callables">
         <dt id="operator ==" class="callable">
           <span class="name"><a href="ex/Dog/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
+            <span class="returntype parameter">&#8594; bool</span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -97,7 +97,7 @@
           <li>@override</li>
         </ol>
       </div>
-      <span class="returntype">dynamic</span>
+      <span class="returntype">bool</span>
       <span class="name ">operator ==</span>
 (<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
     </section>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -371,7 +371,7 @@
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
           <span class="name"><a href="ex/Dog/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
+            <span class="returntype parameter">&#8594; bool</span>
           </span>
         </dt>
         <dd class="inherited">

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -200,7 +200,7 @@
 </dd>
         <dt id="toString" class="callable">
           <span class="name"><a href="ex/Klass/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; dynamic</span>
+            <span class="returntype parameter">&#8594; String</span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/ex/Klass/toString.html
+++ b/testing/test_package_docs/ex/Klass/toString.html
@@ -74,7 +74,7 @@
           <li>@override</li>
         </ol>
       </div>
-      <span class="returntype">dynamic</span>
+      <span class="returntype">String</span>
       <span class="name ">toString</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -299,7 +299,7 @@ that has some operators
         </dd>
         <dt id="incorrectDocReference" class="constant">
           <span class="name "><a href="ex/incorrectDocReference-constant.html">incorrectDocReference</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           This is the same name as a top-level const from the fake lib.
@@ -310,7 +310,7 @@ that has some operators
         </dd>
         <dt id="incorrectDocReferenceFromEx" class="constant">
           <span class="name "><a href="ex/incorrectDocReferenceFromEx-constant.html">incorrectDocReferenceFromEx</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           This should <code>not work</code>.

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -63,6 +63,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
@@ -433,7 +437,7 @@ across... wait for it... two physical lines.</p>
         </dd>
         <dt id="THING" class="constant">
           <span class="name "><a href="fake/LongFirstLine/THING-constant.html">THING</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
+++ b/testing/test_package_docs/fake/LongFirstLine/THING-constant.html
@@ -88,7 +88,7 @@
     <h1>THING constant</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">dynamic</span>
+        <span class="returntype">String</span>
         const <span class="name ">THING</span>
         =
         <span class="constant-value">&#39;yup&#39;</span>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEBase class from the fake library, for the Dart programming language.">
+  <title>MIEEBase class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">MIEEBase<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+  </ol>
+  <div class="self-name">MIEEBase</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEBase&lt;K, V&gt; class</h1>
+
+    
+    <section>
+      <dl class="dl-horizontal">
+        <dt>Inheritance</dt>
+        <dd><ul class="gt-separated dark clazz-relationships">
+          <li>Object</li>
+          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;K, V&gt;</span></li>
+          <li>MIEEBase</li>
+        </ul></dd>
+
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="MIEEBase" class="callable">
+          <span class="name"><a href="fake/MIEEBase/MIEEBase.html">MIEEBase</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="operator []=" class="callable inherited">
+          <span class="name"><a href="fake/MIEEMixin/operator_put.html">operator []=</a></span><span class="signature">(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/MIEEBase-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEBase/MIEEBase.html">MIEEBase</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEBase-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEBase-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEBase-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+      <li class="inherited"><a href="fake/MIEEMixin/operator_put.html">operator []=</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/MIEEBase/MIEEBase.html
+++ b/testing/test_package_docs/fake/MIEEBase/MIEEBase.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEBase constructor from the Class MIEEBase class from the fake library, for the Dart programming language.">
+  <title>MIEEBase constructor - MIEEBase class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEBase-class.html">MIEEBase<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">MIEEBase constructor</li>
+  </ol>
+  <div class="self-name">MIEEBase</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEBase class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEBase-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEBase/MIEEBase.html">MIEEBase</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEBase-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEBase-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEBase-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+      <li class="inherited"><a href="fake/MIEEMixin/operator_put.html">operator []=</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEBase&lt;K, V&gt; constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">MIEEBase&lt;K, V&gt;</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEMixin class from the fake library, for the Dart programming language.">
+  <title>MIEEMixin class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">MIEEMixin<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+  </ol>
+  <div class="self-name">MIEEMixin</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEMixin&lt;K, V&gt; class</h1>
+
+    
+    <section>
+      <dl class="dl-horizontal">
+
+        <dt>Implements</dt>
+        <dd>
+          <ul class="comma-separated clazz-relationships">
+            <li><a href="fake/MIEEThing-class.html">MIEEThing</a><span class="signature">&lt;K, V&gt;</span></li>
+          </ul>
+        </dd>
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="MIEEMixin" class="callable">
+          <span class="name"><a href="fake/MIEEMixin/MIEEMixin.html">MIEEMixin</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator []=" class="callable">
+          <span class="name"><a href="fake/MIEEMixin/operator_put.html">operator []=</a></span><span class="signature">(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          
+          
+</dd>
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/MIEEMixin-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEMixin/MIEEMixin.html">MIEEMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEMixin-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixin-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEMixin-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEMixin/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEMixin/MIEEMixin.html
+++ b/testing/test_package_docs/fake/MIEEMixin/MIEEMixin.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEMixin constructor from the Class MIEEMixin class from the fake library, for the Dart programming language.">
+  <title>MIEEMixin constructor - MIEEMixin class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEMixin-class.html">MIEEMixin<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">MIEEMixin constructor</li>
+  </ol>
+  <div class="self-name">MIEEMixin</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEMixin class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEMixin-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEMixin/MIEEMixin.html">MIEEMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEMixin-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixin-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEMixin-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEMixin/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEMixin&lt;K, V&gt; constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">MIEEMixin&lt;K, V&gt;</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEMixin/operator_put.html
+++ b/testing/test_package_docs/fake/MIEEMixin/operator_put.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator []= method from the MIEEMixin class, for the Dart programming language.">
+  <title>operator []= method - MIEEMixin class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEMixin-class.html">MIEEMixin<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">operator []= abstract method</li>
+  </ol>
+  <div class="self-name">operator []=</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEMixin class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEMixin-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEMixin/MIEEMixin.html">MIEEMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEMixin-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixin-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEMixin-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEMixin/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator []= method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">operator []=</span>
+(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEMixinWithOverride class from the fake library, for the Dart programming language.">
+  <title>MIEEMixinWithOverride class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">MIEEMixinWithOverride<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+  </ol>
+  <div class="self-name">MIEEMixinWithOverride</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEMixinWithOverride&lt;K, V&gt; class</h1>
+
+    <section class="desc markdown">
+      <p>Test an edge case for cases where inherited ExecutableElements can come
+both from private classes and public interfaces.  The test makes sure the
+class still takes precedence (#1561).</p>
+    </section>
+    
+    <section>
+      <dl class="dl-horizontal">
+        <dt>Inheritance</dt>
+        <dd><ul class="gt-separated dark clazz-relationships">
+          <li>Object</li>
+          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;K, V&gt;</span></li>
+          <li><a href="fake/MIEEBase-class.html">MIEEBase</a><span class="signature">&lt;K, V&gt;</span></li>
+          <li>MIEEMixinWithOverride</li>
+        </ul></dd>
+
+
+
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="MIEEMixinWithOverride" class="callable">
+          <span class="name"><a href="fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html">MIEEMixinWithOverride</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="operator []=" class="callable inherited">
+          <span class="name"><a href="fake/MIEEMixinWithOverride/operator_put.html">operator []=</a></span><span class="signature">(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/MIEEMixinWithOverride-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html">MIEEMixinWithOverride</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEMixinWithOverride-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixinWithOverride-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixinWithOverride-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+      <li class="inherited"><a href="fake/MIEEMixinWithOverride/operator_put.html">operator []=</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEMixinWithOverride constructor from the Class MIEEMixinWithOverride class from the fake library, for the Dart programming language.">
+  <title>MIEEMixinWithOverride constructor - MIEEMixinWithOverride class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">MIEEMixinWithOverride constructor</li>
+  </ol>
+  <div class="self-name">MIEEMixinWithOverride</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEMixinWithOverride class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEMixinWithOverride-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html">MIEEMixinWithOverride</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEMixinWithOverride-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixinWithOverride-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixinWithOverride-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+      <li class="inherited"><a href="fake/MIEEMixinWithOverride/operator_put.html">operator []=</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEMixinWithOverride&lt;K, V&gt; constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">MIEEMixinWithOverride&lt;K, V&gt;</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride/operator_put.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride/operator_put.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator []= method from the MIEEMixinWithOverride class, for the Dart programming language.">
+  <title>operator []= method - MIEEMixinWithOverride class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">operator []= method</li>
+  </ol>
+  <div class="self-name">operator []=</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEMixinWithOverride class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEMixinWithOverride-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html">MIEEMixinWithOverride</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEMixinWithOverride-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixinWithOverride-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEMixinWithOverride-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+      <li class="inherited"><a href="fake/MIEEMixinWithOverride/operator_put.html">operator []=</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator []= method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">operator []=</span>
+(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEThing class from the fake library, for the Dart programming language.">
+  <title>MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">MIEEThing<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+  </ol>
+  <div class="self-name">MIEEThing</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEThing&lt;K, V&gt; class</h1>
+
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="MIEEThing" class="callable">
+          <span class="name"><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator []=" class="callable">
+          <span class="name"><a href="fake/MIEEThing/operator_put.html">operator []=</a></span><span class="signature">(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          
+          
+</dd>
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/MIEEThing.html
+++ b/testing/test_package_docs/fake/MIEEThing/MIEEThing.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MIEEThing constructor from the Class MIEEThing class from the fake library, for the Dart programming language.">
+  <title>MIEEThing constructor - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">MIEEThing constructor</li>
+  </ol>
+  <div class="self-name">MIEEThing</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MIEEThing&lt;K, V&gt; constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">MIEEThing&lt;K, V&gt;</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/hashCode.html
+++ b/testing/test_package_docs/fake/MIEEThing/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the MIEEThing class, for the Dart programming language.">
+  <title>hashCode property - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/MIEEThing/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the MIEEThing class, for the Dart programming language.">
+  <title>noSuchMethod method - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/operator_equals.html
+++ b/testing/test_package_docs/fake/MIEEThing/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the MIEEThing class, for the Dart programming language.">
+  <title>operator == method - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/operator_put.html
+++ b/testing/test_package_docs/fake/MIEEThing/operator_put.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator []= method from the MIEEThing class, for the Dart programming language.">
+  <title>operator []= method - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">operator []= abstract method</li>
+  </ol>
+  <div class="self-name">operator []=</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator []= method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">operator []=</span>
+(<wbr><span class="parameter" id="[]=-param-key"><span class="type-annotation">K</span> <span class="parameter-name">key</span>, </span> <span class="parameter" id="[]=-param-value"><span class="type-annotation">V</span> <span class="parameter-name">value</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/runtimeType.html
+++ b/testing/test_package_docs/fake/MIEEThing/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the MIEEThing class, for the Dart programming language.">
+  <title>runtimeType property - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MIEEThing/toString.html
+++ b/testing/test_package_docs/fake/MIEEThing/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the MIEEThing class, for the Dart programming language.">
+  <title>toString method - MIEEThing class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MIEEThing class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/MIEEThing-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/MIEEThing/MIEEThing.html">MIEEThing</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/MIEEThing-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/MIEEThing/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MIEEThing-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/toString.html">toString</a></li>
+    
+      <li class="section-title"><a href="fake/MIEEThing-class.html#operators">Operators</a></li>
+      <li><a href="fake/MIEEThing/operator_put.html">operator []=</a></li>
+      <li class="inherited"><a href="fake/MIEEThing/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -223,6 +223,32 @@ they are correct.
           This is a very long line spread
 across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.html">[...]</a>
         </dd>
+        <dt id="MIEEBase">
+          <span class="name "><a href="fake/MIEEBase-class.html">MIEEBase</a><span class="signature">&lt;K, V&gt;</span></span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="MIEEMixin">
+          <span class="name "><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;K, V&gt;</span></span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="MIEEMixinWithOverride">
+          <span class="name "><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a><span class="signature">&lt;K, V&gt;</span></span>
+        </dt>
+        <dd>
+          Test an edge case for cases where inherited ExecutableElements can come
+both from private classes and public interfaces.  The test makes sure the
+class still takes precedence (#1561).
+        </dd>
+        <dt id="MIEEThing">
+          <span class="name "><a href="fake/MIEEThing-class.html">MIEEThing</a><span class="signature">&lt;K, V&gt;</span></span>
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="MixMeIn">
           <span class="name "><a href="fake/MixMeIn-class.html">MixMeIn</a></span>
         </dt>
@@ -308,7 +334,7 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="DOWN" class="constant">
           <span class="name deprecated"><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           Dynamic-typed down.
@@ -319,7 +345,7 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="greatAnnotation" class="constant">
           <span class="name "><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           This is a great thing.
@@ -330,7 +356,7 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="greatestAnnotation" class="constant">
           <span class="name "><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           This is the greatest thing.
@@ -341,7 +367,7 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="incorrectDocReference" class="constant">
           <span class="name "><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           Referencing something that <code>doesn't exist</code>.
@@ -385,7 +411,7 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="required" class="constant">
           <span class="name "><a href="fake/required-constant.html">required</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           
@@ -396,7 +422,7 @@ across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.h
         </dd>
         <dt id="testingCodeSyntaxInOneLiners" class="constant">
           <span class="name "><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></span>
-          <span class="signature">&#8594; const dynamic</span>
+          <span class="signature">&#8594; const String</span>
         </dt>
         <dd>
           These are code syntaxes: <code>true</code> and <code>false</code>
@@ -766,6 +792,10 @@ default value.
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -62,6 +62,10 @@
       <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
       <li><a href="fake/Interface-class.html">Interface</a></li>
       <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
       <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
       <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -5795,6 +5795,182 @@
   }
  },
  {
+  "name": "MIEEBase",
+  "qualifiedName": "fake.MIEEBase",
+  "href": "fake/MIEEBase-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "MIEEBase",
+  "qualifiedName": "fake.MIEEBase",
+  "href": "fake/MIEEBase/MIEEBase.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEBase",
+   "type": "class"
+  }
+ },
+ {
+  "name": "MIEEMixin",
+  "qualifiedName": "fake.MIEEMixin",
+  "href": "fake/MIEEMixin-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "MIEEMixin",
+  "qualifiedName": "fake.MIEEMixin",
+  "href": "fake/MIEEMixin/MIEEMixin.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEMixin",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator []=",
+  "qualifiedName": "fake.MIEEMixin.[]=",
+  "href": "fake/MIEEMixin/operator_put.html",
+  "type": "method",
+  "overriddenDepth": 1,
+  "enclosedBy": {
+   "name": "MIEEMixin",
+   "type": "class"
+  }
+ },
+ {
+  "name": "MIEEMixinWithOverride",
+  "qualifiedName": "fake.MIEEMixinWithOverride",
+  "href": "fake/MIEEMixinWithOverride-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "MIEEMixinWithOverride",
+  "qualifiedName": "fake.MIEEMixinWithOverride",
+  "href": "fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEMixinWithOverride",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator []=",
+  "qualifiedName": "fake.MIEEMixinWithOverride.[]=",
+  "href": "fake/MIEEMixinWithOverride/operator_put.html",
+  "type": "method",
+  "overriddenDepth": 1,
+  "enclosedBy": {
+   "name": "MIEEMixinWithOverride",
+   "type": "class"
+  }
+ },
+ {
+  "name": "MIEEThing",
+  "qualifiedName": "fake.MIEEThing",
+  "href": "fake/MIEEThing-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "MIEEThing",
+  "qualifiedName": "fake.MIEEThing",
+  "href": "fake/MIEEThing/MIEEThing.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.MIEEThing.==",
+  "href": "fake/MIEEThing/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator []=",
+  "qualifiedName": "fake.MIEEThing.[]=",
+  "href": "fake/MIEEThing/operator_put.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.MIEEThing.hashCode",
+  "href": "fake/MIEEThing/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.MIEEThing.noSuchMethod",
+  "href": "fake/MIEEThing/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.MIEEThing.runtimeType",
+  "href": "fake/MIEEThing/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.MIEEThing.toString",
+  "href": "fake/MIEEThing/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MIEEThing",
+   "type": "class"
+  }
+ },
+ {
   "name": "MixMeIn",
   "qualifiedName": "fake.MixMeIn",
   "href": "fake/MixMeIn-class.html",


### PR DESCRIPTION
Fixes #1561, for great justice.  The strong mode change shifts a lot of types from dynamic to something inferred.  The accompanying refactor also reveals some inherited operators that were disappeared in previous versions (`MultiplyInheritedExecutableElement`s were silently dropped on the floor, as were operators inherited from private classes).