### PR TITLE
Prefer package-local canonicalization and warn on reexported private API across packages

### DIFF
--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -54,6 +54,10 @@ final Map<PackageWarning, PackageWarningHelpText> packageWarningText = const {
       PackageWarning.packageOrderGivesMissingPackageName,
       "category-order-gives-missing-package-name",
       "The category-order flag on the command line was given the name of a nonexistent package"),
+  PackageWarning.reexportedPrivateApiAcrossPackages: const PackageWarningHelpText(
+      PackageWarning.reexportedPrivateApiAcrossPackages,
+      "reexported-private-api-across-packages",
+      "One or more libraries reexports private API members from outside its own package"),
   PackageWarning.unresolvedDocReference: const PackageWarningHelpText(
       PackageWarning.unresolvedDocReference,
       "unresolved-doc-reference",
@@ -113,6 +117,7 @@ enum PackageWarning {
   noCanonicalFound,
   noLibraryLevelDocs,
   packageOrderGivesMissingPackageName,
+  reexportedPrivateApiAcrossPackages,
   unresolvedDocReference,
   unknownMacro,
   brokenLink,


### PR DESCRIPTION
Fixes a small bug in canonicalization when cross-linking packages, where we sometimes might pick the wrong package as canonical when reexporting is going on.  Provide a specific warning if a reexport of private APIs makes canonicalization unreliable.