### PR TITLE
Fix several problems with anonymous functions and type parameters

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -359,6 +359,18 @@ dl dt.callable .name {
   white-space: nowrap;
 }
 
+.type-parameter {
+  white-space: nowrap;
+}
+
+.multi-line-signature .type-parameter {
+  display: -webkit-inline-box;
+}
+
+.multi-line-signature .type-parameter .parameter {
+  margin-left: 0px;
+}
+
 .signature {
   color: #727272;
 }

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -363,12 +363,9 @@ dl dt.callable .name {
   white-space: nowrap;
 }
 
-.multi-line-signature .type-parameter {
-  display: -webkit-inline-box;
-}
-
 .multi-line-signature .type-parameter .parameter {
   margin-left: 0px;
+  display: unset;
 }
 
 .signature {

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -125,9 +125,10 @@ class ParameterizedElementType extends DefinedElementType {
       if (!typeArguments.every((t) => t.name == 'dynamic') &&
           typeArguments.isNotEmpty) {
         buf.write('<span class="signature">');
-        buf.write('&lt;');
-        buf.writeAll(typeArguments.map((t) => t.linkedName), ', ');
-        buf.write('&gt;');
+        buf.write('&lt;<wbr><span class="type-parameter">');
+        buf.writeAll(typeArguments.map((t) => t.linkedName),
+            '</span>, <span class="type-parameter">');
+        buf.write('</span>&gt;');
         buf.write('</span>');
       }
 
@@ -146,9 +147,10 @@ class ParameterizedElementType extends DefinedElementType {
 
       if (!typeArguments.every((t) => t.name == 'dynamic') &&
           typeArguments.isNotEmpty) {
-        buf.write('&lt;');
-        buf.writeAll(typeArguments.map((t) => t.nameWithGenerics), ', ');
-        buf.write('&gt;');
+        buf.write('&lt;<wbr><span class="type-parameter">');
+        buf.writeAll(typeArguments.map((t) => t.nameWithGenerics),
+            '</span>, <span class="type-parameter">');
+        buf.write('</span>&gt;');
       }
       _nameWithGenerics = buf.toString();
     }
@@ -282,6 +284,12 @@ class CallableElementType extends ParameterizedElementType
   CallableElementType(FunctionType t, PackageGraph packageGraph,
       ModelElement element, ElementType returnedFrom)
       : super(t, packageGraph, element, returnedFrom);
+
+  @override
+  String get linkedName {
+    if (name != null && name.isNotEmpty) return super.linkedName;
+    return '${nameWithGenerics}(${element.linkedParams(showNames: false).trim()}) → ${returnType.linkedName}';
+  }
 }
 
 /// This is an anonymous function using the generic function syntax (declared

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -29,8 +29,6 @@ abstract class ElementType extends Privacy {
       assert(f is ParameterizedType || f is TypeParameterType);
       bool isGenericTypeAlias =
           f.element.enclosingElement is GenericTypeAliasElement;
-      // can happen if element is dynamic
-      assert(f.element.library != null);
       if (f is FunctionType) {
         assert(f is ParameterizedType);
         if (isGenericTypeAlias) {
@@ -38,9 +36,7 @@ abstract class ElementType extends Privacy {
           return new CallableGenericTypeAliasElementType(
               f, packageGraph, element, returnedFrom);
         } else {
-          if ((f.name ?? f.element.name) == '' ||
-              (f.name ?? f.element.name) == null) {
-            assert(element is ModelFunctionAnonymous);
+          if (element is ModelFunctionAnonymous) {
             return new CallableAnonymousElementType(
                 f, packageGraph, element, returnedFrom);
           } else {
@@ -301,7 +297,7 @@ class CallableAnonymousElementType extends CallableElementType {
   String get linkedName {
     if (_linkedName == null) {
       _linkedName =
-          '${super.linkedName}<span class="signature">(${element.linkedParams()})</span>';
+          '${returnType.linkedName} ${super.linkedName}<span class="signature">(${element.linkedParams()})</span>';
     }
     return _linkedName;
   }

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -565,8 +565,8 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
   }
 
   if (results.length > 1) {
-    if (results.any((r) => r.library.packageName == library.packageName)) {
-      results.removeWhere((r) => r.library.packageName != library.packageName);
+    if (results.any((r) => r.library?.packageName == library.packageName)) {
+      results.removeWhere((r) => r.library?.packageName != library.packageName);
     }
   }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -225,21 +225,24 @@ class InheritableAccessor extends Accessor with Inheritable {
     InheritableAccessor accessor;
     if (element == null) return null;
     if (inheritedAccessors.contains(element)) {
-      accessor = new ModelElement.from(element, enclosingClass.library, enclosingClass.packageGraph,
+      accessor = new ModelElement.from(
+          element, enclosingClass.library, enclosingClass.packageGraph,
           enclosingClass: enclosingClass);
     } else {
-      accessor = new ModelElement.from(element, enclosingClass.library, enclosingClass.packageGraph);
+      accessor = new ModelElement.from(
+          element, enclosingClass.library, enclosingClass.packageGraph);
     }
     return accessor;
   }
 
   ModelElement _enclosingElement;
   bool _isInherited = false;
-  InheritableAccessor(PropertyAccessorElement element, Library library, PackageGraph packageGraph)
+  InheritableAccessor(PropertyAccessorElement element, Library library,
+      PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
 
-  InheritableAccessor.inherited(
-      PropertyAccessorElement element, Library library, PackageGraph packageGraph, this._enclosingElement,
+  InheritableAccessor.inherited(PropertyAccessorElement element,
+      Library library, PackageGraph packageGraph, this._enclosingElement,
       {Member originalMember})
       : super(element, library, packageGraph, originalMember) {
     _isInherited = true;
@@ -270,8 +273,8 @@ class Accessor extends ModelElement
     implements EnclosedElement {
   GetterSetterCombo _enclosingCombo;
 
-  Accessor(
-      PropertyAccessorElement element, Library library, PackageGraph packageGraph, Member originalMember)
+  Accessor(PropertyAccessorElement element, Library library,
+      PackageGraph packageGraph, Member originalMember)
       : super(element, library, packageGraph, originalMember);
 
   get linkedReturnType {
@@ -370,7 +373,8 @@ class Accessor extends ModelElement
           .findOrCreateLibraryFor(_accessor.enclosingElement.enclosingElement);
     }
 
-    return new ModelElement.from(_accessor.enclosingElement, library, packageGraph);
+    return new ModelElement.from(
+        _accessor.enclosingElement, library, packageGraph);
   }
 
   @override
@@ -458,7 +462,8 @@ class Class extends ModelElement
   List<Field> _inheritedProperties;
   List<Field> _allInstanceProperties;
 
-  Class(ClassElement element, Library library, PackageGraph packageGraph) : super(element, library, packageGraph, null) {
+  Class(ClassElement element, Library library, PackageGraph packageGraph)
+      : super(element, library, packageGraph, null) {
     _mixins = _cls.mixins
         .map((f) {
           ElementType t = new ElementType.from(f, packageGraph);
@@ -712,7 +717,8 @@ class Class extends ModelElement
       }).toSet();
 
       for (ExecutableElement e in inheritedMethodElements) {
-        Method m = new ModelElement.from(e, library, packageGraph, enclosingClass: this);
+        Method m = new ModelElement.from(e, library, packageGraph,
+            enclosingClass: this);
         _inheritedMethods.add(m);
         _genPageMethods.add(m);
       }
@@ -737,7 +743,8 @@ class Class extends ModelElement
             !operatorNames.contains(e.name));
       }).toSet();
       for (ExecutableElement e in inheritedOperatorElements) {
-        Operator o = new ModelElement.from(e, library, packageGraph, enclosingClass: this);
+        Operator o = new ModelElement.from(e, library, packageGraph,
+            enclosingClass: this);
         _inheritedOperators.add(o);
         _genPageOperators.add(o);
       }
@@ -1045,7 +1052,8 @@ class Class extends ModelElement
       // TODO(jcollins-g): Navigation is probably still confusing for
       // half-inherited fields when traversing the inheritance tree.  Make
       // this better, somehow.
-      field = new ModelElement.from(f, library, packageGraph, getter: getter, setter: setter);
+      field = new ModelElement.from(f, library, packageGraph,
+          getter: getter, setter: setter);
     }
     _fields.add(field);
   }
@@ -1081,7 +1089,8 @@ class Class extends ModelElement
 class Constructor extends ModelElement
     with SourceCodeMixin, TypeParameters
     implements EnclosedElement {
-  Constructor(ConstructorElement element, Library library, PackageGraph packageGraph)
+  Constructor(
+      ConstructorElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
 
   @override
@@ -1090,8 +1099,8 @@ class Constructor extends ModelElement
       (enclosingElement as Class).typeParameters;
 
   @override
-  ModelElement get enclosingElement =>
-      new ModelElement.from(_constructor.enclosingElement, library, packageGraph);
+  ModelElement get enclosingElement => new ModelElement.from(
+      _constructor.enclosingElement, library, packageGraph);
 
   String get fullKind {
     if (isConst) return 'const $kind';
@@ -1283,13 +1292,15 @@ abstract class EnclosedElement {
 }
 
 class Enum extends Class {
-  Enum(ClassElement element, Library library, PackageGraph packageGraph) : super(element, library, packageGraph);
+  Enum(ClassElement element, Library library, PackageGraph packageGraph)
+      : super(element, library, packageGraph);
 
   @override
   List<EnumField> get instanceProperties {
     return super
         .instanceProperties
-        .map((Field p) => new ModelElement.from(p.element, p.library, p.packageGraph,
+        .map((Field p) => new ModelElement.from(
+            p.element, p.library, p.packageGraph,
             getter: p.getter, setter: p.setter))
         .toList(growable: false);
   }
@@ -1306,12 +1317,12 @@ class Enum extends Class {
 class EnumField extends Field {
   int _index;
 
-  EnumField(
-      FieldElement element, Library library, PackageGraph packageGraph, Accessor getter, Accessor setter)
+  EnumField(FieldElement element, Library library, PackageGraph packageGraph,
+      Accessor getter, Accessor setter)
       : super(element, library, packageGraph, getter, setter);
 
-  EnumField.forConstant(
-      this._index, FieldElement element, Library library, PackageGraph packageGraph, Accessor getter)
+  EnumField.forConstant(this._index, FieldElement element, Library library,
+      PackageGraph packageGraph, Accessor getter)
       : super(element, library, packageGraph, getter, null);
 
   @override
@@ -1381,15 +1392,21 @@ class Field extends ModelElement
   @override
   final InheritableAccessor setter;
 
-  Field(FieldElement element, Library library, PackageGraph packageGraph, this.getter, this.setter)
+  Field(FieldElement element, Library library, PackageGraph packageGraph,
+      this.getter, this.setter)
       : super(element, library, packageGraph, null) {
     if (getter != null) getter.enclosingCombo = this;
     if (setter != null) setter.enclosingCombo = this;
     _setModelType();
   }
 
-  factory Field.inherited(FieldElement element, Class enclosingClass,
-      Library library, PackageGraph packageGraph, Accessor getter, Accessor setter) {
+  factory Field.inherited(
+      FieldElement element,
+      Class enclosingClass,
+      Library library,
+      PackageGraph packageGraph,
+      Accessor getter,
+      Accessor setter) {
     Field newField = new Field(element, library, packageGraph, getter, setter);
     newField._isInherited = true;
     newField._enclosingClass = enclosingClass;
@@ -1415,7 +1432,8 @@ class Field extends ModelElement
   @override
   ModelElement get enclosingElement {
     if (_enclosingClass == null) {
-      _enclosingClass = new ModelElement.from(_field.enclosingElement, library, packageGraph);
+      _enclosingClass =
+          new ModelElement.from(_field.enclosingElement, library, packageGraph);
     }
     return _enclosingClass;
   }
@@ -1761,8 +1779,8 @@ class Library extends ModelElement with Categorization {
                 new ModelElement.fromElement(e.setter.element, packageGraph);
           }
         }
-        return new ModelElement.from(
-                e.element, packageGraph.findOrCreateLibraryFor(e.element), packageGraph,
+        return new ModelElement.from(e.element,
+                packageGraph.findOrCreateLibraryFor(e.element), packageGraph,
                 getter: getter, setter: setter)
             .fullyQualifiedName;
       }).toList();
@@ -2144,8 +2162,8 @@ class Library extends ModelElement with Categorization {
       Accessor setter;
       if (element.setter != null)
         setter = new ModelElement.from(element.setter, this, packageGraph);
-      ModelElement me =
-          new ModelElement.from(element, this, packageGraph, getter: getter, setter: setter);
+      ModelElement me = new ModelElement.from(element, this, packageGraph,
+          getter: getter, setter: setter);
       _variables.add(me);
     }
 
@@ -2321,7 +2339,8 @@ class Method extends ModelElement
   }
 
   Method.inherited(MethodElement element, this._enclosingClass, Library library,
-      PackageGraph packageGraph, {Member originalMember})
+      PackageGraph packageGraph,
+      {Member originalMember})
       : super(element, library, packageGraph, originalMember) {
     _isInherited = true;
     _calcTypeParameters();
@@ -2336,8 +2355,8 @@ class Method extends ModelElement
   @override
   ModelElement get enclosingElement {
     if (_enclosingClass == null) {
-      _enclosingClass =
-          new ModelElement.from(_method.enclosingElement, library, packageGraph);
+      _enclosingClass = new ModelElement.from(
+          _method.enclosingElement, library, packageGraph);
     }
     return _enclosingClass;
   }
@@ -2437,8 +2456,8 @@ ModelElement resolveMultiplyInheritedElement(
     Library library,
     PackageGraph packageGraph,
     Class enclosingClass) {
-  Iterable<Inheritable> inheritables = e.inheritedElements.map((ee) =>
-      new ModelElement.fromElement(ee, packageGraph) as Inheritable);
+  Iterable<Inheritable> inheritables = e.inheritedElements.map(
+      (ee) => new ModelElement.fromElement(ee, packageGraph) as Inheritable);
   Inheritable foundInheritable;
   int lowIndex = enclosingClass.inheritanceChain.length;
   for (var inheritable in inheritables) {
@@ -2503,8 +2522,8 @@ abstract class ModelElement extends Canonicalization
 
   // TODO(jcollins-g): make _originalMember optional after dart-lang/sdk#15101
   // is fixed.
-  ModelElement(this._element, this._library, this._packageGraph,
-               this._originalMember) {}
+  ModelElement(
+      this._element, this._library, this._packageGraph, this._originalMember) {}
 
   factory ModelElement.fromElement(Element e, PackageGraph p) {
     Library lib = _findOrCreateEnclosingLibraryForStatic(e, p);
@@ -2521,12 +2540,14 @@ abstract class ModelElement extends Canonicalization
   // parameter when given a null.
   /// Do not construct any ModelElements unless they are from this constructor.
   /// Specify enclosingClass only if this is to be an inherited object.
-  factory ModelElement.from(Element e, Library library, PackageGraph packageGraph,
-      {Class enclosingClass,
-      Accessor getter,
-      Accessor setter}) {
+  factory ModelElement.from(
+      Element e, Library library, PackageGraph packageGraph,
+      {Class enclosingClass, Accessor getter, Accessor setter}) {
     assert(packageGraph != null && e != null);
-    assert(library != null || e is ParameterElement || e is TypeParameterElement || e is GenericFunctionTypeElementImpl);
+    assert(library != null ||
+        e is ParameterElement ||
+        e is TypeParameterElement ||
+        e is GenericFunctionTypeElementImpl);
     // With AnalysisDriver, we sometimes get ElementHandles when building
     // docs for the SDK, seen via [Library.importedExportedLibraries].  Why?
     if (e is ElementHandle) {
@@ -2553,8 +2574,8 @@ abstract class ModelElement extends Canonicalization
         newModelElement = new Dynamic(e, packageGraph);
       }
       if (e is MultiplyInheritedExecutableElement) {
-        newModelElement =
-            resolveMultiplyInheritedElement(e, library, packageGraph, enclosingClass);
+        newModelElement = resolveMultiplyInheritedElement(
+            e, library, packageGraph, enclosingClass);
       } else {
         if (e is LibraryElement) {
           newModelElement = new Library(e, packageGraph);
@@ -2587,11 +2608,13 @@ abstract class ModelElement extends Canonicalization
         } else if (e is GenericFunctionTypeElement) {
           if (e is FunctionTypeAliasElement) {
             assert(e.name != '');
-            newModelElement = new ModelFunctionTypedef(e, library, packageGraph);
+            newModelElement =
+                new ModelFunctionTypedef(e, library, packageGraph);
           } else {
             if (e.enclosingElement is GenericTypeAliasElement) {
               assert(e.enclosingElement.name != '');
-              newModelElement = new ModelFunctionTypedef(e, library, packageGraph);
+              newModelElement =
+                  new ModelFunctionTypedef(e, library, packageGraph);
             } else {
               // Allowing null here is allowed as a workaround for
               // dart-lang/sdk#32005.
@@ -2608,17 +2631,19 @@ abstract class ModelElement extends Canonicalization
             if (e.isEnumConstant) {
               int index =
                   e.computeConstantValue().getField(e.name).toIntValue();
-              newModelElement =
-                  new EnumField.forConstant(index, e, library, packageGraph, getter);
+              newModelElement = new EnumField.forConstant(
+                  index, e, library, packageGraph, getter);
             } else if (e.enclosingElement.isEnum) {
-              newModelElement = new EnumField(e, library, packageGraph, getter, setter);
+              newModelElement =
+                  new EnumField(e, library, packageGraph, getter, setter);
             } else {
-              newModelElement = new Field(e, library, packageGraph, getter, setter);
+              newModelElement =
+                  new Field(e, library, packageGraph, getter, setter);
             }
           } else {
             // EnumFields can't be inherited, so this case is simpler.
-            newModelElement =
-                new Field.inherited(e, enclosingClass, library, packageGraph, getter, setter);
+            newModelElement = new Field.inherited(
+                e, enclosingClass, library, packageGraph, getter, setter);
           }
         }
         if (e is ConstructorElement) {
@@ -2628,15 +2653,17 @@ abstract class ModelElement extends Canonicalization
           if (enclosingClass == null)
             newModelElement = new Operator(e, library, packageGraph);
           else
-            newModelElement = new Operator.inherited(e, enclosingClass, library,
-                packageGraph, originalMember: originalMember);
+            newModelElement = new Operator.inherited(
+                e, enclosingClass, library, packageGraph,
+                originalMember: originalMember);
         }
         if (e is MethodElement && !e.isOperator) {
           if (enclosingClass == null)
             newModelElement = new Method(e, library, packageGraph);
           else
-            newModelElement = new Method.inherited(e, enclosingClass, library,
-                packageGraph, originalMember: originalMember);
+            newModelElement = new Method.inherited(
+                e, enclosingClass, library, packageGraph,
+                originalMember: originalMember);
         }
         if (e is TopLevelVariableElement) {
           if (getter == null && setter == null) {
@@ -2645,7 +2672,8 @@ abstract class ModelElement extends Canonicalization
               ..addAll(library.constants);
             newModelElement = allVariables.firstWhere((v) => v.element == e);
           } else {
-            newModelElement = new TopLevelVariable(e, library, packageGraph, getter, setter);
+            newModelElement =
+                new TopLevelVariable(e, library, packageGraph, getter, setter);
           }
         }
         if (e is PropertyAccessorElement) {
@@ -2653,7 +2681,8 @@ abstract class ModelElement extends Canonicalization
           if (e.enclosingElement is ClassElement ||
               e is MultiplyInheritedExecutableElement) {
             if (enclosingClass == null)
-              newModelElement = new InheritableAccessor(e, library, packageGraph);
+              newModelElement =
+                  new InheritableAccessor(e, library, packageGraph);
             else
               newModelElement = new InheritableAccessor.inherited(
                   e, library, packageGraph, enclosingClass,
@@ -2666,8 +2695,8 @@ abstract class ModelElement extends Canonicalization
           newModelElement = new TypeParameter(e, library, packageGraph);
         }
         if (e is ParameterElement) {
-          newModelElement =
-              new Parameter(e, library, packageGraph, originalMember: originalMember);
+          newModelElement = new Parameter(e, library, packageGraph,
+              originalMember: originalMember);
         }
       }
     }
@@ -2813,17 +2842,23 @@ abstract class ModelElement extends Canonicalization
         GetterSetterCombo thisAsCombo = this as GetterSetterCombo;
         if (thisAsCombo.hasGetter) {
           newGetter = new ModelElement.from(
-              thisAsCombo.getter.element, thisAsCombo.getter.definingLibrary, thisAsCombo.getter.packageGraph);
+              thisAsCombo.getter.element,
+              thisAsCombo.getter.definingLibrary,
+              thisAsCombo.getter.packageGraph);
         }
         if (thisAsCombo.hasSetter) {
           newSetter = new ModelElement.from(
-              thisAsCombo.setter.element, thisAsCombo.setter.definingLibrary, thisAsCombo.setter.packageGraph);
+              thisAsCombo.setter.element,
+              thisAsCombo.setter.definingLibrary,
+              thisAsCombo.setter.packageGraph);
         }
       }
       ModelElement fromThis = new ModelElement.from(
-          element, thisInheritable.definingEnclosingElement.library,
+          element,
+          thisInheritable.definingEnclosingElement.library,
           thisInheritable.definingEnclosingElement.packageGraph,
-          getter: newGetter, setter: newSetter);
+          getter: newGetter,
+          setter: newSetter);
       docFrom = fromThis.documentationFrom;
     } else {
       docFrom = [this];
@@ -3581,7 +3616,8 @@ abstract class ModelElement extends Canonicalization
 
 /// A [ModelElement] for a [FunctionElement] that isn't part of a type definition.
 class ModelFunction extends ModelFunctionTyped {
-  ModelFunction(FunctionElement element, Library library, PackageGraph packageGraph)
+  ModelFunction(
+      FunctionElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph);
 
   @override
@@ -3603,7 +3639,8 @@ class ModelFunction extends ModelFunctionTyped {
 /// have a name, but we document it as "Function" to match how these are
 /// written in declarations.
 class ModelFunctionAnonymous extends ModelFunctionTyped {
-  ModelFunctionAnonymous(FunctionTypedElement element, PackageGraph packageGraph)
+  ModelFunctionAnonymous(
+      FunctionTypedElement element, PackageGraph packageGraph)
       : super(element, null, packageGraph) {}
 
   @override
@@ -3619,7 +3656,8 @@ class ModelFunctionAnonymous extends ModelFunctionTyped {
 /// A [ModelElement] for a [GenericModelFunctionElement] that is part of an
 /// explicit typedef.
 class ModelFunctionTypedef extends ModelFunctionTyped {
-  ModelFunctionTypedef(FunctionTypedElement element, Library library, PackageGraph packageGraph)
+  ModelFunctionTypedef(
+      FunctionTypedElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph);
 
   @override
@@ -3641,7 +3679,8 @@ class ModelFunctionTyped extends ModelElement
   @override
   List<TypeParameter> typeParameters = [];
 
-  ModelFunctionTyped(FunctionTypedElement element, Library library, PackageGraph packageGraph)
+  ModelFunctionTyped(
+      FunctionTypedElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph, null) {
     _calcTypeParameters();
   }
@@ -3713,11 +3752,11 @@ class Operator extends Method {
     "%": "modulo"
   };
 
-  Operator(MethodElement element, Library library, PackageGraph packageGraph) : super(element, library, packageGraph);
+  Operator(MethodElement element, Library library, PackageGraph packageGraph)
+      : super(element, library, packageGraph);
 
-  Operator.inherited(
-      MethodElement element, Class enclosingClass, Library library,
-      PackageGraph packageGraph, {Member originalMember})
+  Operator.inherited(MethodElement element, Class enclosingClass,
+      Library library, PackageGraph packageGraph, {Member originalMember})
       : super.inherited(element, enclosingClass, library, packageGraph,
             originalMember: originalMember) {
     _isInherited = true;
@@ -4418,11 +4457,13 @@ class PackageGraph extends Canonicalization with Nameable, Warnable {
         Accessor getter;
         Accessor setter;
         if (e is PropertyInducingElement) {
-          if (e.getter != null) getter = new ModelElement.from(e.getter, lib, packageGraph);
-          if (e.setter != null) setter = new ModelElement.from(e.setter, lib, packageGraph);
+          if (e.getter != null)
+            getter = new ModelElement.from(e.getter, lib, packageGraph);
+          if (e.setter != null)
+            setter = new ModelElement.from(e.setter, lib, packageGraph);
         }
-        modelElement =
-            new ModelElement.from(e, lib, packageGraph, getter: getter, setter: setter);
+        modelElement = new ModelElement.from(e, lib, packageGraph,
+            getter: getter, setter: setter);
       }
       assert(modelElement is! Inheritable);
       if (modelElement != null && !modelElement.isCanonical) {
@@ -4679,7 +4720,9 @@ class Package extends LibraryContainer implements Comparable<Package>, Privacy {
 }
 
 class Parameter extends ModelElement implements EnclosedElement {
-  Parameter(ParameterElement element, Library library, PackageGraph packageGraph, {Member originalMember})
+  Parameter(
+      ParameterElement element, Library library, PackageGraph packageGraph,
+      {Member originalMember})
       : super(element, library, packageGraph, originalMember);
   String get defaultValue {
     if (!hasDefaultValue) return null;
@@ -4875,8 +4918,8 @@ class TopLevelVariable extends ModelElement
   @override
   final Accessor setter;
 
-  TopLevelVariable(TopLevelVariableElement element, Library library, PackageGraph packageGraph,
-      this.getter, this.setter)
+  TopLevelVariable(TopLevelVariableElement element, Library library,
+      PackageGraph packageGraph, this.getter, this.setter)
       : super(element, library, packageGraph, null) {
     if (getter != null) {
       getter.enclosingCombo = this;
@@ -4951,7 +4994,8 @@ class TopLevelVariable extends ModelElement
 class Typedef extends ModelElement
     with SourceCodeMixin, TypeParameters
     implements EnclosedElement {
-  Typedef(FunctionTypeAliasElement element, Library library, PackageGraph packageGraph)
+  Typedef(FunctionTypeAliasElement element, Library library,
+      PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
 
   @override
@@ -4999,7 +5043,8 @@ class Typedef extends ModelElement
 }
 
 class TypeParameter extends ModelElement {
-  TypeParameter(TypeParameterElement element, Library library, PackageGraph packageGraph)
+  TypeParameter(
+      TypeParameterElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
 
   @override

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1328,7 +1328,7 @@ class EnumField extends Field {
   @override
   String get constantValueBase {
     if (name == 'values') {
-      return 'const List&lt;${_field.enclosingElement.name}&gt;';
+      return 'const List&lt;<wbr><span class="type-parameter">${_field.enclosingElement.name}</span>&gt;';
     } else {
       return 'const ${_field.enclosingElement.name}($_index)';
     }
@@ -4895,12 +4895,12 @@ abstract class TypeParameters implements ModelElement {
 
   String get genericParameters {
     if (typeParameters.isEmpty) return '';
-    return '&lt;${typeParameters.map((t) => t.name).join(', ')}&gt;';
+    return '&lt;<wbr><span class="type-parameter">${typeParameters.map((t) => t.name).join('</span>, <span class="type-parameter">')}</span>&gt;';
   }
 
   String get linkedGenericParameters {
     if (typeParameters.isEmpty) return '';
-    return '<span class="signature">&lt;${typeParameters.map((t) => t.linkedName).join(', ')}&gt;</span>';
+    return '<span class="signature">&lt;<wbr><span class="type-parameter">${typeParameters.map((t) => t.linkedName).join('</span>, <span class="type-parameter">')}</span>&gt;</span>';
   }
 
   @override
@@ -5010,7 +5010,7 @@ class Typedef extends ModelElement
       List<TypeParameterElement> genericTypeParameters =
           (element as GenericTypeAliasElement).function.typeParameters;
       if (genericTypeParameters.isNotEmpty) {
-        return '&lt;${genericTypeParameters.map((t) => t.name).join(', ')}&gt;';
+        return '&lt;<wbr><span class="type-parameter">${genericTypeParameters.map((t) => t.name).join('</span>, <span class="type-parameter">')}</span>&gt;';
       }
     } // else, all types are resolved.
     return '';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.40.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.42.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.42.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.43.0"

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1942,8 +1942,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     setUp(() {
       v = exLibrary.properties.firstWhere((p) => p.name == 'number');
       v3 = exLibrary.properties.firstWhere((p) => p.name == 'y');
-      complicatedReturn =
-          fakeLibrary.properties.firstWhere((f) => f.name == 'complicatedReturn');
+      complicatedReturn = fakeLibrary.properties
+          .firstWhere((f) => f.name == 'complicatedReturn');
       nodocGetter = fakeLibrary.properties
           .firstWhere((p) => p.name == 'getterSetterNodocGetter');
       nodocSetter = fakeLibrary.properties
@@ -1958,8 +1958,13 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((p) => p.name == 'mapWithDynamicKeys');
     });
 
-    test('Verify that a complex type parameter with an anonymous function works correctly', () {
-      expect(complicatedReturn.linkedReturnType, equals('<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span>'));
+    test(
+        'Verify that a complex type parameter with an anonymous function works correctly',
+        () {
+      expect(
+          complicatedReturn.linkedReturnType,
+          equals(
+              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span>'));
     });
 
     test('@nodoc on simple property works', () {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1416,7 +1416,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           getAFunctionReturningVoid.linkedReturnType,
           equals(
-              'Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span>'));
+              'void Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span>'));
     });
 
     test(
@@ -1425,7 +1425,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           getAFunctionReturningBool.linkedReturnType,
           equals(
-              'Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span>'));
+              'bool Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span>'));
     });
 
     test('has a fully qualified name', () {
@@ -1937,10 +1937,13 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     TopLevelVariable v3, justGetter, justSetter;
     TopLevelVariable setAndGet, mapWithDynamicKeys;
     TopLevelVariable nodocGetter, nodocSetter;
+    TopLevelVariable complicatedReturn;
 
     setUp(() {
       v = exLibrary.properties.firstWhere((p) => p.name == 'number');
       v3 = exLibrary.properties.firstWhere((p) => p.name == 'y');
+      complicatedReturn =
+          fakeLibrary.properties.firstWhere((f) => f.name == 'complicatedReturn');
       nodocGetter = fakeLibrary.properties
           .firstWhere((p) => p.name == 'getterSetterNodocGetter');
       nodocSetter = fakeLibrary.properties
@@ -1953,6 +1956,10 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           fakeLibrary.properties.firstWhere((p) => p.name == 'setAndGet');
       mapWithDynamicKeys = fakeLibrary.properties
           .firstWhere((p) => p.name == 'mapWithDynamicKeys');
+    });
+
+    test('Verify that a complex type parameter with an anonymous function works correctly', () {
+      expect(complicatedReturn.linkedReturnType, equals('<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span>'));
     });
 
     test('@nodoc on simple property works', () {
@@ -2262,6 +2269,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       t = exLibrary.typedefs.firstWhere((t) => t.name == 'processMessage');
       generic =
           fakeLibrary.typedefs.firstWhere((t) => t.name == 'NewGenericTypedef');
+
       aComplexTypedef =
           exLibrary.typedefs.firstWhere((t) => t.name == 'aComplexTypedef');
       TypedefUsingClass =
@@ -2280,7 +2288,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('anonymous nested functions inside typedefs are handled', () {
       expect(aComplexTypedef, isNotNull);
-      expect(aComplexTypedef.linkedReturnType, startsWith('Function'));
+      expect(aComplexTypedef.linkedReturnType, startsWith('void Function'));
       expect(aComplexTypedef.nameWithGenerics,
           equals('aComplexTypedef&lt;A1, A2, A3&gt;'));
     });
@@ -2290,7 +2298,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           aComplexTypedef.linkedReturnType,
           equals(
-              'Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span>'));
+              'void Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span>'));
       expect(
           aComplexTypedef.linkedParamsLines,
           equals(

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -835,7 +835,10 @@ void main() {
     });
 
     test('class name with generics', () {
-      expect(F.nameWithGenerics, equals('F&lt;T extends String&gt;'));
+      expect(
+          F.nameWithGenerics,
+          equals(
+              'F&lt;<wbr><span class="type-parameter">T extends String</span>&gt;'));
     });
 
     test('correctly finds all the classes', () {
@@ -1062,7 +1065,10 @@ void main() {
     test("has a (synthetic) values constant", () {
       var values = animal.constants.firstWhere((f) => f.name == 'values');
       expect(values, isNotNull);
-      expect(values.constantValue, equals('const List&lt;Animal&gt;'));
+      expect(
+          values.constantValue,
+          equals(
+              'const List&lt;<wbr><span class="type-parameter">Animal</span>&gt;'));
       expect(values.documentation, startsWith('A constant List'));
     });
 
@@ -1173,28 +1179,32 @@ void main() {
 
     test('function returning FutureOr<Null>', () {
       expect(thisIsFutureOrNull.isAsynchronous, isFalse);
-      expect(thisIsFutureOrNull.linkedReturnType,
-          equals('FutureOr<span class="signature">&lt;Null&gt;</span>'));
+      expect(
+          thisIsFutureOrNull.linkedReturnType,
+          equals(
+              'FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span>'));
     });
 
     test('function returning FutureOr<T>', () {
       expect(thisIsFutureOrNull.isAsynchronous, isFalse);
-      expect(thisIsFutureOrT.linkedReturnType,
-          equals('FutureOr<span class="signature">&lt;T&gt;</span>'));
+      expect(
+          thisIsFutureOrT.linkedReturnType,
+          equals(
+              'FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span>'));
     });
 
     test('function with a parameter having type FutureOr<Null>', () {
       expect(
           paramOfFutureOrNull.linkedParams(),
           equals(
-              '<span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;Null&gt;</span></span> <span class="parameter-name">future</span></span>'));
+              '<span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span></span> <span class="parameter-name">future</span></span>'));
     });
 
     test('function with a bound type to FutureOr', () {
       expect(
           typeParamOfFutureOr.linkedGenericParameters,
           equals(
-              '<span class=\"signature\">&lt;T extends FutureOr<span class=\"signature\">&lt;List&gt;</span>&gt;</span>'));
+              '<span class="signature">&lt;<wbr><span class="type-parameter">T extends FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">List</span>&gt;</span></span>&gt;</span>'));
     });
 
     test('docs do not lose brackets in code blocks', () {
@@ -1232,7 +1242,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('supports generic methods', () {
-      expect(genericFunction.nameWithGenerics, 'genericFunction&lt;T&gt;');
+      expect(genericFunction.nameWithGenerics,
+          'genericFunction&lt;<wbr><span class="type-parameter">T</span>&gt;');
     });
   });
 
@@ -1252,21 +1263,21 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       // TODO(jcollins-g): really, these shouldn't be called "parameters" in
       // the span class.
       expect(explicitSetter.linkedReturnType,
-          '<span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;int&gt;</span></span></span>)</span>');
+          '<span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span></span>)</span>');
     });
 
     test('parameterized type from field is correctly displayed', () {
       Field aField = TemplatedInterface.instanceProperties
           .singleWhere((f) => f.name == 'aField');
       expect(aField.linkedReturnType,
-          '<a href=\"ex/AnotherParameterizedClass-class.html\">AnotherParameterizedClass</a><span class="signature">&lt;Stream<span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
     });
 
     test('parameterized type from inherited field is correctly displayed', () {
       Field aInheritedField = TemplatedInterface.inheritedProperties
           .singleWhere((f) => f.name == 'aInheritedField');
       expect(aInheritedField.linkedReturnType,
-          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -1276,7 +1287,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((f) => f.name == 'aGetter')
           .getter;
       expect(aGetter.linkedReturnType,
-          '<a href=\"ex/AnotherParameterizedClass-class.html\">AnotherParameterizedClass</a><span class="signature">&lt;Map<span class="signature">&lt;A, List<span class="signature">&lt;String&gt;</span>&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -1286,7 +1297,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((f) => f.name == 'aInheritedGetter')
           .getter;
       expect(aInheritedGetter.linkedReturnType,
-          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -1296,11 +1307,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((f) => f.name == 'aInheritedSetter')
           .setter;
       expect(aInheritedSetter.allParameters.first.modelType.linkedName,
-          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
       // TODO(jcollins-g): really, these shouldn't be called "parameters" in
       // the span class.
       expect(aInheritedSetter.enclosingCombo.linkedReturnType,
-          '<span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span></span>');
+          '<span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span></span>');
     });
 
     test(
@@ -1309,7 +1320,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       Method aMethodInterface = TemplatedInterface.allInstanceMethods
           .singleWhere((m) => m.name == 'aMethodInterface');
       expect(aMethodInterface.linkedReturnType,
-          '<a href=\"ex/AnotherParameterizedClass-class.html\">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -1318,7 +1329,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       Method aInheritedMethod = TemplatedInterface.allInstanceMethods
           .singleWhere((m) => m.name == 'aInheritedMethod');
       expect(aInheritedMethod.linkedReturnType,
-          '<a href=\"ex/AnotherParameterizedClass-class.html\">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -1328,7 +1339,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .allInstanceMethods
           .singleWhere((m) => m.name == 'aTypedefReturningMethodInterface');
       expect(aTypedefReturningMethodInterface.linkedReturnType,
-          '<a href=\"ex/ParameterizedTypedef.html\">ParameterizedTypedef</a><span class="signature">&lt;List<span class="signature">&lt;String&gt;</span>&gt;</span>');
+          '<a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -1338,7 +1349,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .allInstanceMethods
           .singleWhere((m) => m.name == 'aInheritedTypedefReturningMethod');
       expect(aInheritedTypedefReturningMethod.linkedReturnType,
-          '<a href=\"ex/ParameterizedTypedef.html\">ParameterizedTypedef</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test('parameterized types for inherited operator is correctly displayed',
@@ -1347,9 +1358,9 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .inheritedOperators
           .singleWhere((m) => m.name == 'operator +');
       expect(aInheritedAdditionOperator.linkedReturnType,
-          '<a href=\"ex/ParameterizedClass-class.html\">ParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>');
+          '<a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
       expect(aInheritedAdditionOperator.linkedParams(),
-          '<span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span> <span class="parameter-name">other</span></span>');
+          '<span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">other</span></span>');
     });
 
     test('', () {});
@@ -1425,7 +1436,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           getAFunctionReturningBool.linkedReturnType,
           equals(
-              'bool Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span>'));
+              'bool Function<span class="signature">&lt;<wbr><span class="type-parameter">T4</span>&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span>'));
     });
 
     test('has a fully qualified name', () {
@@ -1499,7 +1510,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('parameter has generics in signature', () {
       expect(testGeneric.parameters[0].modelType.linkedName,
-          'Map<span class="signature">&lt;String, dynamic&gt;</span>');
+          'Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">dynamic</span>&gt;</span>');
     });
 
     test('parameter is a function', () {
@@ -1508,7 +1519,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('generic method type args are rendered', () {
-      expect(testGenericMethod.nameWithGenerics, 'testGenericMethod&lt;T&gt;');
+      expect(testGenericMethod.nameWithGenerics,
+          'testGenericMethod&lt;<wbr><span class="type-parameter">T</span>&gt;');
     });
 
     test('doc for method with no return type', () {
@@ -1928,7 +1940,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           fieldWithTypedef.linkedReturnType,
           equals(
-              '<a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;bool&gt;</span>'));
+              '<a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span>'));
     });
   });
 
@@ -1938,10 +1950,13 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     TopLevelVariable setAndGet, mapWithDynamicKeys;
     TopLevelVariable nodocGetter, nodocSetter;
     TopLevelVariable complicatedReturn;
+    TopLevelVariable importantComputations;
 
     setUp(() {
       v = exLibrary.properties.firstWhere((p) => p.name == 'number');
       v3 = exLibrary.properties.firstWhere((p) => p.name == 'y');
+      importantComputations = fakeLibrary.properties
+          .firstWhere((v) => v.name == 'importantComputations');
       complicatedReturn = fakeLibrary.properties
           .firstWhere((f) => f.name == 'complicatedReturn');
       nodocGetter = fakeLibrary.properties
@@ -1959,12 +1974,29 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test(
+        'Verify that a map containing anonymous functions as values works correctly',
+        () {
+      Iterable<CallableElementType> typeArguments =
+          (importantComputations.modelType.returnType as DefinedElementType)
+              .typeArguments;
+      expect(typeArguments, isNotEmpty);
+      expect(
+          typeArguments.last.linkedName,
+          equals(
+              '(<span class="parameter" id="null-param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span></span>) → dynamic'));
+      expect(
+          importantComputations.linkedReturnType,
+          equals(
+              'Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">(<span class="parameter" id="null-param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span></span>) → dynamic</span>&gt;</span>'));
+    });
+
+    test(
         'Verify that a complex type parameter with an anonymous function works correctly',
         () {
       expect(
           complicatedReturn.linkedReturnType,
           equals(
-              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span>'));
+              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span>'));
     });
 
     test('@nodoc on simple property works', () {
@@ -2147,9 +2179,9 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('displays generic parameters correctly', () {
       expect(constructorTesterDefault.nameWithGenerics,
-          'ConstructorTester&lt;A, B&gt;');
+          'ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;');
       expect(constructorTesterFromSomething.nameWithGenerics,
-          'ConstructorTester&lt;A, B&gt;.fromSomething');
+          'ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;.fromSomething');
     });
 
     test('has a fully qualified name', () {
@@ -2202,15 +2234,17 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('a function returning a Future<void>', () {
-      expect(returningFutureVoid.linkedReturnType,
-          equals('Future<span class="signature">&lt;void&gt;</span>'));
+      expect(
+          returningFutureVoid.linkedReturnType,
+          equals(
+              'Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span>'));
     });
 
     test('a function requiring a Future<void> parameter', () {
       expect(
           aVoidParameter.linkedParams(showMetadata: true, showNames: true),
           equals(
-              '<span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">p1</span></span>'));
+              '<span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">p1</span></span>'));
     });
 
     test('a class that extends Future<void>', () {
@@ -2220,8 +2254,10 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
               '<a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a>'));
       DefinedElementType FutureVoid = ExtendsFutureVoid.publicSuperChain
           .firstWhere((c) => c.name == 'Future');
-      expect(FutureVoid.linkedName,
-          equals('Future<span class="signature">&lt;void&gt;</span>'));
+      expect(
+          FutureVoid.linkedName,
+          equals(
+              'Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span>'));
     });
 
     test('a class that implements Future<void>', () {
@@ -2231,8 +2267,10 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
               '<a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a>'));
       DefinedElementType FutureVoid = ImplementsFutureVoid.publicInterfaces
           .firstWhere((c) => c.name == 'Future');
-      expect(FutureVoid.linkedName,
-          equals('Future<span class="signature">&lt;void&gt;</span>'));
+      expect(
+          FutureVoid.linkedName,
+          equals(
+              'Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span>'));
     });
 
     test('Verify that a mixin with a void type parameter works', () {
@@ -2245,7 +2283,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           ATypeTakingClassVoid.linkedName,
           equals(
-              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;void&gt;</span>'));
+              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span>'));
     });
   });
 
@@ -2288,14 +2326,16 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           theConstructor.linkedParams(),
           equals(
-              '<span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;double&gt;</span></span> <span class="parameter-name">x</span></span>'));
+              '<span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span> <span class="parameter-name">x</span></span>'));
     });
 
     test('anonymous nested functions inside typedefs are handled', () {
       expect(aComplexTypedef, isNotNull);
       expect(aComplexTypedef.linkedReturnType, startsWith('void Function'));
-      expect(aComplexTypedef.nameWithGenerics,
-          equals('aComplexTypedef&lt;A1, A2, A3&gt;'));
+      expect(
+          aComplexTypedef.nameWithGenerics,
+          equals(
+              'aComplexTypedef&lt;<wbr><span class="type-parameter">A1</span>, <span class="type-parameter">A2</span>, <span class="type-parameter">A3</span>&gt;'));
     });
 
     test('anonymous nested functions inside typedefs are handled correctly',
@@ -2328,18 +2368,27 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('linked return type', () {
       expect(t.linkedReturnType, equals('String'));
-      expect(generic.linkedReturnType,
-          equals('List<span class="signature">&lt;S&gt;</span>'));
+      expect(
+          generic.linkedReturnType,
+          equals(
+              'List<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span>'));
     });
 
     test("name with generics", () {
-      expect(t.nameWithGenerics, equals('processMessage&lt;T&gt;'));
-      expect(generic.nameWithGenerics, equals('NewGenericTypedef&lt;T&gt;'));
+      expect(
+          t.nameWithGenerics,
+          equals(
+              'processMessage&lt;<wbr><span class="type-parameter">T</span>&gt;'));
+      expect(
+          generic.nameWithGenerics,
+          equals(
+              'NewGenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt;'));
     });
 
     test("generic parameters", () {
       expect(t.genericParameters, equals(''));
-      expect(generic.genericParameters, equals('&lt;S&gt;'));
+      expect(generic.genericParameters,
+          equals('&lt;<wbr><span class="type-parameter">S</span>&gt;'));
     });
   });
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -300,6 +300,7 @@ void aVoidParameter(Future<void> p1) {}
 
 /// This class extends Future<void>
 abstract class ExtendsFutureVoid extends Future<void> {
+  // ignore: missing_return
   factory ExtendsFutureVoid(FutureOr<void> computation()) {}
 }
 
@@ -308,6 +309,7 @@ abstract class ImplementsFutureVoid implements Future<void> {}
 
 /// This class takes a type, and it might be void.
 class ATypeTakingClass<T> {
+  // ignore: missing_return
   T aMethodMaybeReturningVoid() {}
 }
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -235,7 +235,7 @@ class Cool {
 }
 
 /// A map initialization making use of optional const.
-const Map<int, String> myMap = { 1: "hello" };
+const Map<int, String> myMap = {1: "hello"};
 
 /// A variable initalization making use of optional new.
 Cool aCoolVariable = Cool();

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -221,10 +221,8 @@ typedef T GenericTypedef<T>(T input);
 /// A typedef with the new style generic function syntax.
 typedef NewGenericTypedef<T> = List<S> Function<S>(T, int, bool);
 
-
-
+/// A complicated type parameter to ATypeTakingClass.
 ATypeTakingClass<String Function(int)> get complicatedReturn => null;
-
 
 /// Lots and lots of parameters.
 typedef int LotsAndLotsOfParameters(so, many, parameters, it, should, wrap,

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -177,6 +177,14 @@ class AClassWithFancyProperties {
 
 const _APrivateConstClass CUSTOM_CLASS_PRIVATE = const _APrivateConstClass();
 
+/// Type inference mixing with anonymous functions.
+final importantComputations = {
+  1: (List<num> a) => a[0] + a[1],
+  2: (List<num> a) => a[0] - a[1],
+  3: (List<num> a) => a[0] * a[1],
+  4: (List<num> a) => -a[0]
+};
+
 // No dart docs on purpose. Also, a non-primitive const class.
 const ConstantClass CUSTOM_CLASS = const ConstantClass('custom');
 
@@ -212,6 +220,11 @@ typedef T GenericTypedef<T>(T input);
 
 /// A typedef with the new style generic function syntax.
 typedef NewGenericTypedef<T> = List<S> Function<S>(T, int, bool);
+
+
+
+ATypeTakingClass<String Function(int)> get complicatedReturn => null;
+
 
 /// Lots and lots of parameters.
 typedef int LotsAndLotsOfParameters(so, many, parameters, it, should, wrap,

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -155,13 +155,13 @@ enum constants ala #1445</p>
         </dd>
         <dt id="values" class="constant">
           <span class="name ">values</span>
-          <span class="signature">&#8594; const List<span class="signature">&lt;<a href="ex/Animal-class.html">Animal</a>&gt;</span></span>
+          <span class="signature">&#8594; const List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Animal-class.html">Animal</a></span>&gt;</span></span>
         </dt>
         <dd>
           <p>A constant List of the values in this enum, in order of their declaration.</p>
           
   <div>
-            <span class="signature"><code>const List&lt;Animal&gt;</code></span>
+            <span class="signature"><code>const List&lt;<wbr><span class="type-parameter">Animal</span>&gt;</code></span>
           </div>
         </dd>
       </dl>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass-class.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span> class</li>
+    <li class="self-crumb">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">AnotherParameterizedClass</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>AnotherParameterizedClass&lt;B&gt; class</h1>
+    <h1>AnotherParameterizedClass&lt;<wbr><span class="type-parameter">B</span>&gt; class</h1>
 
     
 

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/AnotherParameterizedClass.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/AnotherParameterizedClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span></a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">AnotherParameterizedClass constructor</li>
   </ol>
   <div class="self-name">AnotherParameterizedClass</div>
@@ -61,11 +61,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>AnotherParameterizedClass&lt;B&gt; constructor</h1>
+    <h1>AnotherParameterizedClass&lt;<wbr><span class="type-parameter">B</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">AnotherParameterizedClass&lt;B&gt;</span>(<wbr>)
+      <span class="name ">AnotherParameterizedClass&lt;<wbr><span class="type-parameter">B</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/hashCode.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span></a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span></a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/operator_equals.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span></a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/runtimeType.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span></a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass/toString.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;B&gt;</span></a></li>
+    <li><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -154,7 +154,7 @@
       <dl class="properties">
         <dt id="fieldWithTypedef" class="property">
           <span class="name"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></span>
-          <span class="signature">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;bool&gt;</span></span>
+          <span class="signature">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>
         </dt>
         <dd>
           fieldWithTypedef docs here
@@ -244,7 +244,7 @@
           
 </dd>
         <dt id="whataclass" class="callable">
-          <span class="name"><a href="ex/Apple/whataclass.html">whataclass</a></span><span class="signature">(<wbr><span class="parameter" id="whataclass-param-list"><span class="type-annotation">List<span class="signature">&lt;<a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;bool&gt;</span>&gt;</span></span> <span class="parameter-name">list</span></span>)
+          <span class="name"><a href="ex/Apple/whataclass.html">whataclass</a></span><span class="signature">(<wbr><span class="parameter" id="whataclass-param-list"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">list</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>

--- a/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
+++ b/testing/test_package_docs/ex/Apple/fieldWithTypedef.html
@@ -79,7 +79,7 @@
     <h1>fieldWithTypedef property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;bool&gt;</span></span>
+          <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>
           <span class="name ">fieldWithTypedef</span>
           <div class="features">final</div>
         </section>

--- a/testing/test_package_docs/ex/Apple/whataclass.html
+++ b/testing/test_package_docs/ex/Apple/whataclass.html
@@ -81,7 +81,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">whataclass</span>
-(<wbr><span class="parameter" id="whataclass-param-list"><span class="type-annotation">List<span class="signature">&lt;<a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;bool&gt;</span>&gt;</span></span> <span class="parameter-name">list</span></span>)
+(<wbr><span class="parameter" id="whataclass-param-list"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">list</span></span>)
     </section>
     <section class="desc markdown">
       <p>Apple docs for whataclass</p>

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -170,7 +170,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
 </dd>
         <dt id="list" class="property">
           <span class="name"><a href="ex/B/list.html">list</a></span>
-          <span class="signature">&#8596; List<span class="signature">&lt;String&gt;</span></span>
+          <span class="signature">&#8596; List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>
         </dt>
         <dd>
           A list of Strings
@@ -186,7 +186,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
 </dd>
         <dt id="fieldWithTypedef" class="property inherited">
           <span class="name"><a href="ex/Apple/fieldWithTypedef.html">fieldWithTypedef</a></span>
-          <span class="signature">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;bool&gt;</span></span>
+          <span class="signature">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>
         </dt>
         <dd class="inherited">
           fieldWithTypedef docs here
@@ -313,7 +313,7 @@ To enable, set <code>autoCompress</code> to <code>true</code>.
           <div class="features">inherited</div>
 </dd>
         <dt id="whataclass" class="callable inherited">
-          <span class="name"><a href="ex/Apple/whataclass.html">whataclass</a></span><span class="signature">(<wbr><span class="parameter" id="whataclass-param-list"><span class="type-annotation">List<span class="signature">&lt;<a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;bool&gt;</span>&gt;</span></span> <span class="parameter-name">list</span></span>)
+          <span class="name"><a href="ex/Apple/whataclass.html">whataclass</a></span><span class="signature">(<wbr><span class="parameter" id="whataclass-param-list"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">list</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>

--- a/testing/test_package_docs/ex/B/list.html
+++ b/testing/test_package_docs/ex/B/list.html
@@ -80,7 +80,7 @@
     <h1>list property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype">List<span class="signature">&lt;String&gt;</span></span>
+          <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>
           <span class="name ">list</span>
           <div class="features">read / write</div>
         </section>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -270,7 +270,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 </dd>
         <dt id="getAnotherClassD" class="callable">
           <span class="name deprecated"><a class="deprecated" href="ex/Dog/getAnotherClassD.html">getAnotherClassD</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<a href="ex/Dog-class.html">Dog</a>&gt;</span></span>
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Dog-class.html">Dog</a></span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -279,7 +279,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 </dd>
         <dt id="getClassA" class="callable">
           <span class="name deprecated"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span></span>
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Apple-class.html">Apple</a></span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -287,7 +287,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           
 </dd>
         <dt id="testGeneric" class="callable">
-          <span class="name"><a href="ex/Dog/testGeneric.html">testGeneric</a></span><span class="signature">(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">args</span></span>)
+          <span class="name"><a href="ex/Dog/testGeneric.html">testGeneric</a></span><span class="signature">(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">args</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -296,7 +296,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           
 </dd>
         <dt id="testGenericMethod" class="callable">
-          <span class="name"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="testGenericMethod-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
+          <span class="name"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="testGenericMethod-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
             <span class="returntype parameter">&#8594; T</span>
           </span>
         </dt>

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -97,7 +97,7 @@
           <li>@<a href="ex/Deprecated-class.html">Deprecated</a>(&#39;before v27.3&#39;)</li>
         </ol>
       </div>
-      <span class="returntype">List<span class="signature">&lt;<a href="ex/Dog-class.html">Dog</a>&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Dog-class.html">Dog</a></span>&gt;</span></span>
       <span class="name deprecated">getAnotherClassD</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -97,7 +97,7 @@
           <li>@deprecated</li>
         </ol>
       </div>
-      <span class="returntype">List<span class="signature">&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Apple-class.html">Apple</a></span>&gt;</span></span>
       <span class="name deprecated">getClassA</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -94,7 +94,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">testGeneric</span>
-(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">args</span></span>)
+(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">args</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">testGenericMethod&lt;T&gt; method</li>
+    <li class="self-crumb">testGenericMethod&lt;<wbr><span class="type-parameter">T</span>&gt; method</li>
   </ol>
   <div class="self-name">testGenericMethod</div>
   <form class="search navbar-right" role="search">
@@ -89,12 +89,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>testGenericMethod&lt;T&gt; method</h1>
+    <h1>testGenericMethod&lt;<wbr><span class="type-parameter">T</span>&gt; method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">T</span>
       <span class="name ">testGenericMethod</span>
-&lt;T&gt;(<wbr><span class="parameter" id="testGenericMethod-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr><span class="parameter" id="testGenericMethod-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">F<span class="signature">&lt;T extends String&gt;</span> class</li>
+    <li class="self-crumb">F<span class="signature">&lt;<wbr><span class="type-parameter">T extends String</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">F</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>F&lt;T extends String&gt; class</h1>
+    <h1>F&lt;<wbr><span class="type-parameter">T extends String</span>&gt; class</h1>
 
     
     <section>
@@ -229,7 +229,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="methodWithGenericParam" class="callable">
-          <span class="name"><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></span><span class="signature">(<wbr>[<span class="parameter" id="methodWithGenericParam-param-msgs"><span class="type-annotation">List<span class="signature">&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span></span> <span class="parameter-name">msgs</span></span> ])
+          <span class="name"><a href="ex/F/methodWithGenericParam.html">methodWithGenericParam</a></span><span class="signature">(<wbr>[<span class="parameter" id="methodWithGenericParam-param-msgs"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Apple-class.html">Apple</a></span>&gt;</span></span> <span class="parameter-name">msgs</span></span> ])
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -257,7 +257,7 @@
 </dd>
         <dt id="getAnotherClassD" class="callable inherited">
           <span class="name deprecated"><a class="deprecated" href="ex/Dog/getAnotherClassD.html">getAnotherClassD</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<a href="ex/Dog-class.html">Dog</a>&gt;</span></span>
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Dog-class.html">Dog</a></span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -266,7 +266,7 @@
 </dd>
         <dt id="getClassA" class="callable inherited">
           <span class="name deprecated"><a class="deprecated" href="ex/Dog/getClassA.html">getClassA</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span></span>
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Apple-class.html">Apple</a></span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -292,7 +292,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="testGeneric" class="callable inherited">
-          <span class="name"><a href="ex/Dog/testGeneric.html">testGeneric</a></span><span class="signature">(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">args</span></span>)
+          <span class="name"><a href="ex/Dog/testGeneric.html">testGeneric</a></span><span class="signature">(<wbr><span class="parameter" id="testGeneric-param-args"><span class="type-annotation">Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">args</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -301,7 +301,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="testGenericMethod" class="callable inherited">
-          <span class="name"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="testGenericMethod-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
+          <span class="name"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="testGenericMethod-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
             <span class="returntype parameter">&#8594; T</span>
           </span>
         </dt>

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/F-class.html">F<span class="signature">&lt;T extends String&gt;</span></a></li>
+    <li><a href="ex/F-class.html">F<span class="signature">&lt;<wbr><span class="type-parameter">T extends String</span>&gt;</span></a></li>
     <li class="self-crumb">F constructor</li>
   </ol>
   <div class="self-name">F</div>
@@ -82,11 +82,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>F&lt;T extends String&gt; constructor</h1>
+    <h1>F&lt;<wbr><span class="type-parameter">T extends String</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">F&lt;T extends String&gt;</span>(<wbr>)
+      <span class="name ">F&lt;<wbr><span class="type-parameter">T extends String</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/F-class.html">F<span class="signature">&lt;T extends String&gt;</span></a></li>
+    <li><a href="ex/F-class.html">F<span class="signature">&lt;<wbr><span class="type-parameter">T extends String</span>&gt;</span></a></li>
     <li class="self-crumb">methodWithGenericParam method</li>
   </ol>
   <div class="self-name">methodWithGenericParam</div>
@@ -87,7 +87,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">methodWithGenericParam</span>
-(<wbr>[<span class="parameter" id="methodWithGenericParam-param-msgs"><span class="type-annotation">List<span class="signature">&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span></span> <span class="parameter-name">msgs</span></span> ])
+(<wbr>[<span class="parameter" id="methodWithGenericParam-param-msgs"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Apple-class.html">Apple</a></span>&gt;</span></span> <span class="parameter-name">msgs</span></span> ])
     </section>
     
     

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/F-class.html">F<span class="signature">&lt;T extends String&gt;</span></a></li>
+    <li><a href="ex/F-class.html">F<span class="signature">&lt;<wbr><span class="type-parameter">T extends String</span>&gt;</span></a></li>
     <li class="self-crumb">test method</li>
   </ol>
   <div class="self-name">test</div>

--- a/testing/test_package_docs/ex/ParameterizedClass-class.html
+++ b/testing/test_package_docs/ex/ParameterizedClass-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">ParameterizedClass<span class="signature">&lt;T&gt;</span> abstract class</li>
+    <li class="self-crumb">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span> abstract class</li>
   </ol>
   <div class="self-name">ParameterizedClass</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ParameterizedClass&lt;T&gt; class</h1>
+    <h1>ParameterizedClass&lt;<wbr><span class="type-parameter">T</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>Support class to test inheritance + type expansion from implements clause.</p>
@@ -145,7 +145,7 @@
       <dl class="properties">
         <dt id="aInheritedField" class="property">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedField.html">aInheritedField</a></span>
-          <span class="signature">&#8596; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="signature">&#8596; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -153,7 +153,7 @@
 </dd>
         <dt id="aInheritedGetter" class="property">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedGetter.html">aInheritedGetter</a></span>
-          <span class="signature">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="signature">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -161,7 +161,7 @@
 </dd>
         <dt id="aInheritedSetter" class="property">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedSetter.html">aInheritedSetter</a></span>
-          <span class="signature">&#8592; <span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span></span></span>
+          <span class="signature">&#8592; <span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span></span></span>
         </dt>
         <dd>
           
@@ -191,7 +191,7 @@
       <dl class="callables">
         <dt id="aInheritedMethod" class="callable">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedMethod.html">aInheritedMethod</a></span><span class="signature">(<wbr><span class="parameter" id="aInheritedMethod-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)
-            <span class="returntype parameter">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -200,7 +200,7 @@
 </dd>
         <dt id="aInheritedTypedefReturningMethod" class="callable">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedTypedefReturningMethod.html">aInheritedTypedefReturningMethod</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;T&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -232,8 +232,8 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator +" class="callable">
-          <span class="name"><a href="ex/ParameterizedClass/operator_plus.html">operator +</a></span><span class="signature">(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;T&gt;</span></span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="ex/ParameterizedClass/operator_plus.html">operator +</a></span><span class="signature">(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/ex/ParameterizedClass/ParameterizedClass.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/ParameterizedClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">ParameterizedClass constructor</li>
   </ol>
   <div class="self-name">ParameterizedClass</div>
@@ -67,11 +67,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ParameterizedClass&lt;T&gt; constructor</h1>
+    <h1>ParameterizedClass&lt;<wbr><span class="type-parameter">T</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">ParameterizedClass&lt;T&gt;</span>(<wbr>)
+      <span class="name ">ParameterizedClass&lt;<wbr><span class="type-parameter">T</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedField.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedField.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">aInheritedField property</li>
   </ol>
   <div class="self-name">aInheritedField</div>
@@ -70,7 +70,7 @@
     <h1>aInheritedField property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           <span class="name ">aInheritedField</span>
           <div class="features">read / write</div>
         </section>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedGetter.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedGetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">aInheritedGetter property</li>
   </ol>
   <div class="self-name">aInheritedGetter</div>
@@ -73,7 +73,7 @@
         <section id="getter">
         
         <section class="multi-line-signature">
-          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           <span class="name ">aInheritedGetter</span>
   
 </section>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedMethod.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">aInheritedMethod abstract method</li>
   </ol>
   <div class="self-name">aInheritedMethod</div>
@@ -70,7 +70,7 @@
     <h1>aInheritedMethod method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+      <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
       <span class="name ">aInheritedMethod</span>
 (<wbr><span class="parameter" id="aInheritedMethod-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)
     </section>

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedSetter.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedSetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">aInheritedSetter property</li>
   </ol>
   <div class="self-name">aInheritedSetter</div>
@@ -76,7 +76,7 @@
         <section class="multi-line-signature">
           <span class="returntype">void</span>
             <span class="name ">aInheritedSetter=</span>
-<span class="signature">(<wbr><span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;T&gt;</span></span> <span class="parameter-name">thingToSet</span></span>)</span>
+<span class="signature">(<wbr><span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span> <span class="parameter-name">thingToSet</span></span>)</span>
           
 </section>
         

--- a/testing/test_package_docs/ex/ParameterizedClass/aInheritedTypedefReturningMethod.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/aInheritedTypedefReturningMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">aInheritedTypedefReturningMethod abstract method</li>
   </ol>
   <div class="self-name">aInheritedTypedefReturningMethod</div>
@@ -70,7 +70,7 @@
     <h1>aInheritedTypedefReturningMethod method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;T&gt;</span></span>
+      <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
       <span class="name ">aInheritedTypedefReturningMethod</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/ex/ParameterizedClass/hashCode.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/operator_equals.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/operator_plus.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/operator_plus.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">operator + abstract method</li>
   </ol>
   <div class="self-name">operator +</div>
@@ -70,9 +70,9 @@
     <h1>operator + method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+      <span class="returntype"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
       <span class="name ">operator +</span>
-(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;T&gt;</span></span> <span class="parameter-name">other</span></span>)
+(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/ex/ParameterizedClass/runtimeType.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/ParameterizedClass/toString.html
+++ b/testing/test_package_docs/ex/ParameterizedClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/ParameterizedTypedef.html
+++ b/testing/test_package_docs/ex/ParameterizedTypedef.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">ParameterizedTypedef&lt;T&gt; typedef</li>
+    <li class="self-crumb">ParameterizedTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</li>
   </ol>
   <div class="self-name">ParameterizedTypedef</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ParameterizedTypedef&lt;T&gt; typedef</h1>
+    <h1>ParameterizedTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">String</span>

--- a/testing/test_package_docs/ex/TemplatedClass-class.html
+++ b/testing/test_package_docs/ex/TemplatedClass-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">TemplatedClass<span class="signature">&lt;X&gt;</span> class</li>
+    <li class="self-crumb">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">TemplatedClass</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>TemplatedClass&lt;X&gt; class</h1>
+    <h1>TemplatedClass&lt;<wbr><span class="type-parameter">X</span>&gt; class</h1>
 
     
 

--- a/testing/test_package_docs/ex/TemplatedClass/TemplatedClass.html
+++ b/testing/test_package_docs/ex/TemplatedClass/TemplatedClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">TemplatedClass constructor</li>
   </ol>
   <div class="self-name">TemplatedClass</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>TemplatedClass&lt;X&gt; constructor</h1>
+    <h1>TemplatedClass&lt;<wbr><span class="type-parameter">X</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">TemplatedClass&lt;X&gt;</span>(<wbr>)
+      <span class="name ">TemplatedClass&lt;<wbr><span class="type-parameter">X</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/TemplatedClass/aMethod.html
+++ b/testing/test_package_docs/ex/TemplatedClass/aMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">aMethod method</li>
   </ol>
   <div class="self-name">aMethod</div>

--- a/testing/test_package_docs/ex/TemplatedClass/hashCode.html
+++ b/testing/test_package_docs/ex/TemplatedClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/TemplatedClass/noSuchMethod.html
+++ b/testing/test_package_docs/ex/TemplatedClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/TemplatedClass/operator_equals.html
+++ b/testing/test_package_docs/ex/TemplatedClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/TemplatedClass/runtimeType.html
+++ b/testing/test_package_docs/ex/TemplatedClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/TemplatedClass/toString.html
+++ b/testing/test_package_docs/ex/TemplatedClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;X&gt;</span></a></li>
+    <li><a href="ex/TemplatedClass-class.html">TemplatedClass<span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/TemplatedInterface-class.html
+++ b/testing/test_package_docs/ex/TemplatedInterface-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">TemplatedInterface<span class="signature">&lt;A&gt;</span> abstract class</li>
+    <li class="self-crumb">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span> abstract class</li>
   </ol>
   <div class="self-name">TemplatedInterface</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>TemplatedInterface&lt;A&gt; class</h1>
+    <h1>TemplatedInterface&lt;<wbr><span class="type-parameter">A</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>Class for testing expansion of type from implements clause.</p>
@@ -119,7 +119,7 @@
         <dt>Implements</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">
-            <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></li>
+            <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></li>
           </ul>
         </dd>
 
@@ -147,7 +147,7 @@
       <dl class="properties">
         <dt id="aField" class="property">
           <span class="name"><a href="ex/TemplatedInterface/aField.html">aField</a></span>
-          <span class="signature">&#8596; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;Stream<span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>&gt;</span></span>
+          <span class="signature">&#8596; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -155,7 +155,7 @@
 </dd>
         <dt id="aGetter" class="property">
           <span class="name"><a href="ex/TemplatedInterface/aGetter.html">aGetter</a></span>
-          <span class="signature">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;Map<span class="signature">&lt;A, List<span class="signature">&lt;String&gt;</span>&gt;</span>&gt;</span></span>
+          <span class="signature">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -163,7 +163,7 @@
 </dd>
         <dt id="aSetter" class="property">
           <span class="name"><a href="ex/TemplatedInterface/aSetter.html">aSetter</a></span>
-          <span class="signature">&#8592; <span class="parameter" id="aSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;bool&gt;</span>&gt;</span></span></span></span>
+          <span class="signature">&#8592; <span class="parameter" id="aSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>&gt;</span></span></span></span>
         </dt>
         <dd>
           
@@ -171,7 +171,7 @@
 </dd>
         <dt id="aInheritedField" class="property inherited">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedField.html">aInheritedField</a></span>
-          <span class="signature">&#8596; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+          <span class="signature">&#8596; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
         </dt>
         <dd class="inherited">
           
@@ -179,7 +179,7 @@
 </dd>
         <dt id="aInheritedGetter" class="property inherited">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedGetter.html">aInheritedGetter</a></span>
-          <span class="signature">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+          <span class="signature">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
         </dt>
         <dd class="inherited">
           
@@ -187,7 +187,7 @@
 </dd>
         <dt id="aInheritedSetter" class="property inherited">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedSetter.html">aInheritedSetter</a></span>
-          <span class="signature">&#8592; <span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span></span></span>
+          <span class="signature">&#8592; <span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span></span></span>
         </dt>
         <dd class="inherited">
           
@@ -217,7 +217,7 @@
       <dl class="callables">
         <dt id="aMethodInterface" class="callable">
           <span class="name"><a href="ex/TemplatedInterface/aMethodInterface.html">aMethodInterface</a></span><span class="signature">(<wbr><span class="parameter" id="aMethodInterface-param-value"><span class="type-annotation">A</span> <span class="parameter-name">value</span></span>)
-            <span class="returntype parameter">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -226,7 +226,7 @@
 </dd>
         <dt id="aTypedefReturningMethodInterface" class="callable">
           <span class="name"><a href="ex/TemplatedInterface/aTypedefReturningMethodInterface.html">aTypedefReturningMethodInterface</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;List<span class="signature">&lt;String&gt;</span>&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -235,7 +235,7 @@
 </dd>
         <dt id="aInheritedMethod" class="callable inherited">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedMethod.html">aInheritedMethod</a></span><span class="signature">(<wbr><span class="parameter" id="aInheritedMethod-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)
-            <span class="returntype parameter">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -244,7 +244,7 @@
 </dd>
         <dt id="aInheritedTypedefReturningMethod" class="callable inherited">
           <span class="name"><a href="ex/ParameterizedClass/aInheritedTypedefReturningMethod.html">aInheritedTypedefReturningMethod</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -276,8 +276,8 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator +" class="callable inherited">
-          <span class="name"><a href="ex/ParameterizedClass/operator_plus.html">operator +</a></span><span class="signature">(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+          <span class="name"><a href="ex/ParameterizedClass/operator_plus.html">operator +</a></span><span class="signature">(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; <a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">

--- a/testing/test_package_docs/ex/TemplatedInterface/TemplatedInterface.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/TemplatedInterface.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">TemplatedInterface constructor</li>
   </ol>
   <div class="self-name">TemplatedInterface</div>
@@ -72,11 +72,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>TemplatedInterface&lt;A&gt; constructor</h1>
+    <h1>TemplatedInterface&lt;<wbr><span class="type-parameter">A</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">TemplatedInterface&lt;A&gt;</span>(<wbr>)
+      <span class="name ">TemplatedInterface&lt;<wbr><span class="type-parameter">A</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/ex/TemplatedInterface/aField.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aField.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">aField property</li>
   </ol>
   <div class="self-name">aField</div>
@@ -75,7 +75,7 @@
     <h1>aField property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;Stream<span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span>&gt;</span></span>
+          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span></span>
           <span class="name ">aField</span>
           <div class="features">read / write</div>
         </section>

--- a/testing/test_package_docs/ex/TemplatedInterface/aGetter.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aGetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">aGetter property</li>
   </ol>
   <div class="self-name">aGetter</div>
@@ -78,7 +78,7 @@
         <section id="getter">
         
         <section class="multi-line-signature">
-          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;Map<span class="signature">&lt;A, List<span class="signature">&lt;String&gt;</span>&gt;</span>&gt;</span></span>
+          <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>&gt;</span></span>
           <span class="name ">aGetter</span>
   
 </section>

--- a/testing/test_package_docs/ex/TemplatedInterface/aMethodInterface.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aMethodInterface.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">aMethodInterface abstract method</li>
   </ol>
   <div class="self-name">aMethodInterface</div>
@@ -75,7 +75,7 @@
     <h1>aMethodInterface method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;int&gt;</span>&gt;</span></span>
+      <span class="returntype"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>
       <span class="name ">aMethodInterface</span>
 (<wbr><span class="parameter" id="aMethodInterface-param-value"><span class="type-annotation">A</span> <span class="parameter-name">value</span></span>)
     </section>

--- a/testing/test_package_docs/ex/TemplatedInterface/aSetter.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aSetter.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">aSetter property</li>
   </ol>
   <div class="self-name">aSetter</div>
@@ -81,7 +81,7 @@
         <section class="multi-line-signature">
           <span class="returntype">void</span>
             <span class="name ">aSetter=</span>
-<span class="signature">(<wbr><span class="parameter" id="aSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;List<span class="signature">&lt;bool&gt;</span>&gt;</span></span> <span class="parameter-name">thingToSet</span></span>)</span>
+<span class="signature">(<wbr><span class="parameter" id="aSetter=-param-thingToSet"><span class="type-annotation"><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">thingToSet</span></span>)</span>
           
 </section>
         

--- a/testing/test_package_docs/ex/TemplatedInterface/aTypedefReturningMethodInterface.html
+++ b/testing/test_package_docs/ex/TemplatedInterface/aTypedefReturningMethodInterface.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="ex/TemplatedInterface-class.html">TemplatedInterface<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">aTypedefReturningMethodInterface abstract method</li>
   </ol>
   <div class="self-name">aTypedefReturningMethodInterface</div>
@@ -75,7 +75,7 @@
     <h1>aTypedefReturningMethodInterface method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;List<span class="signature">&lt;String&gt;</span>&gt;</span></span>
+      <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>
       <span class="name ">aTypedefReturningMethodInterface</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
@@ -154,7 +154,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="getAComplexTypedef" class="callable">
-          <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAComplexTypedef.html">getAComplexTypedef</a></span><span class="signature">&lt;A4, A5, A6&gt;</span><span class="signature">(<wbr>)
+          <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAComplexTypedef.html">getAComplexTypedef</a></span><span class="signature">&lt;<wbr><span class="type-parameter">A4</span>, <span class="type-parameter">A5</span>, <span class="type-parameter">A6</span>&gt;</span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; <a href="ex/aComplexTypedef.html">aComplexTypedef</a></span>
           </span>
         </dt>
@@ -163,8 +163,8 @@
           
 </dd>
         <dt id="getAFunctionReturningBool" class="callable">
-          <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html">getAFunctionReturningBool</a></span><span class="signature">&lt;T1, T2, T3&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; bool Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
+          <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html">getAFunctionReturningBool</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>, <span class="type-parameter">T3</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; bool Function<span class="signature">&lt;<wbr><span class="type-parameter">T4</span>&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
           </span>
         </dt>
         <dd>
@@ -173,7 +173,7 @@ case right for anonymous functions.
           
 </dd>
         <dt id="getAFunctionReturningVoid" class="callable">
-          <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html">getAFunctionReturningVoid</a></span><span class="signature">&lt;T1, T2&gt;</span><span class="signature">(<wbr><span class="parameter" id="getAFunctionReturningVoid-param-callback"><span class="type-annotation">void</span> <span class="parameter-name">callback</span>(<span class="parameter" id="callback-param-argument1"><span class="type-annotation">T1</span> <span class="parameter-name">argument1</span>, </span> <span class="parameter" id="callback-param-argument2"><span class="type-annotation">T2</span> <span class="parameter-name">argument2</span></span>)</span>)
+          <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html">getAFunctionReturningVoid</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="getAFunctionReturningVoid-param-callback"><span class="type-annotation">void</span> <span class="parameter-name">callback</span>(<span class="parameter" id="callback-param-argument1"><span class="type-annotation">T1</span> <span class="parameter-name">argument1</span>, </span> <span class="parameter" id="callback-param-argument2"><span class="type-annotation">T2</span> <span class="parameter-name">argument2</span></span>)</span>)
             <span class="returntype parameter">&#8594; void Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span></span>
           </span>
         </dt>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
@@ -164,7 +164,7 @@
 </dd>
         <dt id="getAFunctionReturningBool" class="callable">
           <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html">getAFunctionReturningBool</a></span><span class="signature">&lt;T1, T2, T3&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
+            <span class="returntype parameter">&#8594; bool Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
           </span>
         </dt>
         <dd>
@@ -174,7 +174,7 @@ case right for anonymous functions.
 </dd>
         <dt id="getAFunctionReturningVoid" class="callable">
           <span class="name"><a href="ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html">getAFunctionReturningVoid</a></span><span class="signature">&lt;T1, T2&gt;</span><span class="signature">(<wbr><span class="parameter" id="getAFunctionReturningVoid-param-callback"><span class="type-annotation">void</span> <span class="parameter-name">callback</span>(<span class="parameter" id="callback-param-argument1"><span class="type-annotation">T1</span> <span class="parameter-name">argument1</span>, </span> <span class="parameter" id="callback-param-argument2"><span class="type-annotation">T2</span> <span class="parameter-name">argument2</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span></span>
+            <span class="returntype parameter">&#8594; void Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAComplexTypedef.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAComplexTypedef.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
-    <li class="self-crumb">getAComplexTypedef&lt;A4, A5, A6&gt; abstract method</li>
+    <li class="self-crumb">getAComplexTypedef&lt;<wbr><span class="type-parameter">A4</span>, <span class="type-parameter">A5</span>, <span class="type-parameter">A6</span>&gt; abstract method</li>
   </ol>
   <div class="self-name">getAComplexTypedef</div>
   <form class="search navbar-right" role="search">
@@ -64,12 +64,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>getAComplexTypedef&lt;A4, A5, A6&gt; method</h1>
+    <h1>getAComplexTypedef&lt;<wbr><span class="type-parameter">A4</span>, <span class="type-parameter">A5</span>, <span class="type-parameter">A6</span>&gt; method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype"><a href="ex/aComplexTypedef.html">aComplexTypedef</a></span>
       <span class="name ">getAComplexTypedef</span>
-&lt;A4, A5, A6&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">A4</span>, <span class="type-parameter">A5</span>, <span class="type-parameter">A6</span>&gt;(<wbr>)
     </section>
     <section class="desc markdown">
       <p>Returns a complex typedef that includes some anonymous typed functions.</p>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
-    <li class="self-crumb">getAFunctionReturningBool&lt;T1, T2, T3&gt; abstract method</li>
+    <li class="self-crumb">getAFunctionReturningBool&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>, <span class="type-parameter">T3</span>&gt; abstract method</li>
   </ol>
   <div class="self-name">getAFunctionReturningBool</div>
   <form class="search navbar-right" role="search">
@@ -64,12 +64,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>getAFunctionReturningBool&lt;T1, T2, T3&gt; method</h1>
+    <h1>getAFunctionReturningBool&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>, <span class="type-parameter">T3</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">bool Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
+      <span class="returntype">bool Function<span class="signature">&lt;<wbr><span class="type-parameter">T4</span>&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
       <span class="name ">getAFunctionReturningBool</span>
-&lt;T1, T2, T3&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>, <span class="type-parameter">T3</span>&gt;(<wbr>)
     </section>
     <section class="desc markdown">
       <p>This helps us make sure we get both the empty and the non-empty

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningBool.html
@@ -67,7 +67,7 @@
     <h1>getAFunctionReturningBool&lt;T1, T2, T3&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
+      <span class="returntype">bool Function<span class="signature">&lt;T4&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span></span>
       <span class="name ">getAFunctionReturningBool</span>
 &lt;T1, T2, T3&gt;(<wbr>)
     </section>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html
@@ -67,7 +67,7 @@
     <h1>getAFunctionReturningVoid&lt;T1, T2&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span></span>
+      <span class="returntype">void Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span></span>
       <span class="name ">getAFunctionReturningVoid</span>
 &lt;T1, T2&gt;(<wbr><span class="parameter" id="getAFunctionReturningVoid-param-callback"><span class="type-annotation">void</span> <span class="parameter-name">callback</span>(<span class="parameter" id="callback-param-argument1"><span class="type-annotation">T1</span> <span class="parameter-name">argument1</span>, </span> <span class="parameter" id="callback-param-argument2"><span class="type-annotation">T2</span> <span class="parameter-name">argument2</span></span>)</span>)
     </section>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs/getAFunctionReturningVoid.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/TypedFunctionsWithoutTypedefs-class.html">TypedFunctionsWithoutTypedefs</a></li>
-    <li class="self-crumb">getAFunctionReturningVoid&lt;T1, T2&gt; abstract method</li>
+    <li class="self-crumb">getAFunctionReturningVoid&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>&gt; abstract method</li>
   </ol>
   <div class="self-name">getAFunctionReturningVoid</div>
   <form class="search navbar-right" role="search">
@@ -64,12 +64,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>getAFunctionReturningVoid&lt;T1, T2&gt; method</h1>
+    <h1>getAFunctionReturningVoid&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>&gt; method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span></span>
       <span class="name ">getAFunctionReturningVoid</span>
-&lt;T1, T2&gt;(<wbr><span class="parameter" id="getAFunctionReturningVoid-param-callback"><span class="type-annotation">void</span> <span class="parameter-name">callback</span>(<span class="parameter" id="callback-param-argument1"><span class="type-annotation">T1</span> <span class="parameter-name">argument1</span>, </span> <span class="parameter" id="callback-param-argument2"><span class="type-annotation">T2</span> <span class="parameter-name">argument2</span></span>)</span>)
+&lt;<wbr><span class="type-parameter">T1</span>, <span class="type-parameter">T2</span>&gt;(<wbr><span class="parameter" id="getAFunctionReturningVoid-param-callback"><span class="type-annotation">void</span> <span class="parameter-name">callback</span>(<span class="parameter" id="callback-param-argument1"><span class="type-annotation">T1</span> <span class="parameter-name">argument1</span>, </span> <span class="parameter" id="callback-param-argument2"><span class="type-annotation">T2</span> <span class="parameter-name">argument2</span></span>)</span>)
     </section>
     <section class="desc markdown">
       <p>Returns a function that returns a void with some generic types sprinkled in.</p>

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">WithGeneric<span class="signature">&lt;T&gt;</span> class</li>
+    <li class="self-crumb">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">WithGeneric</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>WithGeneric&lt;T&gt; class</h1>
+    <h1>WithGeneric&lt;<wbr><span class="type-parameter">T</span>&gt; class</h1>
 
     
     <section>

--- a/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
+++ b/testing/test_package_docs/ex/WithGeneric/WithGeneric.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">WithGeneric constructor</li>
   </ol>
   <div class="self-name">WithGeneric</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>WithGeneric&lt;T&gt; constructor</h1>
+    <h1>WithGeneric&lt;<wbr><span class="type-parameter">T</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">WithGeneric&lt;T&gt;</span>(<wbr><span class="parameter" id="-param-prop"><span class="type-annotation">T</span> <span class="parameter-name">prop</span></span>)
+      <span class="name ">WithGeneric&lt;<wbr><span class="type-parameter">T</span>&gt;</span>(<wbr><span class="parameter" id="-param-prop"><span class="type-annotation">T</span> <span class="parameter-name">prop</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/WithGeneric/hashCode.html
+++ b/testing/test_package_docs/ex/WithGeneric/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
+++ b/testing/test_package_docs/ex/WithGeneric/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/ex/WithGeneric/operator_equals.html
+++ b/testing/test_package_docs/ex/WithGeneric/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/ex/WithGeneric/prop.html
+++ b/testing/test_package_docs/ex/WithGeneric/prop.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">prop property</li>
   </ol>
   <div class="self-name">prop</div>

--- a/testing/test_package_docs/ex/WithGeneric/runtimeType.html
+++ b/testing/test_package_docs/ex/WithGeneric/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/ex/WithGeneric/toString.html
+++ b/testing/test_package_docs/ex/WithGeneric/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="ex/WithGeneric-class.html">WithGeneric<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -115,7 +115,7 @@
         <dt>Inheritance</dt>
         <dd><ul class="gt-separated dark clazz-relationships">
           <li>Object</li>
-          <li><a href="ex/WithGeneric-class.html">WithGeneric</a><span class="signature">&lt;<a href="ex/Apple-class.html">Apple</a>&gt;</span></li>
+          <li><a href="ex/WithGeneric-class.html">WithGeneric</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="ex/Apple-class.html">Apple</a></span>&gt;</span></li>
           <li>WithGenericSub</li>
         </ul></dd>
 

--- a/testing/test_package_docs/ex/aComplexTypedef.html
+++ b/testing/test_package_docs/ex/aComplexTypedef.html
@@ -110,7 +110,7 @@
     <h1>aComplexTypedef&lt;A1, A2, A3&gt; typedef</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
+        <span class="returntype">void Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
         <span class="name ">aComplexTypedef</span>
 (<wbr><span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">String</span></span>)
     </section>

--- a/testing/test_package_docs/ex/aComplexTypedef.html
+++ b/testing/test_package_docs/ex/aComplexTypedef.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">aComplexTypedef&lt;A1, A2, A3&gt; typedef</li>
+    <li class="self-crumb">aComplexTypedef&lt;<wbr><span class="type-parameter">A1</span>, <span class="type-parameter">A2</span>, <span class="type-parameter">A3</span>&gt; typedef</li>
   </ol>
   <div class="self-name">aComplexTypedef</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>aComplexTypedef&lt;A1, A2, A3&gt; typedef</h1>
+    <h1>aComplexTypedef&lt;<wbr><span class="type-parameter">A1</span>, <span class="type-parameter">A2</span>, <span class="type-parameter">A3</span>&gt; typedef</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">void Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -69,7 +69,7 @@
 
       <dl>
         <dt id="AnotherParameterizedClass">
-          <span class="name "><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;B&gt;</span></span>
+          <span class="name "><a href="ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">B</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -141,7 +141,7 @@
           
         </dd>
         <dt id="F">
-          <span class="name "><a href="ex/F-class.html">F</a><span class="signature">&lt;T extends String&gt;</span></span>
+          <span class="name "><a href="ex/F-class.html">F</a><span class="signature">&lt;<wbr><span class="type-parameter">T extends String</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -173,7 +173,7 @@
           A class
         </dd>
         <dt id="ParameterizedClass">
-          <span class="name "><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="name "><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         </dt>
         <dd>
           Support class to test inheritance + type expansion from implements clause.
@@ -210,13 +210,13 @@
 that has some operators
         </dd>
         <dt id="TemplatedClass">
-          <span class="name "><a href="ex/TemplatedClass-class.html">TemplatedClass</a><span class="signature">&lt;X&gt;</span></span>
+          <span class="name "><a href="ex/TemplatedClass-class.html">TemplatedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">X</span>&gt;</span></span>
         </dt>
         <dd>
           
         </dd>
         <dt id="TemplatedInterface">
-          <span class="name "><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a><span class="signature">&lt;A&gt;</span></span>
+          <span class="name "><a href="ex/TemplatedInterface-class.html">TemplatedInterface</a><span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></span>
         </dt>
         <dd>
           Class for testing expansion of type from implements clause.
@@ -228,7 +228,7 @@ that has some operators
           This class has a complicated type situation.
         </dd>
         <dt id="WithGeneric">
-          <span class="name "><a href="ex/WithGeneric-class.html">WithGeneric</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="name "><a href="ex/WithGeneric-class.html">WithGeneric</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -336,7 +336,7 @@ that has some operators
         </dd>
         <dt id="PRETTY_COLORS" class="constant">
           <span class="name "><a href="ex/PRETTY_COLORS-constant.html">PRETTY_COLORS</a></span>
-          <span class="signature">&#8594; const List<span class="signature">&lt;String&gt;</span></span>
+          <span class="signature">&#8594; const List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -409,7 +409,7 @@ that has some operators
           
 </dd>
         <dt id="genericFunction" class="callable">
-          <span class="name"><a href="ex/genericFunction.html">genericFunction</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="genericFunction-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
+          <span class="name"><a href="ex/genericFunction.html">genericFunction</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="genericFunction-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
             <span class="returntype parameter">&#8594; T</span>
           </span>
         </dt>
@@ -439,7 +439,7 @@ enum constants ala #1445
 
       <dl class="callables">
         <dt id="aComplexTypedef" class="callable">
-          <span class="name"><a href="ex/aComplexTypedef.html">aComplexTypedef</a></span><span class="signature">&lt;A1, A2, A3&gt;</span><span class="signature">(<wbr><span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">String</span></span>)
+          <span class="name"><a href="ex/aComplexTypedef.html">aComplexTypedef</a></span><span class="signature">&lt;<wbr><span class="type-parameter">A1</span>, <span class="type-parameter">A2</span>, <span class="type-parameter">A3</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">String</span></span>)
             <span class="returntype parameter">&#8594; void Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
           </span>
         </dt>
@@ -448,7 +448,7 @@ enum constants ala #1445
           
 </dd>
         <dt id="ParameterizedTypedef" class="callable">
-          <span class="name"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="ParameterizedTypedef-param-msg"><span class="type-annotation">T</span> <span class="parameter-name">msg</span>, </span> <span class="parameter" id="ParameterizedTypedef-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)
+          <span class="name"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="ParameterizedTypedef-param-msg"><span class="type-annotation">T</span> <span class="parameter-name">msg</span>, </span> <span class="parameter" id="ParameterizedTypedef-param-foo"><span class="type-annotation">int</span> <span class="parameter-name">foo</span></span>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
         </dt>
@@ -457,7 +457,7 @@ enum constants ala #1445
           
 </dd>
         <dt id="processMessage" class="callable">
-          <span class="name"><a href="ex/processMessage.html">processMessage</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="processMessage-param-msg"><span class="type-annotation">String</span> <span class="parameter-name">msg</span></span>)
+          <span class="name"><a href="ex/processMessage.html">processMessage</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="processMessage-param-msg"><span class="type-annotation">String</span> <span class="parameter-name">msg</span></span>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
         </dt>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -440,7 +440,7 @@ enum constants ala #1445
       <dl class="callables">
         <dt id="aComplexTypedef" class="callable">
           <span class="name"><a href="ex/aComplexTypedef.html">aComplexTypedef</a></span><span class="signature">&lt;A1, A2, A3&gt;</span><span class="signature">(<wbr><span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">String</span></span>)
-            <span class="returntype parameter">&#8594; Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
+            <span class="returntype parameter">&#8594; void Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/ex/genericFunction.html
+++ b/testing/test_package_docs/ex/genericFunction.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">genericFunction&lt;T&gt; function</li>
+    <li class="self-crumb">genericFunction&lt;<wbr><span class="type-parameter">T</span>&gt; function</li>
   </ol>
   <div class="self-name">genericFunction</div>
   <form class="search navbar-right" role="search">
@@ -107,12 +107,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>genericFunction&lt;T&gt; function</h1>
+    <h1>genericFunction&lt;<wbr><span class="type-parameter">T</span>&gt; function</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">T</span>
         <span class="name ">genericFunction</span>
-&lt;T&gt;(<wbr><span class="parameter" id="genericFunction-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr><span class="parameter" id="genericFunction-param-arg"><span class="type-annotation">T</span> <span class="parameter-name">arg</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/ex/processMessage.html
+++ b/testing/test_package_docs/ex/processMessage.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">processMessage&lt;T&gt; typedef</li>
+    <li class="self-crumb">processMessage&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</li>
   </ol>
   <div class="self-name">processMessage</div>
   <form class="search navbar-right" role="search">
@@ -107,7 +107,7 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>processMessage&lt;T&gt; typedef</h1>
+    <h1>processMessage&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">String</span>

--- a/testing/test_package_docs/fake/ABaseClass-class.html
+++ b/testing/test_package_docs/fake/ABaseClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">ATypeTakingClass<span class="signature">&lt;T&gt;</span> class</li>
+    <li class="self-crumb">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">ATypeTakingClass</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ATypeTakingClass&lt;T&gt; class</h1>
+    <h1>ATypeTakingClass&lt;<wbr><span class="type-parameter">T</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>This class takes a type, and it might be void.</p>

--- a/testing/test_package_docs/fake/ATypeTakingClass/ATypeTakingClass.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/ATypeTakingClass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">ATypeTakingClass constructor</li>
   </ol>
   <div class="self-name">ATypeTakingClass</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ATypeTakingClass&lt;T&gt; constructor</h1>
+    <h1>ATypeTakingClass&lt;<wbr><span class="type-parameter">T</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">ATypeTakingClass&lt;T&gt;</span>(<wbr>)
+      <span class="name ">ATypeTakingClass&lt;<wbr><span class="type-parameter">T</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ATypeTakingClass/aMethodMaybeReturningVoid.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/aMethodMaybeReturningVoid.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">aMethodMaybeReturningVoid method</li>
   </ol>
   <div class="self-name">aMethodMaybeReturningVoid</div>

--- a/testing/test_package_docs/fake/ATypeTakingClass/hashCode.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/ATypeTakingClass/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/ATypeTakingClass/operator_equals.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/ATypeTakingClass/runtimeType.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/ATypeTakingClass/toString.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -169,7 +169,7 @@
 
         <dt>Mixes-in</dt>
         <dd><ul class="comma-separated clazz-relationships">
-          <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;void&gt;</span></li>
+          <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></li>
         </ul></dd>
 
 

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -212,7 +212,7 @@ on inheritance and overrides here.</p>
 </dd>
         <dt id="explicitGetterImplicitSetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span>
-          <span class="signature">&#8596; List<span class="signature">&lt;int&gt;</span></span>
+          <span class="signature">&#8596; List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>
         </dt>
         <dd>
           Getter doc for explicitGetterImplicitSetter
@@ -236,7 +236,7 @@ on inheritance and overrides here.</p>
 </dd>
         <dt id="explicitSetter" class="property">
           <span class="name"><a href="fake/ClassWithUnusualProperties/explicitSetter.html">explicitSetter</a></span>
-          <span class="signature">&#8592; <span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;int&gt;</span></span></span>)</span></span>
+          <span class="signature">&#8592; <span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span></span>)</span></span>
         </dt>
         <dd>
           Set to <code>f</code>, and don't warn about <code>bar</code> or <code>baz</code>.

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitGetterImplicitSetter.html
@@ -80,7 +80,7 @@
         <section id="getter">
         
         <section class="multi-line-signature">
-          <span class="returntype">List<span class="signature">&lt;int&gt;</span></span>
+          <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>
           <span class="name ">explicitGetterImplicitSetter</span>
   
 </section>
@@ -96,7 +96,7 @@
         <section class="multi-line-signature">
           <span class="returntype">void</span>
             <span class="name ">explicitGetterImplicitSetter=</span>
-<span class="signature">(<wbr><span class="parameter" id="explicitGetterImplicitSetter=-param-_explicitGetterImplicitSetter"><span class="type-annotation">List<span class="signature">&lt;int&gt;</span></span> <span class="parameter-name">_explicitGetterImplicitSetter</span></span>)</span>
+<span class="signature">(<wbr><span class="parameter" id="explicitGetterImplicitSetter=-param-_explicitGetterImplicitSetter"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span> <span class="parameter-name">_explicitGetterImplicitSetter</span></span>)</span>
           <div class="features">inherited</div>
 </section>
         

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties/explicitSetter.html
@@ -83,7 +83,7 @@
         <section class="multi-line-signature">
           <span class="returntype">void</span>
             <span class="name ">explicitSetter=</span>
-<span class="signature">(<wbr><span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;int&gt;</span></span> <span class="parameter-name">macTruck</span></span>)</span>)</span>
+<span class="signature">(<wbr><span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span> <span class="parameter-name">macTruck</span></span>)</span>)</span>
           
 </section>
         

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -224,13 +224,13 @@ Some constants have long docs.</p>
         </dd>
         <dt id="values" class="constant">
           <span class="name ">values</span>
-          <span class="signature">&#8594; const List<span class="signature">&lt;<a href="fake/Color-class.html">Color</a>&gt;</span></span>
+          <span class="signature">&#8594; const List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="fake/Color-class.html">Color</a></span>&gt;</span></span>
         </dt>
         <dd>
           <p>A constant List of the values in this enum, in order of their declaration.</p>
           
   <div>
-            <span class="signature"><code>const List&lt;Color&gt;</code></span>
+            <span class="signature"><code>const List&lt;<wbr><span class="type-parameter">Color</span>&gt;</code></span>
           </div>
         </dd>
         <dt id="VIOLET" class="constant">

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">ConstructorTester<span class="signature">&lt;A, B&gt;</span> class</li>
+    <li class="self-crumb">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">ConstructorTester</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ConstructorTester&lt;A, B&gt; class</h1>
+    <h1>ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt; class</h1>
 
     
 

--- a/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.fromSomething.html
+++ b/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.fromSomething.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">ConstructorTester.fromSomething constructor</li>
   </ol>
   <div class="self-name">ConstructorTester.fromSomething</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ConstructorTester&lt;A, B&gt;.fromSomething constructor</h1>
+    <h1>ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;.fromSomething constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">ConstructorTester&lt;A, B&gt;.fromSomething</span>(<wbr><span class="parameter" id="fromSomething-param-foo"><span class="type-annotation">A</span> <span class="parameter-name">foo</span></span>)
+      <span class="name ">ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;.fromSomething</span>(<wbr><span class="parameter" id="fromSomething-param-foo"><span class="type-annotation">A</span> <span class="parameter-name">foo</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.html
+++ b/testing/test_package_docs/fake/ConstructorTester/ConstructorTester.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">ConstructorTester constructor</li>
   </ol>
   <div class="self-name">ConstructorTester</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ConstructorTester&lt;A, B&gt; constructor</h1>
+    <h1>ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">ConstructorTester&lt;A, B&gt;</span>(<wbr><span class="parameter" id="-param-param1"><span class="type-annotation">String</span> <span class="parameter-name">param1</span></span>)
+      <span class="name ">ConstructorTester&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span>(<wbr><span class="parameter" id="-param-param1"><span class="type-annotation">String</span> <span class="parameter-name">param1</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ConstructorTester/hashCode.html
+++ b/testing/test_package_docs/fake/ConstructorTester/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/ConstructorTester/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ConstructorTester/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/ConstructorTester/operator_equals.html
+++ b/testing/test_package_docs/fake/ConstructorTester/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/ConstructorTester/runtimeType.html
+++ b/testing/test_package_docs/fake/ConstructorTester/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/ConstructorTester/toString.html
+++ b/testing/test_package_docs/fake/ConstructorTester/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;A, B&gt;</span></a></li>
+    <li><a href="fake/ConstructorTester-class.html">ConstructorTester<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -165,7 +165,7 @@
         <dt>Inheritance</dt>
         <dd><ul class="gt-separated dark clazz-relationships">
           <li>Object</li>
-          <li>Future<span class="signature">&lt;void&gt;</span></li>
+          <li>Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></li>
           <li>ExtendsFutureVoid</li>
         </ul></dd>
 
@@ -180,7 +180,7 @@
 
       <dl class="constructor-summary-list">
         <dt id="ExtendsFutureVoid" class="callable">
-          <span class="name"><a href="fake/ExtendsFutureVoid/ExtendsFutureVoid.html">ExtendsFutureVoid</a></span><span class="signature">(<span class="parameter" id="-param-computation"><span class="type-annotation">FutureOr<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">computation</span>()</span>)</span>
+          <span class="name"><a href="fake/ExtendsFutureVoid/ExtendsFutureVoid.html">ExtendsFutureVoid</a></span><span class="signature">(<span class="parameter" id="-param-computation"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">computation</span>()</span>)</span>
         </dt>
         <dd>
           
@@ -217,7 +217,7 @@
       <dl class="callables">
         <dt id="asStream" class="callable inherited">
           <span class="name"><a href="fake/ExtendsFutureVoid/asStream.html">asStream</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Stream<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Stream<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -226,7 +226,7 @@
 </dd>
         <dt id="catchError" class="callable inherited">
           <span class="name"><a href="fake/ExtendsFutureVoid/catchError.html">catchError</a></span><span class="signature">(<wbr><span class="parameter" id="catchError-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span>, {</span> <span class="parameter" id="catchError-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-error"><span class="type-annotation">Object</span> <span class="parameter-name">error</span></span>)</span> })
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -243,8 +243,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="then" class="callable inherited">
-          <span class="name"><a href="fake/ExtendsFutureVoid/then.html">then</a></span><span class="signature">&lt;S&gt;</span><span class="signature">(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;S&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;S&gt;</span></span>
+          <span class="name"><a href="fake/ExtendsFutureVoid/then.html">then</a></span><span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -252,8 +252,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="timeout" class="callable inherited">
-          <span class="name"><a href="fake/ExtendsFutureVoid/timeout.html">timeout</a></span><span class="signature">(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+          <span class="name"><a href="fake/ExtendsFutureVoid/timeout.html">timeout</a></span><span class="signature">(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -271,7 +271,7 @@
 </dd>
         <dt id="whenComplete" class="callable inherited">
           <span class="name"><a href="fake/ExtendsFutureVoid/whenComplete.html">whenComplete</a></span><span class="signature">(<wbr><span class="parameter" id="whenComplete-param-action"><span class="type-annotation">FutureOr</span> <span class="parameter-name">action</span>()</span>)
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">

--- a/testing/test_package_docs/fake/ExtendsFutureVoid/ExtendsFutureVoid.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid/ExtendsFutureVoid.html
@@ -70,7 +70,7 @@
 
     <section class="multi-line-signature">
       
-      <span class="name ">ExtendsFutureVoid</span>(<wbr><span class="parameter" id="-param-computation"><span class="type-annotation">FutureOr<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">computation</span>()</span>)
+      <span class="name ">ExtendsFutureVoid</span>(<wbr><span class="parameter" id="-param-computation"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">computation</span>()</span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/ExtendsFutureVoid/asStream.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid/asStream.html
@@ -69,7 +69,7 @@
     <h1>asStream method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Stream<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Stream<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">asStream</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid/catchError.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid/catchError.html
@@ -69,7 +69,7 @@
     <h1>catchError method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">catchError</span>
 (<wbr><span class="parameter" id="catchError-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span>, {</span> <span class="parameter" id="catchError-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-error"><span class="type-annotation">Object</span> <span class="parameter-name">error</span></span>)</span> })
     </section>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid/then.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid/then.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
     <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
-    <li class="self-crumb">then&lt;S&gt; abstract method</li>
+    <li class="self-crumb">then&lt;<wbr><span class="type-parameter">S</span>&gt; abstract method</li>
   </ol>
   <div class="self-name">then</div>
   <form class="search navbar-right" role="search">
@@ -66,12 +66,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>then&lt;S&gt; method</h1>
+    <h1>then&lt;<wbr><span class="type-parameter">S</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;S&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span>
       <span class="name ">then</span>
-&lt;S&gt;(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;S&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
+&lt;<wbr><span class="type-parameter">S</span>&gt;(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
     </section>
     
     

--- a/testing/test_package_docs/fake/ExtendsFutureVoid/timeout.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid/timeout.html
@@ -69,9 +69,9 @@
     <h1>timeout method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">timeout</span>
-(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
+(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
     </section>
     
     

--- a/testing/test_package_docs/fake/ExtendsFutureVoid/whenComplete.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid/whenComplete.html
@@ -69,7 +69,7 @@
     <h1>whenComplete method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">whenComplete</span>
 (<wbr><span class="parameter" id="whenComplete-param-action"><span class="type-annotation">FutureOr</span> <span class="parameter-name">action</span>()</span>)
     </section>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">ExtraSpecialList<span class="signature">&lt;E&gt;</span> class</li>
+    <li class="self-crumb">ExtraSpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">ExtraSpecialList</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ExtraSpecialList&lt;E&gt; class</h1>
+    <h1>ExtraSpecialList&lt;<wbr><span class="type-parameter">E</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>This inherits operators.</p>
@@ -165,7 +165,7 @@
         <dt>Inheritance</dt>
         <dd><ul class="gt-separated dark clazz-relationships">
           <li>Object</li>
-          <li>ListBase<span class="signature">&lt;E&gt;</span></li>
+          <li>ListBase<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></li>
           <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
           <li>ExtraSpecialList</li>
         </ul></dd>
@@ -308,7 +308,7 @@
 </dd>
         <dt id="asMap" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/asMap.html">asMap</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;int, dynamic&gt;</span></span>
+            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -316,8 +316,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="cast" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/cast.html">cast</a></span><span class="signature">&lt;R&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;R&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/cast.html">cast</a></span><span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -361,8 +361,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="expand" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/expand.html">expand</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable<span class="signature">&lt;T&gt;</span></span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/expand.html">expand</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -388,7 +388,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="fold" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/fold.html">fold</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+          <span class="name"><a href="fake/SpecialList/fold.html">fold</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
             <span class="returntype parameter">&#8594; T</span>
           </span>
         </dt>
@@ -496,8 +496,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="map" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/map.html">map</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/map.html">map</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -586,8 +586,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="retype" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/retype.html">retype</a></span><span class="signature">&lt;R&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;R&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/retype.html">retype</a></span><span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -721,8 +721,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="whereType" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/whereType.html">whereType</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/whereType.html">whereType</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">

--- a/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList/ExtraSpecialList.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">ExtraSpecialList constructor</li>
   </ol>
   <div class="self-name">ExtraSpecialList</div>
@@ -120,11 +120,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ExtraSpecialList&lt;E&gt; constructor</h1>
+    <h1>ExtraSpecialList&lt;<wbr><span class="type-parameter">E</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">ExtraSpecialList&lt;E&gt;</span>(<wbr>)
+      <span class="name ">ExtraSpecialList&lt;<wbr><span class="type-parameter">E</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">GenericTypedef&lt;T&gt; typedef</li>
+    <li class="self-crumb">GenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</li>
   </ol>
   <div class="self-name">GenericTypedef</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>GenericTypedef&lt;T&gt; typedef</h1>
+    <h1>GenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">T</span>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">HasGenericWithExtends<span class="signature">&lt;T extends <a href="fake/Foo2-class.html">Foo2</a>&gt;</span> class</li>
+    <li class="self-crumb">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends <a href="fake/Foo2-class.html">Foo2</a></span>&gt;</span> class</li>
   </ol>
   <div class="self-name">HasGenericWithExtends</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>HasGenericWithExtends&lt;T extends Foo2&gt; class</h1>
+    <h1>HasGenericWithExtends&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>I have a generic and it extends <a href="fake/Foo2-class.html">Foo2</a></p>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/HasGenericWithExtends.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;T extends Foo2&gt;</span></a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span></a></li>
     <li class="self-crumb">HasGenericWithExtends constructor</li>
   </ol>
   <div class="self-name">HasGenericWithExtends</div>
@@ -61,11 +61,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>HasGenericWithExtends&lt;T extends Foo2&gt; constructor</h1>
+    <h1>HasGenericWithExtends&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">HasGenericWithExtends&lt;T extends Foo2&gt;</span>(<wbr>)
+      <span class="name ">HasGenericWithExtends&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;T extends Foo2&gt;</span></a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;T extends Foo2&gt;</span></a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;T extends Foo2&gt;</span></a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;T extends Foo2&gt;</span></a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;T extends Foo2&gt;</span></a></li>
+    <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends<span class="signature">&lt;<wbr><span class="type-parameter">T extends Foo2</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span> class</li>
+    <li class="self-crumb">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">HasGenerics</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>HasGenerics&lt;X, Y, Z&gt; class</h1>
+    <h1>HasGenerics&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt; class</h1>
 
     
 
@@ -199,7 +199,7 @@
       <dl class="callables">
         <dt id="convertToMap" class="callable">
           <span class="name"><a href="fake/HasGenerics/convertToMap.html">convertToMap</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;X, Y&gt;</span></span>
+            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>&gt;</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
+++ b/testing/test_package_docs/fake/HasGenerics/HasGenerics.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">HasGenerics constructor</li>
   </ol>
   <div class="self-name">HasGenerics</div>
@@ -65,11 +65,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>HasGenerics&lt;X, Y, Z&gt; constructor</h1>
+    <h1>HasGenerics&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">HasGenerics&lt;X, Y, Z&gt;</span>(<wbr><span class="parameter" id="-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="-param-y"><span class="type-annotation">Y</span> <span class="parameter-name">y</span>, </span> <span class="parameter" id="-param-z"><span class="type-annotation">Z</span> <span class="parameter-name">z</span></span>)
+      <span class="name ">HasGenerics&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span>(<wbr><span class="parameter" id="-param-x"><span class="type-annotation">X</span> <span class="parameter-name">x</span>, </span> <span class="parameter" id="-param-y"><span class="type-annotation">Y</span> <span class="parameter-name">y</span>, </span> <span class="parameter" id="-param-z"><span class="type-annotation">Z</span> <span class="parameter-name">z</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/HasGenerics/convertToMap.html
+++ b/testing/test_package_docs/fake/HasGenerics/convertToMap.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">convertToMap method</li>
   </ol>
   <div class="self-name">convertToMap</div>
@@ -68,7 +68,7 @@
     <h1>convertToMap method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Map<span class="signature">&lt;X, Y&gt;</span></span>
+      <span class="returntype">Map<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>&gt;</span></span>
       <span class="name ">convertToMap</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/HasGenerics/doStuff.html
+++ b/testing/test_package_docs/fake/HasGenerics/doStuff.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">doStuff method</li>
   </ol>
   <div class="self-name">doStuff</div>

--- a/testing/test_package_docs/fake/HasGenerics/hashCode.html
+++ b/testing/test_package_docs/fake/HasGenerics/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasGenerics/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/HasGenerics/operator_equals.html
+++ b/testing/test_package_docs/fake/HasGenerics/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/HasGenerics/returnX.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnX.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">returnX method</li>
   </ol>
   <div class="self-name">returnX</div>

--- a/testing/test_package_docs/fake/HasGenerics/returnZ.html
+++ b/testing/test_package_docs/fake/HasGenerics/returnZ.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">returnZ method</li>
   </ol>
   <div class="self-name">returnZ</div>

--- a/testing/test_package_docs/fake/HasGenerics/runtimeType.html
+++ b/testing/test_package_docs/fake/HasGenerics/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/HasGenerics/toString.html
+++ b/testing/test_package_docs/fake/HasGenerics/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;X, Y, Z&gt;</span></a></li>
+    <li><a href="fake/HasGenerics-class.html">HasGenerics<span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -166,7 +166,7 @@
         <dt>Implements</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">
-            <li>Future<span class="signature">&lt;void&gt;</span></li>
+            <li>Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></li>
           </ul>
         </dd>
 
@@ -216,7 +216,7 @@
       <dl class="callables">
         <dt id="asStream" class="callable inherited">
           <span class="name"><a href="fake/ImplementsFutureVoid/asStream.html">asStream</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Stream<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Stream<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -225,7 +225,7 @@
 </dd>
         <dt id="catchError" class="callable inherited">
           <span class="name"><a href="fake/ImplementsFutureVoid/catchError.html">catchError</a></span><span class="signature">(<wbr><span class="parameter" id="catchError-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span>, {</span> <span class="parameter" id="catchError-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-error"><span class="type-annotation">Object</span> <span class="parameter-name">error</span></span>)</span> })
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -242,8 +242,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="then" class="callable inherited">
-          <span class="name"><a href="fake/ImplementsFutureVoid/then.html">then</a></span><span class="signature">&lt;S&gt;</span><span class="signature">(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;S&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;S&gt;</span></span>
+          <span class="name"><a href="fake/ImplementsFutureVoid/then.html">then</a></span><span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -251,8 +251,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="timeout" class="callable inherited">
-          <span class="name"><a href="fake/ImplementsFutureVoid/timeout.html">timeout</a></span><span class="signature">(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+          <span class="name"><a href="fake/ImplementsFutureVoid/timeout.html">timeout</a></span><span class="signature">(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -270,7 +270,7 @@
 </dd>
         <dt id="whenComplete" class="callable inherited">
           <span class="name"><a href="fake/ImplementsFutureVoid/whenComplete.html">whenComplete</a></span><span class="signature">(<wbr><span class="parameter" id="whenComplete-param-action"><span class="type-annotation">FutureOr</span> <span class="parameter-name">action</span>()</span>)
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">

--- a/testing/test_package_docs/fake/ImplementsFutureVoid/asStream.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid/asStream.html
@@ -69,7 +69,7 @@
     <h1>asStream method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Stream<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Stream<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">asStream</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid/catchError.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid/catchError.html
@@ -69,7 +69,7 @@
     <h1>catchError method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">catchError</span>
 (<wbr><span class="parameter" id="catchError-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span>, {</span> <span class="parameter" id="catchError-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-error"><span class="type-annotation">Object</span> <span class="parameter-name">error</span></span>)</span> })
     </section>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid/then.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid/then.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
     <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
-    <li class="self-crumb">then&lt;S&gt; abstract method</li>
+    <li class="self-crumb">then&lt;<wbr><span class="type-parameter">S</span>&gt; abstract method</li>
   </ol>
   <div class="self-name">then</div>
   <form class="search navbar-right" role="search">
@@ -66,12 +66,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>then&lt;S&gt; method</h1>
+    <h1>then&lt;<wbr><span class="type-parameter">S</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;S&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span>
       <span class="name ">then</span>
-&lt;S&gt;(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;S&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
+&lt;<wbr><span class="type-parameter">S</span>&gt;(<wbr><span class="parameter" id="then-param-onValue"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span> <span class="parameter-name">onValue</span>(<span class="parameter" id="onValue-param-value"><span class="type-annotation">T</span> <span class="parameter-name">value</span></span>), {</span> <span class="parameter" id="then-param-onError"><span class="type-annotation">Function</span> <span class="parameter-name">onError</span></span> })
     </section>
     
     

--- a/testing/test_package_docs/fake/ImplementsFutureVoid/timeout.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid/timeout.html
@@ -69,9 +69,9 @@
     <h1>timeout method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">timeout</span>
-(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
+(<wbr><span class="parameter" id="timeout-param-timeLimit"><span class="type-annotation">Duration</span> <span class="parameter-name">timeLimit</span>, {</span> <span class="parameter" id="timeout-param-onTimeout"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">onTimeout</span>()</span> })
     </section>
     
     

--- a/testing/test_package_docs/fake/ImplementsFutureVoid/whenComplete.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid/whenComplete.html
@@ -69,7 +69,7 @@
     <h1>whenComplete method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+      <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
       <span class="name ">whenComplete</span>
 (<wbr><span class="parameter" id="whenComplete-param-action"><span class="type-annotation">FutureOr</span> <span class="parameter-name">action</span>()</span>)
     </section>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -193,7 +193,7 @@ they are correct.</p>
       <dl class="properties">
         <dt id="explicitGetterImplicitSetter" class="property">
           <span class="name"><a href="fake/ImplicitProperties/explicitGetterImplicitSetter.html">explicitGetterImplicitSetter</a></span>
-          <span class="signature">&#8596; List<span class="signature">&lt;int&gt;</span></span>
+          <span class="signature">&#8596; List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>
         </dt>
         <dd>
           Docs for explicitGetterImplicitSetter from ImplicitProperties.

--- a/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
+++ b/testing/test_package_docs/fake/ImplicitProperties/explicitGetterImplicitSetter.html
@@ -69,7 +69,7 @@
     <h1>explicitGetterImplicitSetter property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype">List<span class="signature">&lt;int&gt;</span></span>
+          <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>
           <span class="name ">explicitGetterImplicitSetter</span>
           <div class="features">read / write</div>
         </section>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -255,7 +255,7 @@ across... wait for it... two physical lines.</p>
 </dd>
         <dt id="powers" class="property inherited">
           <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
-          <span class="signature">&#8596; List<span class="signature">&lt;String&gt;</span></span>
+          <span class="signature">&#8596; List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>
         </dt>
         <dd class="inherited">
           In the super class.

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">MIEEBase<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+    <li class="self-crumb">MIEEBase<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span> abstract class</li>
   </ol>
   <div class="self-name">MIEEBase</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEBase&lt;K, V&gt; class</h1>
+    <h1>MIEEBase&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; class</h1>
 
     
     <section>
@@ -162,7 +162,7 @@
         <dt>Inheritance</dt>
         <dd><ul class="gt-separated dark clazz-relationships">
           <li>Object</li>
-          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;K, V&gt;</span></li>
+          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></li>
           <li>MIEEBase</li>
         </ul></dd>
 

--- a/testing/test_package_docs/fake/MIEEBase/MIEEBase.html
+++ b/testing/test_package_docs/fake/MIEEBase/MIEEBase.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEBase-class.html">MIEEBase<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEBase-class.html">MIEEBase<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">MIEEBase constructor</li>
   </ol>
   <div class="self-name">MIEEBase</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEBase&lt;K, V&gt; constructor</h1>
+    <h1>MIEEBase&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">MIEEBase&lt;K, V&gt;</span>(<wbr>)
+      <span class="name ">MIEEBase&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">MIEEMixin<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+    <li class="self-crumb">MIEEMixin<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span> abstract class</li>
   </ol>
   <div class="self-name">MIEEMixin</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEMixin&lt;K, V&gt; class</h1>
+    <h1>MIEEMixin&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; class</h1>
 
     
     <section>
@@ -163,7 +163,7 @@
         <dt>Implements</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">
-            <li><a href="fake/MIEEThing-class.html">MIEEThing</a><span class="signature">&lt;K, V&gt;</span></li>
+            <li><a href="fake/MIEEThing-class.html">MIEEThing</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></li>
           </ul>
         </dd>
 

--- a/testing/test_package_docs/fake/MIEEMixin/MIEEMixin.html
+++ b/testing/test_package_docs/fake/MIEEMixin/MIEEMixin.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEMixin-class.html">MIEEMixin<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEMixin-class.html">MIEEMixin<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">MIEEMixin constructor</li>
   </ol>
   <div class="self-name">MIEEMixin</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEMixin&lt;K, V&gt; constructor</h1>
+    <h1>MIEEMixin&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">MIEEMixin&lt;K, V&gt;</span>(<wbr>)
+      <span class="name ">MIEEMixin&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/MIEEMixin/operator_put.html
+++ b/testing/test_package_docs/fake/MIEEMixin/operator_put.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEMixin-class.html">MIEEMixin<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEMixin-class.html">MIEEMixin<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">operator []= abstract method</li>
   </ol>
   <div class="self-name">operator []=</div>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">MIEEMixinWithOverride<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+    <li class="self-crumb">MIEEMixinWithOverride<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span> abstract class</li>
   </ol>
   <div class="self-name">MIEEMixinWithOverride</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEMixinWithOverride&lt;K, V&gt; class</h1>
+    <h1>MIEEMixinWithOverride&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>Test an edge case for cases where inherited ExecutableElements can come
@@ -167,8 +167,8 @@ class still takes precedence (#1561).</p>
         <dt>Inheritance</dt>
         <dd><ul class="gt-separated dark clazz-relationships">
           <li>Object</li>
-          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;K, V&gt;</span></li>
-          <li><a href="fake/MIEEBase-class.html">MIEEBase</a><span class="signature">&lt;K, V&gt;</span></li>
+          <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></li>
+          <li><a href="fake/MIEEBase-class.html">MIEEBase</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></li>
           <li>MIEEMixinWithOverride</li>
         </ul></dd>
 

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride/MIEEMixinWithOverride.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">MIEEMixinWithOverride constructor</li>
   </ol>
   <div class="self-name">MIEEMixinWithOverride</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEMixinWithOverride&lt;K, V&gt; constructor</h1>
+    <h1>MIEEMixinWithOverride&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">MIEEMixinWithOverride&lt;K, V&gt;</span>(<wbr>)
+      <span class="name ">MIEEMixinWithOverride&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride/operator_put.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride/operator_put.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">operator []= method</li>
   </ol>
   <div class="self-name">operator []=</div>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">MIEEThing<span class="signature">&lt;K, V&gt;</span> abstract class</li>
+    <li class="self-crumb">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span> abstract class</li>
   </ol>
   <div class="self-name">MIEEThing</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEThing&lt;K, V&gt; class</h1>
+    <h1>MIEEThing&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; class</h1>
 
     
     <section>

--- a/testing/test_package_docs/fake/MIEEThing/MIEEThing.html
+++ b/testing/test_package_docs/fake/MIEEThing/MIEEThing.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">MIEEThing constructor</li>
   </ol>
   <div class="self-name">MIEEThing</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>MIEEThing&lt;K, V&gt; constructor</h1>
+    <h1>MIEEThing&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">MIEEThing&lt;K, V&gt;</span>(<wbr>)
+      <span class="name ">MIEEThing&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/MIEEThing/hashCode.html
+++ b/testing/test_package_docs/fake/MIEEThing/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/MIEEThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/MIEEThing/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/MIEEThing/operator_equals.html
+++ b/testing/test_package_docs/fake/MIEEThing/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/MIEEThing/operator_put.html
+++ b/testing/test_package_docs/fake/MIEEThing/operator_put.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">operator []= abstract method</li>
   </ol>
   <div class="self-name">operator []=</div>

--- a/testing/test_package_docs/fake/MIEEThing/runtimeType.html
+++ b/testing/test_package_docs/fake/MIEEThing/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/MIEEThing/toString.html
+++ b/testing/test_package_docs/fake/MIEEThing/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;K, V&gt;</span></a></li>
+    <li><a href="fake/MIEEThing-class.html">MIEEThing<span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">NewGenericTypedef&lt;T&gt; typedef</li>
+    <li class="self-crumb">NewGenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</li>
   </ol>
   <div class="self-name">NewGenericTypedef</div>
   <form class="search navbar-right" role="search">
@@ -154,12 +154,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>NewGenericTypedef&lt;T&gt; typedef</h1>
+    <h1>NewGenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">List<span class="signature">&lt;S&gt;</span></span>
+        <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span>
         <span class="name ">NewGenericTypedef</span>
-&lt;S&gt;(<wbr><span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">T</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">int</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">bool</span></span>)
+&lt;<wbr><span class="type-parameter">S</span>&gt;(<wbr><span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">T</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">int</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">bool</span></span>)
     </section>
 
     <section class="desc markdown">

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">OtherGenericsThing<span class="signature">&lt;A&gt;</span> class</li>
+    <li class="self-crumb">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">OtherGenericsThing</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>OtherGenericsThing&lt;A&gt; class</h1>
+    <h1>OtherGenericsThing&lt;<wbr><span class="type-parameter">A</span>&gt; class</h1>
 
     
 
@@ -199,7 +199,7 @@
       <dl class="callables">
         <dt id="convert" class="callable">
           <span class="name"><a href="fake/OtherGenericsThing/convert.html">convert</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; <a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;A, <a href="fake/Cool-class.html">Cool</a>, String&gt;</span></span>
+            <span class="returntype parameter">&#8594; <a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter"><a href="fake/Cool-class.html">Cool</a></span>, <span class="type-parameter">String</span>&gt;</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/OtherGenericsThing.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">OtherGenericsThing constructor</li>
   </ol>
   <div class="self-name">OtherGenericsThing</div>
@@ -62,11 +62,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>OtherGenericsThing&lt;A&gt; constructor</h1>
+    <h1>OtherGenericsThing&lt;<wbr><span class="type-parameter">A</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">OtherGenericsThing&lt;A&gt;</span>(<wbr>)
+      <span class="name ">OtherGenericsThing&lt;<wbr><span class="type-parameter">A</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/OtherGenericsThing/convert.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/convert.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">convert method</li>
   </ol>
   <div class="self-name">convert</div>
@@ -65,7 +65,7 @@
     <h1>convert method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;A, <a href="fake/Cool-class.html">Cool</a>, String&gt;</span></span>
+      <span class="returntype"><a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter"><a href="fake/Cool-class.html">Cool</a></span>, <span class="type-parameter">String</span>&gt;</span></span>
       <span class="name ">convert</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/OtherGenericsThing/toString.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;A&gt;</span></a></li>
+    <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing<span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">SpecialList<span class="signature">&lt;E&gt;</span> class</li>
+    <li class="self-crumb">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">SpecialList</div>
   <form class="search navbar-right" role="search">
@@ -154,7 +154,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>SpecialList&lt;E&gt; class</h1>
+    <h1>SpecialList&lt;<wbr><span class="type-parameter">E</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>Extends <code>ListBase</code></p>
@@ -165,7 +165,7 @@
         <dt>Inheritance</dt>
         <dd><ul class="gt-separated dark clazz-relationships">
           <li>Object</li>
-          <li>ListBase<span class="signature">&lt;E&gt;</span></li>
+          <li>ListBase<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></li>
           <li>SpecialList</li>
         </ul></dd>
 
@@ -238,7 +238,7 @@
 </dd>
         <dt id="iterator" class="property inherited">
           <span class="name"><a href="fake/SpecialList/iterator.html">iterator</a></span>
-          <span class="signature">&#8594; Iterator<span class="signature">&lt;E&gt;</span></span>
+          <span class="signature">&#8594; Iterator<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
         </dt>
         <dd class="inherited">
           
@@ -254,7 +254,7 @@
 </dd>
         <dt id="reversed" class="property inherited">
           <span class="name"><a href="fake/SpecialList/reversed.html">reversed</a></span>
-          <span class="signature">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+          <span class="signature">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
         </dt>
         <dd class="inherited">
           
@@ -292,7 +292,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="addAll" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/addAll.html">addAll</a></span><span class="signature">(<wbr><span class="parameter" id="addAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span></span>)
+          <span class="name"><a href="fake/SpecialList/addAll.html">addAll</a></span><span class="signature">(<wbr><span class="parameter" id="addAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -311,7 +311,7 @@
 </dd>
         <dt id="asMap" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/asMap.html">asMap</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;int, E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -319,8 +319,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="cast" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/cast.html">cast</a></span><span class="signature">&lt;R&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;R&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/cast.html">cast</a></span><span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -364,8 +364,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="expand" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/expand.html">expand</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable<span class="signature">&lt;T&gt;</span></span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/expand.html">expand</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -391,7 +391,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="fold" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/fold.html">fold</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+          <span class="name"><a href="fake/SpecialList/fold.html">fold</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
             <span class="returntype parameter">&#8594; T</span>
           </span>
         </dt>
@@ -400,8 +400,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="followedBy" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/followedBy.html">followedBy</a></span><span class="signature">(<wbr><span class="parameter" id="followedBy-param-other"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/followedBy.html">followedBy</a></span><span class="signature">(<wbr><span class="parameter" id="followedBy-param-other"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -419,7 +419,7 @@
 </dd>
         <dt id="getRange" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/getRange.html">getRange</a></span><span class="signature">(<wbr><span class="parameter" id="getRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="getRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -454,7 +454,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="insertAll" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/insertAll.html">insertAll</a></span><span class="signature">(<wbr><span class="parameter" id="insertAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="insertAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span></span>)
+          <span class="name"><a href="fake/SpecialList/insertAll.html">insertAll</a></span><span class="signature">(<wbr><span class="parameter" id="insertAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="insertAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -499,8 +499,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="map" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/map.html">map</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/map.html">map</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -571,7 +571,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="replaceRange" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/replaceRange.html">replaceRange</a></span><span class="signature">(<wbr><span class="parameter" id="replaceRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="replaceRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="replaceRange-param-newContents"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">newContents</span></span>)
+          <span class="name"><a href="fake/SpecialList/replaceRange.html">replaceRange</a></span><span class="signature">(<wbr><span class="parameter" id="replaceRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="replaceRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="replaceRange-param-newContents"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">newContents</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -589,8 +589,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="retype" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/retype.html">retype</a></span><span class="signature">&lt;R&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;R&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/retype.html">retype</a></span><span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -598,7 +598,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="setAll" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/setAll.html">setAll</a></span><span class="signature">(<wbr><span class="parameter" id="setAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="setAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span></span>)
+          <span class="name"><a href="fake/SpecialList/setAll.html">setAll</a></span><span class="signature">(<wbr><span class="parameter" id="setAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="setAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -607,7 +607,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="setRange" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/setRange.html">setRange</a></span><span class="signature">(<wbr><span class="parameter" id="setRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="setRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="setRange-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span>, [</span> <span class="parameter" id="setRange-param-skipCount"><span class="type-annotation">int</span> <span class="parameter-name">skipCount</span> = <span class="default-value">0</span></span> ])
+          <span class="name"><a href="fake/SpecialList/setRange.html">setRange</a></span><span class="signature">(<wbr><span class="parameter" id="setRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="setRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="setRange-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span>, [</span> <span class="parameter" id="setRange-param-skipCount"><span class="type-annotation">int</span> <span class="parameter-name">skipCount</span> = <span class="default-value">0</span></span> ])
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -635,7 +635,7 @@
 </dd>
         <dt id="skip" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/skip.html">skip</a></span><span class="signature">(<wbr><span class="parameter" id="skip-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -644,7 +644,7 @@
 </dd>
         <dt id="skipWhile" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/skipWhile.html">skipWhile</a></span><span class="signature">(<wbr><span class="parameter" id="skipWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -662,7 +662,7 @@
 </dd>
         <dt id="sublist" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/sublist.html">sublist</a></span><span class="signature">(<wbr><span class="parameter" id="sublist-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, [</span> <span class="parameter" id="sublist-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span> ])
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -671,7 +671,7 @@
 </dd>
         <dt id="take" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/take.html">take</a></span><span class="signature">(<wbr><span class="parameter" id="take-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -680,7 +680,7 @@
 </dd>
         <dt id="takeWhile" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/takeWhile.html">takeWhile</a></span><span class="signature">(<wbr><span class="parameter" id="takeWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -689,7 +689,7 @@
 </dd>
         <dt id="toList" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/toList.html">toList</a></span><span class="signature">(<wbr>{<span class="parameter" id="toList-param-growable"><span class="type-annotation">bool</span> <span class="parameter-name">growable</span>: <span class="default-value">true</span></span> })
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -698,7 +698,7 @@
 </dd>
         <dt id="toSet" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/toSet.html">toSet</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Set<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Set<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -716,7 +716,7 @@
 </dd>
         <dt id="where" class="callable inherited">
           <span class="name"><a href="fake/SpecialList/where.html">where</a></span><span class="signature">(<wbr><span class="parameter" id="where-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;E&gt;</span></span>
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -724,8 +724,8 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="whereType" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/whereType.html">whereType</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/whereType.html">whereType</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -757,8 +757,8 @@
           
 </dd>
         <dt id="operator +" class="callable inherited">
-          <span class="name"><a href="fake/SpecialList/operator_plus.html">operator +</a></span><span class="signature">(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation">List<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;E&gt;</span></span>
+          <span class="name"><a href="fake/SpecialList/operator_plus.html">operator +</a></span><span class="signature">(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">

--- a/testing/test_package_docs/fake/SpecialList/SpecialList.html
+++ b/testing/test_package_docs/fake/SpecialList/SpecialList.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">SpecialList constructor</li>
   </ol>
   <div class="self-name">SpecialList</div>
@@ -120,11 +120,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>SpecialList&lt;E&gt; constructor</h1>
+    <h1>SpecialList&lt;<wbr><span class="type-parameter">E</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">SpecialList&lt;E&gt;</span>(<wbr>)
+      <span class="name ">SpecialList&lt;<wbr><span class="type-parameter">E</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/fake/SpecialList/add.html
+++ b/testing/test_package_docs/fake/SpecialList/add.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">add method</li>
   </ol>
   <div class="self-name">add</div>

--- a/testing/test_package_docs/fake/SpecialList/addAll.html
+++ b/testing/test_package_docs/fake/SpecialList/addAll.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">addAll method</li>
   </ol>
   <div class="self-name">addAll</div>
@@ -125,7 +125,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">addAll</span>
-(<wbr><span class="parameter" id="addAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span></span>)
+(<wbr><span class="parameter" id="addAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/any.html
+++ b/testing/test_package_docs/fake/SpecialList/any.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">any method</li>
   </ol>
   <div class="self-name">any</div>

--- a/testing/test_package_docs/fake/SpecialList/asMap.html
+++ b/testing/test_package_docs/fake/SpecialList/asMap.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">asMap method</li>
   </ol>
   <div class="self-name">asMap</div>
@@ -123,7 +123,7 @@
     <h1>asMap method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Map<span class="signature">&lt;int, E&gt;</span></span>
+      <span class="returntype">Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">asMap</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/cast.html
+++ b/testing/test_package_docs/fake/SpecialList/cast.html
@@ -25,8 +25,8 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
-    <li class="self-crumb">cast&lt;R&gt; method</li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
+    <li class="self-crumb">cast&lt;<wbr><span class="type-parameter">R</span>&gt; method</li>
   </ol>
   <div class="self-name">cast</div>
   <form class="search navbar-right" role="search">
@@ -120,12 +120,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>cast&lt;R&gt; method</h1>
+    <h1>cast&lt;<wbr><span class="type-parameter">R</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">List<span class="signature">&lt;R&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span></span>
       <span class="name ">cast</span>
-&lt;R&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">R</span>&gt;(<wbr>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/clear.html
+++ b/testing/test_package_docs/fake/SpecialList/clear.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">clear method</li>
   </ol>
   <div class="self-name">clear</div>

--- a/testing/test_package_docs/fake/SpecialList/contains.html
+++ b/testing/test_package_docs/fake/SpecialList/contains.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">contains method</li>
   </ol>
   <div class="self-name">contains</div>

--- a/testing/test_package_docs/fake/SpecialList/elementAt.html
+++ b/testing/test_package_docs/fake/SpecialList/elementAt.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">elementAt method</li>
   </ol>
   <div class="self-name">elementAt</div>

--- a/testing/test_package_docs/fake/SpecialList/every.html
+++ b/testing/test_package_docs/fake/SpecialList/every.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">every method</li>
   </ol>
   <div class="self-name">every</div>

--- a/testing/test_package_docs/fake/SpecialList/expand.html
+++ b/testing/test_package_docs/fake/SpecialList/expand.html
@@ -25,8 +25,8 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
-    <li class="self-crumb">expand&lt;T&gt; method</li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
+    <li class="self-crumb">expand&lt;<wbr><span class="type-parameter">T</span>&gt; method</li>
   </ol>
   <div class="self-name">expand</div>
   <form class="search navbar-right" role="search">
@@ -120,12 +120,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>expand&lt;T&gt; method</h1>
+    <h1>expand&lt;<wbr><span class="type-parameter">T</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;T&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
       <span class="name ">expand</span>
-&lt;T&gt;(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable<span class="signature">&lt;T&gt;</span></span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr><span class="parameter" id="expand-param-f"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/fillRange.html
+++ b/testing/test_package_docs/fake/SpecialList/fillRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">fillRange method</li>
   </ol>
   <div class="self-name">fillRange</div>

--- a/testing/test_package_docs/fake/SpecialList/first.html
+++ b/testing/test_package_docs/fake/SpecialList/first.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">first property</li>
   </ol>
   <div class="self-name">first</div>

--- a/testing/test_package_docs/fake/SpecialList/firstWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/firstWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">firstWhere method</li>
   </ol>
   <div class="self-name">firstWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/fold.html
+++ b/testing/test_package_docs/fake/SpecialList/fold.html
@@ -25,8 +25,8 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
-    <li class="self-crumb">fold&lt;T&gt; method</li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
+    <li class="self-crumb">fold&lt;<wbr><span class="type-parameter">T</span>&gt; method</li>
   </ol>
   <div class="self-name">fold</div>
   <form class="search navbar-right" role="search">
@@ -120,12 +120,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>fold&lt;T&gt; method</h1>
+    <h1>fold&lt;<wbr><span class="type-parameter">T</span>&gt; method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">T</span>
       <span class="name ">fold</span>
-&lt;T&gt;(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr><span class="parameter" id="fold-param-initialValue"><span class="type-annotation">T</span> <span class="parameter-name">initialValue</span>, </span> <span class="parameter" id="fold-param-combine"><span class="type-annotation">T</span> <span class="parameter-name">combine</span>(<span class="parameter" id="combine-param-previousValue"><span class="type-annotation">T</span> <span class="parameter-name">previousValue</span>, </span> <span class="parameter" id="combine-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/followedBy.html
+++ b/testing/test_package_docs/fake/SpecialList/followedBy.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">followedBy method</li>
   </ol>
   <div class="self-name">followedBy</div>
@@ -123,9 +123,9 @@
     <h1>followedBy method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">followedBy</span>
-(<wbr><span class="parameter" id="followedBy-param-other"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">other</span></span>)
+(<wbr><span class="parameter" id="followedBy-param-other"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/forEach.html
+++ b/testing/test_package_docs/fake/SpecialList/forEach.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">forEach method</li>
   </ol>
   <div class="self-name">forEach</div>

--- a/testing/test_package_docs/fake/SpecialList/getRange.html
+++ b/testing/test_package_docs/fake/SpecialList/getRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">getRange method</li>
   </ol>
   <div class="self-name">getRange</div>
@@ -123,7 +123,7 @@
     <h1>getRange method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">getRange</span>
 (<wbr><span class="parameter" id="getRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="getRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/hashCode.html
+++ b/testing/test_package_docs/fake/SpecialList/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/fake/SpecialList/indexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/indexOf.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">indexOf method</li>
   </ol>
   <div class="self-name">indexOf</div>

--- a/testing/test_package_docs/fake/SpecialList/indexWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/indexWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">indexWhere method</li>
   </ol>
   <div class="self-name">indexWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/insert.html
+++ b/testing/test_package_docs/fake/SpecialList/insert.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">insert method</li>
   </ol>
   <div class="self-name">insert</div>

--- a/testing/test_package_docs/fake/SpecialList/insertAll.html
+++ b/testing/test_package_docs/fake/SpecialList/insertAll.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">insertAll method</li>
   </ol>
   <div class="self-name">insertAll</div>
@@ -125,7 +125,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">insertAll</span>
-(<wbr><span class="parameter" id="insertAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="insertAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span></span>)
+(<wbr><span class="parameter" id="insertAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="insertAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/isEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isEmpty.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">isEmpty property</li>
   </ol>
   <div class="self-name">isEmpty</div>

--- a/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
+++ b/testing/test_package_docs/fake/SpecialList/isNotEmpty.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">isNotEmpty property</li>
   </ol>
   <div class="self-name">isNotEmpty</div>

--- a/testing/test_package_docs/fake/SpecialList/iterator.html
+++ b/testing/test_package_docs/fake/SpecialList/iterator.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">iterator property</li>
   </ol>
   <div class="self-name">iterator</div>
@@ -126,7 +126,7 @@
         <section id="getter">
         
         <section class="multi-line-signature">
-          <span class="returntype">Iterator<span class="signature">&lt;E&gt;</span></span>
+          <span class="returntype">Iterator<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           <span class="name ">iterator</span>
   <div class="features">inherited</div>
 </section>

--- a/testing/test_package_docs/fake/SpecialList/join.html
+++ b/testing/test_package_docs/fake/SpecialList/join.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">join method</li>
   </ol>
   <div class="self-name">join</div>

--- a/testing/test_package_docs/fake/SpecialList/last.html
+++ b/testing/test_package_docs/fake/SpecialList/last.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">last property</li>
   </ol>
   <div class="self-name">last</div>

--- a/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexOf.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">lastIndexOf method</li>
   </ol>
   <div class="self-name">lastIndexOf</div>

--- a/testing/test_package_docs/fake/SpecialList/lastIndexWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastIndexWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">lastIndexWhere method</li>
   </ol>
   <div class="self-name">lastIndexWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/lastWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/lastWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">lastWhere method</li>
   </ol>
   <div class="self-name">lastWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/length.html
+++ b/testing/test_package_docs/fake/SpecialList/length.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">length property</li>
   </ol>
   <div class="self-name">length</div>

--- a/testing/test_package_docs/fake/SpecialList/map.html
+++ b/testing/test_package_docs/fake/SpecialList/map.html
@@ -25,8 +25,8 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
-    <li class="self-crumb">map&lt;T&gt; method</li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
+    <li class="self-crumb">map&lt;<wbr><span class="type-parameter">T</span>&gt; method</li>
   </ol>
   <div class="self-name">map</div>
   <form class="search navbar-right" role="search">
@@ -120,12 +120,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>map&lt;T&gt; method</h1>
+    <h1>map&lt;<wbr><span class="type-parameter">T</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;T&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
       <span class="name ">map</span>
-&lt;T&gt;(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr><span class="parameter" id="map-param-f"><span class="type-annotation">T</span> <span class="parameter-name">f</span>(<span class="parameter" id="f-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
+++ b/testing/test_package_docs/fake/SpecialList/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/fake/SpecialList/operator_equals.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/fake/SpecialList/operator_get.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_get.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">operator [] method</li>
   </ol>
   <div class="self-name">operator []</div>

--- a/testing/test_package_docs/fake/SpecialList/operator_plus.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_plus.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">operator + method</li>
   </ol>
   <div class="self-name">operator +</div>
@@ -123,9 +123,9 @@
     <h1>operator + method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">List<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">operator +</span>
-(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation">List<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">other</span></span>)
+(<wbr><span class="parameter" id="+-param-other"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">other</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/operator_put.html
+++ b/testing/test_package_docs/fake/SpecialList/operator_put.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">operator []= method</li>
   </ol>
   <div class="self-name">operator []=</div>

--- a/testing/test_package_docs/fake/SpecialList/reduce.html
+++ b/testing/test_package_docs/fake/SpecialList/reduce.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">reduce method</li>
   </ol>
   <div class="self-name">reduce</div>

--- a/testing/test_package_docs/fake/SpecialList/remove.html
+++ b/testing/test_package_docs/fake/SpecialList/remove.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">remove method</li>
   </ol>
   <div class="self-name">remove</div>

--- a/testing/test_package_docs/fake/SpecialList/removeAt.html
+++ b/testing/test_package_docs/fake/SpecialList/removeAt.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">removeAt method</li>
   </ol>
   <div class="self-name">removeAt</div>

--- a/testing/test_package_docs/fake/SpecialList/removeLast.html
+++ b/testing/test_package_docs/fake/SpecialList/removeLast.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">removeLast method</li>
   </ol>
   <div class="self-name">removeLast</div>

--- a/testing/test_package_docs/fake/SpecialList/removeRange.html
+++ b/testing/test_package_docs/fake/SpecialList/removeRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">removeRange method</li>
   </ol>
   <div class="self-name">removeRange</div>

--- a/testing/test_package_docs/fake/SpecialList/removeWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/removeWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">removeWhere method</li>
   </ol>
   <div class="self-name">removeWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/replaceRange.html
+++ b/testing/test_package_docs/fake/SpecialList/replaceRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">replaceRange method</li>
   </ol>
   <div class="self-name">replaceRange</div>
@@ -125,7 +125,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">replaceRange</span>
-(<wbr><span class="parameter" id="replaceRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="replaceRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="replaceRange-param-newContents"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">newContents</span></span>)
+(<wbr><span class="parameter" id="replaceRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="replaceRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="replaceRange-param-newContents"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">newContents</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/retainWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/retainWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">retainWhere method</li>
   </ol>
   <div class="self-name">retainWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/retype.html
+++ b/testing/test_package_docs/fake/SpecialList/retype.html
@@ -25,8 +25,8 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
-    <li class="self-crumb">retype&lt;R&gt; method</li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
+    <li class="self-crumb">retype&lt;<wbr><span class="type-parameter">R</span>&gt; method</li>
   </ol>
   <div class="self-name">retype</div>
   <form class="search navbar-right" role="search">
@@ -120,12 +120,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>retype&lt;R&gt; method</h1>
+    <h1>retype&lt;<wbr><span class="type-parameter">R</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">List<span class="signature">&lt;R&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">R</span>&gt;</span></span>
       <span class="name ">retype</span>
-&lt;R&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">R</span>&gt;(<wbr>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/reversed.html
+++ b/testing/test_package_docs/fake/SpecialList/reversed.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">reversed property</li>
   </ol>
   <div class="self-name">reversed</div>
@@ -126,7 +126,7 @@
         <section id="getter">
         
         <section class="multi-line-signature">
-          <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+          <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
           <span class="name ">reversed</span>
   <div class="features">inherited</div>
 </section>

--- a/testing/test_package_docs/fake/SpecialList/runtimeType.html
+++ b/testing/test_package_docs/fake/SpecialList/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/fake/SpecialList/setAll.html
+++ b/testing/test_package_docs/fake/SpecialList/setAll.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">setAll method</li>
   </ol>
   <div class="self-name">setAll</div>
@@ -125,7 +125,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">setAll</span>
-(<wbr><span class="parameter" id="setAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="setAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span></span>)
+(<wbr><span class="parameter" id="setAll-param-index"><span class="type-annotation">int</span> <span class="parameter-name">index</span>, </span> <span class="parameter" id="setAll-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span></span>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/setRange.html
+++ b/testing/test_package_docs/fake/SpecialList/setRange.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">setRange method</li>
   </ol>
   <div class="self-name">setRange</div>
@@ -125,7 +125,7 @@
     <section class="multi-line-signature">
       <span class="returntype">void</span>
       <span class="name ">setRange</span>
-(<wbr><span class="parameter" id="setRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="setRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="setRange-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;E&gt;</span></span> <span class="parameter-name">iterable</span>, [</span> <span class="parameter" id="setRange-param-skipCount"><span class="type-annotation">int</span> <span class="parameter-name">skipCount</span> = <span class="default-value">0</span></span> ])
+(<wbr><span class="parameter" id="setRange-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, </span> <span class="parameter" id="setRange-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span>, </span> <span class="parameter" id="setRange-param-iterable"><span class="type-annotation">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> <span class="parameter-name">iterable</span>, [</span> <span class="parameter" id="setRange-param-skipCount"><span class="type-annotation">int</span> <span class="parameter-name">skipCount</span> = <span class="default-value">0</span></span> ])
     </section>
     
     

--- a/testing/test_package_docs/fake/SpecialList/shuffle.html
+++ b/testing/test_package_docs/fake/SpecialList/shuffle.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">shuffle method</li>
   </ol>
   <div class="self-name">shuffle</div>

--- a/testing/test_package_docs/fake/SpecialList/single.html
+++ b/testing/test_package_docs/fake/SpecialList/single.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">single property</li>
   </ol>
   <div class="self-name">single</div>

--- a/testing/test_package_docs/fake/SpecialList/singleWhere.html
+++ b/testing/test_package_docs/fake/SpecialList/singleWhere.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">singleWhere method</li>
   </ol>
   <div class="self-name">singleWhere</div>

--- a/testing/test_package_docs/fake/SpecialList/skip.html
+++ b/testing/test_package_docs/fake/SpecialList/skip.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">skip method</li>
   </ol>
   <div class="self-name">skip</div>
@@ -123,7 +123,7 @@
     <h1>skip method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">skip</span>
 (<wbr><span class="parameter" id="skip-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/skipWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/skipWhile.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">skipWhile method</li>
   </ol>
   <div class="self-name">skipWhile</div>
@@ -123,7 +123,7 @@
     <h1>skipWhile method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">skipWhile</span>
 (<wbr><span class="parameter" id="skipWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/sort.html
+++ b/testing/test_package_docs/fake/SpecialList/sort.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">sort method</li>
   </ol>
   <div class="self-name">sort</div>

--- a/testing/test_package_docs/fake/SpecialList/sublist.html
+++ b/testing/test_package_docs/fake/SpecialList/sublist.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">sublist method</li>
   </ol>
   <div class="self-name">sublist</div>
@@ -123,7 +123,7 @@
     <h1>sublist method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">List<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">sublist</span>
 (<wbr><span class="parameter" id="sublist-param-start"><span class="type-annotation">int</span> <span class="parameter-name">start</span>, [</span> <span class="parameter" id="sublist-param-end"><span class="type-annotation">int</span> <span class="parameter-name">end</span></span> ])
     </section>

--- a/testing/test_package_docs/fake/SpecialList/take.html
+++ b/testing/test_package_docs/fake/SpecialList/take.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">take method</li>
   </ol>
   <div class="self-name">take</div>
@@ -123,7 +123,7 @@
     <h1>take method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">take</span>
 (<wbr><span class="parameter" id="take-param-count"><span class="type-annotation">int</span> <span class="parameter-name">count</span></span>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/takeWhile.html
+++ b/testing/test_package_docs/fake/SpecialList/takeWhile.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">takeWhile method</li>
   </ol>
   <div class="self-name">takeWhile</div>
@@ -123,7 +123,7 @@
     <h1>takeWhile method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">takeWhile</span>
 (<wbr><span class="parameter" id="takeWhile-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/toList.html
+++ b/testing/test_package_docs/fake/SpecialList/toList.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">toList method</li>
   </ol>
   <div class="self-name">toList</div>
@@ -123,7 +123,7 @@
     <h1>toList method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">List<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">toList</span>
 (<wbr>{<span class="parameter" id="toList-param-growable"><span class="type-annotation">bool</span> <span class="parameter-name">growable</span>: <span class="default-value">true</span></span> })
     </section>

--- a/testing/test_package_docs/fake/SpecialList/toSet.html
+++ b/testing/test_package_docs/fake/SpecialList/toSet.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">toSet method</li>
   </ol>
   <div class="self-name">toSet</div>
@@ -123,7 +123,7 @@
     <h1>toSet method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Set<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Set<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">toSet</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/toString.html
+++ b/testing/test_package_docs/fake/SpecialList/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/fake/SpecialList/where.html
+++ b/testing/test_package_docs/fake/SpecialList/where.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
     <li class="self-crumb">where method</li>
   </ol>
   <div class="self-name">where</div>
@@ -123,7 +123,7 @@
     <h1>where method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;E&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
       <span class="name ">where</span>
 (<wbr><span class="parameter" id="where-param-test"><span class="type-annotation">bool</span> <span class="parameter-name">test</span>(<span class="parameter" id="test-param-element"><span class="type-annotation">E</span> <span class="parameter-name">element</span></span>)</span>)
     </section>

--- a/testing/test_package_docs/fake/SpecialList/whereType.html
+++ b/testing/test_package_docs/fake/SpecialList/whereType.html
@@ -25,8 +25,8 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;E&gt;</span></a></li>
-    <li class="self-crumb">whereType&lt;T&gt; method</li>
+    <li><a href="fake/SpecialList-class.html">SpecialList<span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></a></li>
+    <li class="self-crumb">whereType&lt;<wbr><span class="type-parameter">T</span>&gt; method</li>
   </ol>
   <div class="self-name">whereType</div>
   <form class="search navbar-right" role="search">
@@ -120,12 +120,12 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>whereType&lt;T&gt; method</h1>
+    <h1>whereType&lt;<wbr><span class="type-parameter">T</span>&gt; method</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Iterable<span class="signature">&lt;T&gt;</span></span>
+      <span class="returntype">Iterable<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
       <span class="name ">whereType</span>
-&lt;T&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr>)
     </section>
     
     

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -196,7 +196,7 @@
       <dl class="properties">
         <dt id="powers" class="property">
           <span class="name"><a href="fake/SuperAwesomeClass/powers.html">powers</a></span>
-          <span class="signature">&#8596; List<span class="signature">&lt;String&gt;</span></span>
+          <span class="signature">&#8596; List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>
         </dt>
         <dd>
           In the super class.

--- a/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass/powers.html
@@ -67,7 +67,7 @@
     <h1>powers property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype">List<span class="signature">&lt;String&gt;</span></span>
+          <span class="returntype">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>
           <span class="name ">powers</span>
           <div class="features">read / write</div>
         </section>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -163,7 +163,7 @@
 
       <dl class="constructor-summary-list">
         <dt id="TypedefUsingClass" class="callable">
-          <span class="name"><a href="fake/TypedefUsingClass/TypedefUsingClass.html">TypedefUsingClass</a></span><span class="signature">(<span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;double&gt;</span></span> <span class="parameter-name">x</span></span>)</span>
+          <span class="name"><a href="fake/TypedefUsingClass/TypedefUsingClass.html">TypedefUsingClass</a></span><span class="signature">(<span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span> <span class="parameter-name">x</span></span>)</span>
         </dt>
         <dd>
           
@@ -177,7 +177,7 @@
       <dl class="properties">
         <dt id="x" class="property">
           <span class="name"><a href="fake/TypedefUsingClass/x.html">x</a></span>
-          <span class="signature">&#8596; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;double&gt;</span></span>
+          <span class="signature">&#8596; <a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span>
         </dt>
         <dd>
           

--- a/testing/test_package_docs/fake/TypedefUsingClass/TypedefUsingClass.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass/TypedefUsingClass.html
@@ -66,7 +66,7 @@
 
     <section class="multi-line-signature">
       
-      <span class="name ">TypedefUsingClass</span>(<wbr><span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;double&gt;</span></span> <span class="parameter-name">x</span></span>)
+      <span class="name ">TypedefUsingClass</span>(<wbr><span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span> <span class="parameter-name">x</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/fake/TypedefUsingClass/x.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass/x.html
@@ -65,7 +65,7 @@
     <h1>x property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;double&gt;</span></span>
+          <span class="returntype"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span>
           <span class="name ">x</span>
           <div class="features">read / write</div>
         </section>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/aCoolVariable.html
+++ b/testing/test_package_docs/fake/aCoolVariable.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -159,7 +159,7 @@
     <section class="multi-line-signature">
         <span class="returntype">void</span>
         <span class="name ">aVoidParameter</span>
-(<wbr><span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">p1</span></span>)
+(<wbr><span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">p1</span></span>)
     </section>
     <section class="desc markdown">
       <p>This function requires a Future<void> as a parameter</void></p>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the ZERO constant from the fake library, for the Dart programming language.">
-  <title>ZERO constant - fake library - Dart API</title>
+  <meta name="description" content="API docs for the complicatedReturn property from the fake library, for the Dart programming language.">
+  <title>complicatedReturn property - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">ZERO constant</li>
+    <li class="self-crumb">complicatedReturn property</li>
   </ol>
-  <div class="self-name">ZERO</div>
+  <div class="self-name">complicatedReturn</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -154,21 +154,23 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ZERO top-level constant</h1>
+    <h1>complicatedReturn top-level property</h1>
 
+
+    <section id="getter">
+    
     <section class="multi-line-signature">
-      const <span class="name ">ZERO</span>
-      =
-      <span class="constant-value">0</span>
-      
-    </section>
-
+      <span class="returntype"><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span></span>
+      <span class="name ">complicatedReturn</span>
+  
+</section>
+    
     <section class="desc markdown">
-      <p>A constant integer value,
-which is a bit redundant.</p>
-    </section>
-        
+  <p>A complicated type parameter to ATypeTakingClass.</p>
+</section>
 
+</section>
+    
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -160,7 +160,7 @@
     <section id="getter">
     
     <section class="multi-line-signature">
-      <span class="returntype"><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span></span>
+      <span class="returntype"><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span></span>
       <span class="name ">complicatedReturn</span>
   
 </section>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -526,6 +526,14 @@ which is a bit redundant.
           A variable initalization making use of optional new.
           <div class="features">read / write</div>
 </dd>
+        <dt id="complicatedReturn" class="property">
+          <span class="name"><a href="fake/complicatedReturn.html">complicatedReturn</a></span>
+          <span class="signature">&#8594; <a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span></span>
+        </dt>
+        <dd>
+          A complicated type parameter to ATypeTakingClass.
+          <div class="features">read-only</div>
+</dd>
         <dt id="dynamicGetter" class="property">
           <span class="name"><a href="fake/dynamicGetter.html">dynamicGetter</a></span>
           <span class="signature">&#8594; dynamic</span>
@@ -549,6 +557,14 @@ which is a bit redundant.
         <dd>
           Getter docs should be shown.
           <div class="features">read-only</div>
+</dd>
+        <dt id="importantComputations" class="property">
+          <span class="name"><a href="fake/importantComputations.html">importantComputations</a></span>
+          <span class="signature">&#8594; Map<span class="signature">&lt;int, &gt;</span></span>
+        </dt>
+        <dd>
+          Type inference mixing with anonymous functions.
+          <div class="features">final</div>
 </dd>
         <dt id="justGetter" class="property">
           <span class="name"><a href="fake/justGetter.html">justGetter</a></span>
@@ -959,9 +975,11 @@ default value.
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -124,7 +124,7 @@ Don't ask questions.</p>
           Yet another interface that can be implemented.
         </dd>
         <dt id="ATypeTakingClass">
-          <span class="name "><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="name "><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         </dt>
         <dd>
           This class takes a type, and it might be void.
@@ -166,7 +166,7 @@ Don't ask questions.</p>
           For make-better testing of constants. <a href="fake/ConstantClass-class.html">[...]</a>
         </dd>
         <dt id="ConstructorTester">
-          <span class="name "><a href="fake/ConstructorTester-class.html">ConstructorTester</a><span class="signature">&lt;A, B&gt;</span></span>
+          <span class="name "><a href="fake/ConstructorTester-class.html">ConstructorTester</a><span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">B</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -190,7 +190,7 @@ Don't ask questions.</p>
           This class extends Future<void></void>
         </dd>
         <dt id="ExtraSpecialList">
-          <span class="name "><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a><span class="signature">&lt;E&gt;</span></span>
+          <span class="name "><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a><span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
         </dt>
         <dd>
           This inherits operators.
@@ -202,13 +202,13 @@ Don't ask questions.</p>
           link to method from class <a href="ex/Apple/m.html">Apple.m</a>
         </dd>
         <dt id="HasGenerics">
-          <span class="name "><a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;X, Y, Z&gt;</span></span>
+          <span class="name "><a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></span>
         </dt>
         <dd>
           
         </dd>
         <dt id="HasGenericWithExtends">
-          <span class="name "><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a><span class="signature">&lt;T extends <a href="fake/Foo2-class.html">Foo2</a>&gt;</span></span>
+          <span class="name "><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a><span class="signature">&lt;<wbr><span class="type-parameter">T extends <a href="fake/Foo2-class.html">Foo2</a></span>&gt;</span></span>
         </dt>
         <dd>
           I have a generic and it extends <a href="fake/Foo2-class.html">Foo2</a>
@@ -264,19 +264,19 @@ they are correct.
 across... wait for it... two physical lines. <a href="fake/LongFirstLine-class.html">[...]</a>
         </dd>
         <dt id="MIEEBase">
-          <span class="name "><a href="fake/MIEEBase-class.html">MIEEBase</a><span class="signature">&lt;K, V&gt;</span></span>
+          <span class="name "><a href="fake/MIEEBase-class.html">MIEEBase</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></span>
         </dt>
         <dd>
           
         </dd>
         <dt id="MIEEMixin">
-          <span class="name "><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;K, V&gt;</span></span>
+          <span class="name "><a href="fake/MIEEMixin-class.html">MIEEMixin</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></span>
         </dt>
         <dd>
           
         </dd>
         <dt id="MIEEMixinWithOverride">
-          <span class="name "><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a><span class="signature">&lt;K, V&gt;</span></span>
+          <span class="name "><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></span>
         </dt>
         <dd>
           Test an edge case for cases where inherited ExecutableElements can come
@@ -284,7 +284,7 @@ both from private classes and public interfaces.  The test makes sure the
 class still takes precedence (#1561).
         </dd>
         <dt id="MIEEThing">
-          <span class="name "><a href="fake/MIEEThing-class.html">MIEEThing</a><span class="signature">&lt;K, V&gt;</span></span>
+          <span class="name "><a href="fake/MIEEThing-class.html">MIEEThing</a><span class="signature">&lt;<wbr><span class="type-parameter">K</span>, <span class="type-parameter">V</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -308,7 +308,7 @@ class still takes precedence (#1561).
           Test operator references: <a href="fake/OperatorReferenceClass/operator_equals.html">OperatorReferenceClass.==</a>.
         </dd>
         <dt id="OtherGenericsThing">
-          <span class="name "><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a><span class="signature">&lt;A&gt;</span></span>
+          <span class="name "><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a><span class="signature">&lt;<wbr><span class="type-parameter">A</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -320,7 +320,7 @@ class still takes precedence (#1561).
           
         </dd>
         <dt id="SpecialList">
-          <span class="name "><a href="fake/SpecialList-class.html">SpecialList</a><span class="signature">&lt;E&gt;</span></span>
+          <span class="name "><a href="fake/SpecialList-class.html">SpecialList</a><span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span>
         </dt>
         <dd>
           Extends <code>ListBase</code>
@@ -424,7 +424,7 @@ class still takes precedence (#1561).
         </dd>
         <dt id="myMap" class="constant">
           <span class="name "><a href="fake/myMap-constant.html">myMap</a></span>
-          <span class="signature">&#8594; const Map<span class="signature">&lt;int, String&gt;</span></span>
+          <span class="signature">&#8594; const Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">String</span>&gt;</span></span>
         </dt>
         <dd>
           A map initialization making use of optional const.
@@ -528,7 +528,7 @@ which is a bit redundant.
 </dd>
         <dt id="complicatedReturn" class="property">
           <span class="name"><a href="fake/complicatedReturn.html">complicatedReturn</a></span>
-          <span class="signature">&#8594; <a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span>&gt;</span></span>
+          <span class="signature">&#8594; <a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span></span>
         </dt>
         <dd>
           A complicated type parameter to ATypeTakingClass.
@@ -560,7 +560,7 @@ which is a bit redundant.
 </dd>
         <dt id="importantComputations" class="property">
           <span class="name"><a href="fake/importantComputations.html">importantComputations</a></span>
-          <span class="signature">&#8594; Map<span class="signature">&lt;int, &gt;</span></span>
+          <span class="signature">&#8594; Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">(<span class="parameter" id="null-param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span></span>) → dynamic</span>&gt;</span></span>
         </dt>
         <dd>
           Type inference mixing with anonymous functions.
@@ -584,7 +584,7 @@ which is a bit redundant.
 </dd>
         <dt id="mapWithDynamicKeys" class="property">
           <span class="name"><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></span>
-          <span class="signature">&#8596; Map<span class="signature">&lt;dynamic, String&gt;</span></span>
+          <span class="signature">&#8596; Map<span class="signature">&lt;<wbr><span class="type-parameter">dynamic</span>, <span class="type-parameter">String</span>&gt;</span></span>
         </dt>
         <dd>
           
@@ -640,7 +640,7 @@ which is a bit redundant.
           
 </dd>
         <dt id="aVoidParameter" class="callable">
-          <span class="name"><a href="fake/aVoidParameter.html">aVoidParameter</a></span><span class="signature">(<wbr><span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;void&gt;</span></span> <span class="parameter-name">p1</span></span>)
+          <span class="name"><a href="fake/aVoidParameter.html">aVoidParameter</a></span><span class="signature">(<wbr><span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">p1</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -658,7 +658,7 @@ which is a bit redundant.
           
 </dd>
         <dt id="myGenericFunction" class="callable">
-          <span class="name"><a href="fake/myGenericFunction.html">myGenericFunction</a></span><span class="signature">&lt;S&gt;</span><span class="signature">(<wbr><span class="parameter" id="myGenericFunction-param-a"><span class="type-annotation">int</span> <span class="parameter-name">a</span>, </span> <span class="parameter" id="myGenericFunction-param-b"><span class="type-annotation">bool</span> <span class="parameter-name">b</span>, </span> <span class="parameter" id="myGenericFunction-param-c"><span class="type-annotation">S</span> <span class="parameter-name">c</span></span>)
+          <span class="name"><a href="fake/myGenericFunction.html">myGenericFunction</a></span><span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="myGenericFunction-param-a"><span class="type-annotation">int</span> <span class="parameter-name">a</span>, </span> <span class="parameter" id="myGenericFunction-param-b"><span class="type-annotation">bool</span> <span class="parameter-name">b</span>, </span> <span class="parameter" id="myGenericFunction-param-c"><span class="type-annotation">S</span> <span class="parameter-name">c</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -703,7 +703,7 @@ which is a bit redundant.
           
 </dd>
         <dt id="paramOfFutureOrNull" class="callable">
-          <span class="name"><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></span><span class="signature">(<wbr><span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;Null&gt;</span></span> <span class="parameter-name">future</span></span>)
+          <span class="name"><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></span><span class="signature">(<wbr><span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span></span> <span class="parameter-name">future</span></span>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -713,7 +713,7 @@ which is a bit redundant.
 </dd>
         <dt id="returningFutureVoid" class="callable">
           <span class="name"><a href="fake/returningFutureVoid.html">returningFutureVoid</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;void&gt;</span></span>
+            <span class="returntype parameter">&#8594; Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -768,7 +768,7 @@ default value.
 </dd>
         <dt id="thisIsFutureOrNull" class="callable">
           <span class="name"><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; FutureOr<span class="signature">&lt;Null&gt;</span></span>
+            <span class="returntype parameter">&#8594; FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -776,8 +776,8 @@ default value.
           
 </dd>
         <dt id="thisIsFutureOrT" class="callable">
-          <span class="name"><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; FutureOr<span class="signature">&lt;T&gt;</span></span>
+          <span class="name"><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
           </span>
         </dt>
         <dd>
@@ -794,7 +794,7 @@ default value.
           
 </dd>
         <dt id="typeParamOfFutureOr" class="callable">
-          <span class="name"><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></span><span class="signature">&lt;T extends FutureOr<span class="signature">&lt;List&gt;</span>&gt;</span><span class="signature">(<wbr>)
+          <span class="name"><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T extends FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">List</span>&gt;</span></span>&gt;</span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
         </dt>
@@ -841,7 +841,7 @@ default value.
           
 </dd>
         <dt id="GenericTypedef" class="callable">
-          <span class="name"><a href="fake/GenericTypedef.html">GenericTypedef</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="GenericTypedef-param-input"><span class="type-annotation">T</span> <span class="parameter-name">input</span></span>)
+          <span class="name"><a href="fake/GenericTypedef.html">GenericTypedef</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="GenericTypedef-param-input"><span class="type-annotation">T</span> <span class="parameter-name">input</span></span>)
             <span class="returntype parameter">&#8594; T</span>
           </span>
         </dt>
@@ -868,8 +868,8 @@ default value.
           
 </dd>
         <dt id="NewGenericTypedef" class="callable">
-          <span class="name"><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></span><span class="signature">&lt;T&gt;</span><span class="signature">(<wbr><span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">T</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">int</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">bool</span></span>)
-            <span class="returntype parameter">&#8594; List<span class="signature">&lt;S&gt;</span></span>
+          <span class="name"><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></span><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span><span class="signature">(<wbr><span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">T</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">int</span>, </span> <span class="parameter" id="NewGenericTypedef-param-"><span class="type-annotation">bool</span></span>)
+            <span class="returntype parameter">&#8594; List<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span></span>
           </span>
         </dt>
         <dd>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the ZERO constant from the fake library, for the Dart programming language.">
-  <title>ZERO constant - fake library - Dart API</title>
+  <meta name="description" content="API docs for the importantComputations property from the fake library, for the Dart programming language.">
+  <title>importantComputations property - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">ZERO constant</li>
+    <li class="self-crumb">importantComputations property</li>
   </ol>
-  <div class="self-name">ZERO</div>
+  <div class="self-name">importantComputations</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -154,20 +154,18 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ZERO top-level constant</h1>
+    <h1>importantComputations top-level property</h1>
 
     <section class="multi-line-signature">
-      const <span class="name ">ZERO</span>
-      =
-      <span class="constant-value">0</span>
-      
+      <span class="returntype">Map<span class="signature">&lt;int, &gt;</span></span>
+      <span class="name ">importantComputations</span>
+      <div class="features">final</div>
     </section>
-
     <section class="desc markdown">
-      <p>A constant integer value,
-which is a bit redundant.</p>
+      <p>Type inference mixing with anonymous functions.</p>
     </section>
         
+
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -157,7 +157,7 @@
     <h1>importantComputations top-level property</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Map<span class="signature">&lt;int, &gt;</span></span>
+      <span class="returntype">Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">(<span class="parameter" id="null-param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span></span>) → dynamic</span>&gt;</span></span>
       <span class="name ">importantComputations</span>
       <div class="features">final</div>
     </section>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -157,7 +157,7 @@
     <h1>mapWithDynamicKeys top-level property</h1>
 
     <section class="multi-line-signature">
-      <span class="returntype">Map<span class="signature">&lt;dynamic, String&gt;</span></span>
+      <span class="returntype">Map<span class="signature">&lt;<wbr><span class="type-parameter">dynamic</span>, <span class="type-parameter">String</span>&gt;</span></span>
       <span class="name ">mapWithDynamicKeys</span>
       <div class="features">read / write</div>
     </section>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">myGenericFunction&lt;S&gt; function</li>
+    <li class="self-crumb">myGenericFunction&lt;<wbr><span class="type-parameter">S</span>&gt; function</li>
   </ol>
   <div class="self-name">myGenericFunction</div>
   <form class="search navbar-right" role="search">
@@ -154,12 +154,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>myGenericFunction&lt;S&gt; function</h1>
+    <h1>myGenericFunction&lt;<wbr><span class="type-parameter">S</span>&gt; function</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">void</span>
         <span class="name ">myGenericFunction</span>
-&lt;S&gt;(<wbr><span class="parameter" id="myGenericFunction-param-a"><span class="type-annotation">int</span> <span class="parameter-name">a</span>, </span> <span class="parameter" id="myGenericFunction-param-b"><span class="type-annotation">bool</span> <span class="parameter-name">b</span>, </span> <span class="parameter" id="myGenericFunction-param-c"><span class="type-annotation">S</span> <span class="parameter-name">c</span></span>)
+&lt;<wbr><span class="type-parameter">S</span>&gt;(<wbr><span class="parameter" id="myGenericFunction-param-a"><span class="type-annotation">int</span> <span class="parameter-name">a</span>, </span> <span class="parameter" id="myGenericFunction-param-b"><span class="type-annotation">bool</span> <span class="parameter-name">b</span>, </span> <span class="parameter" id="myGenericFunction-param-c"><span class="type-annotation">S</span> <span class="parameter-name">c</span></span>)
     </section>
     <section class="desc markdown">
       <p>A generic function with a type parameter.</p>

--- a/testing/test_package_docs/fake/myMap-constant.html
+++ b/testing/test_package_docs/fake/myMap-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -159,7 +159,7 @@
     <section class="multi-line-signature">
         <span class="returntype">void</span>
         <span class="name ">paramOfFutureOrNull</span>
-(<wbr><span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;Null&gt;</span></span> <span class="parameter-name">future</span></span>)
+(<wbr><span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span></span> <span class="parameter-name">future</span></span>)
     </section>
     <section class="desc markdown">
       <p>Has a parameter explicitly typed <code>FutureOr&lt;Null&gt;</code>.</p>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -157,7 +157,7 @@
     <h1>returningFutureVoid function</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">Future<span class="signature">&lt;void&gt;</span></span>
+        <span class="returntype">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
         <span class="name ">returningFutureVoid</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs/fake/thisIsFutureOr.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -157,7 +157,7 @@
     <h1>thisIsFutureOrNull function</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">FutureOr<span class="signature">&lt;Null&gt;</span></span>
+        <span class="returntype">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span></span>
         <span class="name ">thisIsFutureOrNull</span>
 (<wbr>)
     </section>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">thisIsFutureOrT&lt;T&gt; function</li>
+    <li class="self-crumb">thisIsFutureOrT&lt;<wbr><span class="type-parameter">T</span>&gt; function</li>
   </ol>
   <div class="self-name">thisIsFutureOrT</div>
   <form class="search navbar-right" role="search">
@@ -154,12 +154,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>thisIsFutureOrT&lt;T&gt; function</h1>
+    <h1>thisIsFutureOrT&lt;<wbr><span class="type-parameter">T</span>&gt; function</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">FutureOr<span class="signature">&lt;T&gt;</span></span>
+        <span class="returntype">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         <span class="name ">thisIsFutureOrT</span>
-&lt;T&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">T</span>&gt;(<wbr>)
     </section>
     <section class="desc markdown">
       <p>Explicitly return a <code>FutureOr&lt;T&gt;</code>.</p>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -101,9 +101,11 @@
     
       <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
       <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
       <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
       <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
       <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
       <li><a href="fake/justGetter.html">justGetter</a></li>
       <li><a href="fake/justSetter.html">justSetter</a></li>
       <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">typeParamOfFutureOr&lt;T extends FutureOr&lt;List&gt;&gt; function</li>
+    <li class="self-crumb">typeParamOfFutureOr&lt;<wbr><span class="type-parameter">T extends FutureOr&lt;<wbr><span class="type-parameter">List</span>&gt;</span>&gt; function</li>
   </ol>
   <div class="self-name">typeParamOfFutureOr</div>
   <form class="search navbar-right" role="search">
@@ -154,12 +154,12 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>typeParamOfFutureOr&lt;T extends FutureOr&lt;List&gt;&gt; function</h1>
+    <h1>typeParamOfFutureOr&lt;<wbr><span class="type-parameter">T extends FutureOr&lt;<wbr><span class="type-parameter">List</span>&gt;</span>&gt; function</h1>
 
     <section class="multi-line-signature">
         <span class="returntype">void</span>
         <span class="name ">typeParamOfFutureOr</span>
-&lt;T extends FutureOr&lt;List&gt;&gt;(<wbr>)
+&lt;<wbr><span class="type-parameter">T extends FutureOr&lt;<wbr><span class="type-parameter">List</span>&gt;</span>&gt;(<wbr>)
     </section>
     <section class="desc markdown">
       <p>Has a type parameter bound to <code>FutureOr&lt;List&gt;</code>.</p>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -8182,6 +8182,17 @@
   }
  },
  {
+  "name": "complicatedReturn",
+  "qualifiedName": "fake.complicatedReturn",
+  "href": "fake/complicatedReturn.html",
+  "type": "top-level property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
   "name": "dynamicGetter",
   "qualifiedName": "fake.dynamicGetter",
   "href": "fake/dynamicGetter.html",
@@ -8241,6 +8252,17 @@
   "qualifiedName": "fake.greatestAnnotation",
   "href": "fake/greatestAnnotation-constant.html",
   "type": "top-level constant",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "importantComputations",
+  "qualifiedName": "fake.importantComputations",
+  "href": "fake/importantComputations.html",
+  "type": "top-level property",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -359,6 +359,18 @@ dl dt.callable .name {
   white-space: nowrap;
 }
 
+.type-parameter {
+  white-space: nowrap;
+}
+
+.multi-line-signature .type-parameter {
+  display: -webkit-inline-box;
+}
+
+.multi-line-signature .type-parameter .parameter {
+  margin-left: 0px;
+}
+
 .signature {
   color: #727272;
 }

--- a/testing/test_package_docs/static-assets/styles.css
+++ b/testing/test_package_docs/static-assets/styles.css
@@ -363,12 +363,9 @@ dl dt.callable .name {
   white-space: nowrap;
 }
 
-.multi-line-signature .type-parameter {
-  display: -webkit-inline-box;
-}
-
 .multi-line-signature .type-parameter .parameter {
   margin-left: 0px;
+  display: unset;
 }
 
 .signature {

--- a/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass-class.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li class="self-crumb">Whataclass<span class="signature">&lt;T&gt;</span> class</li>
+    <li class="self-crumb">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span> class</li>
   </ol>
   <div class="self-name">Whataclass</div>
   <form class="search navbar-right" role="search">
@@ -51,7 +51,7 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>Whataclass&lt;T&gt; class</h1>
+    <h1>Whataclass&lt;<wbr><span class="type-parameter">T</span>&gt; class</h1>
 
     <section class="desc markdown">
       <p>Some docs for whataclass</p>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/Whataclass.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">Whataclass constructor</li>
   </ol>
   <div class="self-name">Whataclass</div>
@@ -61,11 +61,11 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>Whataclass&lt;T&gt; constructor</h1>
+    <h1>Whataclass&lt;<wbr><span class="type-parameter">T</span>&gt; constructor</h1>
 
     <section class="multi-line-signature">
       
-      <span class="name ">Whataclass&lt;T&gt;</span>(<wbr>)
+      <span class="name ">Whataclass&lt;<wbr><span class="type-parameter">T</span>&gt;</span>(<wbr>)
     </section>
 
     

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/hashCode.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">hashCode property</li>
   </ol>
   <div class="self-name">hashCode</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/noSuchMethod.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">noSuchMethod method</li>
   </ol>
   <div class="self-name">noSuchMethod</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/operator_equals.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">operator == method</li>
   </ol>
   <div class="self-name">operator ==</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/runtimeType.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">runtimeType property</li>
   </ol>
   <div class="self-name">runtimeType</div>

--- a/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
+++ b/testing/test_package_docs/test_package_imported.main/Whataclass/toString.html
@@ -25,7 +25,7 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="test_package_imported.main/test_package_imported.main-library.html">test_package_imported.main</a></li>
-    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;T&gt;</span></a></li>
+    <li><a href="test_package_imported.main/Whataclass-class.html">Whataclass<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></a></li>
     <li class="self-crumb">toString method</li>
   </ol>
   <div class="self-name">toString</div>

--- a/testing/test_package_docs/test_package_imported.main/test_package_imported.main-library.html
+++ b/testing/test_package_docs/test_package_imported.main/test_package_imported.main-library.html
@@ -66,7 +66,7 @@
 
       <dl>
         <dt id="Whataclass">
-          <span class="name "><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;T&gt;</span></span>
+          <span class="name "><a href="test_package_imported.main/Whataclass-class.html">Whataclass</a><span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span></span>
         </dt>
         <dd>
           Some docs for whataclass


### PR DESCRIPTION
Fixes #1643.  @bergwerf

Anonymous functions as part of type parameters haven't worked very well in dartdoc at times, and an interesting case in #1643 actually led to crashes.  Fix that and a few other related problems:

- Not everything has libraries, so refactor ModelElement.from to require both a library and package graph, and assert if at least one isn't null (root cause of #1643)
- Show anonymous functions when they are type parameters
- Shift style so that we don't line break between parameters of an anonymous function used as a type parameter.