### PR TITLE
Remove direct dependency on front_end package

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -21,7 +21,9 @@ import 'package:analyzer/src/source/package_map_resolver.dart';
 import 'package:analyzer/src/source/sdk_ext.dart';
 // TODO(jcollins-g): Stop using internal analyzer structures somehow.
 import 'package:analyzer/src/context/builder.dart';
+import 'package:analyzer/src/dart/analysis/byte_store.dart';
 import 'package:analyzer/src/dart/analysis/file_state.dart';
+import 'package:analyzer/src/dart/analysis/performance_logger.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/handle.dart';
 import 'package:analyzer/src/dart/sdk/sdk.dart';
@@ -50,8 +52,6 @@ import 'package:dartdoc/src/tool_runner.dart';
 import 'package:dartdoc/src/tuple.dart';
 import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/warnings.dart';
-import 'package:front_end/src/byte_store/byte_store.dart';
-import 'package:front_end/src/base/performance_logger.dart';
 import 'package:path/path.dart' as pathLib;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:package_config/discovery.dart' as package_config;
@@ -6097,7 +6097,6 @@ class PackageBuilder {
   AnalysisDriver _driver;
   AnalysisDriver get driver {
     if (_driver == null) {
-      // The performance log is why we have a direct dependency on front_end.
       PerformanceLog log = new PerformanceLog(null);
       AnalysisDriverScheduler scheduler = new AnalysisDriverScheduler(log);
       AnalysisOptionsImpl options = new AnalysisOptionsImpl();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "0.10.8"
   front_end:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   analyzer: ^0.32.4
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
-  front_end: ^0.1.1
   html: '>=0.12.1 <0.14.0'
   # We don't use http_parser directly; this dep exists to ensure that we get at
   # least version 3.0.3 to work around an issue with 3.0.2.


### PR DESCRIPTION
Fixes #1775.

Per @peter-ahe-google, the direct dependency on front-end is (no longer?) required. 