### PR TITLE
Fix incompatibilities with new Analyzer.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2310,10 +2310,12 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   }
 
   static String getLibraryName(LibraryElement element) {
+    var source = element.source;
+
     String name = element.name;
     if (name == null || name.isEmpty) {
       // handle the case of an anonymous library
-      name = element.definingCompilationUnit.name;
+      name = pathLib.basename(source.fullName);
 
       if (name.endsWith('.dart')) {
         name = name.substring(0, name.length - '.dart'.length);
@@ -2325,7 +2327,6 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     // name is to get source.encoding.
     // This may be wrong or misleading, but developers expect the name
     // of dart:____
-    var source = element.definingCompilationUnit.source;
     name = source.isInSystemLibrary ? source.encoding : name;
 
     return name;
@@ -5938,8 +5939,9 @@ class PackageBuilder {
 
     for (String name in info.packages) {
       Uri uri = info.asMap()[name];
+      String path = pathLib.normalize(pathLib.fromUri(uri));
       fileSystem.Resource resource =
-          PhysicalResourceProvider.INSTANCE.getResource(uri.toFilePath());
+          PhysicalResourceProvider.INSTANCE.getResource(path);
       if (resource is fileSystem.Folder) {
         map[name] = [resource];
       }


### PR DESCRIPTION
1. `CompilationUnitElement.name` is now always `null`. If you need to get a short name of a file - extract it from the full name.

2. `ResourceProvider` requires all names to be absolute and normalized. And `/my/path/` is not normalized, it should be `/my/path`.

@bwilkerson 