### PR TITLE
Add support for injecting HTML

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -39,6 +39,7 @@ import 'package:analyzer/src/dart/element/member.dart'
 import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
+import 'package:crypto/crypto.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/io_utils.dart';
@@ -3142,6 +3143,7 @@ abstract class ModelElement extends Canonicalization
       _rawDocs = _injectExamples(_rawDocs);
       _rawDocs = _injectAnimations(_rawDocs);
       _rawDocs = _stripMacroTemplatesAndAddToIndex(_rawDocs);
+      _rawDocs = _stripHtmlAndAddToIndex(_rawDocs);
     }
     return _rawDocs;
   }
@@ -3287,8 +3289,13 @@ abstract class ModelElement extends Canonicalization
     return false;
   }
 
+  String _htmlDocumentation;
   @override
-  String get documentationAsHtml => _documentation.asHtml;
+  String get documentationAsHtml {
+    if (_htmlDocumentation != null) return _htmlDocumentation;
+    _htmlDocumentation = _injectHtmlFragments(_documentation.asHtml);
+    return _htmlDocumentation;
+  }
 
   @override
   Element get element => _element;
@@ -4047,6 +4054,51 @@ abstract class ModelElement extends Canonicalization
     });
   }
 
+  /// Replace &lt;<dartdoc-html>[digest]</dartdoc-html>&gt; in API comments with
+  /// the contents of the HTML fragment earlier defined by the
+  /// &#123;@inject-html&#125; directive. The [digest] is a SHA1 of the contents
+  /// of the HTML fragment, automatically generated upon parsing the
+  /// &#123;@inject-html&#125; directive.
+  ///
+  /// This markup is generated and inserted by [_stripHtmlAndAddToIndex] when it
+  /// removes the HTML fragment in preparation for markdown processing. It isn't
+  /// meant to be used at a user level.
+  ///
+  /// Example:
+  ///
+  /// You place the fragment in a dartdoc comment:
+  ///
+  ///     Some comments
+  ///     &#123;@inject-html&#125;
+  ///     &lt;p&gt;[HTML contents!]&lt;/p&gt;
+  ///     &#123;@endtemplate&#125;
+  ///     More comments
+  ///
+  /// and [_stripHtmlAndAddToIndex] will replace your HTML fragment with this:
+  ///
+  ///     Some comments
+  ///     &lt;dartdoc-html&gt;4cc02f877240bf69855b4c7291aba8a16e5acce0&lt;/dartdoc-html&gt;
+  ///     More comments
+  ///
+  /// Which will render in the final HTML output as:
+  ///
+  ///     Some comments
+  ///     &lt;p&gt;[HTML contents!]&lt;/p&gt;
+  ///     More comments
+  ///
+  /// And the HTML fragment will not have been processed or changed by Markdown,
+  /// but just injected verbatim.
+  String _injectHtmlFragments(String rawDocs) {
+    final macroRegExp = new RegExp(r'<dartdoc-html>([a-f0-9]+)</dartdoc-html>');
+    return rawDocs.replaceAllMapped(macroRegExp, (match) {
+      String fragment = packageGraph.getHtmlFragment(match[1]);
+      if (fragment == null) {
+        warn(PackageWarning.unknownHtmlFragment, message: match[1]);
+      }
+      return fragment;
+    });
+  }
+
   /// Replace &#123;@macro ...&#125; in API comments with the contents of the macro
   ///
   /// Syntax:
@@ -4084,7 +4136,8 @@ abstract class ModelElement extends Canonicalization
     });
   }
 
-  /// Parse &#123;@template ...&#125; in API comments and store them in the index on the package.
+  /// Parse and remove &#123;@template ...&#125; in API comments and store them
+  /// in the index on the package.
   ///
   /// Syntax:
   ///
@@ -4099,6 +4152,31 @@ abstract class ModelElement extends Canonicalization
     return rawDocs.replaceAllMapped(templateRegExp, (match) {
       packageGraph._addMacro(match[1].trim(), match[2].trim());
       return "";
+    });
+  }
+
+  /// Parse and remove &#123;@inject-html ...&#125; in API comments and store
+  /// them in the index on the package, replacing them with a SHA1 hash of the
+  /// contents, where the HTML will be re-injected after Markdown processing of
+  /// the rest of the text is complete.
+  ///
+  /// Syntax:
+  ///
+  ///     &#123;@inject-html&#125;
+  ///     <p>The HTML to inject.</p>
+  ///     &#123;@end-inject-html&#125;
+  ///
+  String _stripHtmlAndAddToIndex(String rawDocs) {
+    final templateRegExp = new RegExp(
+        r'[ ]*{@inject-html\s*}([\s\S]+?){@end-inject-html}[ ]*\n?',
+        multiLine: true);
+    return rawDocs.replaceAllMapped(templateRegExp, (match) {
+      String fragment = match[1];
+      String digest = sha1.convert(fragment.codeUnits).toString();
+      packageGraph._addHtmlFragment(digest, fragment);
+      // The newlines are so that Markdown will pass this through without
+      // touching it.
+      return '\n<dartdoc-html>$digest</dartdoc-html>\n';
     });
   }
 
@@ -4434,7 +4512,7 @@ class PackageGraph {
     // Go through docs of every ModelElement in package to pre-build the macros
     // index.
     allLocalModelElements.forEach((m) => m.documentationLocal);
-    _macrosAdded = true;
+    _localDocumentationBuilt = true;
 
     // Scan all model elements to insure that interceptor and other special
     // objects are found.
@@ -4539,8 +4617,9 @@ class PackageGraph {
 
   final Map<Element, Library> _elementToLibrary = {};
   final Map<String, String> _macros = {};
+  final Map<String, String> _htmlFragments = {};
   bool allLibrariesAdded = false;
-  bool _macrosAdded = false;
+  bool _localDocumentationBuilt = false;
 
   /// Returns true if there's at least one library documented in the package
   /// that has the same package path as the library for the given element.
@@ -4684,6 +4763,9 @@ class PackageGraph {
         break;
       case PackageWarning.unknownMacro:
         warningMessage = "undefined macro [${message}]";
+        break;
+      case PackageWarning.unknownHtmlFragment:
+        warningMessage = "undefined HTML fragment identifier [${message}]";
         break;
       case PackageWarning.brokenLink:
         warningMessage = 'dartdoc generated a broken link to: ${message}';
@@ -5165,13 +5247,23 @@ class PackageGraph {
   }
 
   String getMacro(String name) {
-    assert(_macrosAdded);
+    assert(_localDocumentationBuilt);
     return _macros[name];
   }
 
   void _addMacro(String name, String content) {
-    assert(!_macrosAdded);
+    assert(!_localDocumentationBuilt);
     _macros[name] = content;
+  }
+
+  String getHtmlFragment(String name) {
+    assert(_localDocumentationBuilt);
+    return _htmlFragments[name];
+  }
+
+  void _addHtmlFragment(String name, String content) {
+    assert(!_localDocumentationBuilt);
+    _htmlFragments[name] = content;
   }
 }
 
@@ -5887,8 +5979,8 @@ abstract class SourceCodeMixin implements Documentable {
 
   String get _crossdartPath {
     var node = element.computeNode();
-    if (node is Declaration && node.element != null) {
-      var source = node.element.source;
+    if (node is Declaration && node.declaredElement != null) {
+      var source = node.declaredElement.source;
       var filePath = source.fullName;
       var uri = source.uri.toString();
       var packageMeta = library.packageGraph.packageMeta;

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -136,6 +136,7 @@ enum PackageWarning {
   reexportedPrivateApiAcrossPackages,
   unresolvedDocReference,
   unknownMacro,
+  unknownHtmlFragment,
   brokenLink,
   orphanedFile,
   unknownFile,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -128,7 +128,7 @@ packages:
     source: hosted
     version: "2.0.2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   analyzer: ^0.33.0
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
+  crypto: ^2.0.6
   html: '>=0.12.1 <0.14.0'
   # We don't use http_parser directly; this dep exists to ensure that we get at
   # least version 3.0.3 to work around an issue with 3.0.2.

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -116,6 +116,25 @@ void main() {
     });
   });
 
+  group('HTML Injection', () {
+    Class htmlInjection;
+    Method injectSimpleHtml;
+
+    setUp(() {
+      htmlInjection = exLibrary.classes.firstWhere((c) => c.name == 'HtmlInjection');
+      injectSimpleHtml =
+          htmlInjection.allInstanceMethods.firstWhere((m) => m.name == 'injectSimpleHtml');
+      packageGraph.allLocalModelElements.forEach((m) => m.documentation);
+    });
+    test("can inject HTML", () {
+      expect(
+          injectSimpleHtml.documentation,
+          contains('\n<dartdoc-html>bad2bbdd4a5cf9efb3212afff4449904756851aa</dartdoc-html>\n'));
+      expect(injectSimpleHtml.documentationAsHtml,
+          contains('   <div style="opacity: 0.5;">[HtmlInjection]</div>'));
+    });
+  });
+
   group('Missing and Remote', () {
     test('Verify that SDK libraries are not canonical when missing', () {
       expect(
@@ -1424,7 +1443,7 @@ void main() {
     });
 
     test('correctly finds all the classes', () {
-      expect(classes, hasLength(29));
+      expect(classes, hasLength(30));
     });
 
     test('abstract', () {

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -75,7 +75,7 @@ void main() {
       );
       expect(errors, isNotEmpty);
       expect(
-          errors[0], contains('Tool "drill" returned non-zero exit code (1)'));
+          errors[0], contains('Tool "drill" returned non-zero exit code'));
       expect(result, isEmpty);
     });
     test("fails if tool in tool map doesn't exist", () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -598,3 +598,11 @@ abstract class ToolUser {
   /// {@end-tool}
   void invokeToolNoInput();
 }
+
+abstract class HtmlInjection {
+  /// Injects some HTML.
+  /// {@inject-html}
+  ///    <div style="opacity: 0.5;">[HtmlInjection]</div>
+  /// {@end-inject-html}
+  void injectSimpleHtml();
+}

--- a/testing/test_package_docs/ex/Animal-class.html
+++ b/testing/test_package_docs/ex/Animal-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/AnotherParameterizedClass-class.html
+++ b/testing/test_package_docs/ex/AnotherParameterizedClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/Apple-class.html
+++ b/testing/test_package_docs/ex/Apple-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/B-class.html
+++ b/testing/test_package_docs/ex/B-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/COLOR-constant.html
+++ b/testing/test_package_docs/ex/COLOR-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/COLOR_GREEN-constant.html
+++ b/testing/test_package_docs/ex/COLOR_GREEN-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
+++ b/testing/test_package_docs/ex/COLOR_ORANGE-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
+++ b/testing/test_package_docs/ex/COMPLEX_COLOR-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/CatString-class.html
+++ b/testing/test_package_docs/ex/CatString-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ConstantCat-class.html
+++ b/testing/test_package_docs/ex/ConstantCat-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/Dog-class.html
+++ b/testing/test_package_docs/ex/Dog-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/E-class.html
+++ b/testing/test_package_docs/ex/E-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ExtendedShortName-class.html
+++ b/testing/test_package_docs/ex/ExtendedShortName-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/F-class.html
+++ b/testing/test_package_docs/ex/F-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs/ex/ForAnnotation-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs/ex/HasAnnotation-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/Helper-class.html
+++ b/testing/test_package_docs/ex/Helper-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/HtmlInjection-class.html
+++ b/testing/test_package_docs/ex/HtmlInjection-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the Cat class from the ex library, for the Dart programming language.">
-  <title>Cat class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the HtmlInjection class from the ex library, for the Dart programming language.">
+  <title>HtmlInjection class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">Cat abstract class</li>
+    <li class="self-crumb">HtmlInjection abstract class</li>
   </ol>
-  <div class="self-name">Cat</div>
+  <div class="self-name">HtmlInjection</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -110,30 +110,16 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-      <h1>Cat class </h1>
+      <h1>HtmlInjection class </h1>
 
     
-    <section>
-      <dl class="dl-horizontal">
-
-
-
-        <dt>Implementers</dt>
-        <dd><ul class="comma-separated clazz-relationships">
-          <li><a href="ex/B-class.html">B</a></li>
-          <li><a href="ex/ConstantCat-class.html">ConstantCat</a></li>
-          <li><a href="ex/Dog-class.html">Dog</a></li>
-        </ul></dd>
-
-      </dl>
-    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="Cat" class="callable">
-          <span class="name"><a href="ex/Cat/Cat.html">Cat</a></span><span class="signature">()</span>
+        <dt id="HtmlInjection" class="callable">
+          <span class="name"><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -141,20 +127,12 @@
       </dl>
     </section>
 
-    <section class="summary offset-anchor" id="instance-properties">
+    <section class="summary offset-anchor inherited" id="instance-properties">
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="isImplemented" class="property">
-          <span class="name"><a href="ex/Cat/isImplemented.html">isImplemented</a></span>
-          <span class="signature">&#8594; bool</span> 
-        </dt>
-        <dd>
-          
-          <div class="features">read-only</div>
-</dd>
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/Cat/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span> 
         </dt>
         <dd class="inherited">
@@ -162,7 +140,7 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="ex/Cat/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span> 
         </dt>
         <dd class="inherited">
@@ -175,17 +153,17 @@
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
-        <dt id="abstractMethod" class="callable">
-          <span class="name"><a href="ex/Cat/abstractMethod.html">abstractMethod</a></span><span class="signature">(<wbr>)
+        <dt id="injectSimpleHtml" class="callable">
+          <span class="name"><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
           </dt>
         <dd>
-          
+          Injects some HTML. <a href="ex/HtmlInjection/injectSimpleHtml.html">[...]</a>
           
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="ex/Cat/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
           </dt>
@@ -194,7 +172,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="ex/Cat/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="ex/HtmlInjection/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
           </dt>
@@ -209,7 +187,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="ex/Cat/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+          <span class="name"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
           </dt>
@@ -227,23 +205,22 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="ex/Cat-class.html#constructors">Constructors</a></li>
-      <li><a href="ex/Cat/Cat.html">Cat</a></li>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
     
-      <li class="section-title">
-        <a href="ex/Cat-class.html#instance-properties">Properties</a>
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title"><a href="ex/Cat-class.html#instance-methods">Methods</a></li>
-      <li><a href="ex/Cat/abstractMethod.html">abstractMethod</a></li>
-      <li class="inherited"><a href="ex/Cat/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="ex/Cat/toString.html">toString</a></li>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="ex/Cat/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs/ex/HtmlInjection/HtmlInjection.html
+++ b/testing/test_package_docs/ex/HtmlInjection/HtmlInjection.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the HtmlInjection constructor from the Class HtmlInjection class from the ex library, for the Dart programming language.">
+  <title>HtmlInjection constructor - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">HtmlInjection constructor</li>
+  </ol>
+  <div class="self-name">HtmlInjection</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>HtmlInjection constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">HtmlInjection</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/HtmlInjection/hashCode.html
+++ b/testing/test_package_docs/ex/HtmlInjection/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the HtmlInjection class, for the Dart programming language.">
+  <title>hashCode property - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/HtmlInjection/injectSimpleHtml.html
+++ b/testing/test_package_docs/ex/HtmlInjection/injectSimpleHtml.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the injectSimpleHtml method from the HtmlInjection class, for the Dart programming language.">
+  <title>injectSimpleHtml method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">injectSimpleHtml abstract method</li>
+  </ol>
+  <div class="self-name">injectSimpleHtml</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>injectSimpleHtml method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">injectSimpleHtml</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Injects some HTML.</p>
+<p>
+   <div style="opacity: 0.5;">[HtmlInjection]</div>
+</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/HtmlInjection/noSuchMethod.html
+++ b/testing/test_package_docs/ex/HtmlInjection/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the HtmlInjection class, for the Dart programming language.">
+  <title>noSuchMethod method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/HtmlInjection/operator_equals.html
+++ b/testing/test_package_docs/ex/HtmlInjection/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the HtmlInjection class, for the Dart programming language.">
+  <title>operator == method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/HtmlInjection/runtimeType.html
+++ b/testing/test_package_docs/ex/HtmlInjection/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the HtmlInjection class, for the Dart programming language.">
+  <title>runtimeType property - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/HtmlInjection/toString.html
+++ b/testing/test_package_docs/ex/HtmlInjection/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the HtmlInjection class, for the Dart programming language.">
+  <title>toString method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/Klass-class.html
+++ b/testing/test_package_docs/ex/Klass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/MY_CAT-constant.html
+++ b/testing/test_package_docs/ex/MY_CAT-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/MyError-class.html
+++ b/testing/test_package_docs/ex/MyError-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs/ex/MyErrorImplements-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/MyException-class.html
+++ b/testing/test_package_docs/ex/MyException-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs/ex/MyExceptionImplements-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
+++ b/testing/test_package_docs/ex/PRETTY_COLORS-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ParameterizedClass-class.html
+++ b/testing/test_package_docs/ex/ParameterizedClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ParameterizedTypedef.html
+++ b/testing/test_package_docs/ex/ParameterizedTypedef.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs/ex/PublicClassExtendsPrivateClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs/ex/PublicClassImplementsPrivateInterface-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ShapeType-class.html
+++ b/testing/test_package_docs/ex/ShapeType-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ShortName-class.html
+++ b/testing/test_package_docs/ex/ShortName-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs/ex/SpecializedDuration-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/TemplatedClass-class.html
+++ b/testing/test_package_docs/ex/TemplatedClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/TemplatedInterface-class.html
+++ b/testing/test_package_docs/ex/TemplatedInterface-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ToolUser-class.html
+++ b/testing/test_package_docs/ex/ToolUser-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
+++ b/testing/test_package_docs/ex/TypedFunctionsWithoutTypedefs-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/WithGeneric-class.html
+++ b/testing/test_package_docs/ex/WithGeneric-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs/ex/WithGenericSub-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/aComplexTypedef.html
+++ b/testing/test_package_docs/ex/aComplexTypedef.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/aThingToDo-class.html
+++ b/testing/test_package_docs/ex/aThingToDo-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/deprecatedField.html
+++ b/testing/test_package_docs/ex/deprecatedField.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/deprecatedGetter.html
+++ b/testing/test_package_docs/ex/deprecatedGetter.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/deprecatedSetter.html
+++ b/testing/test_package_docs/ex/deprecatedSetter.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -171,6 +171,12 @@
 <a href="ex/Apple-class.html">Apple</a>
 <a href="ex/B-class.html">ex.B</a>
         </dd>
+        <dt id="HtmlInjection">
+          <span class="name "><a href="ex/HtmlInjection-class.html">HtmlInjection</a></span> 
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="Klass">
           <span class="name "><a href="ex/Klass-class.html">Klass</a></span> 
         </dt>
@@ -533,6 +539,7 @@ enum constants ala #1445
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/function1.html
+++ b/testing/test_package_docs/ex/function1.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/genericFunction.html
+++ b/testing/test_package_docs/ex/genericFunction.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReference-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
+++ b/testing/test_package_docs/ex/incorrectDocReferenceFromEx-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/number.html
+++ b/testing/test_package_docs/ex/number.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/processMessage.html
+++ b/testing/test_package_docs/ex/processMessage.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/ex/y.html
+++ b/testing/test_package_docs/ex/y.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1948,6 +1948,94 @@
   }
  },
  {
+  "name": "HtmlInjection",
+  "qualifiedName": "ex.HtmlInjection",
+  "href": "ex/HtmlInjection-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
+  }
+ },
+ {
+  "name": "HtmlInjection",
+  "qualifiedName": "ex.HtmlInjection",
+  "href": "ex/HtmlInjection/HtmlInjection.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "ex.HtmlInjection.==",
+  "href": "ex/HtmlInjection/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "ex.HtmlInjection.hashCode",
+  "href": "ex/HtmlInjection/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "injectSimpleHtml",
+  "qualifiedName": "ex.HtmlInjection.injectSimpleHtml",
+  "href": "ex/HtmlInjection/injectSimpleHtml.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "ex.HtmlInjection.noSuchMethod",
+  "href": "ex/HtmlInjection/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "ex.HtmlInjection.runtimeType",
+  "href": "ex/HtmlInjection/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "ex.HtmlInjection.toString",
+  "href": "ex/HtmlInjection/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
   "name": "Klass",
   "qualifiedName": "ex.Klass",
   "href": "ex/Klass-class.html",

--- a/testing/test_package_docs_dev/ex/Animal-class.html
+++ b/testing/test_package_docs_dev/ex/Animal-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/AnotherParameterizedClass-class.html
+++ b/testing/test_package_docs_dev/ex/AnotherParameterizedClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/Apple-class.html
+++ b/testing/test_package_docs_dev/ex/Apple-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/B-class.html
+++ b/testing/test_package_docs_dev/ex/B-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/COLOR-constant.html
+++ b/testing/test_package_docs_dev/ex/COLOR-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/COLOR_GREEN-constant.html
+++ b/testing/test_package_docs_dev/ex/COLOR_GREEN-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/COLOR_ORANGE-constant.html
+++ b/testing/test_package_docs_dev/ex/COLOR_ORANGE-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/COMPLEX_COLOR-constant.html
+++ b/testing/test_package_docs_dev/ex/COMPLEX_COLOR-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/Cat-class.html
+++ b/testing/test_package_docs_dev/ex/Cat-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/CatString-class.html
+++ b/testing/test_package_docs_dev/ex/CatString-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ConstantCat-class.html
+++ b/testing/test_package_docs_dev/ex/ConstantCat-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/Deprecated-class.html
+++ b/testing/test_package_docs_dev/ex/Deprecated-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/Dog-class.html
+++ b/testing/test_package_docs_dev/ex/Dog-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/E-class.html
+++ b/testing/test_package_docs_dev/ex/E-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ExtendedShortName-class.html
+++ b/testing/test_package_docs_dev/ex/ExtendedShortName-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/F-class.html
+++ b/testing/test_package_docs_dev/ex/F-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ForAnnotation-class.html
+++ b/testing/test_package_docs_dev/ex/ForAnnotation-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/HasAnnotation-class.html
+++ b/testing/test_package_docs_dev/ex/HasAnnotation-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/Helper-class.html
+++ b/testing/test_package_docs_dev/ex/Helper-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/HtmlInjection-class.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the Cat class from the ex library, for the Dart programming language.">
-  <title>Cat class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the HtmlInjection class from the ex library, for the Dart programming language.">
+  <title>HtmlInjection class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
-    <li class="self-crumb">Cat abstract class</li>
+    <li class="self-crumb">HtmlInjection abstract class</li>
   </ol>
-  <div class="self-name">Cat</div>
+  <div class="self-name">HtmlInjection</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -110,30 +110,16 @@
   </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-      <h1>Cat class </h1>
+      <h1>HtmlInjection class </h1>
 
     
-    <section>
-      <dl class="dl-horizontal">
-
-
-
-        <dt>Implementers</dt>
-        <dd><ul class="comma-separated clazz-relationships">
-          <li><a href="ex/B-class.html">B</a></li>
-          <li><a href="ex/ConstantCat-class.html">ConstantCat</a></li>
-          <li><a href="ex/Dog-class.html">Dog</a></li>
-        </ul></dd>
-
-      </dl>
-    </section>
 
     <section class="summary offset-anchor" id="constructors">
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">
-        <dt id="Cat" class="callable">
-          <span class="name"><a href="ex/Cat/Cat.html">Cat</a></span><span class="signature">()</span>
+        <dt id="HtmlInjection" class="callable">
+          <span class="name"><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></span><span class="signature">()</span>
         </dt>
         <dd>
           
@@ -141,20 +127,12 @@
       </dl>
     </section>
 
-    <section class="summary offset-anchor" id="instance-properties">
+    <section class="summary offset-anchor inherited" id="instance-properties">
       <h2>Properties</h2>
 
       <dl class="properties">
-        <dt id="isImplemented" class="property">
-          <span class="name"><a href="ex/Cat/isImplemented.html">isImplemented</a></span>
-          <span class="signature">&#8594; bool</span> 
-        </dt>
-        <dd>
-          
-          <div class="features">read-only</div>
-</dd>
         <dt id="hashCode" class="property inherited">
-          <span class="name"><a href="ex/Cat/hashCode.html">hashCode</a></span>
+          <span class="name"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></span>
           <span class="signature">&#8594; int</span> 
         </dt>
         <dd class="inherited">
@@ -162,7 +140,7 @@
           <div class="features">read-only, inherited</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="ex/Cat/runtimeType.html">runtimeType</a></span>
+          <span class="name"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></span>
           <span class="signature">&#8594; Type</span> 
         </dt>
         <dd class="inherited">
@@ -175,17 +153,17 @@
     <section class="summary offset-anchor" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
-        <dt id="abstractMethod" class="callable">
-          <span class="name"><a href="ex/Cat/abstractMethod.html">abstractMethod</a></span><span class="signature">(<wbr>)
+        <dt id="injectSimpleHtml" class="callable">
+          <span class="name"><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; void</span>
           </span>
           </dt>
         <dd>
-          
+          Injects some HTML. <a href="ex/HtmlInjection/injectSimpleHtml.html">[...]</a>
           
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="ex/Cat/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
           </dt>
@@ -194,7 +172,7 @@
           <div class="features">inherited</div>
 </dd>
         <dt id="toString" class="callable inherited">
-          <span class="name"><a href="ex/Cat/toString.html">toString</a></span><span class="signature">(<wbr>)
+          <span class="name"><a href="ex/HtmlInjection/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
           </dt>
@@ -209,7 +187,7 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable inherited">
-          <span class="name"><a href="ex/Cat/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+          <span class="name"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
           </dt>
@@ -227,23 +205,22 @@
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
     <ol>
-      <li class="section-title"><a href="ex/Cat-class.html#constructors">Constructors</a></li>
-      <li><a href="ex/Cat/Cat.html">Cat</a></li>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
     
-      <li class="section-title">
-        <a href="ex/Cat-class.html#instance-properties">Properties</a>
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Cat/isImplemented.html">isImplemented</a></li>
-      <li class="inherited"><a href="ex/Cat/hashCode.html">hashCode</a></li>
-      <li class="inherited"><a href="ex/Cat/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
     
-      <li class="section-title"><a href="ex/Cat-class.html#instance-methods">Methods</a></li>
-      <li><a href="ex/Cat/abstractMethod.html">abstractMethod</a></li>
-      <li class="inherited"><a href="ex/Cat/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="ex/Cat/toString.html">toString</a></li>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
     
-      <li class="section-title inherited"><a href="ex/Cat-class.html#operators">Operators</a></li>
-      <li class="inherited"><a href="ex/Cat/operator_equals.html">operator ==</a></li>
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
     
     
     

--- a/testing/test_package_docs_dev/ex/HtmlInjection/HtmlInjection.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/HtmlInjection.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the HtmlInjection constructor from the Class HtmlInjection class from the ex library, for the Dart programming language.">
+  <title>HtmlInjection constructor - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">HtmlInjection constructor</li>
+  </ol>
+  <div class="self-name">HtmlInjection</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>HtmlInjection constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">HtmlInjection</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/HtmlInjection/hashCode.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/hashCode.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the HtmlInjection class, for the Dart programming language.">
+  <title>hashCode property - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/HtmlInjection/injectSimpleHtml.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/injectSimpleHtml.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the injectSimpleHtml method from the HtmlInjection class, for the Dart programming language.">
+  <title>injectSimpleHtml method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">injectSimpleHtml abstract method</li>
+  </ol>
+  <div class="self-name">injectSimpleHtml</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>injectSimpleHtml method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">void</span>
+      <span class="name ">injectSimpleHtml</span>
+(<wbr>)
+    </section>
+    <section class="desc markdown">
+      <p>Injects some HTML.</p>
+<p>
+   <div style="opacity: 0.5;">[HtmlInjection]</div>
+</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/HtmlInjection/noSuchMethod.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the HtmlInjection class, for the Dart programming language.">
+  <title>noSuchMethod method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/HtmlInjection/operator_equals.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the HtmlInjection class, for the Dart programming language.">
+  <title>operator == method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/HtmlInjection/runtimeType.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/runtimeType.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the HtmlInjection class, for the Dart programming language.">
+  <title>runtimeType property - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/HtmlInjection/toString.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the HtmlInjection class, for the Dart programming language.">
+  <title>toString method - HtmlInjection class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HtmlInjection class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/HtmlInjection/HtmlInjection.html">HtmlInjection</a></li>
+    
+      <li class="section-title inherited">
+        <a href="ex/HtmlInjection-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="ex/HtmlInjection/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/HtmlInjection-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/HtmlInjection/injectSimpleHtml.html">injectSimpleHtml</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="ex/HtmlInjection-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/HtmlInjection/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/ex/Klass-class.html
+++ b/testing/test_package_docs_dev/ex/Klass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/MY_CAT-constant.html
+++ b/testing/test_package_docs_dev/ex/MY_CAT-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/MyError-class.html
+++ b/testing/test_package_docs_dev/ex/MyError-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/MyErrorImplements-class.html
+++ b/testing/test_package_docs_dev/ex/MyErrorImplements-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/MyException-class.html
+++ b/testing/test_package_docs_dev/ex/MyException-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/MyExceptionImplements-class.html
+++ b/testing/test_package_docs_dev/ex/MyExceptionImplements-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/PRETTY_COLORS-constant.html
+++ b/testing/test_package_docs_dev/ex/PRETTY_COLORS-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ParameterizedClass-class.html
+++ b/testing/test_package_docs_dev/ex/ParameterizedClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ParameterizedTypedef.html
+++ b/testing/test_package_docs_dev/ex/ParameterizedTypedef.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/PublicClassExtendsPrivateClass-class.html
+++ b/testing/test_package_docs_dev/ex/PublicClassExtendsPrivateClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/PublicClassImplementsPrivateInterface-class.html
+++ b/testing/test_package_docs_dev/ex/PublicClassImplementsPrivateInterface-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ShapeType-class.html
+++ b/testing/test_package_docs_dev/ex/ShapeType-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ShortName-class.html
+++ b/testing/test_package_docs_dev/ex/ShortName-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/SpecializedDuration-class.html
+++ b/testing/test_package_docs_dev/ex/SpecializedDuration-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/TemplatedClass-class.html
+++ b/testing/test_package_docs_dev/ex/TemplatedClass-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/TemplatedInterface-class.html
+++ b/testing/test_package_docs_dev/ex/TemplatedInterface-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ToolUser-class.html
+++ b/testing/test_package_docs_dev/ex/ToolUser-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/TypedFunctionsWithoutTypedefs-class.html
+++ b/testing/test_package_docs_dev/ex/TypedFunctionsWithoutTypedefs-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/WithGeneric-class.html
+++ b/testing/test_package_docs_dev/ex/WithGeneric-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/WithGenericSub-class.html
+++ b/testing/test_package_docs_dev/ex/WithGenericSub-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/aComplexTypedef.html
+++ b/testing/test_package_docs_dev/ex/aComplexTypedef.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/aThingToDo-class.html
+++ b/testing/test_package_docs_dev/ex/aThingToDo-class.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/deprecated-constant.html
+++ b/testing/test_package_docs_dev/ex/deprecated-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/deprecatedField.html
+++ b/testing/test_package_docs_dev/ex/deprecatedField.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/deprecatedGetter.html
+++ b/testing/test_package_docs_dev/ex/deprecatedGetter.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/deprecatedSetter.html
+++ b/testing/test_package_docs_dev/ex/deprecatedSetter.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/ex-library.html
+++ b/testing/test_package_docs_dev/ex/ex-library.html
@@ -171,6 +171,12 @@
 <a href="ex/Apple-class.html">Apple</a>
 <a href="ex/B-class.html">ex.B</a>
         </dd>
+        <dt id="HtmlInjection">
+          <span class="name "><a href="ex/HtmlInjection-class.html">HtmlInjection</a></span> 
+        </dt>
+        <dd>
+          
+        </dd>
         <dt id="Klass">
           <span class="name "><a href="ex/Klass-class.html">Klass</a></span> 
         </dt>
@@ -533,6 +539,7 @@ enum constants ala #1445
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/function1.html
+++ b/testing/test_package_docs_dev/ex/function1.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/genericFunction.html
+++ b/testing/test_package_docs_dev/ex/genericFunction.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/incorrectDocReference-constant.html
+++ b/testing/test_package_docs_dev/ex/incorrectDocReference-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/incorrectDocReferenceFromEx-constant.html
+++ b/testing/test_package_docs_dev/ex/incorrectDocReferenceFromEx-constant.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/number.html
+++ b/testing/test_package_docs_dev/ex/number.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/processMessage.html
+++ b/testing/test_package_docs_dev/ex/processMessage.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/ex/y.html
+++ b/testing/test_package_docs_dev/ex/y.html
@@ -55,6 +55,7 @@
       <li><a href="ex/ForAnnotation-class.html">ForAnnotation</a></li>
       <li><a href="ex/HasAnnotation-class.html">HasAnnotation</a></li>
       <li><a href="ex/Helper-class.html">Helper</a></li>
+      <li><a href="ex/HtmlInjection-class.html">HtmlInjection</a></li>
       <li><a href="ex/Klass-class.html">Klass</a></li>
       <li><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a></li>
       <li><a href="ex/PublicClassExtendsPrivateClass-class.html">PublicClassExtendsPrivateClass</a></li>

--- a/testing/test_package_docs_dev/index.json
+++ b/testing/test_package_docs_dev/index.json
@@ -1959,6 +1959,94 @@
   }
  },
  {
+  "name": "HtmlInjection",
+  "qualifiedName": "ex.HtmlInjection",
+  "href": "ex/HtmlInjection-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ex",
+   "type": "library"
+  }
+ },
+ {
+  "name": "HtmlInjection",
+  "qualifiedName": "ex.HtmlInjection",
+  "href": "ex/HtmlInjection/HtmlInjection.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "ex.HtmlInjection.==",
+  "href": "ex/HtmlInjection/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "ex.HtmlInjection.hashCode",
+  "href": "ex/HtmlInjection/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "injectSimpleHtml",
+  "qualifiedName": "ex.HtmlInjection.injectSimpleHtml",
+  "href": "ex/HtmlInjection/injectSimpleHtml.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "ex.HtmlInjection.noSuchMethod",
+  "href": "ex/HtmlInjection/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "ex.HtmlInjection.runtimeType",
+  "href": "ex/HtmlInjection/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "ex.HtmlInjection.toString",
+  "href": "ex/HtmlInjection/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HtmlInjection",
+   "type": "class"
+  }
+ },
+ {
   "name": "Klass",
   "qualifiedName": "ex.Klass",
   "href": "ex/Klass-class.html",


### PR DESCRIPTION
This adds support for a new dartdoc directive that allows injecting raw HTML into the dartdoc output.

```dart
  ///     {@inject-html}
  ///     <p>[The HTML to inject.]</p>
  ///     {@end-inject-html}
```

This HTML will bypass the markdown processing entirely, so it doesn't get reference linking.