### PR TITLE
Support flutter in cross-links and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ branches:
 cache:
   directories:
   - $HOME/.pub-cache
+  - $HOME/.dartdoc_grinder

--- a/README.md
+++ b/README.md
@@ -114,8 +114,14 @@ Unrecognized options will be ignored.  Supported options:
   * **linkTo**:  For other packages depending on this one, if this map is defined those packages
     will use the settings here to control how hyperlinks to the package are generated.
     This will override the default for packages hosted on pub.dartlang.org.
-    * url:  A string indicating the base URL for documentation of this package.  The following
-      strings will be substituted in to complete the URL:
+    * **url**:  A string indicating the base URL for documentation of this package.  Ordinarily
+      you do not need to set this in the package: consider --link-to-hosted and
+      --link-to-sdks instead of this option if you need to build your own website with
+      dartdoc.
+
+      The following strings will be substituted in to complete the URL:
+      * `%b%`: The branch as indicated by text in the version.  2.0.0-dev.3 is branch "dev".
+        No branch is considered to be "stable".
       * `%n%`: The name of this package, as defined in pubspec.yaml.
       * `%v%`: The version of this package as defined in pubspec.yaml.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,7 @@ analyzer:
     - 'lib/templates/*.html'
     - 'pub.dartlang.org/**'
     - 'testing/**'
+    - 'testing/test_package_flutter_plugin/**'
 linter:
   rules:
     - annotate_overrides

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -69,7 +69,7 @@ main(List<String> arguments) async {
   logInfo("Generating documentation for '${config.topLevelPackageMeta}' into "
       "${outputDir.absolute.path}${Platform.pathSeparator}");
 
-  Dartdoc dartdoc = await Dartdoc.withDefaultGenerators(config, outputDir);
+  Dartdoc dartdoc = await Dartdoc.withDefaultGenerators(config);
 
   dartdoc.onCheckProgress.listen(logProgress);
   await Chain.capture(() async {

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -43,32 +43,30 @@ const String dartdocVersion = '0.18.1';
 /// directory.
 class Dartdoc extends PackageBuilder {
   final List<Generator> generators;
-  final Directory outputDir;
   final Set<String> writtenFiles = new Set();
+  Directory outputDir;
 
   // Fires when the self checks make progress.
   final StreamController<String> _onCheckProgress =
       new StreamController(sync: true);
 
-  Dartdoc._(DartdocOptionContext config, this.generators, this.outputDir)
-      : super(config) {
+  Dartdoc._(DartdocOptionContext config, this.generators) : super(config) {
+    outputDir = new Directory(config.output)..createSync(recursive: true);
     generators.forEach((g) => g.onFileCreated.listen(logProgress));
   }
 
   /// An asynchronous factory method that builds Dartdoc's file writers
   /// and returns a Dartdoc object with them.
-  static withDefaultGenerators(
-      DartdocOptionContext config, Directory outputDir) async {
+  static withDefaultGenerators(DartdocOptionContext config) async {
     List<Generator> generators =
         await initGenerators(config as GeneratorContext);
-    return new Dartdoc._(config, generators, outputDir);
+    return new Dartdoc._(config, generators);
   }
 
   /// Basic synchronous factory that gives a stripped down Dartdoc that won't
   /// use generators.  Useful for testing.
-  factory Dartdoc.withoutGenerators(
-      DartdocOptionContext config, Directory outputDir) {
-    return new Dartdoc._(config, [], outputDir);
+  factory Dartdoc.withoutGenerators(DartdocOptionContext config) {
+    return new Dartdoc._(config, []);
   }
 
   Stream<String> get onCheckProgress => _onCheckProgress.stream;
@@ -345,25 +343,28 @@ class Dartdoc extends PackageBuilder {
     // (newPathToCheck, newFullPath)
     Set<Tuple2<String, String>> toVisit = new Set();
 
+    final RegExp ignoreHyperlinks = new RegExp(r'^(https:|http:|mailto:|ftp:)');
     for (String href in stringLinks) {
-      Uri uri;
-      try {
-        uri = Uri.parse(href);
-      } catch (FormatError) {}
+      if (!href.startsWith(ignoreHyperlinks)) {
+        Uri uri;
+        try {
+          uri = Uri.parse(href);
+        } catch (FormatError) {}
 
-      if (uri == null || !uri.hasAuthority && !uri.hasFragment) {
-        var full;
-        if (baseHref != null) {
-          full = '${pathLib.dirname(pathToCheck)}/$baseHref/$href';
-        } else {
-          full = '${pathLib.dirname(pathToCheck)}/$href';
-        }
-        var newPathToCheck = pathLib.normalize(full);
-        String newFullPath = pathLib.joinAll([origin, newPathToCheck]);
-        newFullPath = pathLib.normalize(newFullPath);
-        if (!visited.contains(newFullPath)) {
-          toVisit.add(new Tuple2(newPathToCheck, newFullPath));
-          visited.add(newFullPath);
+        if (uri == null || !uri.hasAuthority && !uri.hasFragment) {
+          var full;
+          if (baseHref != null) {
+            full = '${pathLib.dirname(pathToCheck)}/$baseHref/$href';
+          } else {
+            full = '${pathLib.dirname(pathToCheck)}/$href';
+          }
+          var newPathToCheck = pathLib.normalize(full);
+          String newFullPath = pathLib.joinAll([origin, newPathToCheck]);
+          newFullPath = pathLib.normalize(newFullPath);
+          if (!visited.contains(newFullPath)) {
+            toVisit.add(new Tuple2(newPathToCheck, newFullPath));
+            visited.add(newFullPath);
+          }
         }
       }
     }

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -32,7 +32,7 @@ const int _kIntVal = 0;
 const double _kDoubleVal = 0.0;
 const bool _kBoolVal = true;
 
-String _resolveTildePath(String originalPath) {
+String resolveTildePath(String originalPath) {
   if (originalPath == null || !originalPath.startsWith('~/')) {
     return originalPath;
   }
@@ -97,11 +97,11 @@ class _OptionValueWithContext<T> {
   T get resolvedValue {
     if (value is List<String>) {
       return (value as List<String>)
-          .map((v) => pathContext.canonicalize(_resolveTildePath(v)))
+          .map((v) => pathContext.canonicalize(resolveTildePath(v)))
           .cast<String>()
           .toList() as T;
     } else if (value is String) {
-      return pathContext.canonicalize(_resolveTildePath(value as String)) as T;
+      return pathContext.canonicalize(resolveTildePath(value as String)) as T;
     } else {
       throw new UnsupportedError('Type $T is not supported for resolvedValue');
     }
@@ -117,7 +117,7 @@ class _OptionValueWithContext<T> {
 /// of sanity checks are also built in to these classes so that file existence
 /// can be verified, types constrained, and defaults provided.
 ///
-/// Use via implementations [DartdocOptionSet], [DartdocOptionBoth],
+/// Use via implementations [DartdocOptionSet], [DartdocOptionArgFile],
 /// [DartdocOptionArgOnly], and [DartdocOptionFileOnly].
 abstract class DartdocOption<T> {
   /// This is the value returned if we couldn't find one otherwise.
@@ -154,7 +154,6 @@ abstract class DartdocOption<T> {
   // command line arguments and yaml data to real types.
   //
   // Condense the ugly all in one place, this set of getters.
-
   bool get _isString => _kStringVal is T;
   bool get _isListString => _kListStringVal is T;
   bool get _isMapString => _kMapStringVal is T;
@@ -181,7 +180,7 @@ abstract class DartdocOption<T> {
 
   /// Parse these as string arguments (from argv) with the argument parser.
   /// Call before calling [valueAt] for any [DartdocOptionArgOnly] or
-  /// [DartdocOptionBoth] in this tree.
+  /// [DartdocOptionArgFile] in this tree.
   void _parseArguments(List<String> arguments) {
     __argResults = argParser.parse(arguments);
   }
@@ -303,23 +302,121 @@ abstract class DartdocOption<T> {
   }
 }
 
+/// A class that defaults to a value computed from a closure, but can be
+/// overridden by a file.
+class DartdocOptionFileSynth<T> extends DartdocOption<T>
+    with DartdocSyntheticOption<T>, _DartdocFileOption<T> {
+  bool _parentDirOverridesChild;
+  @override
+  T Function(DartdocSyntheticOption<T>, Directory) _compute;
+  DartdocOptionFileSynth(String name, this._compute,
+      {bool mustExist = false,
+      String help = '',
+      bool isDir = false,
+      bool isFile = false,
+      bool parentDirOverridesChild})
+      : super._(name, null, help, isDir, isFile, mustExist) {
+    _parentDirOverridesChild = parentDirOverridesChild;
+  }
+
+  @override
+  T valueAt(Directory dir) {
+    _OptionValueWithContext result = _valueAtFromFile(dir);
+    if (result?.definingFile != null) {
+      return _handlePathsInContext(result);
+    }
+    return _valueAtFromSynthetic(dir);
+  }
+
+  @override
+  void _onMissing(
+      _OptionValueWithContext valueWithContext, String missingPath) {
+    if (valueWithContext.definingFile != null) {
+      _onMissingFromFiles(valueWithContext, missingPath);
+    } else {
+      _onMissingFromSynthetic(valueWithContext, missingPath);
+    }
+  }
+
+  @override
+  bool get parentDirOverridesChild => _parentDirOverridesChild;
+}
+
+/// A class that defaults to a value computed from a closure, but can
+/// be overridden on the command line.
+class DartdocOptionArgSynth<T> extends DartdocOption<T>
+    with DartdocSyntheticOption<T>, _DartdocArgOption<T> {
+  String _abbr;
+  bool _hide;
+  bool _negatable;
+  bool _splitCommas;
+
+  @override
+  T Function(DartdocSyntheticOption<T>, Directory) _compute;
+  DartdocOptionArgSynth(String name, this._compute,
+      {String abbr,
+      bool mustExist = false,
+      String help = '',
+      bool isDir = false,
+      bool isFile = false,
+      bool negatable,
+      bool splitCommas})
+      : super._(name, null, help, isDir, isFile, mustExist) {
+    _hide = hide;
+    _negatable = negatable;
+    _splitCommas = splitCommas;
+    _abbr = abbr;
+  }
+
+  @override
+  void _onMissing(
+      _OptionValueWithContext valueWithContext, String missingPath) {
+    _onMissingFromArgs(valueWithContext, missingPath);
+  }
+
+  @override
+  T valueAt(Directory dir) {
+    if (_argResults.wasParsed(argName)) {
+      return _valueAtFromArgs();
+    }
+    return _valueAtFromSynthetic(dir);
+  }
+
+  @override
+  String get abbr => _abbr;
+  @override
+  bool get hide => _hide;
+  @override
+  bool get negatable => _negatable;
+
+  @override
+  bool get splitCommas => _splitCommas;
+}
+
 /// A synthetic option takes a closure at construction time that computes
 /// the value of the configuration option based on other configuration options.
 /// Does not protect against closures that self-reference.  If [mustExist] and
 /// [isDir] or [isFile] is set, computed values will be resolved to canonical
 /// paths.
-class DartdocOptionSynthetic<T> extends DartdocOption<T> {
-  T Function(DartdocOptionSynthetic, Directory) _compute;
-
-  DartdocOptionSynthetic(String name, this._compute,
+class DartdocOptionSyntheticOnly<T> extends DartdocOption<T>
+    with DartdocSyntheticOption<T> {
+  @override
+  T Function(DartdocSyntheticOption<T>, Directory) _compute;
+  DartdocOptionSyntheticOnly(String name, this._compute,
       {bool mustExist = false,
       String help = '',
       bool isDir = false,
       bool isFile = false})
       : super._(name, null, help, isDir, isFile, mustExist);
+}
+
+abstract class DartdocSyntheticOption<T> implements DartdocOption<T> {
+  T Function(DartdocSyntheticOption<T>, Directory) get _compute;
 
   @override
-  T valueAt(Directory dir) {
+  T valueAt(Directory dir) => _valueAtFromSynthetic(dir);
+
+  T _valueAtFromSynthetic(Directory dir) {
     _OptionValueWithContext context =
         new _OptionValueWithContext<T>(_compute(this, dir), dir.path);
     return _handlePathsInContext(context);
@@ -327,6 +424,10 @@ class DartdocOptionSynthetic<T> extends DartdocOption<T> {
 
   @override
   void _onMissing(
+          _OptionValueWithContext valueWithContext, String missingPath) =>
+      _onMissingFromSynthetic(valueWithContext, missingPath);
+
+  void _onMissingFromSynthetic(
       _OptionValueWithContext valueWithContext, String missingPath) {
     String description =
         'Synthetic configuration option ${name} from <internal>';
@@ -409,7 +510,7 @@ class DartdocOptionArgOnly<T> extends DartdocOption<T>
 }
 
 /// A [DartdocOption] that works with command line arguments and dartdoc_options files.
-class DartdocOptionBoth<T> extends DartdocOption<T>
+class DartdocOptionArgFile<T> extends DartdocOption<T>
     with _DartdocArgOption<T>, _DartdocFileOption<T> {
   String _abbr;
   bool _hide;
@@ -417,7 +518,7 @@ class DartdocOptionBoth<T> extends DartdocOption<T>
   bool _parentDirOverridesChild;
   bool _splitCommas;
 
-  DartdocOptionBoth(String name, T defaultsTo,
+  DartdocOptionArgFile(String name, T defaultsTo,
       {String abbr,
       bool mustExist = false,
       String help: '',
@@ -438,24 +539,16 @@ class DartdocOptionBoth<T> extends DartdocOption<T>
   @override
   void _onMissing(
       _OptionValueWithContext valueWithContext, String missingPath) {
-    String dartdocYaml;
-    String description;
     if (valueWithContext.definingFile != null) {
-      dartdocYaml = pathLib.canonicalize(pathLib.join(
-          valueWithContext.canonicalDirectoryPath,
-          valueWithContext.definingFile));
-      description = 'Field ${fieldName} from ${dartdocYaml}';
+      _onMissingFromFiles(valueWithContext, missingPath);
     } else {
-      description = 'Argument --${argName}';
+      _onMissingFromArgs(valueWithContext, missingPath);
     }
-    throw new DartdocFileMissing(
-        '$description, set to ${valueWithContext.value}, resolves to missing path: "${missingPath}"');
   }
-
-  @override
 
   /// Try to find an explicit argument setting this value, but if not, fall back to files
   /// finally, the default.
+  @override
   T valueAt(Directory dir) {
     T value = _valueAtFromArgs();
     if (value == null) value = _valueAtFromFiles(dir);
@@ -489,16 +582,6 @@ class DartdocOptionFileOnly<T> extends DartdocOption<T>
   }
 
   @override
-  void _onMissing(
-      _OptionValueWithContext valueWithContext, String missingPath) {
-    String dartdocYaml = pathLib.canonicalize(pathLib.join(
-        valueWithContext.canonicalDirectoryPath,
-        valueWithContext.definingFile));
-    throw new DartdocFileMissing(
-        'Field ${fieldName} from ${dartdocYaml}, set to ${valueWithContext.value}, resolves to missing path: "${missingPath}"');
-  }
-
-  @override
   bool get parentDirOverridesChild => _parentDirOverridesChild;
 }
 
@@ -520,6 +603,10 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
 
   @override
   void _onMissing(
+          _OptionValueWithContext valueWithContext, String missingPath) =>
+      _onMissingFromFiles(valueWithContext, missingPath);
+
+  void _onMissingFromFiles(
       _OptionValueWithContext valueWithContext, String missingPath) {
     String dartdocYaml = pathLib.join(
         valueWithContext.canonicalDirectoryPath, valueWithContext.definingFile);
@@ -643,16 +730,16 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
 
 /// Mixin class implementing command-line arguments for [DartdocOption].
 abstract class _DartdocArgOption<T> implements DartdocOption<T> {
-  /// For [ArgsParser], set to true if the argument can be negated with --no on the command line.
+  /// For [ArgParser], set to true if the argument can be negated with --no on the command line.
   bool get negatable;
 
-  /// For [ArgsParser], set to true if a single string argument will be broken into a list on commas.
+  /// For [ArgParser], set to true if a single string argument will be broken into a list on commas.
   bool get splitCommas;
 
-  /// For [ArgsParser], set to true to hide this from the help menu.
+  /// For [ArgParser], set to true to hide this from the help menu.
   bool get hide;
 
-  /// For [ArgsParser], set to a single character to have a short version of the command line argument.
+  /// For [ArgParser], set to a single character to have a short version of the command line argument.
   String get abbr;
 
   /// valueAt for arguments ignores the [dir] parameter and only uses command
@@ -682,6 +769,10 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
 
   @override
   void _onMissing(
+          _OptionValueWithContext valueWithContext, String missingPath) =>
+      _onMissingFromArgs(valueWithContext, missingPath);
+
+  void _onMissingFromArgs(
       _OptionValueWithContext valueWithContext, String missingPath) {
     throw new DartdocFileMissing(
         'Argument --${argName}, set to ${valueWithContext.value}, resolves to missing path: "${missingPath}"');
@@ -757,7 +848,7 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
     } else if (_isInt || _isDouble || _isString) {
       argParser.addOption(argName,
           abbr: abbr,
-          defaultsTo: defaultsTo.toString(),
+          defaultsTo: defaultsTo?.toString() ?? null,
           help: help,
           hide: hide);
     } else if (_isListString || _isMapString) {
@@ -832,6 +923,7 @@ class DartdocOptionContext {
   List<String> get excludePackages =>
       optionSet['excludePackages'].valueAt(context);
 
+  String get flutterRoot => optionSet['flutterRoot'].valueAt(context);
   bool get hideSdkText => optionSet['hideSdkText'].valueAt(context);
   List<String> get include => optionSet['include'].valueAt(context);
   List<String> get includeExternal =>
@@ -842,9 +934,8 @@ class DartdocOptionContext {
   // ignore: unused_element
   String get _input => optionSet['input'].valueAt(context);
   String get inputDir => optionSet['inputDir'].valueAt(context);
-  bool get linkToExternal => optionSet['linkTo']['external'].valueAt(context);
-  String get linkToExternalUrl =>
-      optionSet['linkTo']['externalUrl'].valueAt(context);
+  bool get linkToRemote => optionSet['linkTo']['remote'].valueAt(context);
+  String get linkToUrl => optionSet['linkTo']['url'].valueAt(context);
 
   /// _linkToHosted is only used to construct synthetic options.
   // ignore: unused_element
@@ -878,19 +969,20 @@ Future<List<DartdocOption>> createDartdocOptions() async {
     new DartdocOptionArgOnly<bool>('addCrossdart', false,
         help: 'Add Crossdart links to the source code pieces.',
         negatable: true),
-    new DartdocOptionBoth<double>('ambiguousReexportScorerMinConfidence', 0.1,
+    new DartdocOptionArgFile<double>(
+        'ambiguousReexportScorerMinConfidence', 0.1,
         help:
             'Minimum scorer confidence to suppress warning on ambiguous reexport.'),
     new DartdocOptionArgOnly<bool>('autoIncludeDependencies', false,
         help:
             'Include all the used libraries into the docs, even the ones not in the current package or "include-external"',
         negatable: true),
-    new DartdocOptionBoth<List<String>>('categoryOrder', [],
+    new DartdocOptionArgFile<List<String>>('categoryOrder', [],
         help:
             "A list of categories (not package names) to place first when grouping symbols on dartdoc's sidebar. "
             'Unmentioned categories are sorted after these.'),
-    new DartdocOptionSynthetic<List<String>>('dropTextFrom',
-        (DartdocOptionSynthetic option, Directory dir) {
+    new DartdocOptionSyntheticOnly<List<String>>('dropTextFrom',
+        (DartdocSyntheticOption<List<String>> option, Directory dir) {
       if (option.parent['hideSdkText'].valueAt(dir)) {
         return [
           'dart.async',
@@ -913,22 +1005,32 @@ Future<List<DartdocOption>> createDartdocOptions() async {
       }
       return [];
     }, help: 'Remove text from libraries with the following names.'),
-    new DartdocOptionBoth<String>('examplePathPrefix', null,
+    new DartdocOptionArgFile<String>('examplePathPrefix', null,
         isDir: true,
         help: 'Prefix for @example paths.\n(defaults to the project root)',
         mustExist: true),
-    new DartdocOptionBoth<List<String>>('exclude', [],
+    new DartdocOptionArgFile<List<String>>('exclude', [],
         help: 'Library names to ignore.', splitCommas: true),
     new DartdocOptionArgOnly<List<String>>('excludePackages', [],
         help: 'Package names to ignore.', splitCommas: true),
+    // This could be a ArgOnly, but trying to not provide too many ways
+    // to set the flutter root.
+    new DartdocOptionSyntheticOnly<String>(
+      'flutterRoot',
+      (DartdocSyntheticOption<String> option, Directory dir) =>
+          resolveTildePath(Platform.environment['FLUTTER_ROOT']),
+      isDir: true,
+      help: 'Root of the Flutter SDK, specified from environment.',
+      mustExist: true,
+    ),
     new DartdocOptionArgOnly<bool>('hideSdkText', false,
         hide: true,
         help:
             'Drop all text for SDK components.  Helpful for integration tests for dartdoc, probably not useful for anything else.',
         negatable: true),
-    new DartdocOptionBoth<List<String>>('include', [],
+    new DartdocOptionArgFile<List<String>>('include', [],
         help: 'Library names to generate docs for.', splitCommas: true),
-    new DartdocOptionBoth<List<String>>('includeExternal', null,
+    new DartdocOptionArgFile<List<String>>('includeExternal', null,
         isFile: true,
         help:
             'Additional (external) dart files to include; use "dir/fileName", '
@@ -939,8 +1041,8 @@ Future<List<DartdocOption>> createDartdocOptions() async {
         help: 'Show source code blocks.', negatable: true),
     new DartdocOptionArgOnly<String>('input', Directory.current.path,
         isDir: true, help: 'Path to source directory', mustExist: true),
-    new DartdocOptionSynthetic<String>('inputDir',
-        (DartdocOptionSynthetic option, Directory dir) {
+    new DartdocOptionSyntheticOnly<String>('inputDir',
+        (DartdocSyntheticOption<String> option, Directory dir) {
       if (option.parent['sdkDocs'].valueAt(dir)) {
         return option.parent['sdkDir'].valueAt(dir);
       }
@@ -951,23 +1053,6 @@ Future<List<DartdocOption>> createDartdocOptions() async {
         mustExist: true),
     new DartdocOptionSet('linkTo')
       ..addAll([
-        new DartdocOptionArgOnly<bool>('external', false,
-            help: 'Allow links to be generated for packages outside this one.',
-            negatable: true),
-        new DartdocOptionSynthetic<String>('externalUrl',
-            (DartdocOptionSynthetic option, Directory dir) {
-          String url = option.parent['url'].valueAt(dir);
-          if (url != null) {
-            return url;
-          }
-          String hostedAt =
-              option.parent.parent['packageMeta'].valueAt(dir).hostedAt;
-          if (hostedAt != null) {
-            Map<String, String> hostMap = option.parent['hosted'].valueAt(dir);
-            if (hostMap.containsKey(hostedAt)) return hostMap[hostedAt];
-          }
-          return '';
-        }, help: 'Url to use for this particular package.'),
         new DartdocOptionArgOnly<Map<String, String>>(
             'hosted',
             {
@@ -975,14 +1060,41 @@ Future<List<DartdocOption>> createDartdocOptions() async {
                   'https://pub.dartlang.org/documentation/%n%/%v%'
             },
             help: 'Specify URLs for hosted pub packages'),
-        new DartdocOptionFileOnly<String>('url', null,
-            help: 'Use external linkage for this package, with this base url'),
+        new DartdocOptionArgOnly<Map<String, String>>(
+          'sdks',
+          {
+            'Dart': 'https://api.dartlang.org/%b%/%v%',
+            'Flutter': 'https://docs.flutter.io/flutter',
+          },
+          help: 'Specify URLs for SDKs.',
+        ),
+        new DartdocOptionFileSynth<String>('url',
+            (DartdocSyntheticOption<String> option, Directory dir) {
+          PackageMeta packageMeta =
+              option.parent.parent['packageMeta'].valueAt(dir);
+          // Prefer SDK check first, then pub cache check.
+          String inSdk = packageMeta
+              .sdkType(option.parent.parent['flutterRoot'].valueAt(dir));
+          if (inSdk != null) {
+            Map<String, String> sdks = option.parent['sdks'].valueAt(dir);
+            if (sdks.containsKey(inSdk)) return sdks[inSdk];
+          }
+          String hostedAt = packageMeta.hostedAt;
+          if (hostedAt != null) {
+            Map<String, String> hostMap = option.parent['hosted'].valueAt(dir);
+            if (hostMap.containsKey(hostedAt)) return hostMap[hostedAt];
+          }
+          return '';
+        }, help: 'Url to use for this particular package.'),
+        new DartdocOptionArgOnly<bool>('remote', false,
+            help: 'Allow links to be generated for packages outside this one.',
+            negatable: true),
       ]),
     new DartdocOptionArgOnly<String>('output', pathLib.join('doc', 'api'),
         isDir: true, help: 'Path to output directory.'),
-    new DartdocOptionSynthetic<PackageMeta>(
+    new DartdocOptionSyntheticOnly<PackageMeta>(
       'packageMeta',
-      (DartdocOptionSynthetic option, Directory dir) {
+      (DartdocSyntheticOption<PackageMeta> option, Directory dir) {
         PackageMeta packageMeta = new PackageMeta.fromDir(dir);
         if (packageMeta == null) {
           throw new DartdocOptionError(
@@ -997,12 +1109,19 @@ Future<List<DartdocOption>> createDartdocOptions() async {
             'Unmentioned categories are sorted after these.'),
     new DartdocOptionArgOnly<bool>('sdkDocs', false,
         help: 'Generate ONLY the docs for the Dart SDK.', negatable: false),
-    new DartdocOptionArgOnly<String>('sdkDir', defaultSdkDir.absolute.path,
-        help: 'Path to the SDK directory.', isDir: true, mustExist: true),
+    new DartdocOptionArgSynth<String>('sdkDir',
+        (DartdocSyntheticOption<String> option, Directory dir) {
+      if ((option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
+          .requiresFlutter) {
+        return pathLib.join(option.root['flutterRoot'].valueAt(dir), 'bin',
+            'cache', 'dart-sdk');
+      }
+      return defaultSdkDir.absolute.path;
+    }, help: 'Path to the SDK directory.', isDir: true, mustExist: true),
     new DartdocOptionArgOnly<bool>('showWarnings', false,
         help: 'Display all warnings.', negatable: false),
-    new DartdocOptionSynthetic<PackageMeta>('topLevelPackageMeta',
-        (DartdocOptionSynthetic option, Directory dir) {
+    new DartdocOptionSyntheticOnly<PackageMeta>('topLevelPackageMeta',
+        (DartdocSyntheticOption<PackageMeta> option, Directory dir) {
       PackageMeta packageMeta = new PackageMeta.fromDir(
           new Directory(option.parent['inputDir'].valueAt(dir)));
       if (packageMeta == null) {

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1108,8 +1108,9 @@ Future<List<DartdocOption>> createDartdocOptions() async {
         help: 'Generate ONLY the docs for the Dart SDK.', negatable: false),
     new DartdocOptionArgSynth<String>('sdkDir',
         (DartdocSyntheticOption<String> option, Directory dir) {
-      if ((option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
-          .requiresFlutter) {
+      if (!option.parent['sdkDocs'].valueAt(dir) &&
+          (option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
+              .requiresFlutter) {
         return pathLib.join(option.root['flutterRoot'].valueAt(dir), 'bin',
             'cache', 'dart-sdk');
       }

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -941,9 +941,6 @@ class DartdocOptionContext {
   // ignore: unused_element
   String get _linkToHosted => optionSet['linkTo']['hosted'].valueAt(context);
 
-  /// _linkToUrl is only used to construct synthetic options.
-  // ignore: unused_element
-  String get _linkToUrl => optionSet['linkTo']['url'].valueAt(context);
   String get output => optionSet['output'].valueAt(context);
   PackageMeta get packageMeta => optionSet['packageMeta'].valueAt(context);
   List<String> get packageOrder => optionSet['packageOrder'].valueAt(context);

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -179,24 +179,24 @@ abstract class GeneratorContext implements DartdocOptionContext {
 Future<List<DartdocOption>> createGeneratorOptions() async {
   await _setSdkFooterCopyrightUri();
   return <DartdocOption>[
-    new DartdocOptionBoth<String>('favicon', null,
+    new DartdocOptionArgFile<String>('favicon', null,
         isFile: true,
         help: 'A path to a favicon for the generated docs.',
         mustExist: true),
-    new DartdocOptionBoth<List<String>>('footer', [],
+    new DartdocOptionArgFile<List<String>>('footer', [],
         isFile: true,
         help: 'paths to footer files containing HTML text.',
         mustExist: true,
         splitCommas: true),
-    new DartdocOptionBoth<List<String>>('footerText', [],
+    new DartdocOptionArgFile<List<String>>('footerText', [],
         isFile: true,
         help:
             'paths to footer-text files (optional text next to the package name '
             'and version).',
         mustExist: true,
         splitCommas: true),
-    new DartdocOptionSynthetic<List<String>>('footerTextPaths',
-        (DartdocOptionSynthetic option, Directory dir) {
+    new DartdocOptionSyntheticOnly<List<String>>('footerTextPaths',
+        (DartdocSyntheticOption<List<String>> option, Directory dir) {
       List<String> footerTextPaths = <String>[];
       // TODO(jcollins-g): Eliminate special casing for SDK and use config file.
       if (new PackageMeta.fromDir(dir).isSdk) {
@@ -205,7 +205,7 @@ Future<List<DartdocOption>> createGeneratorOptions() async {
       footerTextPaths.addAll(option.parent['footerText'].valueAt(dir));
       return footerTextPaths;
     }),
-    new DartdocOptionBoth<List<String>>('header', [],
+    new DartdocOptionArgFile<List<String>>('header', [],
         isFile: true,
         help: 'paths to header files containing HTML text.',
         splitCommas: true),

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -195,16 +195,24 @@ Future<List<DartdocOption>> createGeneratorOptions() async {
             'and version).',
         mustExist: true,
         splitCommas: true),
-    new DartdocOptionSyntheticOnly<List<String>>('footerTextPaths',
-        (DartdocSyntheticOption<List<String>> option, Directory dir) {
-      List<String> footerTextPaths = <String>[];
-      // TODO(jcollins-g): Eliminate special casing for SDK and use config file.
-      if (new PackageMeta.fromDir(dir).isSdk) {
-        footerTextPaths.add(_sdkFooterCopyrightUri.toFilePath());
-      }
-      footerTextPaths.addAll(option.parent['footerText'].valueAt(dir));
-      return footerTextPaths;
-    }),
+    new DartdocOptionSyntheticOnly<List<String>>(
+      'footerTextPaths',
+      (DartdocSyntheticOption<List<String>> option, Directory dir) {
+        List<String> footerTextPaths = <String>[];
+        // TODO(jcollins-g): Eliminate special casing for SDK and use config file.
+        if ((option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
+                .isSdk ==
+            true) {
+          footerTextPaths
+              .add(pathLib.canonicalize(_sdkFooterCopyrightUri.toFilePath()));
+        }
+        footerTextPaths.addAll(option.parent['footerText'].valueAt(dir));
+        return footerTextPaths;
+      },
+      isFile: true,
+      help: 'paths to footer-text-files (adding special case for SDK)',
+      mustExist: true,
+    ),
     new DartdocOptionArgFile<List<String>>('header', [],
         isFile: true,
         help: 'paths to header files containing HTML text.',

--- a/lib/src/html/html_generator.dart
+++ b/lib/src/html/html_generator.dart
@@ -198,11 +198,11 @@ Future<List<DartdocOption>> createGeneratorOptions() async {
     new DartdocOptionSyntheticOnly<List<String>>(
       'footerTextPaths',
       (DartdocSyntheticOption<List<String>> option, Directory dir) {
-        List<String> footerTextPaths = <String>[];
+        final List<String> footerTextPaths = <String>[];
+        final PackageMeta topLevelPackageMeta =
+            option.root['topLevelPackageMeta'].valueAt(dir);
         // TODO(jcollins-g): Eliminate special casing for SDK and use config file.
-        if ((option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
-                .isSdk ==
-            true) {
+        if (topLevelPackageMeta.isSdk == true) {
           footerTextPaths
               .add(pathLib.canonicalize(_sdkFooterCopyrightUri.toFilePath()));
         }

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -66,7 +66,7 @@ final newLinePartOfRegexp = new RegExp('\npart of ');
 
 final RegExp quotables = new RegExp(r'[ "\r\n\$]');
 
-/// Best used with Future<void>.
+/// Best used with Future<Null>.
 class MultiFutureTracker<T> {
   /// Approximate maximum number of simultaneous active Futures.
   final int parallel;
@@ -76,13 +76,15 @@ class MultiFutureTracker<T> {
   MultiFutureTracker(this.parallel);
 
   /// Adds a Future to the queue of outstanding Futures, and returns a Future
-  /// that completes only when the number of Futures outstanding is <= parallel.
+  /// that completes only when the number of Futures outstanding is < [parallel]
+  /// (and so it is OK to start another).
+  ///
   /// That can be extremely brief and there's no longer a guarantee after that
   /// point that another async task has not added a Future to the list.
   void addFuture(Future<T> future) async {
     _queue.add(future);
     future.then((f) => _queue.remove(future));
-    await _waitUntil(parallel);
+    await _waitUntil(parallel - 1);
   }
 
   /// Wait until fewer or equal to this many Futures are outstanding.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -80,8 +80,8 @@ int byFeatureOrdering(String a, String b) {
   return compareAsciiLowerCaseNatural(a, b);
 }
 
-final RegExp locationSplitter = new RegExp(r"(package:|[\\/;.])");
-final RegExp substituteNameVersion = new RegExp(r"%([bnv])%");
+final RegExp locationSplitter = new RegExp(r'(package:|[\\/;.])');
+final RegExp substituteNameVersion = new RegExp(r'%([bnv])%');
 
 /// Mixin for subclasses of ModelElement representing Elements that can be
 /// inherited from one class to another.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -48,6 +48,7 @@ import 'package:dartdoc/src/warnings.dart';
 import 'package:front_end/src/byte_store/byte_store.dart';
 import 'package:front_end/src/base/performance_logger.dart';
 import 'package:path/path.dart' as pathLib;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:tuple/tuple.dart';
 import 'package:package_config/discovery.dart' as package_config;
 
@@ -80,7 +81,7 @@ int byFeatureOrdering(String a, String b) {
 }
 
 final RegExp locationSplitter = new RegExp(r"(package:|[\\/;.])");
-final RegExp substituteName = new RegExp(r"%([nv])%");
+final RegExp substituteNameVersion = new RegExp(r"%([bnv])%");
 
 /// Mixin for subclasses of ModelElement representing Elements that can be
 /// inherited from one class to another.
@@ -544,7 +545,7 @@ class Class extends ModelElement
   }
 
   /// This class might be canonical for elements it does not contain.
-  /// See [canonicalEnclosingElement].
+  /// See [Inheritable.canonicalEnclosingElement].
   bool contains(Element element) => allElements.containsKey(element);
 
   ModelElement findModelElement(Element element) => allElements[element];
@@ -1755,7 +1756,7 @@ class Library extends ModelElement with Categorization {
 
   /// [allModelElements] resolved to their original names.
   ///
-  /// A collection of [ModelElement.fullyQualifiedNames] for [ModelElement]s
+  /// A collection of [ModelElement.fullyQualifiedName]s for [ModelElement]s
   /// documented with this library, but these ModelElements and names correspond
   /// to the defining library where each originally came from with respect
   /// to inheritance and reexporting.  Most useful for error reporting.
@@ -3463,11 +3464,11 @@ abstract class ModelElement extends Canonicalization
     return lib;
   }
 
-  /// Replace {@example ...} in API comments with the content of named file.
+  /// Replace &#123;@example ...&#125; in API comments with the content of named file.
   ///
   /// Syntax:
   ///
-  ///     {@example PATH [region=NAME] [lang=NAME]}
+  ///     &#123;@example PATH [region=NAME] [lang=NAME]&#125;
   ///
   /// where PATH and NAME are tokens _without_ whitespace; NAME can optionally be
   /// quoted (use of quotes is for backwards compatibility and discouraged).
@@ -3476,10 +3477,11 @@ abstract class ModelElement extends Canonicalization
   /// named `dir/file-r.ext.md`, relative to the project root directory (of the
   /// project for which the docs are being generated).
   ///
-  /// Examples:
+  /// Examples: (escaped in this comment to show literal values in dartdoc's
+  ///            dartdoc)
   ///
-  ///     {@example examples/angular/quickstart/web/main.dart}
-  ///     {@example abc/def/xyz_component.dart region=template lang=html}
+  ///     &#123;@example examples/angular/quickstart/web/main.dart&#125;
+  ///     &#123;@example abc/def/xyz_component.dart region=template lang=html&#125;
   ///
   String _injectExamples(String rawdocs) {
     final dirPath = package.packageMeta.dir.path;
@@ -3621,7 +3623,7 @@ class ModelFunction extends ModelFunctionTyped {
   FunctionElement get _func => (element as FunctionElement);
 }
 
-/// A [ModelElement] for a [GenericModelFunctionElement] that is an
+/// A [ModelElement] for a [FunctionTypedElement] that is an
 /// explicit typedef.
 ///
 /// Distinct from ModelFunctionTypedef in that it doesn't
@@ -3642,7 +3644,7 @@ class ModelFunctionAnonymous extends ModelFunctionTyped {
   bool get isPublic => false;
 }
 
-/// A [ModelElement] for a [GenericModelFunctionElement] that is part of an
+/// A [ModelElement] for a [FunctionTypedElement] that is part of an
 /// explicit typedef.
 class ModelFunctionTypedef extends ModelFunctionTyped {
   ModelFunctionTypedef(
@@ -3948,7 +3950,7 @@ class PackageGraph extends Canonicalization
   String get location => '(top level package)';
 
   /// Flush out any warnings we might have collected while
-  /// [_packageWarningOptions.autoFlush] was false.
+  /// [PackageWarningOptions.autoFlush] was false.
   void flushWarnings() {
     _packageWarningCounter.maybeFlush();
   }
@@ -4669,7 +4671,7 @@ abstract class LibraryContainer extends Nameable
 
 /// A category is a subcategory of a package, containing libraries tagged
 /// with a @category identifier.  Comparable so it can be sorted according to
-/// [config.categoryOrder].
+/// [DartdocOptionContext.categoryOrder].
 class Category extends LibraryContainer {
   final String _name;
 
@@ -4773,7 +4775,7 @@ class Package extends LibraryContainer
 
   DocumentLocation get documentedWhere {
     if (!isLocal) {
-      if (config.linkToExternal && config.linkToExternalUrl.isNotEmpty) {
+      if (config.linkToRemote && config.linkToUrl.isNotEmpty) {
         return DocumentLocation.remote;
       } else {
         return DocumentLocation.missing;
@@ -4793,10 +4795,22 @@ class Package extends LibraryContainer
     if (_baseHref == null) {
       if (documentedWhere == DocumentLocation.remote) {
         _baseHref =
-            config.linkToExternalUrl.replaceAllMapped(substituteName, (m) {
+            config.linkToUrl.replaceAllMapped(substituteNameVersion, (m) {
           switch (m.group(1)) {
+            // Return the prerelease tag of the release if a prerelease,
+            // or 'stable' otherwise. Mostly coded around
+            // the Dart SDK's use of dev/stable, but theoretically applicable
+            // elsewhere.
+            case 'b':
+              {
+                Version version = new Version.parse(packageMeta.version);
+                return version.isPreRelease
+                    ? version.preRelease.first
+                    : 'stable';
+              }
             case 'n':
               return name;
+            // The full version string of the package.
             case 'v':
               return packageMeta.version;
           }

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -140,16 +140,18 @@ abstract class PackageMeta {
   /// Returns 'Dart' or 'Flutter' (preferentially, 'Flutter' when the answer is
   /// "both"), or null if this package is not part of a SDK.
   String sdkType(String flutterRootPath) {
-    String flutterPackages = pathLib.join(flutterRootPath, 'packages');
-    String flutterBinCache = pathLib.join(flutterRootPath, 'bin', 'cache');
+    if (flutterRootPath != null) {
+      String flutterPackages = pathLib.join(flutterRootPath, 'packages');
+      String flutterBinCache = pathLib.join(flutterRootPath, 'bin', 'cache');
 
-    /// Don't include examples or other non-SDK components as being the
-    /// "Flutter SDK".
-    if (pathLib.isWithin(
-            flutterPackages, pathLib.canonicalize(dir.absolute.path)) ||
-        pathLib.isWithin(
-            flutterBinCache, pathLib.canonicalize(dir.absolute.path))) {
-      return 'Flutter';
+      /// Don't include examples or other non-SDK components as being the
+      /// "Flutter SDK".
+      if (pathLib.isWithin(
+              flutterPackages, pathLib.canonicalize(dir.absolute.path)) ||
+          pathLib.isWithin(
+              flutterBinCache, pathLib.canonicalize(dir.absolute.path))) {
+        return 'Flutter';
+      }
     }
     return isSdk ? 'Dart' : null;
   }

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -132,8 +132,31 @@ abstract class PackageMeta {
     return _packageMetaCache[dir.absolute.path];
   }
 
+  /// Returns true if this represents a 'Dart' SDK.  A package can be part of
+  /// Dart and Flutter at the same time, but if we are part of a Dart SDK
+  /// sdkType should never return null.
   bool get isSdk;
+
+  /// Returns 'Dart' or 'Flutter' (preferentially, 'Flutter' when the answer is
+  /// "both"), or null if this package is not part of a SDK.
+  String sdkType(String flutterRootPath) {
+    String flutterPackages = pathLib.join(flutterRootPath, 'packages');
+    String flutterBinCache = pathLib.join(flutterRootPath, 'bin', 'cache');
+
+    /// Don't include examples or other non-SDK components as being the
+    /// "Flutter SDK".
+    if (pathLib.isWithin(
+            flutterPackages, pathLib.canonicalize(dir.absolute.path)) ||
+        pathLib.isWithin(
+            flutterBinCache, pathLib.canonicalize(dir.absolute.path))) {
+      return 'Flutter';
+    }
+    return isSdk ? 'Dart' : null;
+  }
+
   bool get needsPubGet => false;
+
+  bool get requiresFlutter;
 
   void runPubGet();
 
@@ -255,7 +278,7 @@ class _FilePackageMeta extends PackageMeta {
       StringBuffer buf = new StringBuffer();
       buf.writeln('${result.stdout}');
       buf.writeln('${result.stderr}');
-      throw DartdocFailure('pub get failed: ${buf.toString().trim()}');
+      throw new DartdocFailure('pub get failed: ${buf.toString().trim()}');
     }
   }
 
@@ -267,6 +290,10 @@ class _FilePackageMeta extends PackageMeta {
   String get description => _pubspec['description'];
   @override
   String get homepage => _pubspec['homepage'];
+
+  @override
+  bool get requiresFlutter =>
+      _pubspec['environment']?.containsKey('flutter') == true;
 
   @override
   FileContents getReadmeContents() {
@@ -354,6 +381,9 @@ class _SdkMeta extends PackageMeta {
       'Dart programming language.';
   @override
   String get homepage => 'https://github.com/dart-lang/sdk';
+
+  @override
+  bool get requiresFlutter => false;
 
   @override
   FileContents getReadmeContents() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.50.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.51.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,12 +254,12 @@ packages:
     source: hosted
     version: "1.3.4"
   pub_semver:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.7"
   quiver:
     dependency: "direct main"
     description:
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.49.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.50.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   mustache4dart: ^2.1.1
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
+  pub_semver: ^1.3.7
   quiver: ^0.27.0
   resource: ^2.1.2
   stack_trace: ^1.4.2
@@ -33,7 +34,6 @@ dev_dependencies:
   io: ^0.3.0
   http: ^0.11.0
   meta: ^1.0.0
-  pub_semver: ^1.0.0
   test: '^0.12.24'
 executables:
   dartdoc: null

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -44,6 +44,13 @@ void main() {
           .firstWhere((p) => p.name == 'useSomethingInAnotherPackage');
       expect(tuple.documentedWhere, equals(DocumentLocation.remote));
       expect(
+          (useSomethingInAnotherPackage.modelType.typeArguments.first
+                  as ParameterizedElementType)
+              .element
+              .package
+              .documentedWhere,
+          equals(DocumentLocation.remote));
+      expect(
           useSomethingInAnotherPackage.modelType.linkedName,
           startsWith(
               '<a href="https://pub.dartlang.org/documentation/tuple/1.0.1/tuple/Tuple2-class.html">Tuple2</a>'));

--- a/testing/test_package_flutter_plugin/.gitignore
+++ b/testing/test_package_flutter_plugin/.gitignore
@@ -1,0 +1,3 @@
+ios/
+doc/api/
+pubspec.lock

--- a/testing/test_package_flutter_plugin/analysis_options.yaml
+++ b/testing/test_package_flutter_plugin/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - '**'

--- a/testing/test_package_flutter_plugin/lib/testlib.dart
+++ b/testing/test_package_flutter_plugin/lib/testlib.dart
@@ -1,0 +1,12 @@
+/// This is a demonstration of interlinking with Flutter-using pub packages.
+library testlib;
+
+import 'package:flutter/material.dart';
+
+/// This widget is the best stateful widget ever.
+class MyAwesomeWidget extends StatefulWidget {
+  MyAwesomeWidget({Key key}) : super(key: key) {}
+
+  @override
+  State<MyAwesomeWidget> createState() => null;
+}

--- a/testing/test_package_flutter_plugin/pubspec.yaml
+++ b/testing/test_package_flutter_plugin/pubspec.yaml
@@ -1,0 +1,12 @@
+name: test_package_flutter_plugin
+version: 0.1.0
+description: A happy flutter almost plugin being documented
+homepage: http://github.com/dart-lang/dartdoc/tree/master/testing/test_package_flutter_plugin
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+environment:
+  sdk: ">2.0.0-dev.48.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -740,8 +740,12 @@ testPreviewDart2() async {
   List<String> parameters = ['--preview-dart-2', '--enable-asserts'];
 
   // sdk#32901 is really bad on Windows.
-  for (File dartFile in testFiles.where((f) =>
-      !f.path.endsWith('html_generator_test.dart') && !Platform.isWindows)) {
+  for (File dartFile in testFiles
+      .where((f) =>
+          !f.path.endsWith('html_generator_test.dart') && !Platform.isWindows)
+      .where((f) =>
+          // grinder stopped working with preview-dart-2.
+          !f.path.endsWith('grind_test.dart'))) {
     // absolute path to work around dart-lang/sdk#32901
     await testFutures.addFuture(new SubprocessLauncher(
             'dart2-${pathLib.basename(dartFile.absolute.path)}')

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -34,7 +34,7 @@ expectFileContains(String path, List<Pattern> items) {
 }
 
 /// Run no more than 4 futures in parallel with this.
-final MultiFutureTracker testFutures = new MultiFutureTracker(4);
+final MultiFutureTracker testFutures = new MultiFutureTracker(Platform.environment.containsKey('TRAVIS') ? 1 : 6);
 
 // Directory.systemTemp is not a constant.  So wrap it.
 Directory createTempSync(String prefix) =>

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -34,7 +34,7 @@ expectFileContains(String path, List<Pattern> items) {
 }
 
 /// Run no more than 4 futures in parallel with this.
-final MultiFutureTracker testFutures = new MultiFutureTracker(Platform.numberOfProcessors);
+final MultiFutureTracker testFutures = new MultiFutureTracker(Platform.environment.containsKey('TRAVIS') ? 2 : Platform.numberOfProcessors);
 
 // Directory.systemTemp is not a constant.  So wrap it.
 Directory createTempSync(String prefix) =>

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -46,7 +46,8 @@ RandomAccessFile _updateLock;
 Future<Null> _lockFuture;
 
 /// Returns true if we need to replace the existing flutter.  We never release
-/// this lock until the program exits.
+/// this lock until the program exits to prevent edge cases from spontaneously
+/// deciding to download a new Flutter SDK in the middle of a run.
 Future<bool> acquireUpdateLock() async {
   if (_updateLock != null) {
     await _lockFuture;
@@ -64,7 +65,7 @@ Future<bool> acquireUpdateLock() async {
   if (lastSynced.existsSync()) {
     DateTime lastSyncedTime = new DateTime.fromMillisecondsSinceEpoch(
         int.parse(await lastSynced.readAsString()));
-    if (lastSyncedTime.difference(new DateTime.now()) < new Duration(hours: 4))
+    if (new DateTime.now().difference(lastSyncedTime) < new Duration(hours: 4))
       return false;
   }
   return true;

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -33,8 +33,8 @@ expectFileContains(String path, List<Pattern> items) {
   }
 }
 
-/// Run no more than 6 futures in parallel with this.
-final MultiFutureTracker testFutures = new MultiFutureTracker(6);
+/// Run no more than 4 futures in parallel with this.
+final MultiFutureTracker testFutures = new MultiFutureTracker(4);
 
 // Directory.systemTemp is not a constant.  So wrap it.
 Directory createTempSync(String prefix) =>

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -728,6 +728,7 @@ publish() async {
 
 @Task('Run all the tests.')
 test() async {
+  print ('processors: ${Platform.numberOfProcessors}');
   await testPreviewDart2();
   await testDart1();
   await testFutures.wait();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -36,7 +36,7 @@ expectFileContains(String path, List<Pattern> items) {
 /// Run no more than the number of processors available in parallel.
 final MultiFutureTracker testFutures = new MultiFutureTracker(
     Platform.environment.containsKey('TRAVIS')
-        ? 1
+        ? 2
         : Platform.numberOfProcessors);
 
 // Directory.systemTemp is not a constant.  So wrap it.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -33,8 +33,11 @@ expectFileContains(String path, List<Pattern> items) {
   }
 }
 
-/// Run no more than 4 futures in parallel with this.
-final MultiFutureTracker testFutures = new MultiFutureTracker(Platform.environment.containsKey('TRAVIS') ? 2 : Platform.numberOfProcessors);
+/// Run no more than the number of processors available in parallel.
+final MultiFutureTracker testFutures = new MultiFutureTracker(
+    Platform.environment.containsKey('TRAVIS')
+        ? 1
+        : Platform.numberOfProcessors);
 
 // Directory.systemTemp is not a constant.  So wrap it.
 Directory createTempSync(String prefix) =>
@@ -728,7 +731,6 @@ publish() async {
 
 @Task('Run all the tests.')
 test() async {
-  print ('processors: ${Platform.numberOfProcessors}');
   await testPreviewDart2();
   await testDart1();
   await testFutures.wait();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -78,7 +78,9 @@ Future<FlutterRepo> get cleanFlutterRepo async {
   if (_cleanFlutterRepo == null) {
     _cleanFlutterRepo = FlutterRepo.fromPath(cleanFlutterDir.path, {}, 'clean');
     if (await acquireUpdateLock()) {
-      await cleanFlutterDir.delete(recursive: true);
+      if (cleanFlutterDir.existsSync()) {
+        await cleanFlutterDir.delete(recursive: true);
+      }
       await cleanFlutterDir.create(recursive: true);
       FlutterRepo repo = await _cleanFlutterRepo;
       await repo._init();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -63,10 +63,13 @@ Future<FlutterRepo> get cleanFlutterRepo async {
     await cleanFlutterDir.parent.create(recursive: true);
     assert(_lockFuture == null);
     _lockFuture = new File(pathLib.join(cleanFlutterDir.parent.path, 'lock'))
-        .openSync(mode: FileMode.WRITE).lock();
+        .openSync(mode: FileMode.WRITE)
+        .lock();
     await _lockFuture;
-    File lastSynced = new File(pathLib.join(cleanFlutterDir.parent.path, 'lastSynced'));
-    FlutterRepo newRepo = new FlutterRepo.fromPath(cleanFlutterDir.path, {}, 'clean');
+    File lastSynced =
+        new File(pathLib.join(cleanFlutterDir.parent.path, 'lastSynced'));
+    FlutterRepo newRepo =
+        new FlutterRepo.fromPath(cleanFlutterDir.path, {}, 'clean');
 
     // We have a repository, but is it up to date?
     DateTime lastSyncedTime;
@@ -75,15 +78,16 @@ Future<FlutterRepo> get cleanFlutterRepo async {
           int.parse(lastSynced.readAsStringSync()));
     }
     if (lastSyncedTime == null ||
-        new DateTime.now().difference(lastSyncedTime) > new Duration(hours: 4)) {
+        new DateTime.now().difference(lastSyncedTime) >
+            new Duration(hours: 4)) {
       // Rebuild the repository.
       if (cleanFlutterDir.existsSync()) {
         cleanFlutterDir.deleteSync(recursive: true);
       }
       cleanFlutterDir.createSync(recursive: true);
       await newRepo._init();
-      await lastSynced
-          .writeAsString((new DateTime.now()).millisecondsSinceEpoch.toString());
+      await lastSynced.writeAsString(
+          (new DateTime.now()).millisecondsSinceEpoch.toString());
     }
     _cleanFlutterRepo.complete(newRepo);
   }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -34,7 +34,7 @@ expectFileContains(String path, List<Pattern> items) {
 }
 
 /// Run no more than 4 futures in parallel with this.
-final MultiFutureTracker testFutures = new MultiFutureTracker(Platform.environment.containsKey('TRAVIS') ? 1 : 6);
+final MultiFutureTracker testFutures = new MultiFutureTracker(Platform.numberOfProcessors);
 
 // Directory.systemTemp is not a constant.  So wrap it.
 Directory createTempSync(String prefix) =>

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -15,26 +15,12 @@ if [ "$DARTDOC_BOT" = "sdk-docs" ]; then
   # silence stdout but echo stderr
   echo ""
   echo "Building and validating SDK docs..."
-
   pub run grinder validate-sdk-docs
-
   echo "SDK docs process finished"
 elif [ "$DARTDOC_BOT" = "flutter" ]; then
   echo "Running flutter dartdoc bot"
-
-  pub run grinder build-flutter-docs
+  pub run grinder validate-flutter-docs
 else
   echo "Running main dartdoc bot"
-
-  # Verify that the libraries are error free.
-  pub run grinder analyze
-
-  # Run dartdoc on test_package.
-  (cd testing/test_package; dart -c ../../bin/dartdoc.dart)
-
-  # And on test_package_small.
-  (cd testing/test_package_small; dart -c ../../bin/dartdoc.dart)
-
-  # Run the tests.
-  pub run test
+  pub run grinder buildbot
 fi

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -21,10 +21,6 @@ elif [ "$DARTDOC_BOT" = "flutter" ]; then
   echo "Running flutter dartdoc bot"
   pub run grinder validate-flutter-docs
 else
-  echo "running model_test"
-  pub get
-  /home/travis/dart-sdk/bin/dart --preview-dart-2 --enable-asserts /home/travis/build/dart-lang/dartdoc/test/model_test.dart
-
   echo "Running main dartdoc bot"
   pub run grinder buildbot
 fi

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -21,6 +21,10 @@ elif [ "$DARTDOC_BOT" = "flutter" ]; then
   echo "Running flutter dartdoc bot"
   pub run grinder validate-flutter-docs
 else
+  echo "running model_test"
+  pub get
+  /home/travis/dart-sdk/bin/dart --preview-dart-2 --enable-asserts /home/travis/build/dart-lang/dartdoc/test/model_test.dart
+
   echo "Running main dartdoc bot"
   pub run grinder buildbot
 fi


### PR DESCRIPTION
A batch of changes refining the cross-linking mechanism introduced in #1678.  With this, I think it's ready for prime-time use.

- dartdoc_options _onMissing is refactored to be less repetitive
- linkToUrl is now a new FileSynth type of dartdoc option (synthetic default, overridable via file).  Adds tests for that new type.
- Add a branch substitution in URL calculations (so we don't have to hardcode "dev") 
- Add a persistent, automatic flutter SDK installation to the grinder that Travis can reuse, refactor existing tests to use it, and write a new test for the new flutter cross-link.
- Use the new Dart1/Dart2 test runner on Travis as well as AppVeyor, and fix up grinder to not overparallelize on Travis and cause random timeouts.  