### PR TITLE
Disable parallelism again (leaving travis changes in place)

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -40,7 +40,7 @@ final String defaultPubCache =
 /// Run no more than the number of processors available in parallel.
 final MultiFutureTracker testFutures = new MultiFutureTracker(
     Platform.environment.containsKey('TRAVIS')
-        ? 2
+        ? 1
         : Platform.numberOfProcessors);
 
 // Directory.systemTemp is not a constant.  So wrap it.


### PR DESCRIPTION
Right after landing the travis change and reenabling parallelism, of course, we get another flake.

Since I can't find any more evidence for an overall memory usage increase, it may just be we're really close to the edge anyway and some difference in which tests are running when is responsible for the OOMs.

Dropping parallelism here to make the tests pass reliably again.