### PR TITLE
Update analyzer to 0.31.2-alpha.2.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -16,8 +16,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/file_system/file_system.dart' as fileSystem;
 import 'package:analyzer/file_system/physical_file_system.dart';
-import 'package:analyzer/source/package_map_resolver.dart';
-import 'package:analyzer/source/sdk_ext.dart';
+import 'package:analyzer/src/source/package_map_resolver.dart';
+import 'package:analyzer/src/source/sdk_ext.dart';
 // TODO(jcollins-g): Stop using internal analyzer structures somehow.
 import 'package:analyzer/src/context/builder.dart';
 import 'package:analyzer/src/dart/analysis/file_state.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.2-alpha.1"
+    version: "0.31.2-alpha.2"
   args:
     dependency: "direct main"
     description:
@@ -91,7 +91,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.11"
+    version: "0.1.0-alpha.12"
   glob:
     dependency: transitive
     description:
@@ -141,13 +141,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.2+1"
-  isolate:
-    dependency: transitive
-    description:
-      name: isolate
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   js:
     dependency: transitive
     description:
@@ -161,7 +154,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.11"
+    version: "0.3.0-alpha.12"
   logging:
     dependency: "direct main"
     description:
@@ -408,4 +401,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.49.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,4 +401,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.51.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,10 @@ homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=2.0.0-dev.9.0 <3.0.0'
 dependencies:
-  analyzer: '0.31.2-alpha.1'
+  analyzer: '0.31.2-alpha.2'
   args: '>=0.13.0 <2.0.0'
   collection: ^1.2.0
-  front_end: ^0.1.0-alpha.11
+  front_end: ^0.1.0-alpha.12
   html: '>=0.12.1 <0.14.0'
   # We don't use http_parser directly; this dep exists to ensure that we get at
   # least version 3.0.3 to work around an issue with 3.0.2.

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
-import 'package:io/io.dart';
 import 'package:path/path.dart' as pathLib;
 import 'package:test/test.dart';
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -609,8 +609,11 @@ testPreviewDart2() async {
   List<String> parameters = ['--preview-dart-2', '--enable-asserts'];
 
   // sdk#32901 is really bad on Windows.
-  for (File dartFile in testFiles.where((f) =>
-      !f.path.endsWith('html_generator_test.dart') && !Platform.isWindows)) {
+  for (File dartFile in testFiles
+      .where((f) =>
+          !f.path.endsWith('html_generator_test.dart') && !Platform.isWindows)
+      .where((f) =>
+          !f.path.endsWith('grind_test.dart'))) {
     // absolute path to work around dart-lang/sdk#32901
     await testFutures.addFuture(new SubprocessLauncher(
             'dart2-${pathLib.basename(dartFile.absolute.path)}')


### PR DESCRIPTION
Also drops the grinder test from --preview-dart-2 as that stopped working around SDK .50 or thereabouts.