### PR TITLE
Prepare for 0.19.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 0.19.1
 * Update `package:markdown` to `2.0.0`, which includes many improvements –
   especially to the parsing of links.
+* Update analyzer to 0.32.0.
+* Fix bug where --version didn't do anything (#1692)
+* Switch dartdoc_test to an integration test and add basic Dart 2.0
+  integration tests
 
 ## 0.19.0
 * Build documentation through the Package object (#1659)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 0.19.1
 * Update `package:markdown` to `2.0.0`, which includes many improvements –
   especially to the parsing of links.
-* Update analyzer to 0.32.0.
-* Fix bug where --version didn't do anything (#1692)
+* Update analyzer to 0.32.0, mustache4dart to 2.1.2, and grinder for 0.8.2 for Dart 2 fixes.
+* Fix bug where --version printed help instead of the version number. (#1692)
 * Switch dartdoc_test to an integration test and add basic Dart 2.0
-  integration tests
+  integration tests.
+* Do not crash on unversioned packages (#1688).
 
 ## 0.19.0
 * Build documentation through the Package object (#1659)

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -37,7 +37,7 @@ export 'package:dartdoc/src/package_meta.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String dartdocVersion = '0.19.1-dev';
+const String dartdocVersion = '0.19.1';
 
 /// Helper class to initialize the default generators since they require
 /// GeneratorContext.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.2-alpha.2"
+    version: "0.32.0"
   args:
     dependency: "direct main"
     description:
@@ -22,13 +22,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.6"
-  barback:
-    dependency: transitive
-    description:
-      name: barback
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.15.2+14"
   boolean_selector:
     dependency: transitive
     description:
@@ -91,7 +84,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.12"
+    version: "0.1.0"
   glob:
     dependency: transitive
     description:
@@ -154,7 +147,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.12"
+    version: "0.3.0"
   logging:
     dependency: "direct main"
     description:
@@ -175,14 +168,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+4"
+    version: "0.12.2+1"
   meta:
     dependency: "direct dev"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.5"
   mime:
     dependency: transitive
     description:
@@ -357,7 +350,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.32+1"
+    version: "0.12.38+1"
   tuple:
     dependency: "direct main"
     description:
@@ -401,4 +394,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.55.0"
+  dart: ">=2.0.0-dev.54.0 <=2.0.0-dev.55.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.19.1-dev
+version: 0.19.1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=2.0.0-dev.54.0 <3.0.0'
 dependencies:
-  analyzer: '0.31.2-alpha.2'
+  analyzer: 0.32.0
   args: '>=0.13.0 <2.0.0'
   collection: ^1.2.0
-  front_end: ^0.1.0-alpha.12
+  front_end: ^0.1.0
   html: '>=0.12.1 <0.14.0'
   # We don't use http_parser directly; this dep exists to ensure that we get at
   # least version 3.0.3 to work around an issue with 3.0.2.

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -60,7 +60,6 @@ void main() {
           contains(stringLink));
     });
 
-
     test('generate docs for ${pathLib.basename(testPackageDir.path)} works',
         () async {
       Dartdoc dartdoc = await Dartdoc.withDefaultGenerators(

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.19.1-dev">
+  <meta name="generator" content="made with love by dartdoc 0.19.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
Update analyzer to 0.32.0 with better support for Dart 2 (#1668) esp. on Mac and Linux, but still blocked on dart-lang/sdk#32901 for Windows. Depending on the fix, Dartdoc may run with preview-dart-2 on all platforms on this version once that bug is resolved.