### PR TITLE
Fix validate-sdk-docs

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.40.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.43.0"

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -224,7 +224,7 @@ class Cool {
 }
 
 /// A map initialization making use of optional const.
-const Map<int, String> myMap = { 1: "hello" };
+const Map<int, String> myMap = {1: "hello"};
 
 /// A variable initalization making use of optional new.
 Cool aCoolVariable = Cool();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -627,8 +627,8 @@ updateTestPackageDocs() async {
 @Task('Validate the SDK doc build.')
 @Depends(buildSdkDocs)
 validateSdkDocs() {
-  const expectedLibCount = 19;
-
+  const expectedLibCount = 7;
+  const expectedSubLibCount = 12;
   File indexHtml = joinFile(sdkDocsDir, ['index.html']);
   if (!indexHtml.existsSync()) {
     fail('no index.html found for SDK docs');
@@ -642,12 +642,20 @@ validateSdkDocs() {
   }
   log('$foundLibs index.html dart: entries found');
 
+  int foundSubLibs =
+      _findCount(indexContents, '<li class="section-subitem"><a href="dart-');
+  if (foundSubLibs != expectedSubLibCount) {
+    fail(
+        'expected $expectedSubLibCount dart: index.html entries in categories, found $foundSubLibs');
+  }
+  log('$foundSubLibs index.html dart: entries in categories found');
+
   // check for the existence of certain files/dirs
   var libsLength =
       sdkDocsDir.listSync().where((fs) => fs.path.contains('dart-')).length;
-  if (libsLength != expectedLibCount) {
+  if (libsLength != expectedLibCount + expectedSubLibCount) {
     fail('docs not generated for all the SDK libraries, '
-        'expected $expectedLibCount directories, generated $libsLength directories');
+        'expected ${expectedLibCount + expectedSubLibCount} directories, generated $libsLength directories');
   }
   log('$libsLength dart: libraries found');
 


### PR DESCRIPTION
After 0.18.0 and the category changes were pushed to the SDK, that broke the validation in dartdoc's grinder.  This fixes that.