### PR TITLE
Fix list markdown not being handled correctly

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -951,8 +951,6 @@ class Documentation {
     return _commentRefs;
   }
 
-  String get raw => _element.documentation;
-
   void _renderHtmlForDartdoc(bool processAllDocs) {
     Tuple3<String, String, bool> renderResults =
         _renderMarkdownToHtml(processAllDocs);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -36,6 +36,7 @@ String stripCommonWhitespace(String str) {
 }
 
 String stripComments(String str) {
+  bool cStyle = false;
   if (str == null) return null;
   StringBuffer buf = new StringBuffer();
 
@@ -53,15 +54,16 @@ String stripComments(String str) {
   } else {
     if (str.startsWith('/**')) {
       str = str.substring(3);
+      cStyle = true;
     }
     if (str.endsWith('*/')) {
       str = str.substring(0, str.length - 2);
     }
     str = stripCommonWhitespace(str);
     for (String line in str.split('\n')) {
-      if (line.startsWith('* ')) {
+      if (cStyle && line.startsWith('* ')) {
         buf.write('${line.substring(2)}\n');
-      } else if (line.startsWith('*')) {
+      } else if (cStyle && line.startsWith('*')) {
         buf.write('${line.substring(1)}\n');
       } else {
         buf.write('$line\n');

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -718,6 +718,7 @@ void main() {
   group('Docs as HTML', () {
     Class Apple, B, superAwesomeClass, foo2;
     TopLevelVariable incorrectDocReferenceFromEx;
+    TopLevelVariable bulletDoced;
     ModelFunction thisIsAsync;
     ModelFunction topLevelFunction;
 
@@ -738,7 +739,8 @@ void main() {
       Apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
       specialList =
           fakeLibrary.classes.firstWhere((c) => c.name == 'SpecialList');
-
+      bulletDoced =
+          fakeLibrary.constants.firstWhere((c) => c.name == 'bulletDoced');
       topLevelFunction =
           fakeLibrary.functions.firstWhere((f) => f.name == 'topLevelFunction');
       thisIsAsync =
@@ -1071,6 +1073,10 @@ void main() {
       Iterable<Match> matches = new RegExp('In the super class')
           .allMatches(powers.documentationAsHtml);
       expect(matches, hasLength(1));
+    });
+
+    test('bullet points work in top level variables', () {
+      expect(bulletDoced.documentationAsHtml, contains('<li>'));
     });
   });
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -35,6 +35,13 @@ void main() {
       expect(stripComments('///One line.'), equals('One line.'));
     });
 
+    test('multiple runs with multiline comments', () {
+      expect(stripComments(stripComments('''
+          /// A line.
+          /// * An asterisk
+      ''')), equals('A line.\n* An asterisk'));
+    });
+
     test('multi-line comment', () {
       comment = '''
         /// First line.
@@ -93,6 +100,15 @@ void main() {
   });
 
   group('/**-style', () {
+    test('multiple runs with cstyle comments', () {
+      expect(stripComments(stripComments('''
+          /**
+           * A line.
+           * * An asterisk
+           */
+      ''')), equals('A line.\n* An asterisk'));
+    });
+
     test('one-line comment', () {
       expect(stripComments('/** One line. */'), equals('One line.'));
     });

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -89,6 +89,17 @@ class HasGenerics<X, Y, Z> {
   Map<X, Y> convertToMap() => null;
 }
 
+/// Bullet point documentation.
+///
+/// This top level constant has bullet points.
+///
+/// * A bullet point.
+/// * Another even better bullet point.
+/// * A bullet point that wraps onto a second line, without creating a new
+///   bullet point or paragraph.
+/// * A fourth bullet point.
+const String bulletDoced = 'Foo bar baz';
+
 /// This class uses a pragma annotation.
 @pragma('Hello world')
 class HasPragma {}

--- a/testing/test_package_docs/fake/ABaseClass-class.html
+++ b/testing/test_package_docs/fake/ABaseClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/HasPragma-class.html
+++ b/testing/test_package_docs/fake/HasPragma-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/aCoolVariable.html
+++ b/testing/test_package_docs/fake/aCoolVariable.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs/fake/bulletDoced-constant.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the ImplementingThingy2 class from the fake library, for the Dart programming language.">
-  <title>ImplementingThingy2 class - fake library - Dart API</title>
+  <meta name="description" content="API docs for the bulletDoced constant from the fake library, for the Dart programming language.">
+  <title>bulletDoced constant - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">ImplementingThingy2 abstract class</li>
+    <li class="self-crumb">bulletDoced constant</li>
   </ol>
-  <div class="self-name">ImplementingThingy2</div>
+  <div class="self-name">bulletDoced</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -156,157 +156,28 @@
       <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
       <li><a href="fake/Oops-class.html">Oops</a></li>
     </ol>
-  </div>
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>ImplementingThingy2 class</h1>
+    <h1>bulletDoced top-level constant</h1>
 
-    
-    <section>
-      <dl class="dl-horizontal">
-
-        <dt>Implements</dt>
-        <dd>
-          <ul class="comma-separated clazz-relationships">
-            <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
-            <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
-          </ul>
-        </dd>
-
-
-
-      </dl>
+    <section class="multi-line-signature">
+      const <span class="name ">bulletDoced</span>
+      =
+      <span class="constant-value">&#39;Foo bar baz&#39;</span>
+      
     </section>
 
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">
-        <dt id="ImplementingThingy2" class="callable">
-          <span class="name"><a href="fake/ImplementingThingy2/ImplementingThingy2.html">ImplementingThingy2</a></span><span class="signature">()</span>
-        </dt>
-        <dd>
-          
-        </dd>
-      </dl>
+    <section class="desc markdown">
+      <p>Bullet point documentation.</p>
+<p>This top level constant has bullet points.</p><ul><li>A bullet point.</li><li>Another even better bullet point.</li><li>A bullet point that wraps onto a second line, without creating a new
+bullet point or paragraph.</li><li>A fourth bullet point.</li></ul>
     </section>
-
-    <section class="summary offset-anchor inherited" id="instance-properties">
-      <h2>Properties</h2>
-
-      <dl class="properties">
-        <dt id="aImplementingThingy" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy2/aImplementingThingy.html">aImplementingThingy</a></span>
-          <span class="signature">&#8594; <a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></span>
-        </dt>
-        <dd class="inherited">
-          BaseThingy2's doc for aImplementingThingy.
-          <div class="features">read-only, inherited</div>
-</dd>
-        <dt id="aImplementingThingyField" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></span>
-          <span class="signature">&#8596; <a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read / write, inherited</div>
-</dd>
-        <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-        <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="fake/BaseThingy/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">read-only, inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="instance-methods">
-      <h2>Methods</h2>
-      <dl class="callables">
-        <dt id="aImplementingThingyMethod" class="callable inherited">
-          <span class="name"><a href="fake/BaseThingy/aImplementingThingyMethod.html">aImplementingThingyMethod</a></span><span class="signature">(<wbr><span class="parameter" id="aImplementingThingyMethod-param-parameter"><span class="type-annotation"><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></span> <span class="parameter-name">parameter</span></span>)
-            <span class="returntype parameter">&#8594; void</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-        <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="fake/BaseThingy/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-        <dt id="toString" class="callable inherited">
-          <span class="name"><a href="fake/BaseThingy/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-    <section class="summary offset-anchor inherited" id="operators">
-      <h2>Operators</h2>
-      <dl class="callables">
-        <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="fake/BaseThingy/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
-          </span>
-        </dt>
-        <dd class="inherited">
-          
-          <div class="features">inherited</div>
-</dd>
-      </dl>
-    </section>
-
-
-
+        
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-    <ol>
-      <li class="section-title"><a href="fake/ImplementingThingy2-class.html#constructors">Constructors</a></li>
-      <li><a href="fake/ImplementingThingy2/ImplementingThingy2.html">ImplementingThingy2</a></li>
-    
-      <li class="section-title inherited">
-        <a href="fake/ImplementingThingy2-class.html#instance-properties">Properties</a>
-      </li>
-      <li class="inherited"><a href="fake/BaseThingy2/aImplementingThingy.html">aImplementingThingy</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/aImplementingThingyField.html">aImplementingThingyField</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/runtimeType.html">runtimeType</a></li>
-    
-      <li class="section-title inherited"><a href="fake/ImplementingThingy2-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/aImplementingThingyMethod.html">aImplementingThingyMethod</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/toString.html">toString</a></li>
-    
-      <li class="section-title inherited"><a href="fake/ImplementingThingy2-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="fake/BaseThingy/operator_equals.html">operator ==</a></li>
-    
-    
-    
-    </ol>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -362,6 +362,17 @@ class still takes precedence (#1561).
       <h2>Constants</h2>
 
       <dl class="properties">
+        <dt id="bulletDoced" class="constant">
+          <span class="name "><a href="fake/bulletDoced-constant.html">bulletDoced</a></span>
+          <span class="signature">&#8594; const String</span>
+        </dt>
+        <dd>
+          Bullet point documentation. <a href="fake/bulletDoced-constant.html">[...]</a>
+          
+  <div>
+            <span class="signature"><code>&#39;Foo bar baz&#39;</code></span>
+          </div>
+        </dd>
         <dt id="CUSTOM_CLASS" class="constant">
           <span class="name "><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></span>
           <span class="signature">&#8594; const <a href="fake/ConstantClass-class.html">ConstantClass</a></span>
@@ -989,6 +1000,7 @@ default value.
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/mustGetThis.html
+++ b/testing/test_package_docs/fake/mustGetThis.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/myMap-constant.html
+++ b/testing/test_package_docs/fake/myMap-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs/fake/thisIsFutureOr.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs/fake/useSomethingInTheSdk.html
@@ -85,6 +85,7 @@
       <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
       <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -8413,6 +8413,17 @@
   }
  },
  {
+  "name": "bulletDoced",
+  "qualifiedName": "fake.bulletDoced",
+  "href": "fake/bulletDoced-constant.html",
+  "type": "top-level constant",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
   "name": "complicatedReturn",
   "qualifiedName": "fake.complicatedReturn",
   "href": "fake/complicatedReturn.html",


### PR DESCRIPTION
Fixes #1722.

Fix stripComments so it can be run multiple times against the same source. Otherwise, it can remove bullet points because it thinks they are part of a C-style comment block.