### PR TITLE
Remove name parameter from animation directive.

### DIFF
--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -90,6 +90,10 @@ final Map<PackageWarning, PackageWarningHelpText> packageWarningText = const {
       PackageWarning.invalidParameter,
       "invalidParameter",
       "A parameter given to a dartdoc directive was invalid."),
+  PackageWarning.deprecated: const PackageWarningHelpText(
+      PackageWarning.deprecated,
+      "deprecated",
+      "A dartdoc directive has a deprecated format."),
 };
 
 /// Something that package warnings can be called on.  Optionally associated
@@ -130,6 +134,7 @@ enum PackageWarning {
   missingFromSearchIndex,
   typeAsHtml,
   invalidParameter,
+  deprecated,
 }
 
 /// Warnings it is OK to skip if we can determine the warnable isn't documented.

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -357,16 +357,48 @@ class Dog implements Cat, E {
 
   /// Animation method
   ///
-  /// {@animation methodAnimation 100 100 http://host/path/to/video.mp4}
+  /// {@animation 100 100 http://host/path/to/video.mp4}
   /// More docs
   void withAnimation() {}
 
+  /// Animation method with name
+  ///
+  /// {@animation 100 100 http://host/path/to/video.mp4 id=namedAnimation}
+  /// More docs
+  void withNamedAnimation() {}
+
+  /// Animation method with quoted name
+  ///
+  /// {@animation 100 100 http://host/path/to/video.mp4 id="quotedNamedAnimation"}
+  /// {@animation 100 100 http://host/path/to/video.mp4 id='quotedNamedAnimation2'}
+  /// More docs
+  void withQuotedNamedAnimation() {}
+
+  /// Animation method with invalid name
+  ///
+  /// {@animation 100 100 http://host/path/to/video.mp4 id=2isNot-A-ValidName}
+  /// More docs
+  void withInvalidNamedAnimation() {}
+
+  /// Deprecated animation method format.
+  ///
+  /// {@animation deprecatedAnimation 100 100 http://host/path/to/video.mp4}
+  /// More docs
+  void withDeprecatedAnimation() {}
+
   /// Non-Unique Animation method (between methods)
+  ///
+  /// {@animation 100 100 http://host/path/to/video.mp4 id=barHerderAnimation}
+  /// {@animation 100 100 http://host/path/to/video.mp4n id=barHerderAnimation}
+  /// More docs
+  void withAnimationNonUnique() {}
+
+  /// Non-Unique deprecated Animation method (between methods)
   ///
   /// {@animation fooHerderAnimation 100 100 http://host/path/to/video.mp4}
   /// {@animation fooHerderAnimation 100 100 http://host/path/to/video.mp4}
   /// More docs
-  void withAnimationNonUnique() {}
+  void withAnimationNonUniqueDeprecated() {}
 
   /// Malformed Animation method with wrong parameters
   ///
@@ -376,17 +408,17 @@ class Dog implements Cat, E {
 
   /// Malformed Animation method with non-integer width
   ///
-  /// {@animation badWidthAnimation 100px 100 http://host/path/to/video.mp4}
+  /// {@animation 100px 100 http://host/path/to/video.mp4 id=badWidthAnimation}
   /// More docs
   void withAnimationBadWidth() {}
 
   /// Malformed Animation method with non-integer height
   ///
-  /// {@animation badHeightAnimation 100 100px http://host/path/to/video.mp4}
+  /// {@animation 100 100px http://host/path/to/video.mp4 id=badHeightAnimation}
   /// More docs
   void withAnimationBadHeight() {}
 
-  /// Animation in one line doc {@animation oneLine 100 100 http://host/path/to/video.mp4}
+  /// Animation in one line doc {@animation 100 100 http://host/path/to/video.mp4}
   ///
   /// This tests to see that we do the right thing if the animation is in
   /// the one line doc above.
@@ -394,8 +426,22 @@ class Dog implements Cat, E {
 
   /// Animation inline in text.
   ///
-  /// Tests to see that an inline {@animation inline 100 100 http://host/path/to/video.mp4} works as expected.
+  /// Tests to see that an inline {@animation 100 100 http://host/path/to/video.mp4} works as expected.
   void withAnimationInline() {}
+
+  /// Animation with out-of-order id argument.
+  ///
+  /// Tests to see that out of order arguments work.
+  /// {@animation 100 100 id=outOfOrder http://host/path/to/video.mp4}
+  /// works as expected.
+  void withAnimationOutOfOrder() {}
+
+  /// Animation with an argument that is not the id.
+  ///
+  /// Tests to see that it gives an error when arguments that are not
+  /// recognized are added.
+  /// {@animation 100 100 http://host/path/to/video.mp4 name=theName}
+  void withAnimationUnknownArg() {}
 
   void testGeneric(Map<String, dynamic> args) {}
 

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -117,7 +117,7 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
 </code></pre>
 <pre class="language-dart"><code class="language-dart">var test = 1;
 </code></pre>
-<pre class="language-dart"><code>var test = 1;
+<pre class="language-dart"><code class="language-dart">var test = 1;
 </code></pre>
     </section>
     
@@ -367,6 +367,33 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           Non-Unique Animation method (between methods) <a href="ex/Dog/withAnimationNonUnique.html">[...]</a>
           
 </dd>
+        <dt id="withAnimationNonUniqueDeprecated" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Non-Unique deprecated Animation method (between methods) <a href="ex/Dog/withAnimationNonUniqueDeprecated.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationOutOfOrder" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation with out-of-order id argument. <a href="ex/Dog/withAnimationOutOfOrder.html">[...]</a>
+          
+</dd>
+        <dt id="withAnimationUnknownArg" class="callable">
+          <span class="name"><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation with an argument that is not the id. <a href="ex/Dog/withAnimationUnknownArg.html">[...]</a>
+          
+</dd>
         <dt id="withAnimationWrongParams" class="callable">
           <span class="name"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -374,6 +401,24 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         </dt>
         <dd>
           Malformed Animation method with wrong parameters <a href="ex/Dog/withAnimationWrongParams.html">[...]</a>
+          
+</dd>
+        <dt id="withDeprecatedAnimation" class="callable">
+          <span class="name"><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Deprecated animation method format. <a href="ex/Dog/withDeprecatedAnimation.html">[...]</a>
+          
+</dd>
+        <dt id="withInvalidNamedAnimation" class="callable">
+          <span class="name"><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation method with invalid name <a href="ex/Dog/withInvalidNamedAnimation.html">[...]</a>
           
 </dd>
         <dt id="withMacro" class="callable">
@@ -394,6 +439,15 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
           Foo macro content
           
 </dd>
+        <dt id="withNamedAnimation" class="callable">
+          <span class="name"><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation method with name <a href="ex/Dog/withNamedAnimation.html">[...]</a>
+          
+</dd>
         <dt id="withPrivateMacro" class="callable">
           <span class="name"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -401,6 +455,15 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
         </dt>
         <dd>
           Use a privately defined macro: Private macro content
+          
+</dd>
+        <dt id="withQuotedNamedAnimation" class="callable">
+          <span class="name"><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd>
+          Animation method with quoted name <a href="ex/Dog/withQuotedNamedAnimation.html">[...]</a>
           
 </dd>
         <dt id="withUndefinedMacro" class="callable">
@@ -551,10 +614,17 @@ A selection of dog flavors:</p><ul><li>beef</li><li>poultry</li></ul>
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
+++ b/testing/test_package_docs/ex/Dog/Dog.deprecatedCreate.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/Dog.html
+++ b/testing/test_package_docs/ex/Dog/Dog.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/aFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aFinalField.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
+++ b/testing/test_package_docs/ex/Dog/aGetterReturningRandomThings.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/aName-constant.html
+++ b/testing/test_package_docs/ex/Dog/aName-constant.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
+++ b/testing/test_package_docs/ex/Dog/aProtectedFinalField.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
+++ b/testing/test_package_docs/ex/Dog/aStaticConstField-constant.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/abstractMethod.html
+++ b/testing/test_package_docs/ex/Dog/abstractMethod.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/createDog.html
+++ b/testing/test_package_docs/ex/Dog/createDog.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedField.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedField.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedGetter.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/Dog/deprecatedSetter.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/foo.html
+++ b/testing/test_package_docs/ex/Dog/foo.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/getAnotherClassD.html
+++ b/testing/test_package_docs/ex/Dog/getAnotherClassD.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/getClassA.html
+++ b/testing/test_package_docs/ex/Dog/getClassA.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/isImplemented.html
+++ b/testing/test_package_docs/ex/Dog/isImplemented.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/name.html
+++ b/testing/test_package_docs/ex/Dog/name.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/operator_equals.html
+++ b/testing/test_package_docs/ex/Dog/operator_equals.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/somethingTasty.html
+++ b/testing/test_package_docs/ex/Dog/somethingTasty.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/staticGetterSetter.html
+++ b/testing/test_package_docs/ex/Dog/staticGetterSetter.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/testGeneric.html
+++ b/testing/test_package_docs/ex/Dog/testGeneric.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/testGenericMethod.html
+++ b/testing/test_package_docs/ex/Dog/testGenericMethod.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/testMethod.html
+++ b/testing/test_package_docs/ex/Dog/testMethod.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimation.html
+++ b/testing/test_package_docs/ex/Dog/withAnimation.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
@@ -105,11 +112,11 @@
     </section>
     <section class="desc markdown">
       <p>Animation method</p><div style="position: relative;">
-  <div id="methodAnimation_play_button_" onclick="if (methodAnimation.paused) {
-                  methodAnimation.play();
+  <div id="animation_1_play_button_" onclick="if (animation_1.paused) {
+                  animation_1.play();
                   this.style.display = 'none';
                 } else {
-                  methodAnimation.pause();
+                  animation_1.pause();
                   this.style.display = 'block';
                 }" style="position:absolute;
               width:100px;
@@ -119,12 +126,12 @@
               background-repeat: no-repeat;
               background-image: url(static-assets/play_button.svg);">
   </div>
-  <video id="methodAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+  <video id="animation_1" style="width:100px; height:100px;" onclick="if (this.paused) {
                     this.play();
-                    methodAnimation_play_button_.style.display = 'none';
+                    animation_1_play_button_.style.display = 'none';
                   } else {
                     this.pause();
-                    methodAnimation_play_button_.style.display = 'block';
+                    animation_1_play_button_.style.display = 'block';
                   }" loop="">
     <source src="http://host/path/to/video.mp4" type="video/mp4">
   </video>

--- a/testing/test_package_docs/ex/Dog/withAnimationBadHeight.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationBadHeight.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimationBadWidth.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationBadWidth.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/withAnimationInOneLineDoc.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationInOneLineDoc.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
@@ -105,11 +112,11 @@
     </section>
     <section class="desc markdown">
       <p>Animation in one line doc </p><div style="position: relative;">
-  <div id="oneLine_play_button_" onclick="if (oneLine.paused) {
-                  oneLine.play();
+  <div id="animation_1_play_button_" onclick="if (animation_1.paused) {
+                  animation_1.play();
                   this.style.display = 'none';
                 } else {
-                  oneLine.pause();
+                  animation_1.pause();
                   this.style.display = 'block';
                 }" style="position:absolute;
               width:100px;
@@ -119,12 +126,12 @@
               background-repeat: no-repeat;
               background-image: url(static-assets/play_button.svg);">
   </div>
-  <video id="oneLine" style="width:100px; height:100px;" onclick="if (this.paused) {
+  <video id="animation_1" style="width:100px; height:100px;" onclick="if (this.paused) {
                     this.play();
-                    oneLine_play_button_.style.display = 'none';
+                    animation_1_play_button_.style.display = 'none';
                   } else {
                     this.pause();
-                    oneLine_play_button_.style.display = 'block';
+                    animation_1_play_button_.style.display = 'block';
                   }" loop="">
     <source src="http://host/path/to/video.mp4" type="video/mp4">
   </video>

--- a/testing/test_package_docs/ex/Dog/withAnimationInline.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationInline.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
@@ -106,11 +113,11 @@
     <section class="desc markdown">
       <p>Animation inline in text.</p>
 <p>Tests to see that an inline </p><div style="position: relative;">
-  <div id="inline_play_button_" onclick="if (inline.paused) {
-                  inline.play();
+  <div id="animation_1_play_button_" onclick="if (animation_1.paused) {
+                  animation_1.play();
                   this.style.display = 'none';
                 } else {
-                  inline.pause();
+                  animation_1.pause();
                   this.style.display = 'block';
                 }" style="position:absolute;
               width:100px;
@@ -120,12 +127,12 @@
               background-repeat: no-repeat;
               background-image: url(static-assets/play_button.svg);">
   </div>
-  <video id="inline" style="width:100px; height:100px;" onclick="if (this.paused) {
+  <video id="animation_1" style="width:100px; height:100px;" onclick="if (this.paused) {
                     this.play();
-                    inline_play_button_.style.display = 'none';
+                    animation_1_play_button_.style.display = 'none';
                   } else {
                     this.pause();
-                    inline_play_button_.style.display = 'block';
+                    animation_1_play_button_.style.display = 'block';
                   }" loop="">
     <source src="http://host/path/to/video.mp4" type="video/mp4">
   </video>

--- a/testing/test_package_docs/ex/Dog/withAnimationNonUnique.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationNonUnique.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>
@@ -105,11 +112,11 @@
     </section>
     <section class="desc markdown">
       <p>Non-Unique Animation method (between methods)</p><div style="position: relative;">
-  <div id="fooHerderAnimation_play_button_" onclick="if (fooHerderAnimation.paused) {
-                  fooHerderAnimation.play();
+  <div id="barHerderAnimation_play_button_" onclick="if (barHerderAnimation.paused) {
+                  barHerderAnimation.play();
                   this.style.display = 'none';
                 } else {
-                  fooHerderAnimation.pause();
+                  barHerderAnimation.pause();
                   this.style.display = 'block';
                 }" style="position:absolute;
               width:100px;
@@ -119,12 +126,12 @@
               background-repeat: no-repeat;
               background-image: url(static-assets/play_button.svg);">
   </div>
-  <video id="fooHerderAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+  <video id="barHerderAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
                     this.play();
-                    fooHerderAnimation_play_button_.style.display = 'none';
+                    barHerderAnimation_play_button_.style.display = 'none';
                   } else {
                     this.pause();
-                    fooHerderAnimation_play_button_.style.display = 'block';
+                    barHerderAnimation_play_button_.style.display = 'block';
                   }" loop="">
     <source src="http://host/path/to/video.mp4" type="video/mp4">
   </video>

--- a/testing/test_package_docs/ex/Dog/withAnimationNonUniqueDeprecated.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationNonUniqueDeprecated.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationNonUniqueDeprecated method from the Dog class, for the Dart programming language.">
+  <title>withAnimationNonUniqueDeprecated method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withAnimationNonUniqueDeprecated method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withAnimationNonUniqueDeprecated</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,40 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withAnimationNonUniqueDeprecated method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withAnimationNonUniqueDeprecated</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Non-Unique deprecated Animation method (between methods)</p><div style="position: relative;">
+  <div id="fooHerderAnimation_play_button_" onclick="if (fooHerderAnimation.paused) {
+                  fooHerderAnimation.play();
+                  this.style.display = 'none';
+                } else {
+                  fooHerderAnimation.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="fooHerderAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    fooHerderAnimation_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    fooHerderAnimation_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>More docs</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withAnimationOutOfOrder.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationOutOfOrder.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationOutOfOrder method from the Dog class, for the Dart programming language.">
+  <title>withAnimationOutOfOrder method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withAnimationOutOfOrder method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withAnimationOutOfOrder</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,41 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withAnimationOutOfOrder method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withAnimationOutOfOrder</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Animation with out-of-order id argument.</p>
+<p>Tests to see that out of order arguments work.</p><div style="position: relative;">
+  <div id="outOfOrder_play_button_" onclick="if (outOfOrder.paused) {
+                  outOfOrder.play();
+                  this.style.display = 'none';
+                } else {
+                  outOfOrder.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="outOfOrder" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    outOfOrder_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    outOfOrder_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>works as expected.</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withAnimationUnknownArg.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationUnknownArg.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withAnimationUnknownArg method from the Dog class, for the Dart programming language.">
+  <title>withAnimationUnknownArg method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withAnimationUnknownArg method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withAnimationUnknownArg</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,17 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withAnimationUnknownArg method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withAnimationUnknownArg</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Animation with an argument that is not the id.</p>
+<p>Tests to see that it gives an error when arguments that are not
+recognized are added.</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withAnimationWrongParams.html
+++ b/testing/test_package_docs/ex/Dog/withAnimationWrongParams.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/withDeprecatedAnimation.html
+++ b/testing/test_package_docs/ex/Dog/withDeprecatedAnimation.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withDeprecatedAnimation method from the Dog class, for the Dart programming language.">
+  <title>withDeprecatedAnimation method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withDeprecatedAnimation method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withDeprecatedAnimation</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,40 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withDeprecatedAnimation method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withDeprecatedAnimation</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Deprecated animation method format.</p><div style="position: relative;">
+  <div id="deprecatedAnimation_play_button_" onclick="if (deprecatedAnimation.paused) {
+                  deprecatedAnimation.play();
+                  this.style.display = 'none';
+                } else {
+                  deprecatedAnimation.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="deprecatedAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    deprecatedAnimation_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    deprecatedAnimation_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>More docs</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withInvalidNamedAnimation.html
+++ b/testing/test_package_docs/ex/Dog/withInvalidNamedAnimation.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withInvalidNamedAnimation method from the Dog class, for the Dart programming language.">
+  <title>withInvalidNamedAnimation method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withInvalidNamedAnimation method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withInvalidNamedAnimation</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,16 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withInvalidNamedAnimation method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withInvalidNamedAnimation</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Animation method with invalid name</p>
+<p>More docs</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withMacro2.html
+++ b/testing/test_package_docs/ex/Dog/withMacro2.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/withNamedAnimation.html
+++ b/testing/test_package_docs/ex/Dog/withNamedAnimation.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withNamedAnimation method from the Dog class, for the Dart programming language.">
+  <title>withNamedAnimation method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withNamedAnimation method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withNamedAnimation</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,40 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withNamedAnimation method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withNamedAnimation</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Animation method with name</p><div style="position: relative;">
+  <div id="namedAnimation_play_button_" onclick="if (namedAnimation.paused) {
+                  namedAnimation.play();
+                  this.style.display = 'none';
+                } else {
+                  namedAnimation.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="namedAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    namedAnimation_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    namedAnimation_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>More docs</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withPrivateMacro.html
+++ b/testing/test_package_docs/ex/Dog/withPrivateMacro.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/Dog/withQuotedNamedAnimation.html
+++ b/testing/test_package_docs/ex/Dog/withQuotedNamedAnimation.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the withMacro method from the Dog class, for the Dart programming language.">
-  <title>withMacro method - Dog class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the withQuotedNamedAnimation method from the Dog class, for the Dart programming language.">
+  <title>withQuotedNamedAnimation method - Dog class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Dog-class.html">Dog</a></li>
-    <li class="self-crumb">withMacro method</li>
+    <li class="self-crumb">withQuotedNamedAnimation method</li>
   </ol>
-  <div class="self-name">withMacro</div>
+  <div class="self-name">withQuotedNamedAnimation</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -103,17 +103,64 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>withMacro method</h1>
+    <h1>withQuotedNamedAnimation method</h1>
 
     <section class="multi-line-signature">
       <span class="returntype">void</span>
-      <span class="name ">withMacro</span>
+      <span class="name ">withQuotedNamedAnimation</span>
 (<wbr>)
     </section>
     <section class="desc markdown">
-      <p>Macro method</p>
-<p>Foo macro content
-More docs</p>
+      <p>Animation method with quoted name</p><div style="position: relative;">
+  <div id="quotedNamedAnimation_play_button_" onclick="if (quotedNamedAnimation.paused) {
+                  quotedNamedAnimation.play();
+                  this.style.display = 'none';
+                } else {
+                  quotedNamedAnimation.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="quotedNamedAnimation" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    quotedNamedAnimation_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    quotedNamedAnimation_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div><div style="position: relative;">
+  <div id="quotedNamedAnimation2_play_button_" onclick="if (quotedNamedAnimation2.paused) {
+                  quotedNamedAnimation2.play();
+                  this.style.display = 'none';
+                } else {
+                  quotedNamedAnimation2.pause();
+                  this.style.display = 'block';
+                }" style="position:absolute;
+              width:100px;
+              height:100px;
+              z-index:100000;
+              background-position: center;
+              background-repeat: no-repeat;
+              background-image: url(static-assets/play_button.svg);">
+  </div>
+  <video id="quotedNamedAnimation2" style="width:100px; height:100px;" onclick="if (this.paused) {
+                    this.play();
+                    quotedNamedAnimation2_play_button_.style.display = 'none';
+                  } else {
+                    this.pause();
+                    quotedNamedAnimation2_play_button_.style.display = 'block';
+                  }" loop="">
+    <source src="http://host/path/to/video.mp4" type="video/mp4">
+  </video>
+</div>
+<p>More docs</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/Dog/withUndefinedMacro.html
+++ b/testing/test_package_docs/ex/Dog/withUndefinedMacro.html
@@ -71,10 +71,17 @@
       <li><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
       <li class="inherited"><a href="ex/E/noSuchMethod.html">noSuchMethod</a></li>
       <li class="inherited"><a href="ex/E/toString.html">toString</a></li>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -381,6 +381,33 @@
           Non-Unique Animation method (between methods) <a href="ex/Dog/withAnimationNonUnique.html">[...]</a>
           <div class="features">inherited</div>
 </dd>
+        <dt id="withAnimationNonUniqueDeprecated" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Non-Unique deprecated Animation method (between methods) <a href="ex/Dog/withAnimationNonUniqueDeprecated.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationOutOfOrder" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation with out-of-order id argument. <a href="ex/Dog/withAnimationOutOfOrder.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withAnimationUnknownArg" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation with an argument that is not the id. <a href="ex/Dog/withAnimationUnknownArg.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
         <dt id="withAnimationWrongParams" class="callable inherited">
           <span class="name"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -388,6 +415,24 @@
         </dt>
         <dd class="inherited">
           Malformed Animation method with wrong parameters <a href="ex/Dog/withAnimationWrongParams.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withDeprecatedAnimation" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Deprecated animation method format. <a href="ex/Dog/withDeprecatedAnimation.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withInvalidNamedAnimation" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation method with invalid name <a href="ex/Dog/withInvalidNamedAnimation.html">[...]</a>
           <div class="features">inherited</div>
 </dd>
         <dt id="withMacro" class="callable inherited">
@@ -408,6 +453,15 @@
           Foo macro content
           <div class="features">inherited</div>
 </dd>
+        <dt id="withNamedAnimation" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation method with name <a href="ex/Dog/withNamedAnimation.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
         <dt id="withPrivateMacro" class="callable inherited">
           <span class="name"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
@@ -415,6 +469,15 @@
         </dt>
         <dd class="inherited">
           Use a privately defined macro: Private macro content
+          <div class="features">inherited</div>
+</dd>
+        <dt id="withQuotedNamedAnimation" class="callable inherited">
+          <span class="name"><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Animation method with quoted name <a href="ex/Dog/withQuotedNamedAnimation.html">[...]</a>
           <div class="features">inherited</div>
 </dd>
         <dt id="withUndefinedMacro" class="callable inherited">
@@ -486,10 +549,17 @@
       <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li class="inherited"><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li class="inherited"><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
     
       <li class="section-title inherited"><a href="ex/F-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/F/F.html
+++ b/testing/test_package_docs/ex/F/F.html
@@ -74,10 +74,17 @@
       <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li class="inherited"><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li class="inherited"><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
     
       <li class="section-title inherited"><a href="ex/F-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/F/methodWithGenericParam.html
+++ b/testing/test_package_docs/ex/F/methodWithGenericParam.html
@@ -74,10 +74,17 @@
       <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li class="inherited"><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li class="inherited"><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
     
       <li class="section-title inherited"><a href="ex/F-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/ex/F/test.html
+++ b/testing/test_package_docs/ex/F/test.html
@@ -74,10 +74,17 @@
       <li class="inherited"><a href="ex/Dog/withAnimationInline.html">withAnimationInline</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationInOneLineDoc.html">withAnimationInOneLineDoc</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationNonUnique.html">withAnimationNonUnique</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationNonUniqueDeprecated.html">withAnimationNonUniqueDeprecated</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationOutOfOrder.html">withAnimationOutOfOrder</a></li>
+      <li class="inherited"><a href="ex/Dog/withAnimationUnknownArg.html">withAnimationUnknownArg</a></li>
       <li class="inherited"><a href="ex/Dog/withAnimationWrongParams.html">withAnimationWrongParams</a></li>
+      <li class="inherited"><a href="ex/Dog/withDeprecatedAnimation.html">withDeprecatedAnimation</a></li>
+      <li class="inherited"><a href="ex/Dog/withInvalidNamedAnimation.html">withInvalidNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro.html">withMacro</a></li>
       <li class="inherited"><a href="ex/Dog/withMacro2.html">withMacro2</a></li>
+      <li class="inherited"><a href="ex/Dog/withNamedAnimation.html">withNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withPrivateMacro.html">withPrivateMacro</a></li>
+      <li class="inherited"><a href="ex/Dog/withQuotedNamedAnimation.html">withQuotedNamedAnimation</a></li>
       <li class="inherited"><a href="ex/Dog/withUndefinedMacro.html">withUndefinedMacro</a></li>
     
       <li class="section-title inherited"><a href="ex/F-class.html#operators">Operators</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1322,9 +1322,64 @@
   }
  },
  {
+  "name": "withAnimationNonUniqueDeprecated",
+  "qualifiedName": "ex.Dog.withAnimationNonUniqueDeprecated",
+  "href": "ex/Dog/withAnimationNonUniqueDeprecated.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationOutOfOrder",
+  "qualifiedName": "ex.Dog.withAnimationOutOfOrder",
+  "href": "ex/Dog/withAnimationOutOfOrder.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withAnimationUnknownArg",
+  "qualifiedName": "ex.Dog.withAnimationUnknownArg",
+  "href": "ex/Dog/withAnimationUnknownArg.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
   "name": "withAnimationWrongParams",
   "qualifiedName": "ex.Dog.withAnimationWrongParams",
   "href": "ex/Dog/withAnimationWrongParams.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withDeprecatedAnimation",
+  "qualifiedName": "ex.Dog.withDeprecatedAnimation",
+  "href": "ex/Dog/withDeprecatedAnimation.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withInvalidNamedAnimation",
+  "qualifiedName": "ex.Dog.withInvalidNamedAnimation",
+  "href": "ex/Dog/withInvalidNamedAnimation.html",
   "type": "method",
   "overriddenDepth": 0,
   "enclosedBy": {
@@ -1355,9 +1410,31 @@
   }
  },
  {
+  "name": "withNamedAnimation",
+  "qualifiedName": "ex.Dog.withNamedAnimation",
+  "href": "ex/Dog/withNamedAnimation.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
   "name": "withPrivateMacro",
   "qualifiedName": "ex.Dog.withPrivateMacro",
   "href": "ex/Dog/withPrivateMacro.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Dog",
+   "type": "class"
+  }
+ },
+ {
+  "name": "withQuotedNamedAnimation",
+  "qualifiedName": "ex.Dog.withQuotedNamedAnimation",
+  "href": "ex/Dog/withQuotedNamedAnimation.html",
   "type": "method",
   "overriddenDepth": 0,
   "enclosedBy": {


### PR DESCRIPTION
This PR removes the required first argument for the `{@animation...}` directive, making it into an optional argument.

It also builds a way to parse arguments for directives that is more consistent, and leverages the Dart arg parser.  The arguments may be quoted in order to contain spaces if needed. Updates _injectExamples to use this parser as well as the _injectAnimations function.

The old animation directive form is still supported, but will give a deprecation warning if used.  I also added a new type of warning for this: `PackageWarning.deprecated`.