### PR TITLE
Prepare for dartdoc 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.24.1-dev
+## 0.24.1
 * Added more metadata (element name, project name, etc.) to external tool invocations.
+  (#1801)
 * Fixed a bug where not specifying --show-warnings caused dartdoc to report success
-  even when errors were present.
+  even when errors were present. (#1805)
 
 ## 0.24.0
 * Add 'override' to feature list for members which override a superclass (#981)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.24.1-dev';
+const packageVersion = '0.24.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.24.1-dev
+version: 0.24.1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/testing/test_package_docs/__404error.html
+++ b/testing/test_package_docs/__404error.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.24.1-dev">
+  <meta name="generator" content="made with love by dartdoc 0.24.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 

--- a/testing/test_package_docs/index.html
+++ b/testing/test_package_docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.24.1-dev">
+  <meta name="generator" content="made with love by dartdoc 0.24.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 

--- a/testing/test_package_docs_dev/__404error.html
+++ b/testing/test_package_docs_dev/__404error.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.24.1-dev">
+  <meta name="generator" content="made with love by dartdoc 0.24.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 

--- a/testing/test_package_docs_dev/index.html
+++ b/testing/test_package_docs_dev/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.24.1-dev">
+  <meta name="generator" content="made with love by dartdoc 0.24.1">
   <meta name="description" content="test_package API docs, for the Dart programming language.">
   <title>test_package - Dart API docs</title>
 


### PR DESCRIPTION
Release to fix a bug where dartdoc failed to return non-zero on critical errors (fixed in #1805).