### PR TITLE
Eliminate relative imports where possible and workaround inheritance problem in reexported classes

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -13,19 +13,18 @@ import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/source.dart';
-import 'package:dartdoc/src/utils.dart';
-import 'package:html/dom.dart' show Element, Document;
-import 'package:html/parser.dart' show parse;
-import 'package:path/path.dart' as pathLib;
-
-import 'package:tuple/tuple.dart';
 import 'package:dartdoc/src/config.dart';
 import 'package:dartdoc/src/generator.dart';
 import 'package:dartdoc/src/html/html_generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
+import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/warnings.dart';
+import 'package:html/dom.dart' show Element, Document;
+import 'package:html/parser.dart' show parse;
+import 'package:path/path.dart' as pathLib;
+import 'package:tuple/tuple.dart';
 
 export 'package:dartdoc/src/config.dart';
 export 'package:dartdoc/src/dartdoc_options.dart';

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -28,6 +28,7 @@ import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';
 
 export 'package:dartdoc/src/config.dart';
+export 'package:dartdoc/src/dartdoc_options.dart';
 export 'package:dartdoc/src/element_type.dart';
 export 'package:dartdoc/src/generator.dart';
 export 'package:dartdoc/src/model.dart';

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -19,19 +19,19 @@ import 'package:html/parser.dart' show parse;
 import 'package:path/path.dart' as pathLib;
 
 import 'package:tuple/tuple.dart';
-import 'src/config.dart';
-import 'src/generator.dart';
-import 'src/html/html_generator.dart';
-import 'src/logging.dart';
-import 'src/model.dart';
-import 'src/package_meta.dart';
-import 'src/warnings.dart';
+import 'package:dartdoc/src/config.dart';
+import 'package:dartdoc/src/generator.dart';
+import 'package:dartdoc/src/html/html_generator.dart';
+import 'package:dartdoc/src/logging.dart';
+import 'package:dartdoc/src/model.dart';
+import 'package:dartdoc/src/package_meta.dart';
+import 'package:dartdoc/src/warnings.dart';
 
-export 'src/config.dart';
-export 'src/element_type.dart';
-export 'src/generator.dart';
-export 'src/model.dart';
-export 'src/package_meta.dart';
+export 'package:dartdoc/src/config.dart';
+export 'package:dartdoc/src/element_type.dart';
+export 'package:dartdoc/src/generator.dart';
+export 'package:dartdoc/src/model.dart';
+export 'package:dartdoc/src/package_meta.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -18,10 +18,9 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dartdoc/dartdoc.dart';
+import 'package:dartdoc/src/logging.dart';
 import 'package:path/path.dart' as pathLib;
 import 'package:yaml/yaml.dart';
-
-import 'logging.dart';
 
 /// Constants to help with type checking, because T is int and so forth
 /// don't work in Dart.

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -4,7 +4,7 @@
 
 library debugger_helper;
 
-import "dart:developer" as dev;
+import 'dart:developer' as dev;
 
 get debugger =>
     const String.fromEnvironment('DEBUG') == null ? _nodebugger : dev.debugger;

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -7,8 +7,7 @@ library dartdoc.element_type;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-
-import 'model.dart';
+import 'package:dartdoc/src/model.dart';
 
 /// Base class representing a type in Dartdoc.  It wraps a [DartType], and
 /// may link to a [ModelElement].

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -8,7 +8,7 @@ library dartdoc.generator;
 import 'dart:async' show Stream, Future;
 import 'dart:io' show File;
 
-import 'model.dart' show PackageGraph;
+import 'package:dartdoc/src/model.dart' show PackageGraph;
 
 /// An abstract class that defines a generator that generates documentation for
 /// a given package.

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -7,13 +7,12 @@ library dartdoc.html_generator;
 import 'dart:async' show Future, StreamController, Stream;
 import 'dart:io' show File;
 
-import 'package:path/path.dart' as pathLib;
-
 import 'package:dartdoc/src/generator.dart';
-import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/html/html_generator_instance.dart';
 import 'package:dartdoc/src/html/template_data.dart';
 import 'package:dartdoc/src/html/templates.dart';
+import 'package:dartdoc/src/model.dart';
+import 'package:path/path.dart' as pathLib;
 
 typedef String Renderer(String input);
 

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -9,11 +9,11 @@ import 'dart:io' show File;
 
 import 'package:path/path.dart' as pathLib;
 
-import '../generator.dart';
-import '../model.dart';
-import 'html_generator_instance.dart';
-import 'template_data.dart';
-import 'templates.dart';
+import 'package:dartdoc/src/generator.dart';
+import 'package:dartdoc/src/model.dart';
+import 'package:dartdoc/src/html/html_generator_instance.dart';
+import 'package:dartdoc/src/html/template_data.dart';
+import 'package:dartdoc/src/html/templates.dart';
 
 typedef String Renderer(String input);
 

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -7,15 +7,15 @@ import 'dart:convert' show JsonEncoder;
 import 'dart:io' show File;
 
 import 'package:collection/collection.dart' show compareNatural;
-import 'package:dartdoc/src/logging.dart';
-import 'package:dartdoc/src/model.dart';
-import 'package:dartdoc/src/model_utils.dart';
-import 'package:dartdoc/src/warnings.dart';
 import 'package:dartdoc/src/html/html_generator.dart' show HtmlGeneratorOptions;
 import 'package:dartdoc/src/html/resource_loader.dart' as loader;
 import 'package:dartdoc/src/html/resources.g.dart' as resources;
 import 'package:dartdoc/src/html/template_data.dart';
 import 'package:dartdoc/src/html/templates.dart';
+import 'package:dartdoc/src/logging.dart';
+import 'package:dartdoc/src/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
+import 'package:dartdoc/src/warnings.dart';
 import 'package:mustache4dart/mustache4dart.dart';
 import 'package:path/path.dart' as pathLib;
 

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -7,18 +7,17 @@ import 'dart:convert' show JsonEncoder;
 import 'dart:io' show File;
 
 import 'package:collection/collection.dart' show compareNatural;
+import 'package:dartdoc/src/logging.dart';
+import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
+import 'package:dartdoc/src/warnings.dart';
+import 'package:dartdoc/src/html/html_generator.dart' show HtmlGeneratorOptions;
+import 'package:dartdoc/src/html/resource_loader.dart' as loader;
+import 'package:dartdoc/src/html/resources.g.dart' as resources;
+import 'package:dartdoc/src/html/template_data.dart';
+import 'package:dartdoc/src/html/templates.dart';
 import 'package:mustache4dart/mustache4dart.dart';
 import 'package:path/path.dart' as pathLib;
-
-import '../logging.dart';
-import '../model.dart';
-import '../warnings.dart';
-import 'html_generator.dart' show HtmlGeneratorOptions;
-import 'resource_loader.dart' as loader;
-import 'resources.g.dart' as resources;
-import 'template_data.dart';
-import 'templates.dart';
 
 typedef void FileWriter(String path, Object content, {bool allowOverwrite});
 

--- a/lib/src/html/template_data.dart
+++ b/lib/src/html/template_data.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../model.dart';
+import 'package:dartdoc/src/model.dart';
 
 abstract class HtmlOptions {
   String get relCanonicalPrefix;

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -6,6 +6,7 @@ library dartdoc.templates;
 
 import 'dart:async' show Future;
 import 'dart:io' show File;
+
 import 'package:dartdoc/src/html/resource_loader.dart' as loader;
 import 'package:mustache4dart/mustache4dart.dart';
 

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -6,10 +6,8 @@ library dartdoc.templates;
 
 import 'dart:async' show Future;
 import 'dart:io' show File;
-
+import 'package:dartdoc/src/html/resource_loader.dart' as loader;
 import 'package:mustache4dart/mustache4dart.dart';
-
-import 'resource_loader.dart' as loader;
 
 const _partials = const <String>[
   'callable',

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -11,13 +11,12 @@ import 'dart:math';
 import 'package:analyzer/dart/ast/ast.dart' hide TypeParameter;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
+import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
+import 'package:dartdoc/src/warnings.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:markdown/markdown.dart' as md;
 import 'package:tuple/tuple.dart';
-
-import 'model.dart';
-import 'warnings.dart';
 
 const validHtmlTags = const [
   "a",

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -922,9 +922,9 @@ class Class extends ModelElement
     if (__inheritedElements == null) {
       __inheritedElements = [];
       Map<String, ExecutableElement> cmap =
-          library.inheritanceManager.getMembersInheritedFromClasses(element);
+          definingLibrary.inheritanceManager.getMembersInheritedFromClasses(element);
       Map<String, ExecutableElement> imap =
-          library.inheritanceManager.getMembersInheritedFromInterfaces(element);
+          definingLibrary.inheritanceManager.getMembersInheritedFromInterfaces(element);
       __inheritedElements.addAll(cmap.values);
       __inheritedElements
           .addAll(imap.values.where((e) => !cmap.containsKey(e.name)));

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -35,23 +35,22 @@ import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member, ParameterMember;
 import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:collection/collection.dart';
+import 'package:dartdoc/src/config.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
+import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/io_utils.dart';
+import 'package:dartdoc/src/line_number_cache.dart';
+import 'package:dartdoc/src/logging.dart';
+import 'package:dartdoc/src/markdown_processor.dart' show Documentation;
+import 'package:dartdoc/src/model_utils.dart';
+import 'package:dartdoc/src/package_meta.dart' show PackageMeta, FileContents;
+import 'package:dartdoc/src/utils.dart';
+import 'package:dartdoc/src/warnings.dart';
 import 'package:front_end/src/byte_store/byte_store.dart';
 import 'package:front_end/src/base/performance_logger.dart';
 import 'package:path/path.dart' as pathLib;
 import 'package:tuple/tuple.dart';
 import 'package:package_config/discovery.dart' as package_config;
-
-import 'config.dart';
-import 'element_type.dart';
-import 'line_number_cache.dart';
-import 'logging.dart';
-import 'markdown_processor.dart' show Documentation;
-import 'model_utils.dart';
-import 'package_meta.dart' show PackageMeta, FileContents;
-import 'utils.dart';
-import 'warnings.dart';
 
 int byName(Nameable a, Nameable b) =>
     compareAsciiLowerCaseNatural(a.name, b.name);

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -3,10 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:tuple/tuple.dart';
-
-import 'logging.dart';
 
 class PackageWarningHelpText {
   final String warningName;

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:io' hide ProcessException;
 
 import 'package:dartdoc/src/io_utils.dart';


### PR DESCRIPTION
Relative imports when mixed with absolute imports can produce inconsistent analysis results, confusing Dartdoc and its tests.  Fix dartdoc's own use of imports internally to prevent this from being a possible issue.

Also add a workaround for dart-lang/sdk#32923, making sure that we calculate inheritance using the defining library.