### PR TITLE
Prepare for dartdoc 0.20.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.20.1
+* Remove name parameter from `@animation` parameter handling, with backwards compatibility
+  (#1715)
+* Scrollbar width increased for main body text (#1711)
+* Make a missing FLUTTER_ROOT environment variable have a better error message
+  (#1714)
+* Add a missing static resource (#1708)
+* Add test to make sure that static resource file is automatically rebuilt
+  (#1708)
+
 ## 0.20.0
 * include and exclude are now available in dartdoc_options.yaml as supported options
   (#1700, #1674)

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -37,7 +37,7 @@ export 'package:dartdoc/src/package_meta.dart';
 
 const String name = 'dartdoc';
 // Update when pubspec version changes.
-const String dartdocVersion = '0.20.0';
+const String dartdocVersion = '0.20.1';
 
 /// Helper class to initialize the default generators since they require
 /// GeneratorContext.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.20.0
+version: 0.20.1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.20.0">
+  <meta name="generator" content="made with love by dartdoc 0.20.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
Update version information and changelog for new version (assumes #1717 will land)