### PR TITLE
Fix angular package fetch on dartdoc bots

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -22,7 +22,12 @@ elif [ "$DARTDOC_BOT" = "flutter" ]; then
   pub run grinder validate-flutter-docs
 elif [ "$DARTDOC_BOT" = "packages" ]; then
   echo "Running packages dartdoc bot"
-  PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
+  DART_VERSION=`dart --version 2>&1 | awk '{print $4}'`
+  if [ ${DART_VERSION} != 2.0.0 ] ; then
+    PACKAGE_NAME=angular PACKAGE_VERSION=">=5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
+  else
+    PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
+  fi
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"
   DARTDOC_GRIND_STEP=buildbot-no-publish pub run grinder test-with-analyzer-sdk


### PR DESCRIPTION
Newer versions of angular can't do "pub get" on less than a 2.1 dev version.  Pin versions appropriately in our bots in response.