### PR TITLE
Add "Menlo" to monospace font list.

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -219,7 +219,7 @@ a, a:hover {
 }
 
 pre.prettyprint {
-  font-family: 'Source Code Pro', monospace;
+  font-family: 'Source Code Pro', Menlo, monospace;
   color: black;
   border-radius: 0;
   font-size: 15px;
@@ -247,7 +247,7 @@ pre {
 }
 
 code {
-  font-family: 'Source Code Pro', monospace;
+  font-family: 'Source Code Pro', Menlo, monospace;
   /* overriding bootstrap */
   color: inherit;
   padding: 0.2em 0.4em;

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -219,7 +219,7 @@ a, a:hover {
 }
 
 pre.prettyprint {
-  font-family: 'Source Code Pro', monospace;
+  font-family: 'Source Code Pro', Menlo, monospace;
   color: black;
   border-radius: 0;
   font-size: 15px;
@@ -247,7 +247,7 @@ pre {
 }
 
 code {
-  font-family: 'Source Code Pro', monospace;
+  font-family: 'Source Code Pro', Menlo, monospace;
   /* overriding bootstrap */
   color: inherit;
   padding: 0.2em 0.4em;


### PR DESCRIPTION
"Source Code Pro" is not installed on Mac, and the default monospace font makes the table's markdown-formatted fixed table's header line stick out. (Screenshots in this issue thread: https://github.com/dart-lang/pub-dartlang-dart/issues/1125#issuecomment-376279853).

Closes #1644