### PR TITLE
More correctly remove indentation from documentation comments.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,7 +18,7 @@ String convertTabs(String str) {
       String char = new String.fromCharCode(rune);
       if (char == '\t') {
         int shiftChars = kTabWidth - position % kTabWidth;
-        for (int count = 0 ; count < shiftChars; ++count) {
+        for (int count = 0; count < shiftChars; ++count) {
           buf.write(' ');
           ++position;
         }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,14 +3,76 @@
 // BSD-style license that can be found in the LICENSE file.
 library dartdoc.utils;
 
+final RegExp leadingWhiteSpace = new RegExp(r'^( *)[^ ]');
+const int kTabWidth = 8;
+
+/// Try to do something with tabs, by converting them to spaces.
+String convertTabs(String str) {
+  StringBuffer buf = new StringBuffer();
+  List<String> lines = str.split('\n');
+
+  int lineno = 1;
+  for (String line in lines) {
+    int position = 0;
+    for (int rune in line.runes) {
+      String char = new String.fromCharCode(rune);
+      if (char == '\t') {
+        int shiftChars = kTabWidth - position % kTabWidth;
+        for (int count = 0 ; count < shiftChars; ++count) {
+          buf.write(' ');
+          ++position;
+        }
+      } else {
+        buf.write(char);
+        ++position;
+      }
+    }
+    if (lineno < lines.length) {
+      buf.write('\n');
+    }
+    ++lineno;
+  }
+  return buf.toString();
+}
+
+String stripCommonWhitespace(String str) {
+  str = convertTabs(str);
+  StringBuffer buf = new StringBuffer();
+  List<String> lines = str.split('\n');
+  int minimumSeen;
+
+  for (String line in lines) {
+    if (line.isNotEmpty) {
+      Match m = leadingWhiteSpace.firstMatch(line);
+      if (m != null) {
+        if (minimumSeen == null || m.group(1).length < minimumSeen) {
+          minimumSeen = m.group(1).length;
+        }
+      }
+    }
+  }
+  minimumSeen ??= 0;
+  int lineno = 1;
+  for (String line in lines) {
+    if (line.length >= minimumSeen) {
+      buf.write('${line.substring(minimumSeen)}\n');
+    } else {
+      if (lineno < lines.length) {
+        buf.write('\n');
+      }
+    }
+    ++lineno;
+  }
+  return buf.toString();
+}
+
 String stripComments(String str) {
   if (str == null) return null;
-
   StringBuffer buf = new StringBuffer();
 
   if (str.startsWith('///')) {
+    str = stripCommonWhitespace(str);
     for (String line in str.split('\n')) {
-      line = line.trimLeft();
       if (line.startsWith('/// ')) {
         buf.write('${line.substring(4)}\n');
       } else if (line.startsWith('///')) {
@@ -26,9 +88,8 @@ String stripComments(String str) {
     if (str.endsWith('*/')) {
       str = str.substring(0, str.length - 2);
     }
-    str = str.trim();
+    str = stripCommonWhitespace(str);
     for (String line in str.split('\n')) {
-      line = line.trimLeft();
       if (line.startsWith('* ')) {
         buf.write('${line.substring(2)}\n');
       } else if (line.startsWith('*')) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,40 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 library dartdoc.utils;
 
-final RegExp leadingWhiteSpace = new RegExp(r'^( *)[^ ]');
-const int kTabWidth = 8;
-
-/// Try to do something with tabs, by converting them to spaces.
-String convertTabs(String str) {
-  StringBuffer buf = new StringBuffer();
-  List<String> lines = str.split('\n');
-
-  int lineno = 1;
-  for (String line in lines) {
-    int position = 0;
-    for (int rune in line.runes) {
-      String char = new String.fromCharCode(rune);
-      if (char == '\t') {
-        int shiftChars = kTabWidth - position % kTabWidth;
-        for (int count = 0; count < shiftChars; ++count) {
-          buf.write(' ');
-          ++position;
-        }
-      } else {
-        buf.write(char);
-        ++position;
-      }
-    }
-    if (lineno < lines.length) {
-      buf.write('\n');
-    }
-    ++lineno;
-  }
-  return buf.toString();
-}
+final RegExp leadingWhiteSpace = new RegExp(r'^([ \t]*)[^ ]');
 
 String stripCommonWhitespace(String str) {
-  str = convertTabs(str);
   StringBuffer buf = new StringBuffer();
   List<String> lines = str.split('\n');
   int minimumSeen;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,4 +415,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-dev.24.0"
+  dart: ">=2.0.0-dev <=2.0.0-dev.30.0"

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1502,6 +1502,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     Field explicitNonDocumentedInBaseClassGetter;
     Field documentedPartialFieldInSubclassOnly;
     Field ExtraSpecialListLength;
+    Field aProperty;
 
     setUp(() {
       c = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
@@ -1558,6 +1559,27 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((c) => c.name == 'SpecialList')
           .allInstanceProperties
           .firstWhere((f) => f.name == 'length');
+      aProperty = fakeLibrary.classes
+          .firstWhere((c) => c.name == 'AClassWithFancyProperties')
+          .allInstanceProperties
+          .firstWhere((f) => f.name == 'aProperty');
+    });
+
+    test('indentation is not lost inside indented code samples', () {
+      expect(aProperty.documentation, equals(
+          'This property is quite fancy, and requires sample code to understand.\n'
+              '\n'
+              '```dart\n'
+              'AClassWithFancyProperties x = new AClassWithFancyProperties();\n'
+              '\n'
+              'if (x.aProperty.contains(\'Hello\')) {\n'
+              '  print("I am indented!");\n'
+              '  if (x.aProperty.contains(\'World\')) {\n'
+              '    print ("I am indented even more!!!");\n'
+              '  }\n'
+              '}\n'
+              '```'
+      ));
     });
 
     test('annotations from getters and setters are accumulated in Fields', () {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -177,27 +177,19 @@ void main() {
     });
   });
 
-  group('convertTabs', () {
-    test('basic tab conversion', () {
-      String input = '\t\t stuff\n'
-                     '\t  \t stuff\n'
-                     '        \t stuff\n';
-      String output = '                 stuff\n'
-                      '                 stuff\n'
-                      '                 stuff\n';
-      expect(convertTabs(input), equals(output));
-    });
-  });
-
   group('leadingWhitespace', () {
     test('strip common leading whitespace, but no more', () {
       String input = '   3 space indent\n'
                      '    4 space indent (one preserved)\n'
                      '       7 space indent (four preserved)\n'
+                     '\t  2 spaces, one tab (same as 3 space)\n'
+                     '    \t4 spaces, one tab (preserve the tab)\n'
                      '   3 space indent again\n';
       String output = '3 space indent\n'
                       ' 4 space indent (one preserved)\n'
                       '    7 space indent (four preserved)\n'
+                      '2 spaces, one tab (same as 3 space)\n'
+                      ' \t4 spaces, one tab (preserve the tab)\n'
                       '3 space indent again\n';
       expect(stripCommonWhitespace(input), equals(output));
     });

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -179,11 +179,11 @@ void main() {
 
   group('convertTabs', () {
     test('basic tab conversion', () {
-      String input = '\t\t stuff\n' +
-                     '\t  \t stuff\n' +
+      String input = '\t\t stuff\n'
+                     '\t  \t stuff\n'
                      '        \t stuff\n';
-      String output = '                 stuff\n' +
-                      '                 stuff\n' +
+      String output = '                 stuff\n'
+                      '                 stuff\n'
                       '                 stuff\n';
       expect(convertTabs(input), equals(output));
     });
@@ -191,13 +191,13 @@ void main() {
 
   group('leadingWhitespace', () {
     test('strip common leading whitespace, but no more', () {
-      String input = '   3 space indent\n' +
-                     '    4 space indent (one preserved)\n' +
-                     '       7 space indent (four preserved)\n' +
+      String input = '   3 space indent\n'
+                     '    4 space indent (one preserved)\n'
+                     '       7 space indent (four preserved)\n'
                      '   3 space indent again\n';
-      String output = '3 space indent\n' +
-                      ' 4 space indent (one preserved)\n' +
-                      '    7 space indent (four preserved)\n' +
+      String output = '3 space indent\n'
+                      ' 4 space indent (one preserved)\n'
+                      '    7 space indent (four preserved)\n'
                       '3 space indent again\n';
       expect(stripCommonWhitespace(input), equals(output));
     });

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -176,4 +176,30 @@ void main() {
       expect(truncateString('foo bar baz qux', 10), 'foo bar ba…');
     });
   });
+
+  group('convertTabs', () {
+    test('basic tab conversion', () {
+      String input = '\t\t stuff\n' +
+                     '\t  \t stuff\n' +
+                     '        \t stuff\n';
+      String output = '                 stuff\n' +
+                      '                 stuff\n' +
+                      '                 stuff\n';
+      expect(convertTabs(input), equals(output));
+    });
+  });
+
+  group('leadingWhitespace', () {
+    test('strip common leading whitespace, but no more', () {
+      String input = '   3 space indent\n' +
+                     '    4 space indent (one preserved)\n' +
+                     '       7 space indent (four preserved)\n' +
+                     '   3 space indent again\n';
+      String output = '3 space indent\n' +
+                      ' 4 space indent (one preserved)\n' +
+                      '    7 space indent (four preserved)\n' +
+                      '3 space indent again\n';
+      expect(stripCommonWhitespace(input), equals(output));
+    });
+  });
 }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -164,6 +164,22 @@ class _APrivateConstClass {
   const _APrivateConstClass();
 }
 
+class AClassWithFancyProperties {
+  /// This property is quite fancy, and requires sample code to understand.
+  ///
+  /// ```dart
+  /// AClassWithFancyProperties x = new AClassWithFancyProperties();
+  ///
+  /// if (x.aProperty.contains('Hello')) {
+  ///   print("I am indented!");
+  ///   if (x.aProperty.contains('World')) {
+  ///     print ("I am indented even more!!!");
+  ///   }
+  /// }
+  /// ```
+  String aProperty;
+}
+
 const _APrivateConstClass CUSTOM_CLASS_PRIVATE = const _APrivateConstClass();
 
 // No dart docs on purpose. Also, a non-primitive const class.

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the WithGetterAndSetter class from the fake library, for the Dart programming language.">
-  <title>WithGetterAndSetter class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the AClassWithFancyProperties class from the fake library, for the Dart programming language.">
+  <title>AClassWithFancyProperties class - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">WithGetterAndSetter class</li>
+    <li class="self-crumb">AClassWithFancyProperties class</li>
   </ol>
-  <div class="self-name">WithGetterAndSetter</div>
+  <div class="self-name">AClassWithFancyProperties</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -133,31 +133,16 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>WithGetterAndSetter class</h1>
+    <h1>AClassWithFancyProperties class</h1>
 
-    <section class="desc markdown">
-      <p>Tests a single field with explict getter and setter.</p>
-    </section>
     
-    <section>
-      <dl class="dl-horizontal">
-
-
-
-        <dt>Implemented by</dt>
-        <dd><ul class="comma-separated clazz-relationships">
-          <li><a href="two_exports/BaseClass-class.html">BaseClass</a></li>
-        </ul></dd>
-
-      </dl>
-    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="WithGetterAndSetter" class="callable">
-          <span class="name"><a href="fake/WithGetterAndSetter/WithGetterAndSetter.html">WithGetterAndSetter</a></span><span class="signature">()</span>
+        <dt id="AClassWithFancyProperties" class="callable">
+          <span class="name"><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -169,16 +154,16 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="lengthX" class="property">
-          <span class="name"><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></span>
-          <span class="signature">&#8596; int</span>
+        <dt id="aProperty" class="property">
+          <span class="name"><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></span>
+          <span class="signature">&#8596; String</span>
         </dt>
         <dd>
-          Returns a length. <a href="fake/WithGetterAndSetter/lengthX.html">[...]</a>
+          This property is quite fancy, and requires sample code to understand. <a href="fake/AClassWithFancyProperties/aProperty.html">[...]</a>
           <div class="features">read / write</div>
 </dd>
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span>
         </dt>
         <dd class="inherited">
@@ -186,7 +171,7 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span>
         </dt>
         <dd class="inherited">
@@ -200,7 +185,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
         </dt>
@@ -209,7 +194,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
         </dt>
@@ -224,7 +209,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="fake/WithGetterAndSetter/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+          <span class="name"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
         </dt>
@@ -242,22 +227,22 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="fake/WithGetterAndSetter-class.html#constructors">Constructors</a></li>
-      <li><a href="fake/WithGetterAndSetter/WithGetterAndSetter.html">WithGetterAndSetter</a></li>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
     
       <li class="section-title">
-        <a href="fake/WithGetterAndSetter-class.html#instance-properties">Properties</a>
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="fake/WithGetterAndSetter/lengthX.html">lengthX</a></li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/runtimeType.html">runtimeType</a></li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/toString.html">toString</a></li>
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="fake/WithGetterAndSetter-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/WithGetterAndSetter/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/AClassWithFancyProperties.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/AClassWithFancyProperties.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the AClassWithFancyProperties constructor from the Class AClassWithFancyProperties class from the fake library, for the Dart programming language.">
+  <title>AClassWithFancyProperties constructor - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">AClassWithFancyProperties constructor</li>
+  </ol>
+  <div class="self-name">AClassWithFancyProperties</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>AClassWithFancyProperties constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">AClassWithFancyProperties</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/aProperty.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/aProperty.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aProperty property from the AClassWithFancyProperties class, for the Dart programming language.">
+  <title>aProperty property - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">aProperty property</li>
+  </ol>
+  <div class="self-name">aProperty</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>aProperty property</h1>
+
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">aProperty</span>
+          <div class="features">read / write</div>
+        </section>
+        <section class="desc markdown">
+          <p>This property is quite fancy, and requires sample code to understand.</p>
+<pre class="language-dart"><code class="language-dart">AClassWithFancyProperties x = new AClassWithFancyProperties();
+
+if (x.aProperty.contains('Hello')) {
+  print("I am indented!");
+  if (x.aProperty.contains('World')) {
+    print ("I am indented even more!!!");
+  }
+}
+</code></pre>
+        </section>
+                
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/hashCode.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the AClassWithFancyProperties class, for the Dart programming language.">
+  <title>hashCode property - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/noSuchMethod.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the AClassWithFancyProperties class, for the Dart programming language.">
+  <title>noSuchMethod method - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/operator_equals.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the AClassWithFancyProperties class, for the Dart programming language.">
+  <title>operator == method - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/runtimeType.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the AClassWithFancyProperties class, for the Dart programming language.">
+  <title>runtimeType property - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties/toString.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the AClassWithFancyProperties class, for the Dart programming language.">
+  <title>toString method - AClassWithFancyProperties class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AClassWithFancyProperties class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/AClassWithFancyProperties-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/AClassWithFancyProperties/AClassWithFancyProperties.html">AClassWithFancyProperties</a></li>
+    
+      <li class="section-title">
+        <a href="fake/AClassWithFancyProperties-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="fake/AClassWithFancyProperties/aProperty.html">aProperty</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/AClassWithFancyProperties-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/AClassWithFancyProperties/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -89,6 +89,12 @@ Don't ask questions.</p>
         <dd>
           Verify super-mixins don't break Dartdoc.
         </dd>
+        <dt id="AClassWithFancyProperties">
+          <span class="name "><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></span>
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="AMixinCallingSuper">
           <span class="name "><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></span>
         </dt>
@@ -744,6 +750,7 @@ default value.
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -40,6 +40,7 @@
     <ol>
       <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
       <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
       <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
       <li><a href="fake/Annotation-class.html">Annotation</a></li>
       <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -3617,6 +3617,94 @@
   }
  },
  {
+  "name": "AClassWithFancyProperties",
+  "qualifiedName": "fake.AClassWithFancyProperties",
+  "href": "fake/AClassWithFancyProperties-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "AClassWithFancyProperties",
+  "qualifiedName": "fake.AClassWithFancyProperties",
+  "href": "fake/AClassWithFancyProperties/AClassWithFancyProperties.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.AClassWithFancyProperties.==",
+  "href": "fake/AClassWithFancyProperties/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "aProperty",
+  "qualifiedName": "fake.AClassWithFancyProperties.aProperty",
+  "href": "fake/AClassWithFancyProperties/aProperty.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.AClassWithFancyProperties.hashCode",
+  "href": "fake/AClassWithFancyProperties/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.AClassWithFancyProperties.noSuchMethod",
+  "href": "fake/AClassWithFancyProperties/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.AClassWithFancyProperties.runtimeType",
+  "href": "fake/AClassWithFancyProperties/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.AClassWithFancyProperties.toString",
+  "href": "fake/AClassWithFancyProperties/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AClassWithFancyProperties",
+   "type": "class"
+  }
+ },
+ {
   "name": "AMixinCallingSuper",
   "qualifiedName": "fake.AMixinCallingSuper",
   "href": "fake/AMixinCallingSuper-class.html",


### PR DESCRIPTION
Fixes #1608.  (And when deployed, verified it will fix the example from flutter/flutter#14687).

Dartdoc was simply stripping all whitespace from the beginning of each line in some cases, rather than doing the minimum necessary to shift the comment as a whole.  

This change still preserves the behavior of eliminating whitespace on the first line.  So in the unlikely event something like this happens:

```dart
   ///      I'm way over here
   /// But I'm not.
   bool isHappy;         
```

It will look the same as this:
```dart
   /// I'm way over here
   /// But I'm not.
   bool isHappy;         
```

