### PR TITLE
Workaround for isInSdk

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2006,8 +2006,6 @@ class Library extends ModelElement with Categorization {
 
   bool get isAnonymous => element.name == null || element.name.isEmpty;
 
-  bool get isInSdk => _libraryElement.isInSdk;
-
   @override
   String get kind => 'library';
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -22,7 +22,8 @@ abstract class PackageMeta {
 
   /// Use this instead of fromDir where possible.
   factory PackageMeta.fromElement(LibraryElement libraryElement) {
-    if (libraryElement.isInSdk) return new PackageMeta.fromDir(getSdkDir());
+    // Workaround for dart-lang/sdk#32707.  Replace with isInSdk once that works.
+    if (libraryElement.source.uri.scheme == 'dart') return new PackageMeta.fromDir(getSdkDir());
     return new PackageMeta.fromDir(
         new File(pathLib.canonicalize(libraryElement.source.fullName)).parent);
   }

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -122,14 +122,15 @@ void main() {
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:async'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:bear'), isTrue);
-      expect(p.packages.length, equals(2));
-      // Things that do not override the core SDK belong in their own package?
+      expect(p.packages.length, equals(1));
+      // Things that do not override the core SDK do not belong in their own package.
       expect(p.packages["Dart"].isSdk, isTrue);
-      expect(p.packages["test_package_embedder_yaml"].isSdk, isFalse);
-      expect(
-          p.publicLibraries,
-          everyElement((Library l) =>
-              (l.element as LibraryElement).isInSdk == l.packageMeta.isSdk));
+      expect(p.packages["test_package_embedder_yaml"], isNull);
+      // Should be true once dart-lang/sdk#32707 is fixed.
+      //expect(
+      //    p.publicLibraries,
+      //    everyElement((Library l) =>
+      //        (l.element as LibraryElement).isInSdk == l.packageMeta.isSdk));
       // Ensure that we actually parsed some source by checking for
       // the 'Bear' class.
       Library dart_bear =
@@ -137,9 +138,7 @@ void main() {
       expect(dart_bear, isNotNull);
       expect(
           dart_bear.allClasses.map((cls) => cls.name).contains('Bear'), isTrue);
-      expect(p.packages["test_package_embedder_yaml"].publicLibraries,
-          contains(dart_bear));
-      expect(p.packages["Dart"].publicLibraries, hasLength(2));
+      expect(p.packages["Dart"].publicLibraries, hasLength(3));
     });
   });
 }


### PR DESCRIPTION
This is a workaround for dart-lang/sdk#32707, fixes problems with Flutter's SDK docs.