### PR TITLE
Adding animation directive for injecting animated diagrams

### DIFF
--- a/lib/resources/play_button.svg
+++ b/lib/resources/play_button.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="68" viewBox="0 0 17.992 17.992"><path d="M17.992 8.996A8.996 8.996 0 1 0 0 8.996a8.996 8.996 0 0 0 17.992 0m-2.23 0l-9.895 5.713V3.282l9.896 5.714h2.229z" fill-opacity=".198"/><path d="M15.763 8.996l-9.896 5.713V3.283z" fill="#7d7d7d" fill-opacity=".821"/></svg>

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3528,16 +3528,16 @@ abstract class ModelElement extends Canonicalization
     });
   }
 
-  /// Replace {@animation ...} in API comments with some HTML to manage an
+  /// Replace &#123;@animation ...&#125; in API comments with some HTML to manage an
   /// MPEG 4 video as an animation.
   ///
   /// Syntax:
   ///
-  ///     {@animation NAME WIDTH HEIGHT URL}
+  ///     &#123;@animation NAME WIDTH HEIGHT URL&#125;
   ///
   /// Example:
   ///
-  ///     {@animation my_video 300 300 https://foo.com/path/to/video.mp4}
+  ///     &#123;@animation my_video 300 300 https://example.com/path/to/video.mp4&#125;
   ///
   /// Which will render the HTML necessary for embedding a simple click-to-play
   /// HTML5 video player with no controls.
@@ -3655,28 +3655,29 @@ abstract class ModelElement extends Canonicalization
   </video>
 </div>
 
-      ''';
+''';  // String must end at beginning of line, or following inline text will be
+      // indented.
     });
   }
 
-  /// Replace {@macro ...} in API comments with the contents of the macro
+  /// Replace &#123;@macro ...&#125; in API comments with the contents of the macro
   ///
   /// Syntax:
   ///
-  ///     {@macro NAME}
+  ///     &#123;@macro NAME&#125;
   ///
   /// Example:
   ///
   /// You define the template in any comment for a documentable entity like:
   ///
-  ///     {@template foo}
+  ///     &#123;@template foo&#125;
   ///     Foo contents!
-  ///     {@endtemplate}
+  ///     &#123;@endtemplate&#125;
   ///
   /// and them somewhere use it like this:
   ///
   ///     Some comments
-  ///     {@macro foo}
+  ///     &#123;@macro foo&#125;
   ///     More comments
   ///
   /// Which will render
@@ -3696,13 +3697,13 @@ abstract class ModelElement extends Canonicalization
     });
   }
 
-  /// Parse {@template ...} in API comments and store them in the index on the package.
+  /// Parse &#123;@template ...&#125; in API comments and store them in the index on the package.
   ///
   /// Syntax:
   ///
-  ///     {@template NAME}
+  ///     &#123;@template NAME&#125;
   ///     The contents of the macro
-  ///     {@endtemplate}
+  ///     &#123;@endtemplate&#125;
   ///
   String _stripMacroTemplatesAndAddToIndex(String rawDocs) {
     final templateRegExp = new RegExp(

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -86,6 +86,10 @@ final Map<PackageWarning, PackageWarningHelpText> packageWarningText = const {
       PackageWarning.typeAsHtml,
       "typeAsHtml",
       "Use of <> in a comment for type parameters is being treated as HTML by markdown"),
+  PackageWarning.invalidParameter: const PackageWarningHelpText(
+      PackageWarning.invalidParameter,
+      "invalidParameter",
+      "A parameter given to a dartdoc directive was invalid."),
 };
 
 /// Something that package warnings can be called on.  Optionally associated
@@ -125,6 +129,7 @@ enum PackageWarning {
   unknownFile,
   missingFromSearchIndex,
   typeAsHtml,
+  invalidParameter,
 }
 
 /// Warnings it is OK to skip if we can determine the warnable isn't documented.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.54.0 <=2.0.0-dev.56.0"
+  dart: ">=2.0.0-dev.54.0 <=2.0.0-dev.58.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.54.0 <=2.0.0-dev.55.0"
+  dart: ">=2.0.0-dev.54.0 <=2.0.0-dev.56.0"

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -496,6 +496,70 @@ void main() {
     });
   });
 
+  group('Animation', () {
+    Class dog;
+    Method withAnimation;
+    Method withAnimationNonUnique;
+    Method withAnimationWrongParams;
+    Method withAnimationBadWidth;
+    Method withAnimationBadHeight;
+
+    setUp(() {
+      dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
+      withAnimation =
+          dog.allInstanceMethods.firstWhere((m) => m.name == 'withAnimation');
+      withAnimationNonUnique = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withAnimationNonUnique');
+      withAnimationWrongParams = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withAnimationWrongParams');
+      withAnimationBadWidth = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withAnimationBadWidth');
+      withAnimationBadHeight = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withAnimationBadHeight');
+      packageGraph.allLocalModelElements.forEach((m) => m.documentation);
+    });
+
+    test("renders an animation within the method documentation", () {
+      expect(
+          withAnimation.documentation, contains('<video id="methodAnimation"'));
+    });
+    test("warns on a non-unique animation within a method", () {
+      expect(
+          packageGraph.packageWarningCounter.hasWarning(
+              withAnimationNonUnique,
+              PackageWarning.invalidParameter,
+              'An animation has a non-unique name: fooHerderAnimation. Animation names '
+              'must be unique.'),
+          isTrue);
+    });
+    test("warns on animation with missing parameters", () {
+      expect(
+          packageGraph.packageWarningCounter.hasWarning(
+              withAnimationWrongParams,
+              PackageWarning.invalidParameter,
+              'Invalid @animation directive: {@animation http://host/path/to/video.mp4}\n'
+              'Animation directives must be of the form: {@animation NAME '
+              'WIDTH HEIGHT URL}'),
+          isTrue);
+    });
+    test("warns on animation with non-integer width", () {
+      expect(
+          packageGraph.packageWarningCounter.hasWarning(
+              withAnimationBadWidth,
+              PackageWarning.invalidParameter,
+              'An animation has an invalid width (badWidthAnimation): 100px. The width must be an integer.'),
+          isTrue);
+    });
+    test("warns on animation with non-integer height", () {
+      expect(
+          packageGraph.packageWarningCounter.hasWarning(
+              withAnimationBadHeight,
+              PackageWarning.invalidParameter,
+              'An animation has an invalid height (badHeightAnimation): 100px. The height must be an integer.'),
+          isTrue);
+    });
+  });
+
   group('MultiplyInheritedExecutableElement handling', () {
     Class BaseThingy, BaseThingy2, ImplementingThingy2;
     Method aImplementingThingyMethod;
@@ -1019,7 +1083,7 @@ void main() {
     });
 
     test('get methods', () {
-      expect(Dog.publicInstanceMethods, hasLength(12));
+      expect(Dog.publicInstanceMethods, hasLength(17));
     });
 
     test('get operators', () {
@@ -1084,6 +1148,11 @@ void main() {
             'testGenericMethod',
             'testMethod',
             'toString',
+            'withAnimation',
+            'withAnimationBadHeight',
+            'withAnimationBadWidth',
+            'withAnimationNonUnique',
+            'withAnimationWrongParams',
             'withMacro',
             'withMacro2',
             'withPrivateMacro',

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -503,6 +503,8 @@ void main() {
     Method withAnimationWrongParams;
     Method withAnimationBadWidth;
     Method withAnimationBadHeight;
+    Method withAnimationInOneLineDoc;
+    Method withAnimationInline;
 
     setUp(() {
       dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
@@ -516,6 +518,10 @@ void main() {
           .firstWhere((m) => m.name == 'withAnimationBadWidth');
       withAnimationBadHeight = dog.allInstanceMethods
           .firstWhere((m) => m.name == 'withAnimationBadHeight');
+      withAnimationInOneLineDoc = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withAnimationInOneLineDoc');
+      withAnimationInline = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withAnimationInline');
       packageGraph.allLocalModelElements.forEach((m) => m.documentation);
     });
 
@@ -557,6 +563,16 @@ void main() {
               PackageWarning.invalidParameter,
               'An animation has an invalid height (badHeightAnimation): 100px. The height must be an integer.'),
           isTrue);
+    });
+    test("Doesn't place animations in one line doc", () {
+      expect(
+          withAnimationInline.oneLineDoc, isNot(contains('<video')));
+      expect(
+          withAnimationInline.documentation, contains('<video'));
+    });
+    test("Handles animations inline properly", () {
+      expect(
+          withAnimationInline.documentation, isNot(contains('  works')));
     });
   });
 
@@ -1083,7 +1099,7 @@ void main() {
     });
 
     test('get methods', () {
-      expect(Dog.publicInstanceMethods, hasLength(17));
+      expect(Dog.publicInstanceMethods, hasLength(19));
     });
 
     test('get operators', () {
@@ -1151,6 +1167,8 @@ void main() {
             'withAnimation',
             'withAnimationBadHeight',
             'withAnimationBadWidth',
+            'withAnimationInline',
+            'withAnimationInOneLineDoc',
             'withAnimationNonUnique',
             'withAnimationWrongParams',
             'withMacro',

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -386,6 +386,17 @@ class Dog implements Cat, E {
   /// More docs
   void withAnimationBadHeight() {}
 
+  /// Animation in one line doc {@animation oneLine 100 100 http://host/path/to/video.mp4}
+  ///
+  /// This tests to see that we do the right thing if the animation is in
+  /// the one line doc above.
+  void withAnimationInOneLineDoc() {}
+
+  /// Animation inline in text.
+  ///
+  /// Tests to see that an inline {@animation inline 100 100 http://host/path/to/video.mp4} works as expected.
+  void withAnimationInline() {}
+
   void testGeneric(Map<String, dynamic> args) {}
 
   void testMethod(Iterable it) {}

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -355,6 +355,37 @@ class Dog implements Cat, E {
   /// Don't define this:  {@macro ThatDoesNotExist}
   void withUndefinedMacro() {}
 
+  /// Animation method
+  ///
+  /// {@animation methodAnimation 100 100 http://host/path/to/video.mp4}
+  /// More docs
+  void withAnimation() {}
+
+  /// Non-Unique Animation method (between methods)
+  ///
+  /// {@animation fooHerderAnimation 100 100 http://host/path/to/video.mp4}
+  /// {@animation fooHerderAnimation 100 100 http://host/path/to/video.mp4}
+  /// More docs
+  void withAnimationNonUnique() {}
+
+  /// Malformed Animation method with wrong parameters
+  ///
+  /// {@animation http://host/path/to/video.mp4}
+  /// More docs
+  void withAnimationWrongParams() {}
+
+  /// Malformed Animation method with non-integer width
+  ///
+  /// {@animation badWidthAnimation 100px 100 http://host/path/to/video.mp4}
+  /// More docs
+  void withAnimationBadWidth() {}
+
+  /// Malformed Animation method with non-integer height
+  ///
+  /// {@animation badHeightAnimation 100 100px http://host/path/to/video.mp4}
+  /// More docs
+  void withAnimationBadHeight() {}
+
   void testGeneric(Map<String, dynamic> args) {}
 
   void testMethod(Iterable it) {}

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -313,6 +313,51 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           
           
 </dd>
+        <dt id="withAnimation" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimation.html">withAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation method <a href="ex/Dog/withAnimation.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationBadHeight" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Malformed Animation method with non-integer height <a href="ex/Dog/withAnimationBadHeight.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationBadWidth" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Malformed Animation method with non-integer width <a href="ex/Dog/withAnimationBadWidth.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationNonUnique" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Non-Unique Animation method (between methods) <a href="ex/Dog/withAnimationNonUnique.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationWrongParams" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Malformed Animation method with wrong parameters <a href="ex/Dog/withAnimationWrongParams.html">[...]</a>
+          
+</dd>
         <dt id="withMacro" class="callable">
           <span class="name"><a href="ex/Dog/withMacro.html">withMacro</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -482,6 +527,11 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -340,6 +340,24 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           Malformed Animation method with non-integer width <a href="ex/Dog/withAnimationBadWidth.html">[...]</a>
           
 </dd>
+        <dt id="withAnimationInline" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation inline in text. <a href="ex/Dog/withAnimationInline.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationInOneLineDoc" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation in one line doc  <a href="ex/Dog/withAnimationInOneLineDoc.html">[...]</a>
+          
+</dd>
         <dt id="withAnimationNonUnique" class="callable">
           <span class="name"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -530,6 +548,8 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aName-constant.html
+++ b/testing/test_package_docs/ex/Dog/aName-constant.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aName-constant.html
+++ b/testing/test_package_docs/ex/Dog/aName-constant.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimation.html
+++ b/testing/test_package_docs/ex/Dog/withAnimation.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the deprecatedField property from the Dog class, for the Dart programming language.">
-  <title>deprecatedField property - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimation method from the Dog class, for the Dart programming language.">
+  <title>withAnimation method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb"><span class="deprecated">deprecatedField</span> property</li>
+    <li class="self-crumb">withAnimation method</li>
   </ol>
-  <div class="self-name">deprecatedField</div>
+  <div class="self-name">withAnimation</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -94,14 +94,43 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>deprecatedField property</h1>
+    <h1>withAnimation method</h1>
 
-        <section class="multi-line-signature">
-          <span class="returntype">int</span>
-          <span class="name deprecated">deprecatedField</span>
-          <div class="features">read / write</div>
-        </section>
-                
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">withAnimation</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Animation method</p><div style="position: relative;">
+  <div id="methodAnimation_play_button_" onclick="if (methodAnimation.paused) {
+                  methodAnimation.play();
+                  this.style.display = 'none';
+                } else {
+                  methodAnimation.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="methodAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    methodAnimation_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    methodAnimation_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>More docs</p>
+    </section>
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/withAnimationBadHeight.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationBadHeight.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimationBadHeight.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationBadHeight.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the deprecatedField property from the Dog class, for the Dart programming language.">
-  <title>deprecatedField property - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationBadHeight method from the Dog class, for the Dart programming language.">
+  <title>withAnimationBadHeight method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb"><span class="deprecated">deprecatedField</span> property</li>
+    <li class="self-crumb">withAnimationBadHeight method</li>
   </ol>
-  <div class="self-name">deprecatedField</div>
+  <div class="self-name">withAnimationBadHeight</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -94,14 +94,19 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>deprecatedField property</h1>
+    <h1>withAnimationBadHeight method</h1>
 
-        <section class="multi-line-signature">
-          <span class="returntype">int</span>
-          <span class="name deprecated">deprecatedField</span>
-          <div class="features">read / write</div>
-        </section>
-                
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">withAnimationBadHeight</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Malformed Animation method with non-integer height</p>
+<p>More docs</p>
+    </section>
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/withAnimationBadWidth.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationBadWidth.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimationBadWidth.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationBadWidth.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the deprecatedField property from the Dog class, for the Dart programming language.">
-  <title>deprecatedField property - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationBadWidth method from the Dog class, for the Dart programming language.">
+  <title>withAnimationBadWidth method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb"><span class="deprecated">deprecatedField</span> property</li>
+    <li class="self-crumb">withAnimationBadWidth method</li>
   </ol>
-  <div class="self-name">deprecatedField</div>
+  <div class="self-name">withAnimationBadWidth</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -94,14 +94,19 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>deprecatedField property</h1>
+    <h1>withAnimationBadWidth method</h1>
 
-        <section class="multi-line-signature">
-          <span class="returntype">int</span>
-          <span class="name deprecated">deprecatedField</span>
-          <div class="features">read / write</div>
-        </section>
-                
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">withAnimationBadWidth</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Malformed Animation method with non-integer width</p>
+<p>More docs</p>
+    </section>
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/withAnimationInOneLineDoc.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationInOneLineDoc.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withAnimation method from the Dog class, for the Dart programming language.">
-  <title>withAnimation method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationInOneLineDoc method from the Dog class, for the Dart programming language.">
+  <title>withAnimationInOneLineDoc method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withAnimation method</li>
+    <li class="self-crumb">withAnimationInOneLineDoc method</li>
   </ol>
-  <div class="self-name">withAnimation</div>
+  <div class="self-name">withAnimationInOneLineDoc</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -96,20 +96,20 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withAnimation method</h1>
+    <h1>withAnimationInOneLineDoc method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withAnimation</span>
+      <span class="name ">withAnimationInOneLineDoc</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Animation method</p><div style="position: relative;">
-  <div id="methodAnimation_play_button_" onclick="if (methodAnimation.paused) {
-                  methodAnimation.play();
+      <p>Animation in one line doc </p><div style="position: relative;">
+  <div id="oneLine_play_button_" onclick="if (oneLine.paused) {
+                  oneLine.play();
                   this.style.display = 'none';
                 } else {
-                  methodAnimation.pause();
+                  oneLine.pause();
                   this.style.display = 'block';
                 }" style="position:absolute;
               width:100px;
@@ -119,17 +119,18 @@
               background-repeat: no-repeat;
               background-image: url(static-assets/play_button.svg);">
   </div>
-  <video id="methodAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+  <video id="oneLine" style="width:100px; height:100px;" onclick="if (this.paused) {
                     this.play();
-                    methodAnimation_play_button_.style.display = 'none';
+                    oneLine_play_button_.style.display = 'none';
                   } else {
                     this.pause();
-                    methodAnimation_play_button_.style.display = 'block';
+                    oneLine_play_button_.style.display = 'block';
                   }" loop="">
     <source src="http://host/path/to/video.mp4" type="video/mp4">
   </video>
 </div>
-<p>More docs</p>
+<p>This tests to see that we do the right thing if the animation is in
+the one line doc above.</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withAnimationInline.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationInline.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withAnimation method from the Dog class, for the Dart programming language.">
-  <title>withAnimation method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationInline method from the Dog class, for the Dart programming language.">
+  <title>withAnimationInline method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withAnimation method</li>
+    <li class="self-crumb">withAnimationInline method</li>
   </ol>
-  <div class="self-name">withAnimation</div>
+  <div class="self-name">withAnimationInline</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -96,20 +96,21 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withAnimation method</h1>
+    <h1>withAnimationInline method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withAnimation</span>
+      <span class="name ">withAnimationInline</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Animation method</p><div style="position: relative;">
-  <div id="methodAnimation_play_button_" onclick="if (methodAnimation.paused) {
-                  methodAnimation.play();
+      <p>Animation inline in text.</p>
+<p>Tests to see that an inline </p><div style="position: relative;">
+  <div id="inline_play_button_" onclick="if (inline.paused) {
+                  inline.play();
                   this.style.display = 'none';
                 } else {
-                  methodAnimation.pause();
+                  inline.pause();
                   this.style.display = 'block';
                 }" style="position:absolute;
               width:100px;
@@ -119,17 +120,17 @@
               background-repeat: no-repeat;
               background-image: url(static-assets/play_button.svg);">
   </div>
-  <video id="methodAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+  <video id="inline" style="width:100px; height:100px;" onclick="if (this.paused) {
                     this.play();
-                    methodAnimation_play_button_.style.display = 'none';
+                    inline_play_button_.style.display = 'none';
                   } else {
                     this.pause();
-                    methodAnimation_play_button_.style.display = 'block';
+                    inline_play_button_.style.display = 'block';
                   }" loop="">
     <source src="http://host/path/to/video.mp4" type="video/mp4">
   </video>
 </div>
-<p>More docs</p>
+<p> works as expected.</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withAnimationNonUnique.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationNonUnique.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimationNonUnique.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationNonUnique.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the deprecatedField property from the Dog class, for the Dart programming language.">
-  <title>deprecatedField property - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationNonUnique method from the Dog class, for the Dart programming language.">
+  <title>withAnimationNonUnique method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb"><span class="deprecated">deprecatedField</span> property</li>
+    <li class="self-crumb">withAnimationNonUnique method</li>
   </ol>
-  <div class="self-name">deprecatedField</div>
+  <div class="self-name">withAnimationNonUnique</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -94,14 +94,43 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>deprecatedField property</h1>
+    <h1>withAnimationNonUnique method</h1>
 
-        <section class="multi-line-signature">
-          <span class="returntype">int</span>
-          <span class="name deprecated">deprecatedField</span>
-          <div class="features">read / write</div>
-        </section>
-                
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">withAnimationNonUnique</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Non-Unique Animation method (between methods)</p><div style="position: relative;">
+  <div id="fooHerderAnimation_play_button_" onclick="if (fooHerderAnimation.paused) {
+                  fooHerderAnimation.play();
+                  this.style.display = 'none';
+                } else {
+                  fooHerderAnimation.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="fooHerderAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    fooHerderAnimation_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    fooHerderAnimation_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>More docs</p>
+    </section>
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/withAnimationWrongParams.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationWrongParams.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimationWrongParams.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationWrongParams.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the deprecatedField property from the Dog class, for the Dart programming language.">
-  <title>deprecatedField property - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationWrongParams method from the Dog class, for the Dart programming language.">
+  <title>withAnimationWrongParams method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb"><span class="deprecated">deprecatedField</span> property</li>
+    <li class="self-crumb">withAnimationWrongParams method</li>
   </ol>
-  <div class="self-name">deprecatedField</div>
+  <div class="self-name">withAnimationWrongParams</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -94,14 +94,19 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>deprecatedField property</h1>
+    <h1>withAnimationWrongParams method</h1>
 
-        <section class="multi-line-signature">
-          <span class="returntype">int</span>
-          <span class="name deprecated">deprecatedField</span>
-          <div class="features">read / write</div>
-        </section>
-                
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">withAnimationWrongParams</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Malformed Animation method with wrong parameters</p>
+<p>More docs</p>
+    </section>
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/ex/Dog/withMacro.html
+++ b/testing/test_package_docs/ex/Dog/withMacro.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withMacro.html
+++ b/testing/test_package_docs/ex/Dog/withMacro.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withPrivateMacro.html
+++ b/testing/test_package_docs/ex/Dog/withPrivateMacro.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withPrivateMacro.html
+++ b/testing/test_package_docs/ex/Dog/withPrivateMacro.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withUndefinedMacro.html
+++ b/testing/test_package_docs/ex/Dog/withUndefinedMacro.html
@@ -68,6 +68,8 @@
       <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/Dog/withUndefinedMacro.html
+++ b/testing/test_package_docs/ex/Dog/withUndefinedMacro.html
@@ -65,6 +65,11 @@
       <li><a href="ex/Dog/testGeneric.html">testGeneric</a></li>
       <li><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li><a href="ex/Dog/testMethod.html">testMethod</a></li>
+      <li><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -354,6 +354,24 @@
           Malformed Animation method with non-integer width <a href="ex/Dog/withAnimationBadWidth.html">[...]</a>
           <div class="features">inherited</div>
 </dd>
+        <dt id="withAnimationInline" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation inline in text. <a href="ex/Dog/withAnimationInline.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationInOneLineDoc" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation in one line doc  <a href="ex/Dog/withAnimationInOneLineDoc.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
         <dt id="withAnimationNonUnique" class="callable inherited">
           <span class="name"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -465,6 +483,8 @@
       <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -327,6 +327,51 @@
           
           <div class="features">inherited</div>
 </dd>
+        <dt id="withAnimation" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimation.html">withAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation method <a href="ex/Dog/withAnimation.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationBadHeight" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Malformed Animation method with non-integer height <a href="ex/Dog/withAnimationBadHeight.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationBadWidth" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Malformed Animation method with non-integer width <a href="ex/Dog/withAnimationBadWidth.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationNonUnique" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Non-Unique Animation method (between methods) <a href="ex/Dog/withAnimationNonUnique.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationWrongParams" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Malformed Animation method with wrong parameters <a href="ex/Dog/withAnimationWrongParams.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
         <dt id="withMacro" class="callable inherited">
           <span class="name"><a href="ex/Dog/withMacro.html">withMacro</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -417,6 +462,11 @@
       <li class="inherited"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li class="inherited"><a href="ex/Dog/testMethod.html">testMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -68,6 +68,11 @@
       <li class="inherited"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li class="inherited"><a href="ex/Dog/testMethod.html">testMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -71,6 +71,8 @@
       <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -68,6 +68,11 @@
       <li class="inherited"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li class="inherited"><a href="ex/Dog/testMethod.html">testMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -71,6 +71,8 @@
       <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -68,6 +68,11 @@
       <li class="inherited"><a href="ex/Dog/testGenericMethod.html">testGenericMethod</a></li>
       <li class="inherited"><a href="ex/Dog/testMethod.html">testMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -71,6 +71,8 @@
       <li class="inherited"><a href="ex/Dog/withAnimation.html">withAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadHeight.html">withAnimationBadHeight</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationBadWidth.html">withAnimationBadWidth</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1256,6 +1256,61 @@
   }
  },
  {
+  "name": "withAnimation",
+  "qualifiedName": "ex.Dog.withAnimation",
+  "href": "ex/Dog/withAnimation.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationBadHeight",
+  "qualifiedName": "ex.Dog.withAnimationBadHeight",
+  "href": "ex/Dog/withAnimationBadHeight.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationBadWidth",
+  "qualifiedName": "ex.Dog.withAnimationBadWidth",
+  "href": "ex/Dog/withAnimationBadWidth.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationNonUnique",
+  "qualifiedName": "ex.Dog.withAnimationNonUnique",
+  "href": "ex/Dog/withAnimationNonUnique.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationWrongParams",
+  "qualifiedName": "ex.Dog.withAnimationWrongParams",
+  "href": "ex/Dog/withAnimationWrongParams.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
   "name": "withMacro",
   "qualifiedName": "ex.Dog.withMacro",
   "href": "ex/Dog/withMacro.html",

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1289,6 +1289,28 @@
   }
  },
  {
+  "name": "withAnimationInOneLineDoc",
+  "qualifiedName": "ex.Dog.withAnimationInOneLineDoc",
+  "href": "ex/Dog/withAnimationInOneLineDoc.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationInline",
+  "qualifiedName": "ex.Dog.withAnimationInline",
+  "href": "ex/Dog/withAnimationInline.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
   "name": "withAnimationNonUnique",
   "qualifiedName": "ex.Dog.withAnimationNonUnique",
   "href": "ex/Dog/withAnimationNonUnique.html",


### PR DESCRIPTION
This PR adds an animation directive that allows embedding of animations as MPEG 4 videos. The idea is to allow animated diagrams to be placed in documentation.

It places a play button over the video until clicked, at which point it hides the play button and plays the video until clicked again, when it pauses and the play button reappears.

The syntax for adding an animation is:
```
{@animation name 100 200 http://host.com/path/to/video.mp4}
```

Where the `name` is a unique name that is used for the id of the video tag, and the numbers are the width and height of the diagram in pixels.