### PR TITLE
update the gitattributes for generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 *.dart eol=lf
+
+# Don't collapse in github code reviews by default.
+lib/src/version.dart linguist-generated=false
+lib/src/html/resources.g.dart linguist-generated=false
+
+# Do collapse in github code reviews by default.
+testing/test_package_docs/** linguist-generated=true
+testing/test_package_docs_dev/** linguist-generated=true


### PR DESCRIPTION
Update the gitattributes for generated code:

- do show github diffs for our (few) small generated files
- don't show for our (large number) of checked in golden master doc files

This updated whether a generated file is shown as collapsed in the github UI by default; for collapsed ones, its still possible to click on them to show for diff.

<img width="1551" alt="screen shot 2018-10-15 at 10 47 07 am" src="https://user-images.githubusercontent.com/1269969/46968556-5cfc1280-d068-11e8-849a-bcc2052e842a.png">

@jcollins-g 