### PR TITLE
Allow element.library to be null for dynamic

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2765,7 +2765,8 @@ abstract class ModelElement extends Canonicalization
     assert(library != null ||
         e is ParameterElement ||
         e is TypeParameterElement ||
-        e is GenericFunctionTypeElementImpl);
+        e is GenericFunctionTypeElementImpl ||
+        e.kind == ElementKind.DYNAMIC);
     // With AnalysisDriver, we sometimes get ElementHandles when building
     // docs for the SDK, seen via [Library.importedExportedLibraries].  Why?
     if (e is ElementHandle) {


### PR DESCRIPTION
Recent change in head analyzer broke travis, here:

https://travis-ci.org/dart-lang/dartdoc/jobs/439730750#L460

DynamicElementImpl used to return dart:core as its .library, but no longer.  It's not actually needed for anything in dartdoc when the element is dynamic, so the assert was overly broad here to include dynamic elements.  Updated the assert.

FYI @bwilkerson 