### PR TITLE
Print exit code when throwing process exception

### DIFF
--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -212,7 +212,7 @@ class SubprocessLauncher {
     int exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw new ProcessException(executable, arguments,
-          "SubprocessLauncher got non-zero exitCode", exitCode);
+          "SubprocessLauncher got non-zero exitCode: $exitCode", exitCode);
     }
     return jsonObjects;
   }


### PR DESCRIPTION
Another attempt to add debugging information to catch #1770.  This should enable us to find out whether the subprocess died due to signal, at least.