### PR TITLE
Make mixins appear with reexports

### DIFF
--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -543,6 +543,11 @@ void main() {
       expect(exLibrary.hasPublicExceptions, isTrue);
     });
 
+    test('has mixins', () {
+      expect(fakeLibrary.hasPublicMixins, isTrue);
+      expect(reexportTwoLib.hasPublicMixins, isTrue);
+    });
+
     test('has enums', () {
       expect(exLibrary.hasPublicEnums, isTrue);
     });
@@ -1204,7 +1209,8 @@ void main() {
     test('doc comment inherited from getter', () {
       Field getterWithDocs = subForDocComments.instanceProperties
           .firstWhere((m) => m.name == 'getterWithDocs');
-      expect(getterWithDocs.documentationAsHtml, contains('Some really great topics.'));
+      expect(getterWithDocs.documentationAsHtml,
+          contains('Some really great topics.'));
     });
 
     test(

--- a/testing/test_package/lib/reexport_two.dart
+++ b/testing/test_package/lib/reexport_two.dart
@@ -5,3 +5,5 @@
 library reexport_two;
 
 export 'src/somelib.dart';
+
+export 'src/mixins.dart' show MixedIn, AMixin;

--- a/testing/test_package/lib/src/mixins.dart
+++ b/testing/test_package/lib/src/mixins.dart
@@ -1,0 +1,3 @@
+library mixins;
+
+export 'mixins_base.dart';

--- a/testing/test_package/lib/src/mixins_base.dart
+++ b/testing/test_package/lib/src/mixins_base.dart
@@ -1,0 +1,11 @@
+library mixins_base;
+
+mixin AMixin {}
+
+class ThisClass {
+  String property;
+}
+
+/// A class that extends another class with a new-style mixin, then is
+/// reexported a couple of times similar to how Flutter does things.
+class MixedIn extends ThisClass with AMixin {}

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -9621,6 +9621,83 @@
   "overriddenDepth": 0
  },
  {
+  "name": "AMixin",
+  "qualifiedName": "reexport_two.AMixin",
+  "href": "reexport_two/AMixin/AMixin.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "AMixin",
+  "qualifiedName": "reexport_two.AMixin",
+  "href": "reexport_two/AMixin-mixin.html",
+  "type": "mixin",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "reexport_two",
+   "type": "library"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "reexport_two.AMixin.==",
+  "href": "reexport_two/AMixin/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "reexport_two.AMixin.hashCode",
+  "href": "reexport_two/AMixin/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "reexport_two.AMixin.noSuchMethod",
+  "href": "reexport_two/AMixin/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "reexport_two.AMixin.runtimeType",
+  "href": "reexport_two/AMixin/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "reexport_two.AMixin.toString",
+  "href": "reexport_two/AMixin/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
   "name": "AUnicornClass",
   "qualifiedName": "reexport_two.AUnicornClass",
   "href": "reexport_two/AUnicornClass-class.html",
@@ -9694,6 +9771,39 @@
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "AUnicornClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "MixedIn",
+  "qualifiedName": "reexport_two.MixedIn",
+  "href": "reexport_two/MixedIn-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "reexport_two",
+   "type": "library"
+  }
+ },
+ {
+  "name": "MixedIn",
+  "qualifiedName": "reexport_two.MixedIn",
+  "href": "reexport_two/MixedIn/MixedIn.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MixedIn",
+   "type": "class"
+  }
+ },
+ {
+  "name": "property",
+  "qualifiedName": "reexport_two.MixedIn.property",
+  "href": "reexport_two/MixedIn/property.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MixedIn",
    "type": "class"
   }
  },

--- a/testing/test_package_docs/reexport_two/AMixin-mixin.html
+++ b/testing/test_package_docs/reexport_two/AMixin-mixin.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the SomeClass class from the reexport_two library, for the Dart programming language.">
-  <title>SomeClass class - reexport_two library - Dart API</title>
+  <meta name="description" content="API docs for the AMixin mixin from the reexport_two library, for the Dart programming language.">
+  <title>AMixin mixin - reexport_two library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
-    <li class="self-crumb">SomeClass class</li>
+    <li class="self-crumb">AMixin mixin</li>
   </ol>
-  <div class="self-name">SomeClass</div>
+  <div class="self-name">AMixin</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -57,16 +57,33 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-      <h1>SomeClass class </h1>
+      <h1>AMixin mixin </h1>
 
     
+    <section>
+      <dl class="dl-horizontal">
+        <dt>Superclass Constraints</dt>
+        <dd><ul class="comma-separated dark mixin-relationships">
+          <li>Object</li>
+        </ul></dd>
+
+
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated mixin-relationships">
+          <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="SomeClass" class="callable">
-          <span class="name"><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></span><span class="signature">()</span>
+        <dt id="AMixin" class="callable">
+          <span class="name"><a href="reexport_two/AMixin/AMixin.html">AMixin</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -79,7 +96,7 @@
 
       <dl class="properties">
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span> 
         </dt>
         <dd class="inherited">
@@ -87,7 +104,7 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span> 
         </dt>
         <dd class="inherited">
@@ -101,7 +118,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
           </dt>
@@ -110,7 +127,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="reexport_two/AMixin/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
           </dt>
@@ -125,7 +142,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
           </dt>
@@ -143,21 +160,21 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="reexport_two/SomeClass-class.html#constructors">Constructors</a></li>
-      <li><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></li>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
     
       <li class="section-title inherited">
-        <a href="reexport_two/SomeClass-class.html#instance-properties">Properties</a>
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/toString.html">toString</a></li>
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs/reexport_two/AMixin/AMixin.html
+++ b/testing/test_package_docs/reexport_two/AMixin/AMixin.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the AMixin constructor from the Mixin AMixin class from the reexport_two library, for the Dart programming language.">
+  <title>AMixin constructor - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">AMixin constructor</li>
+  </ol>
+  <div class="self-name">AMixin</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>AMixin constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">AMixin</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/AMixin/hashCode.html
+++ b/testing/test_package_docs/reexport_two/AMixin/hashCode.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the AMixin class, for the Dart programming language.">
+  <title>hashCode property - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/AMixin/noSuchMethod.html
+++ b/testing/test_package_docs/reexport_two/AMixin/noSuchMethod.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the AMixin class, for the Dart programming language.">
+  <title>noSuchMethod method - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/AMixin/operator_equals.html
+++ b/testing/test_package_docs/reexport_two/AMixin/operator_equals.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the AMixin class, for the Dart programming language.">
+  <title>operator == method - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/AMixin/runtimeType.html
+++ b/testing/test_package_docs/reexport_two/AMixin/runtimeType.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the AMixin class, for the Dart programming language.">
+  <title>runtimeType property - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/AMixin/toString.html
+++ b/testing/test_package_docs/reexport_two/AMixin/toString.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the AMixin class, for the Dart programming language.">
+  <title>toString method - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/AUnicornClass-class.html
+++ b/testing/test_package_docs/reexport_two/AUnicornClass-class.html
@@ -40,10 +40,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     

--- a/testing/test_package_docs/reexport_two/MixedIn-class.html
+++ b/testing/test_package_docs/reexport_two/MixedIn-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the SomeClass class from the reexport_two library, for the Dart programming language.">
-  <title>SomeClass class - reexport_two library - Dart API</title>
+  <meta name="description" content="API docs for the MixedIn class from the reexport_two library, for the Dart programming language.">
+  <title>MixedIn class - reexport_two library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
-    <li class="self-crumb">SomeClass class</li>
+    <li class="self-crumb">MixedIn class</li>
   </ol>
-  <div class="self-name">SomeClass</div>
+  <div class="self-name">MixedIn</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -57,16 +57,32 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-      <h1>SomeClass class </h1>
+      <h1>MixedIn class </h1>
 
+    <section class="desc markdown">
+      <p>A class that extends another class with a new-style mixin, then is
+reexported a couple of times similar to how Flutter does things.</p>
+    </section>
     
+    <section>
+      <dl class="dl-horizontal">
+
+
+        <dt>Mixed in types</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+        </ul></dd>
+
+
+      </dl>
+    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="SomeClass" class="callable">
-          <span class="name"><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></span><span class="signature">()</span>
+        <dt id="MixedIn" class="callable">
+          <span class="name"><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -79,15 +95,23 @@
 
       <dl class="properties">
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span> 
         </dt>
         <dd class="inherited">
           
           <div class="features">read-only, inherited</div>
 </dd>
+        <dt id="property" class="property inherited">
+          <span class="name"><a href="reexport_two/MixedIn/property.html">property</a></span>
+          <span class="signature">&#8596; String</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read / write, inherited</div>
+</dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span> 
         </dt>
         <dd class="inherited">
@@ -101,7 +125,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
           </dt>
@@ -110,7 +134,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="reexport_two/AMixin/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
           </dt>
@@ -125,7 +149,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
           </dt>
@@ -143,21 +167,22 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="reexport_two/SomeClass-class.html#constructors">Constructors</a></li>
-      <li><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></li>
+      <li class="section-title"><a href="reexport_two/MixedIn-class.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></li>
     
       <li class="section-title inherited">
-        <a href="reexport_two/SomeClass-class.html#instance-properties">Properties</a>
+        <a href="reexport_two/MixedIn-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/MixedIn/property.html">property</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/toString.html">toString</a></li>
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs/reexport_two/MixedIn/MixedIn.html
+++ b/testing/test_package_docs/reexport_two/MixedIn/MixedIn.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MixedIn constructor from the Class MixedIn class from the reexport_two library, for the Dart programming language.">
+  <title>MixedIn constructor - MixedIn class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
+    <li class="self-crumb">MixedIn constructor</li>
+  </ol>
+  <div class="self-name">MixedIn</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MixedIn class</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/MixedIn-class.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/MixedIn-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/MixedIn/property.html">property</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MixedIn constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">MixedIn</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/MixedIn/property.html
+++ b/testing/test_package_docs/reexport_two/MixedIn/property.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the property property from the MixedIn class, for the Dart programming language.">
+  <title>property property - MixedIn class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
+    <li class="self-crumb">property property</li>
+  </ol>
+  <div class="self-name">property</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MixedIn class</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/MixedIn-class.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/MixedIn-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/MixedIn/property.html">property</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>property property</h1>
+
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">property</span>
+          <div class="features">read / write, inherited</div>
+        </section>
+                
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/reexport_two/YetAnotherClass-class.html
+++ b/testing/test_package_docs/reexport_two/YetAnotherClass-class.html
@@ -40,10 +40,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     

--- a/testing/test_package_docs/reexport_two/reexport_two-library.html
+++ b/testing/test_package_docs/reexport_two/reexport_two-library.html
@@ -80,6 +80,13 @@
         <dd>
           
         </dd>
+        <dt id="MixedIn">
+          <span class="name "><a href="reexport_two/MixedIn-class.html">MixedIn</a></span> 
+        </dt>
+        <dd>
+          A class that extends another class with a new-style mixin, then is
+reexported a couple of times similar to how Flutter does things.
+        </dd>
         <dt id="SomeClass">
           <span class="name "><a href="reexport_two/SomeClass-class.html">SomeClass</a></span> 
         </dt>
@@ -101,6 +108,18 @@
       </dl>
     </section>
 
+    <section class="summary offset-anchor" id="mixins">
+      <h2>Mixins</h2>
+
+      <dl>
+        <dt id="AMixin">
+          <span class="name "><a href="reexport_two/AMixin-mixin.html">AMixin</a></span> 
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
 
 
 
@@ -115,10 +134,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     

--- a/testing/test_package_docs_dev/index.json
+++ b/testing/test_package_docs_dev/index.json
@@ -9632,6 +9632,83 @@
   "overriddenDepth": 0
  },
  {
+  "name": "AMixin",
+  "qualifiedName": "reexport_two.AMixin",
+  "href": "reexport_two/AMixin/AMixin.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "AMixin",
+  "qualifiedName": "reexport_two.AMixin",
+  "href": "reexport_two/AMixin-mixin.html",
+  "type": "mixin",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "reexport_two",
+   "type": "library"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "reexport_two.AMixin.==",
+  "href": "reexport_two/AMixin/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "reexport_two.AMixin.hashCode",
+  "href": "reexport_two/AMixin/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "reexport_two.AMixin.noSuchMethod",
+  "href": "reexport_two/AMixin/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "reexport_two.AMixin.runtimeType",
+  "href": "reexport_two/AMixin/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "reexport_two.AMixin.toString",
+  "href": "reexport_two/AMixin/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "AMixin",
+   "type": "mixin"
+  }
+ },
+ {
   "name": "AUnicornClass",
   "qualifiedName": "reexport_two.AUnicornClass",
   "href": "reexport_two/AUnicornClass-class.html",
@@ -9705,6 +9782,39 @@
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "AUnicornClass",
+   "type": "class"
+  }
+ },
+ {
+  "name": "MixedIn",
+  "qualifiedName": "reexport_two.MixedIn",
+  "href": "reexport_two/MixedIn-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "reexport_two",
+   "type": "library"
+  }
+ },
+ {
+  "name": "MixedIn",
+  "qualifiedName": "reexport_two.MixedIn",
+  "href": "reexport_two/MixedIn/MixedIn.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MixedIn",
+   "type": "class"
+  }
+ },
+ {
+  "name": "property",
+  "qualifiedName": "reexport_two.MixedIn.property",
+  "href": "reexport_two/MixedIn/property.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MixedIn",
    "type": "class"
   }
  },

--- a/testing/test_package_docs_dev/reexport_two/AMixin-mixin.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin-mixin.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the SomeClass class from the reexport_two library, for the Dart programming language.">
-  <title>SomeClass class - reexport_two library - Dart API</title>
+  <meta name="description" content="API docs for the AMixin mixin from the reexport_two library, for the Dart programming language.">
+  <title>AMixin mixin - reexport_two library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
-    <li class="self-crumb">SomeClass class</li>
+    <li class="self-crumb">AMixin mixin</li>
   </ol>
-  <div class="self-name">SomeClass</div>
+  <div class="self-name">AMixin</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -57,16 +57,33 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-      <h1>SomeClass class </h1>
+      <h1>AMixin mixin </h1>
 
     
+    <section>
+      <dl class="dl-horizontal">
+        <dt>Superclass Constraints</dt>
+        <dd><ul class="comma-separated dark mixin-relationships">
+          <li>Object</li>
+        </ul></dd>
+
+
+
+
+        <dt>Implemented by</dt>
+        <dd><ul class="comma-separated mixin-relationships">
+          <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
+        </ul></dd>
+
+      </dl>
+    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="SomeClass" class="callable">
-          <span class="name"><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></span><span class="signature">()</span>
+        <dt id="AMixin" class="callable">
+          <span class="name"><a href="reexport_two/AMixin/AMixin.html">AMixin</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -79,7 +96,7 @@
 
       <dl class="properties">
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span> 
         </dt>
         <dd class="inherited">
@@ -87,7 +104,7 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span> 
         </dt>
         <dd class="inherited">
@@ -101,7 +118,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
           </dt>
@@ -110,7 +127,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="reexport_two/AMixin/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
           </dt>
@@ -125,7 +142,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
           </dt>
@@ -143,21 +160,21 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="reexport_two/SomeClass-class.html#constructors">Constructors</a></li>
-      <li><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></li>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
     
       <li class="section-title inherited">
-        <a href="reexport_two/SomeClass-class.html#instance-properties">Properties</a>
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/toString.html">toString</a></li>
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs_dev/reexport_two/AMixin/AMixin.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin/AMixin.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the AMixin constructor from the Mixin AMixin class from the reexport_two library, for the Dart programming language.">
+  <title>AMixin constructor - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">AMixin constructor</li>
+  </ol>
+  <div class="self-name">AMixin</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>AMixin constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">AMixin</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/AMixin/hashCode.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin/hashCode.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the AMixin class, for the Dart programming language.">
+  <title>hashCode property - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/AMixin/noSuchMethod.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin/noSuchMethod.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the AMixin class, for the Dart programming language.">
+  <title>noSuchMethod method - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/AMixin/operator_equals.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin/operator_equals.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the AMixin class, for the Dart programming language.">
+  <title>operator == method - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/AMixin/runtimeType.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin/runtimeType.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the AMixin class, for the Dart programming language.">
+  <title>runtimeType property - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/AMixin/toString.html
+++ b/testing/test_package_docs_dev/reexport_two/AMixin/toString.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the AMixin class, for the Dart programming language.">
+  <title>toString method - AMixin class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>AMixin mixin</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/AMixin-mixin.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/AMixin/AMixin.html">AMixin</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/AMixin-mixin.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/AMixin-mixin.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/AUnicornClass-class.html
+++ b/testing/test_package_docs_dev/reexport_two/AUnicornClass-class.html
@@ -40,10 +40,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     

--- a/testing/test_package_docs_dev/reexport_two/MixedIn-class.html
+++ b/testing/test_package_docs_dev/reexport_two/MixedIn-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the SomeClass class from the reexport_two library, for the Dart programming language.">
-  <title>SomeClass class - reexport_two library - Dart API</title>
+  <meta name="description" content="API docs for the MixedIn class from the reexport_two library, for the Dart programming language.">
+  <title>MixedIn class - reexport_two library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
-    <li class="self-crumb">SomeClass class</li>
+    <li class="self-crumb">MixedIn class</li>
   </ol>
-  <div class="self-name">SomeClass</div>
+  <div class="self-name">MixedIn</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -57,16 +57,32 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-      <h1>SomeClass class </h1>
+      <h1>MixedIn class </h1>
 
+    <section class="desc markdown">
+      <p>A class that extends another class with a new-style mixin, then is
+reexported a couple of times similar to how Flutter does things.</p>
+    </section>
     
+    <section>
+      <dl class="dl-horizontal">
+
+
+        <dt>Mixed in types</dt>
+        <dd><ul class="comma-separated clazz-relationships">
+          <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
+        </ul></dd>
+
+
+      </dl>
+    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="SomeClass" class="callable">
-          <span class="name"><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></span><span class="signature">()</span>
+        <dt id="MixedIn" class="callable">
+          <span class="name"><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -79,15 +95,23 @@
 
       <dl class="properties">
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span> 
         </dt>
         <dd class="inherited">
           
           <div class="features">read-only, inherited</div>
 </dd>
+        <dt id="property" class="property inherited">
+          <span class="name"><a href="reexport_two/MixedIn/property.html">property</a></span>
+          <span class="signature">&#8596; String</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read / write, inherited</div>
+</dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span> 
         </dt>
         <dd class="inherited">
@@ -101,7 +125,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
           </dt>
@@ -110,7 +134,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="reexport_two/AMixin/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
           </dt>
@@ -125,7 +149,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+          <span class="name"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
           </dt>
@@ -143,21 +167,22 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="reexport_two/SomeClass-class.html#constructors">Constructors</a></li>
-      <li><a href="reexport_two/SomeClass/SomeClass.html">SomeClass</a></li>
+      <li class="section-title"><a href="reexport_two/MixedIn-class.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></li>
     
       <li class="section-title inherited">
-        <a href="reexport_two/SomeClass-class.html#instance-properties">Properties</a>
+        <a href="reexport_two/MixedIn-class.html#instance-properties">Properties</a>
       </li>
-      <li class="inherited"><a href="reexport_two/SomeClass/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/MixedIn/property.html">property</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#instance-methods">Methods</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/toString.html">toString</a></li>
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="reexport_two/SomeClass-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="reexport_two/SomeClass/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs_dev/reexport_two/MixedIn/MixedIn.html
+++ b/testing/test_package_docs_dev/reexport_two/MixedIn/MixedIn.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the MixedIn constructor from the Class MixedIn class from the reexport_two library, for the Dart programming language.">
+  <title>MixedIn constructor - MixedIn class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
+    <li class="self-crumb">MixedIn constructor</li>
+  </ol>
+  <div class="self-name">MixedIn</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MixedIn class</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/MixedIn-class.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/MixedIn-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/MixedIn/property.html">property</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>MixedIn constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">MixedIn</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/MixedIn/property.html
+++ b/testing/test_package_docs_dev/reexport_two/MixedIn/property.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the property property from the MixedIn class, for the Dart programming language.">
+  <title>property property - MixedIn class - reexport_two library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="reexport_two/reexport_two-library.html">reexport_two</a></li>
+    <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
+    <li class="self-crumb">property property</li>
+  </ol>
+  <div class="self-name">property</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MixedIn class</h5>
+    <ol>
+      <li class="section-title"><a href="reexport_two/MixedIn-class.html#constructors">Constructors</a></li>
+      <li><a href="reexport_two/MixedIn/MixedIn.html">MixedIn</a></li>
+    
+      <li class="section-title inherited">
+        <a href="reexport_two/MixedIn-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="reexport_two/AMixin/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="reexport_two/MixedIn/property.html">property</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="reexport_two/MixedIn-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="reexport_two/AMixin/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>property property</h1>
+
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">property</span>
+          <div class="features">read / write, inherited</div>
+        </section>
+                
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/reexport_two/SomeClass-class.html
+++ b/testing/test_package_docs_dev/reexport_two/SomeClass-class.html
@@ -40,10 +40,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     

--- a/testing/test_package_docs_dev/reexport_two/YetAnotherClass-class.html
+++ b/testing/test_package_docs_dev/reexport_two/YetAnotherClass-class.html
@@ -40,10 +40,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     

--- a/testing/test_package_docs_dev/reexport_two/reexport_two-library.html
+++ b/testing/test_package_docs_dev/reexport_two/reexport_two-library.html
@@ -80,6 +80,13 @@
         <dd>
           
         </dd>
+        <dt id="MixedIn">
+          <span class="name "><a href="reexport_two/MixedIn-class.html">MixedIn</a></span> 
+        </dt>
+        <dd>
+          A class that extends another class with a new-style mixin, then is
+reexported a couple of times similar to how Flutter does things.
+        </dd>
         <dt id="SomeClass">
           <span class="name "><a href="reexport_two/SomeClass-class.html">SomeClass</a></span> 
         </dt>
@@ -101,6 +108,18 @@
       </dl>
     </section>
 
+    <section class="summary offset-anchor" id="mixins">
+      <h2>Mixins</h2>
+
+      <dl>
+        <dt id="AMixin">
+          <span class="name "><a href="reexport_two/AMixin-mixin.html">AMixin</a></span> 
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
 
 
 
@@ -115,10 +134,13 @@
     <ol>
       <li class="section-title"><a href="reexport_two/reexport_two-library.html#classes">Classes</a></li>
       <li><a href="reexport_two/AUnicornClass-class.html">AUnicornClass</a></li>
+      <li><a href="reexport_two/MixedIn-class.html">MixedIn</a></li>
       <li><a href="reexport_two/SomeClass-class.html">SomeClass</a></li>
       <li><a href="reexport_one/SomeOtherClass-class.html">SomeOtherClass</a></li>
       <li><a href="reexport_two/YetAnotherClass-class.html">YetAnotherClass</a></li>
     
+      <li class="section-title"><a href="reexport_two/reexport_two-library.html#mixins">Mixins</a></li>
+      <li><a href="reexport_two/AMixin-mixin.html">AMixin</a></li>
     
     
     


### PR DESCRIPTION
Fixes #1785.

Sometimes MixinElementImpls are wrapped in ClassElementHandles, specifically when there are reexports involved.  Add a test for this case and fix the bug.