### PR TITLE
Make dartdoc tests work where --preview-dart-2 is the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 sudo: false
 dart:
-  - "dev/raw/2.0.0-dev.63.0"
+  - "dev/raw/latest"
 env:
   - DARTDOC_BOT=main
   # TODO(devoncarew): add angulardart support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 install:
-  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/raw/2.0.0-dev.63.0/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - set PATH=%PATH%;C:\tools\dart-sdk\bin

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -66,7 +66,7 @@ final newLinePartOfRegexp = new RegExp('\npart of ');
 
 final RegExp quotables = new RegExp(r'[ "\r\n\$]');
 
-/// Best used with Future<Null>.
+/// Best used with Future<void>.
 class MultiFutureTracker<T> {
   /// Approximate maximum number of simultaneous active Futures.
   final int parallel;
@@ -105,7 +105,7 @@ class SubprocessLauncher {
   String get prefix => context.isNotEmpty ? '$context: ' : '';
 
   // from flutter:dev/tools/dartdoc.dart, modified
-  static Future<Null> _printStream(Stream<List<int>> stream, Stdout output,
+  static Future<void> _printStream(Stream<List<int>> stream, Stdout output,
       {String prefix: '', Iterable<String> Function(String line) filter}) {
     assert(prefix != null);
     if (filter == null) filter = (line) => [line];
@@ -188,9 +188,9 @@ class SubprocessLauncher {
 
     Process process = await Process.start(executable, arguments,
         workingDirectory: workingDirectory, environment: environment);
-    Future<Null> stdoutFuture = _printStream(process.stdout, stdout,
+    Future<void> stdoutFuture = _printStream(process.stdout, stdout,
         prefix: prefix, filter: jsonCallback);
-    Future<Null> stderrFuture = _printStream(process.stderr, stderr,
+    Future<void> stderrFuture = _printStream(process.stderr, stderr,
         prefix: prefix, filter: jsonCallback);
     await Future.wait([stderrFuture, stdoutFuture, process.exitCode]);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,4 +492,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: "2.0.0-dev.64.1"
+  dart: ">=2.0.0-dev.59.0 <=2.0.0-dev.63.0.flutter-4c9689c1d2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,4 +492,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.59.0 <=2.0.0-dev.63.0"
+  dart: "2.0.0-dev.64.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
-  sdk: '>=2.0.0-dev.64.1 <3.0.0'
+  sdk: '>=2.0.0-dev.59.0 <3.0.0'
 dependencies:
   analyzer: ^0.32.1
   args: '>=1.4.1 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
-  sdk: '>=2.0.0-dev.59.0 <3.0.0'
+  sdk: '>=2.0.0-dev.64.1 <3.0.0'
 dependencies:
   analyzer: ^0.32.1
   args: '>=1.4.1 <2.0.0'

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -337,7 +337,7 @@ Future<List<Map>> _buildSdkDocs(String sdkDocsPath, Future<String> futureCwd,
   return await launcher.runStreamed(
       Platform.resolvedExecutable,
       [
-        '--checked',
+        '--enable-asserts',
         pathLib.join('bin', 'dartdoc.dart'),
         '--output',
         '${sdkDocsPath}',
@@ -361,7 +361,7 @@ Future<List<Map>> _buildTestPackageDocs(
   return await launcher.runStreamed(
       Platform.resolvedExecutable,
       [
-        '--checked',
+        '--enable-asserts',
         pathLib.join(cwd, 'bin', 'dartdoc.dart'),
         '--output',
         outputDir,
@@ -605,7 +605,7 @@ Future<String> _buildPubPackageDocs(String pubPackageName,
   await launcher.runStreamed(
       Platform.resolvedExecutable,
       [
-        '--checked',
+        '--enable-asserts',
         pathLib.join(Directory.current.absolute.path, 'bin', 'dartdoc.dart'),
         '--json',
         '--show-progress',
@@ -752,7 +752,7 @@ testDart2() async {
 testDartdoc() async {
   var launcher = new SubprocessLauncher('test-dartdoc');
   await launcher.runStreamed(Platform.resolvedExecutable,
-      ['--checked', 'bin/dartdoc.dart', '--output', dartdocDocsDir.path]);
+      ['--enable-asserts', 'bin/dartdoc.dart', '--output', dartdocDocsDir.path]);
   expectFileContains(pathLib.join(dartdocDocsDir.path, 'index.html'),
       ['<title>dartdoc - Dart API docs</title>']);
   final RegExp object = new RegExp('<li>Object</li>', multiLine: true);
@@ -768,7 +768,7 @@ testDartdocRemote() async {
       '<a href="https://api.dartlang.org/(dev|stable)/[^/]*/dart-core/Object-class.html">Object</a>',
       multiLine: true);
   await launcher.runStreamed(Platform.resolvedExecutable, [
-    '--checked',
+    '--enable-asserts',
     'bin/dartdoc.dart',
     '--link-to-remote',
     '--output',
@@ -796,7 +796,7 @@ Future<WarningsCollection> _buildDartdocFlutterPluginDocs() async {
       await flutterRepo.launcher.runStreamed(
           Platform.resolvedExecutable,
           [
-            '--checked',
+            '--enable-asserts',
             pathLib.join(Directory.current.path, 'bin', 'dartdoc.dart'),
             '--json',
             '--link-to-remote',
@@ -844,7 +844,7 @@ updateTestPackageDocs() async {
   await launcher.runStreamed(
       Platform.resolvedExecutable,
       [
-        '--checked',
+        '--enable-asserts',
         pathLib.join('..', '..', 'bin', 'dartdoc.dart'),
         '--auto-include-dependencies',
         '--example-path-prefix',

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -715,13 +715,13 @@ List<File> get binFiles => new Directory('bin')
     .listSync(recursive: true)
     .where((e) => e is File && e.path.endsWith('.dart'))
     .cast<File>()
-      ..toList();
+    .toList();
 
 List<File> get testFiles => new Directory('test')
     .listSync(recursive: true)
     .where((e) => e is File && e.path.endsWith('test.dart'))
     .cast<File>()
-      ..toList();
+    .toList();
 
 testDart2() async {
   List<String> parameters = ['--enable-asserts'];

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -50,7 +50,7 @@ Directory createTempSync(String prefix) =>
 final Memoizer tempdirsCache = new Memoizer();
 
 /// Global so that the lock is retained for the life of the process.
-Future<Null> _lockFuture;
+Future<void> _lockFuture;
 Completer<FlutterRepo> _cleanFlutterRepo;
 
 /// Returns true if we need to replace the existing flutter.  We never release
@@ -520,7 +520,7 @@ class FlutterRepo {
         new SubprocessLauncher('flutter${label == null ? "" : "-$label"}', env);
   }
 
-  Future<Null> _init() async {
+  Future<void> _init() async {
     new Directory(flutterPath).createSync(recursive: true);
     await launcher.runStreamed(
         'git', ['clone', 'https://github.com/flutter/flutter.git', '.'],
@@ -654,7 +654,8 @@ _getPackageVersion() {
 @Task('Rebuild generated files')
 build() async {
   var launcher = new SubprocessLauncher('build');
-  await launcher.runStreamed(sdkBin('pub'), ['run', 'build_runner', 'build', '--delete-conflicting-outputs']);
+  await launcher.runStreamed(sdkBin('pub'),
+      ['run', 'build_runner', 'build', '--delete-conflicting-outputs']);
 }
 
 /// Paths in this list are relative to lib/.
@@ -677,7 +678,8 @@ checkBuild() async {
     }
   }
 
-  await launcher.runStreamed(sdkBin('pub'), ['run', 'build_runner', 'build', '--delete-conflicting-outputs']);
+  await launcher.runStreamed(sdkBin('pub'),
+      ['run', 'build_runner', 'build', '--delete-conflicting-outputs']);
   for (String relPath in _generated_files_list) {
     File newVersion = new File(pathLib.join('lib', relPath));
     if (!await newVersion.exists()) {
@@ -751,8 +753,12 @@ testDart2() async {
 @Task('Generate docs for dartdoc')
 testDartdoc() async {
   var launcher = new SubprocessLauncher('test-dartdoc');
-  await launcher.runStreamed(Platform.resolvedExecutable,
-      ['--enable-asserts', 'bin/dartdoc.dart', '--output', dartdocDocsDir.path]);
+  await launcher.runStreamed(Platform.resolvedExecutable, [
+    '--enable-asserts',
+    'bin/dartdoc.dart',
+    '--output',
+    dartdocDocsDir.path
+  ]);
   expectFileContains(pathLib.join(dartdocDocsDir.path, 'index.html'),
       ['<title>dartdoc - Dart API docs</title>']);
   final RegExp object = new RegExp('<li>Object</li>', multiLine: true);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -707,8 +707,7 @@ publish() async {
 
 @Task('Run all the tests.')
 test() async {
-  await testPreviewDart2();
-  await testDart1();
+  await testDart2();
   await testFutures.wait();
 }
 
@@ -724,8 +723,8 @@ List<File> get testFiles => new Directory('test')
     .cast<File>()
       ..toList();
 
-testPreviewDart2() async {
-  List<String> parameters = ['--preview-dart-2', '--enable-asserts'];
+testDart2() async {
+  List<String> parameters = ['--enable-asserts'];
 
   for (File dartFile in testFiles) {
     await testFutures.addFuture(
@@ -740,30 +739,6 @@ testPreviewDart2() async {
   for (File dartFile in binFiles) {
     await testFutures.addFuture(new SubprocessLauncher(
             'dart2-bin-${pathLib.basename(dartFile.path)}-help')
-        .runStreamed(
-            Platform.resolvedExecutable,
-            <String>[]
-              ..addAll(parameters)
-              ..add(dartFile.path)
-              ..add('--help')));
-  }
-}
-
-testDart1() async {
-  List<String> parameters = ['--checked'];
-  for (File dartFile in testFiles) {
-    await testFutures.addFuture(
-        new SubprocessLauncher('dart1-${pathLib.basename(dartFile.path)}')
-            .runStreamed(
-                Platform.resolvedExecutable,
-                <String>[]
-                  ..addAll(parameters)
-                  ..add(dartFile.path)));
-  }
-
-  for (File dartFile in binFiles) {
-    await testFutures.addFuture(new SubprocessLauncher(
-            'dart1-bin-${pathLib.basename(dartFile.path)}-help')
         .runStreamed(
             Platform.resolvedExecutable,
             <String>[]


### PR DESCRIPTION
Unpin our travis/appveyor from 63.0 and don't bother testing Dart 1 anymore.