### PR TITLE
Add tests and patch up remaining dartdoc_options.yaml options

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,7 @@ dartdoc:
 
 Unrecognized options will be ignored.  Supported options:
 
-  * **ambiguousReexportScorerMinConfidence**:  The ambiguous reexport scorer will emit a warning if
-    it is not at least this confident.  Adjusting this may be necessary for some complex
-    packages but most of the time, the default is OK.  Default: 0.1
+
   * **categories**:  More details for each category/topic.  For topics you'd like to document, specify
     the markdown file with `markdown:` to use for the category page.  Optionally, rename the
     category from the source code into a display name with 'name:'.  If there is no matching category
@@ -156,7 +154,13 @@ Unrecognized options will be ignored.  Supported options:
 
 In general, paths are relative to the directory the dartdoc_options.yaml the option is defined in
 and should be specified as POSIX paths.  Dartdoc will convert POSIX paths automatically on Windows.
- 
+
+Unsupported and experimental options:
+
+   * **ambiguousReexportScorerMinConfidence**:  The ambiguous reexport scorer will emit a warning if
+     it is not at least this confident.  Adjusting this may be necessary for some complex
+     packages but most of the time, the default is OK.  Default: 0.1
+
 ### Categories
 
 You can tag libraries or top level classes, functions, and variables in their documentation with

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ dartdoc:
 
 Unrecognized options will be ignored.  Supported options:
 
-
   * **categories**:  More details for each category/topic.  For topics you'd like to document, specify
     the markdown file with `markdown:` to use for the category page.  Optionally, rename the
     category from the source code into a display name with 'name:'.  If there is no matching category

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ authoring doc comments for Dart with `dartdoc`.
 Creating a file named dartdoc_options.yaml at the top of your package can change how Dartdoc
 generates docs.  
 
+An example:
+
 ```yaml
 dartdoc:
   categories: 
@@ -110,21 +112,34 @@ dartdoc:
       markdown: doc/Second.md
       name: Great
   categoryOrder: ["First Category", "Second Category"]
+  examplePathPrefix: 'subdir/with/examples'
+  includeExternal: ['bin/unusually_located_library.dart']
   linkTo:
     url: "https://my.dartdocumentationsite.org/dev/%v%"
+  showUndocumentedCategories: true
 ```
 
 Unrecognized options will be ignored.  Supported options:
 
+  * **ambiguousReexportScorerMinConfidence**:  The ambiguous reexport scorer will emit a warning if
+    it is not at least this confident.  Adjusting this may be necessary for some complex
+    packages but most of the time, the default is OK.  Default: 0.1
   * **categories**:  More details for each category/topic.  For topics you'd like to document, specify
     the markdown file with `markdown:` to use for the category page.  Optionally, rename the
     category from the source code into a display name with 'name:'.  If there is no matching category
     defined in dartdoc_options.yaml, those declared categories in the source code will be invisible.
   * **categoryOrder**:  Specify the order of topics for display in the sidebar and
     the package page.
+  * **examplePathPrefix**: Specify the location of the example directory for resolving `@example`
+    directives.
   * **exclude**:  Specify a list of library names to avoid generating docs for,
     overriding any specified in include.
+  * **favicon**:  A path to a favicon for the generated docs.
+  * **footer**: A list of paths to footer files containing HTML text.
+  * **footerText**: A list of paths to text files for optional text next to the package name and version
+  * **header**:  A list of paths to header files containing HTML text.
   * **include**:  Specify a list of library names to generate docs for, ignoring all others.
+  * **includeExternal**:  Specify a list of library filenames to add to the list of documented libraries.
   * **linkTo**:  For other packages depending on this one, if this map is defined those packages
     will use the settings here to control how hyperlinks to the package are generated.
     This will override the default for packages hosted on pub.dartlang.org.
@@ -139,19 +154,8 @@ Unrecognized options will be ignored.  Supported options:
       * `%n%`: The name of this package, as defined in pubspec.yaml.
       * `%v%`: The version of this package as defined in pubspec.yaml.
 
-The following are experimental options whose semantics are in flux and may be buggy.  If you
-use one, please keep a close eye on the changing semantics.  In general, paths are relative
-to the directory the dartdoc_options.yaml the option is defined in and should be specified
-as POSIX paths.  Dartdoc will convert POSIX paths automatically on Windows.
-
-  * **ambiguousReexportScorerMinConfidence**:  The ambiguous reexport scorer will emit a warning if
-  it is not at least this confident.  Default: 0.1
-  * **examplePathPrefix**:  Specify the prefix for the example paths, defaulting to the project root.
-  * **favicon**:  A path to a favicon for the generated docs.
-  * **footer**: A list of paths to footer files containing HTML text.
-  * **footerText**: A list of paths to text files for optional text next to the package name and version
-  * **header**:  A list of paths to header files containing HTML text.
-  * **includeExternal**:  Specify a list of library filenames to add to the list of documented libraries.
+In general, paths are relative to the directory the dartdoc_options.yaml the option is defined in
+and should be specified as POSIX paths.  Dartdoc will convert POSIX paths automatically on Windows.
  
 ### Categories
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6471,7 +6471,8 @@ class PackageBuilder {
   Iterable<String> _includeExternalsFrom(Iterable<String> files) {
     Set<String> includeExternalsFound = new Set();
     for (String file in files) {
-      DartdocOptionContext fileContext = new DartdocOptionContext.fromContext(config, new File(file));
+      DartdocOptionContext fileContext =
+          new DartdocOptionContext.fromContext(config, new File(file));
       if (fileContext.includeExternal != null) {
         includeExternalsFound.addAll(fileContext.includeExternal);
       }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6392,6 +6392,7 @@ class PackageBuilder {
       /// source list.
       if (originalSources == null) originalSources = new Set()..addAll(sources);
       files.addAll(driver.knownFiles);
+      files.addAll(_includeExternalsFrom(driver.knownFiles));
       current = _packageMetasForFiles(files);
       // To get canonicalization correct for non-locally documented packages
       // (so we can generate the right hyperlinks), it's vital that we
@@ -6462,6 +6463,21 @@ class PackageBuilder {
     }
   }
 
+  /// Calculate includeExternals based on a list of files.  Assumes each
+  /// file might be part of a [DartdocOptionContext], and loads those
+  /// objects to find any [DartdocOptionContext.includeExternal] configurations
+  /// therein.
+  Iterable<String> _includeExternalsFrom(Iterable<String> files) {
+    Set<String> includeExternalsFound = new Set();
+    for (String file in files) {
+      DartdocOptionContext fileContext = new DartdocOptionContext.fromContext(config, new File(file));
+      if (fileContext.includeExternal != null) {
+        includeExternalsFound.addAll(fileContext.includeExternal);
+      }
+    }
+    return includeExternalsFound;
+  }
+
   Set<String> get getFiles {
     Set<String> files = new Set();
     files.addAll(config.topLevelPackageMeta.isSdk
@@ -6477,11 +6493,8 @@ class PackageBuilder {
         files.add(source.fullName);
       });
     }
-    // Use the includeExternals.
-    for (String fullName in driver.knownFiles) {
-      if (config.includeExternal.any((string) => fullName.endsWith(string)))
-        files.add(fullName);
-    }
+
+    files.addAll(_includeExternalsFrom(files));
     return new Set.from(files.map((s) => new File(s).absolute.path));
   }
 

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -47,9 +47,11 @@ void main() {
       });
 
       test('generator parameters', () async {
-        File favicon = new File(pathLib.joinAll([tempDir.path, 'static-assets', 'favicon.png']));
+        File favicon = new File(
+            pathLib.joinAll([tempDir.path, 'static-assets', 'favicon.png']));
         File index = new File(pathLib.joinAll([tempDir.path, 'index.html']));
-        expect(favicon.readAsStringSync(), contains('Not really a png, but a test file'));
+        expect(favicon.readAsStringSync(),
+            contains('Not really a png, but a test file'));
         String indexString = index.readAsStringSync();
         expect(indexString, contains('Footer things'));
         expect(indexString, contains('footer.txt data'));
@@ -57,12 +59,17 @@ void main() {
       });
 
       test('examplePathPrefix', () async {
-        Class UseAnExampleHere = p.allCanonicalModelElements.firstWhere((ModelElement c) => c.name == 'UseAnExampleHere');
-        expect(UseAnExampleHere.documentationAsHtml, contains('An example of an example in an unusual example location.'));
+        Class UseAnExampleHere = p.allCanonicalModelElements
+            .firstWhere((ModelElement c) => c.name == 'UseAnExampleHere');
+        expect(
+            UseAnExampleHere.documentationAsHtml,
+            contains(
+                'An example of an example in an unusual example location.'));
       });
 
       test('includeExternal and showUndocumentedCategories', () async {
-        Class Something = p.allCanonicalModelElements.firstWhere((ModelElement c) => c.name == 'Something');
+        Class Something = p.allCanonicalModelElements
+            .firstWhere((ModelElement c) => c.name == 'Something');
         expect(Something.isPublic, isTrue);
         expect(Something.displayedCategories, isNotEmpty);
       });
@@ -73,20 +80,33 @@ void main() {
       Package testPackageOptions;
 
       setUp(() async {
-        results = await (await buildDartdoc(['--link-to-remote'], testPackageOptionsImporter)).generateDocsBase();
-        testPackageOptions = results.packageGraph.packages.firstWhere((Package p) => p.name == 'test_package_options');
+        results = await (await buildDartdoc(
+                ['--link-to-remote'], testPackageOptionsImporter))
+            .generateDocsBase();
+        testPackageOptions = results.packageGraph.packages
+            .firstWhere((Package p) => p.name == 'test_package_options');
       });
 
       test('linkToUrl', () async {
-        Library main = testPackageOptions.allLibraries.firstWhere((Library l) => l.name == 'main');
-        Class UseAnExampleHere = main.allClasses.firstWhere((Class c) => c.name == 'UseAnExampleHere');
-        expect(testPackageOptions.documentedWhere, equals(DocumentLocation.remote));
-        expect(UseAnExampleHere.href, equals('https://nonexistingsuperpackage.topdomain/test_package_options/0.0.1/main/UseAnExampleHere-class.html'));
+        Library main = testPackageOptions.allLibraries
+            .firstWhere((Library l) => l.name == 'main');
+        Class UseAnExampleHere = main.allClasses
+            .firstWhere((Class c) => c.name == 'UseAnExampleHere');
+        expect(testPackageOptions.documentedWhere,
+            equals(DocumentLocation.remote));
+        expect(
+            UseAnExampleHere.href,
+            equals(
+                'https://nonexistingsuperpackage.topdomain/test_package_options/0.0.1/main/UseAnExampleHere-class.html'));
       });
 
       test('includeExternal works via remote', () async {
-        Library unusualLibrary = testPackageOptions.allLibraries.firstWhere((Library l) => l.name == 'unusualLibrary');
-        expect(unusualLibrary.allClasses.firstWhere((Class c) => c.name == 'Something'), isNotNull);
+        Library unusualLibrary = testPackageOptions.allLibraries
+            .firstWhere((Library l) => l.name == 'unusualLibrary');
+        expect(
+            unusualLibrary.allClasses
+                .firstWhere((Class c) => c.name == 'Something'),
+            isNotNull);
       });
     });
 

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -31,6 +31,10 @@ final Directory testPackageIncludeExclude =
     new Directory('testing/test_package_include_exclude');
 final Directory testPackageImportExportError =
     new Directory('testing/test_package_import_export_error');
+final Directory testPackageOptions =
+    new Directory('testing/test_package_options');
+final Directory testPackageOptionsImporter =
+    new Directory('testing/test_package_options_importer');
 
 /// Convenience factory to build a [DartdocGeneratorOptionContext] and associate
 /// it with a [DartdocOptionSet] based on the current working directory and/or

--- a/testing/test_package_options/anicon.png
+++ b/testing/test_package_options/anicon.png
@@ -1,0 +1,1 @@
+Not really a png, but a test file

--- a/testing/test_package_options/bin/unusual_library.dart
+++ b/testing/test_package_options/bin/unusual_library.dart
@@ -1,0 +1,4 @@
+/// A library placed in an unusual place.
+library unusual-library;
+
+class Something {}

--- a/testing/test_package_options/bin/unusual_library.dart
+++ b/testing/test_package_options/bin/unusual_library.dart
@@ -1,4 +1,4 @@
 /// A library placed in an unusual place.
-library unusual-library;
+library unusualLibrary;
 
 class Something {}

--- a/testing/test_package_options/dartdoc_options.yaml
+++ b/testing/test_package_options/dartdoc_options.yaml
@@ -1,8 +1,10 @@
 dartdoc:
   examplePathPrefix: 'package_examples'
-  includeExternal: ['bin/foobar.dart']
+  favicon: 'anicon.png'
+  footer: ['extras/footer-things.html']
+  footerText: ['extras/footer.txt']
+  header: ['extras/header.html']
+  includeExternal: ['bin/unusual_library.dart']
   linkTo:
     url: 'https://nonexistingsuperpackage.topdomain/%n%/%v%'
   showUndocumentedCategories: true
-
-

--- a/testing/test_package_options/dartdoc_options.yaml
+++ b/testing/test_package_options/dartdoc_options.yaml
@@ -1,0 +1,8 @@
+dartdoc:
+  examplePathPrefix: 'package_examples'
+  includeExternal: ['bin/foobar.dart']
+  linkTo:
+    url: 'https://nonexistingsuperpackage.topdomain/%n%/%v%'
+  showUndocumentedCategories: true
+
+

--- a/testing/test_package_options/extras/footer-things.html
+++ b/testing/test_package_options/extras/footer-things.html
@@ -1,0 +1,2 @@
+Footer things.
+

--- a/testing/test_package_options/extras/footer.txt
+++ b/testing/test_package_options/extras/footer.txt
@@ -1,0 +1,1 @@
+footer.txt data

--- a/testing/test_package_options/extras/header.html
+++ b/testing/test_package_options/extras/header.html
@@ -1,0 +1,1 @@
+HTML header file

--- a/testing/test_package_options/lib/main.dart
+++ b/testing/test_package_options/lib/main.dart
@@ -3,7 +3,7 @@
 /// Reference an example in a non-default location, based on dartdoc_options.yaml.
 ///
 /// {@example foo.dart}
-///
+/// {@category Undocumented}
 class UseAnExampleHere {
 }
 

--- a/testing/test_package_options/lib/main.dart
+++ b/testing/test_package_options/lib/main.dart
@@ -1,9 +1,5 @@
-
-
 /// Reference an example in a non-default location, based on dartdoc_options.yaml.
 ///
 /// {@example foo.dart}
 /// {@category Undocumented}
-class UseAnExampleHere {
-}
-
+class UseAnExampleHere {}

--- a/testing/test_package_options/lib/main.dart
+++ b/testing/test_package_options/lib/main.dart
@@ -1,0 +1,9 @@
+
+
+/// Reference an example in a non-default location, based on dartdoc_options.yaml.
+///
+/// {@example foo.dart}
+///
+class UseAnExampleHere {
+}
+

--- a/testing/test_package_options/package_examples/foo.dart.md
+++ b/testing/test_package_options/package_examples/foo.dart.md
@@ -1,0 +1,3 @@
+```
+/// An example of an example in an unusual example location.
+```

--- a/testing/test_package_options/pubspec.yaml
+++ b/testing/test_package_options/pubspec.yaml
@@ -1,3 +1,5 @@
 name: test_package_options
 version: 0.0.1
 description: A simple console application.
+environment:
+  sdk: '>=2.0.0 <3.0.0'

--- a/testing/test_package_options/pubspec.yaml
+++ b/testing/test_package_options/pubspec.yaml
@@ -1,0 +1,3 @@
+name: test_package_options
+version: 0.0.1
+description: A simple console application.

--- a/testing/test_package_options_importer/lib/main.dart
+++ b/testing/test_package_options_importer/lib/main.dart
@@ -1,0 +1,3 @@
+import 'package:test_package_options/main.dart';
+
+class X extends UseAnExampleHere {}

--- a/testing/test_package_options_importer/pubspec.yaml
+++ b/testing/test_package_options_importer/pubspec.yaml
@@ -1,0 +1,8 @@
+name: test_package_options_importer
+version: 0.0.1
+description: A simple console application.
+environment:
+  sdk: '>=2.0.0 <3.0.0'
+dependencies:
+  test_package_options:
+    path: '../test_package_options'


### PR DESCRIPTION
Fixes #1674.

Finally finishes that feature request by cleaning up the remaining options.

* Makes includeExternal function at all (this was accidentally a noop previously).  
* Adds tests for examplePathPrefix, favicon, footer, footerText, header, and includeExternal.
