### PR TITLE
Prepare for dartdoc v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.18.1
+* Fix problems with the embedded SDK detection that cropped up in
+  the package refactor (#1648, #1651)
+* Fix issues with anonymous functions and type parameters (#1651)
+* Add Menlo to the monospace font list to improve table
+  formatting (#1647)
+
 ## 0.18.0
 * Rename category_order flag to package_order. (#1634, #1636)
 * Use Google's CDN for jquery. (#1637)

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -36,7 +36,7 @@ export 'src/sdk.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String version = '0.18.0';
+const String version = '0.18.1';
 
 final String defaultOutDir = pathLib.join('doc', 'api');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.18.0
+version: 0.18.1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.18.0">
+  <meta name="generator" content="made with love by dartdoc 0.18.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
Flutter needs a new release to fix some broken links on the API docs for the Dart SDK.