### PR TITLE
Add a travis bot for testing dartdoc against SDK head analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DARTDOC_BOT=packages
   - DARTDOC_BOT=flutter
   - DARTDOC_BOT=sdk-docs
+  - DARTDOC_BOT=sdk-analyzer
 script: ./tool/travis.sh
 
 os:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -210,6 +210,10 @@ void analyze() async {
 }
 
 @Task('analyze, test, and self-test dartdoc')
+@Depends(analyze, checkBuild, test, testDartdoc)
+void buildbotNoPublish() => null;
+
+@Task('analyze, test, and self-test dartdoc')
 @Depends(analyze, checkBuild, test, testDartdoc, tryPublish)
 void buildbot() => null;
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -362,6 +362,51 @@ Future<String> createComparisonDartdoc() async {
   return dartdocClean.path;
 }
 
+/// Helper function to create a clean version of dartdoc (based on the current
+/// directory, assumed to be a git repository), configured to use the head
+/// version of the Dart SDK for analyzer, front-end, and kernel.
+Future<String> createSdkDartdoc() async {
+  var launcher = new SubprocessLauncher('create-sdk-dartdoc');
+  Directory dartdocSdk = Directory.systemTemp.createTempSync('dartdoc-sdk');
+  await launcher
+      .runStreamed('git', ['clone', Directory.current.path, dartdocSdk.path]);
+  await launcher.runStreamed('git', ['checkout'],
+      workingDirectory: dartdocSdk.path);
+
+  Directory sdkClone = Directory.systemTemp.createTempSync('sdk-checkout');
+  await launcher.runStreamed('git', [
+    'clone',
+    '--depth',
+    '1',
+    'https://github.com/dart-lang/sdk.git',
+    sdkClone.path
+  ]);
+  File dartdocPubspec = new File(pathLib.join(dartdocSdk.path, 'pubspec.yaml'));
+  dartdocPubspec.writeAsStringSync('''
+dependency_overrides:
+  analyzer:
+    path: '${sdkClone.path}/pkg/analyzer'
+  front_end:
+    path: '${sdkClone.path}/pkg/front_end'
+  kernel:
+    path: '${sdkClone.path}/pkg/kernel'
+''', mode: FileMode.append);
+
+  await launcher.runStreamed(sdkBin('pub'), ['get'],
+      workingDirectory: dartdocSdk.path);
+  return dartdocSdk.path;
+}
+
+@Task('Run grind tasks with the analyzer SDK.')
+Future<void> testWithAnalyzerSdk() async {
+  var launcher = new SubprocessLauncher('test-with-analyzer-sdk');
+  var sdkDartdoc = await createSdkDartdoc();
+  final String defaultGrindParameter =
+      Platform.environment['DARTDOC_GRIND_STEP'] ?? 'test';
+  launcher.runStreamed(sdkBin('pub'), ['run', 'grinder', defaultGrindParameter],
+      workingDirectory: sdkDartdoc);
+}
+
 Future<List<Map>> _buildSdkDocs(String sdkDocsPath, Future<String> futureCwd,
     [String label]) async {
   if (label == null) label = '';

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -403,7 +403,7 @@ Future<void> testWithAnalyzerSdk() async {
   var sdkDartdoc = await createSdkDartdoc();
   final String defaultGrindParameter =
       Platform.environment['DARTDOC_GRIND_STEP'] ?? 'test';
-  launcher.runStreamed(sdkBin('pub'), ['run', 'grinder', defaultGrindParameter],
+  await launcher.runStreamed(sdkBin('pub'), ['run', 'grinder', defaultGrindParameter],
       workingDirectory: sdkDartdoc);
 }
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -25,7 +25,7 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"
-  DARTDOC_GRIND_STEP=buildbot pub run grinder test-with-analyzer-sdk
+  DARTDOC_GRIND_STEP=buildbot-no-publish pub run grinder test-with-analyzer-sdk
 else
   echo "Running main dartdoc bot"
   pub run grinder buildbot

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -23,6 +23,9 @@ elif [ "$DARTDOC_BOT" = "flutter" ]; then
 elif [ "$DARTDOC_BOT" = "packages" ]; then
   echo "Running packages dartdoc bot"
   PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
+elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
+  echo "Running main dartdoc bot against the SDK analyzer"
+  DARTDOC_GRIND_STEP=buildbot pub run grinder test-with-analyzer-sdk
 else
   echo "Running main dartdoc bot"
   pub run grinder buildbot


### PR DESCRIPTION
This will make it a little easier/faster to detect breaking changes in the SDK before they start impacting dartdoc, and verify that new changes to dartdoc will still work with the head SDK.