### PR TITLE
Fix embedded SDK detection by library

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:path/path.dart' as pathLib;
 
 import 'model.dart';
 
@@ -20,21 +19,7 @@ class LocalConfig {
   LocalConfig._(this.categoryMap, this.packageMeta);
 
   factory LocalConfig.fromLibrary(LibraryElement element) {
-    return new LocalConfig._({}, getPackageMeta(element));
-  }
-
-  static PackageMeta getPackageMeta(LibraryElement element) {
-    String sourcePath = element.source.fullName;
-    File file = new File(pathLib.canonicalize(sourcePath));
-    Directory dir = file.parent;
-    while (dir.parent.path != dir.path && dir.existsSync()) {
-      File pubspec = new File(pathLib.join(dir.path, 'pubspec.yaml'));
-      if (pubspec.existsSync()) {
-        return new PackageMeta.fromDir(dir);
-      }
-      dir = dir.parent;
-    }
-    return null;
+    return new LocalConfig._({}, new PackageMeta.fromElement(element));
   }
 }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2047,7 +2047,7 @@ class Library extends ModelElement with Categorization {
   PackageMeta _packageMeta;
   PackageMeta get packageMeta {
     if (_packageMeta == null) {
-      _packageMeta = getPackageMeta(element);
+      _packageMeta = new PackageMeta.fromElement(element);
     }
     return _packageMeta;
   }
@@ -2200,12 +2200,6 @@ class Library extends ModelElement with Categorization {
     }
     assert(!name.startsWith('file:'));
     return name;
-  }
-
-  static PackageMeta getPackageMeta(Element element) {
-    String sourcePath = element.source.fullName;
-    return new PackageMeta.fromDir(
-        new File(pathLib.canonicalize(sourcePath)).parent);
   }
 
   static String getLibraryName(LibraryElement element) {
@@ -4582,7 +4576,7 @@ class Package extends LibraryContainer implements Comparable<Package>, Privacy {
   // Workaround for mustache4dart issue where templates do not recognize
   // inherited properties as being in-context.
   @override
-  List<Library> get publicLibraries => super.publicLibraries;
+  Iterable<Library> get publicLibraries => super.publicLibraries;
 
   /// A map of category name to the category itself.
   Map<String, Category> get nameToCategory {
@@ -5267,7 +5261,8 @@ class PackageBuilder {
           await driver.getLibraryByUri(source.uri.toString());
       if (library != null) {
         if (!isExcluded(Library.getLibraryName(library)) &&
-            !excludePackages.contains(Library.getPackageMeta(library)?.name)) {
+            !excludePackages
+                .contains(new PackageMeta.fromElement(library)?.name)) {
           libraries.add(library);
           sources.add(source);
         }

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -6,6 +6,7 @@ library dartdoc.package_meta;
 
 import 'dart:io';
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/sdk.dart';
 import 'package:path/path.dart' as pathLib;
 import 'package:yaml/yaml.dart';
@@ -18,6 +19,13 @@ abstract class PackageMeta {
   final Directory dir;
 
   PackageMeta(this.dir);
+
+  /// Use this instead of fromDir where possible.
+  factory PackageMeta.fromElement(LibraryElement libraryElement) {
+    if (libraryElement.isInSdk) return new PackageMeta.fromDir(getSdkDir());
+    return new PackageMeta.fromDir(
+        new File(pathLib.canonicalize(libraryElement.source.fullName)).parent);
+  }
 
   /// This factory is guaranteed to return the same object for any given
   /// [dir.absolute.path].  Multiple [dir.absolute.path]s will resolve to the

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.42.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.40.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -6,6 +6,7 @@ library dartdoc.dartdoc_test;
 
 import 'dart:io';
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -121,6 +122,14 @@ void main() {
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:async'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:bear'), isTrue);
+      expect(p.packages.length, equals(2));
+      // Things that do not override the core SDK belong in their own package?
+      expect(p.packages["Dart"].isSdk, isTrue);
+      expect(p.packages["test_package_embedder_yaml"].isSdk, isFalse);
+      expect(
+          p.publicLibraries,
+          everyElement((Library l) =>
+              (l.element as LibraryElement).isInSdk == l.packageMeta.isSdk));
       // Ensure that we actually parsed some source by checking for
       // the 'Bear' class.
       Library dart_bear =
@@ -128,6 +137,9 @@ void main() {
       expect(dart_bear, isNotNull);
       expect(
           dart_bear.allClasses.map((cls) => cls.name).contains('Bear'), isTrue);
+      expect(p.packages["test_package_embedder_yaml"].publicLibraries,
+          contains(dart_bear));
+      expect(p.packages["Dart"].publicLibraries, hasLength(2));
     });
   });
 }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -224,7 +224,7 @@ class Cool {
 }
 
 /// A map initialization making use of optional const.
-const Map<int, String> myMap = { 1: "hello" };
+const Map<int, String> myMap = {1: "hello"};
 
 /// A variable initalization making use of optional new.
 Cool aCoolVariable = Cool();
@@ -289,6 +289,7 @@ void aVoidParameter(Future<void> p1) {}
 
 /// This class extends Future<void>
 abstract class ExtendsFutureVoid extends Future<void> {
+  // ignore: missing_return
   factory ExtendsFutureVoid(FutureOr<void> computation()) {}
 }
 
@@ -297,6 +298,7 @@ abstract class ImplementsFutureVoid implements Future<void> {}
 
 /// This class takes a type, and it might be void.
 class ATypeTakingClass<T> {
+  // ignore: missing_return
   T aMethodMaybeReturningVoid() {}
 }
 


### PR DESCRIPTION
The refactor in #1639 broke embedded SDK detection for cases like Flutter.  Add tests for detection of the SDK through libraryElements and fix the bug.