### PR TITLE
Fix flutter bot problems and a macro issue

### DIFF
--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -85,6 +85,7 @@ void main() {
       }
       // This must be synced with ../tool/grind.dart's updateTestPackageDocs().
       var args = <String>[
+        '--enable-asserts',
         dartdocBin,
         '--auto-include-dependencies',
         '--example-path-prefix',

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -695,7 +695,9 @@ void main() {
 
   group('Macros', () {
     Class dog;
+    Enum MacrosFromAccessors;
     Method withMacro, withMacro2, withPrivateMacro, withUndefinedMacro;
+    EnumField macroReferencedHere;
 
     setUp(() {
       dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
@@ -707,7 +709,12 @@ void main() {
           .firstWhere((m) => m.name == 'withPrivateMacro');
       withUndefinedMacro = dog.allInstanceMethods
           .firstWhere((m) => m.name == 'withUndefinedMacro');
-      packageGraph.allLocalModelElements.forEach((m) => m.documentation);
+      MacrosFromAccessors = fakeLibrary.enums.firstWhere((e) => e.name == 'MacrosFromAccessors');
+      macroReferencedHere = MacrosFromAccessors.publicConstants.firstWhere((e) => e.name == 'macroReferencedHere');
+    });
+
+    test("renders a macro defined within a enum", () {
+      expect(macroReferencedHere.documentationAsHtml, contains('This is a macro defined in an Enum accessor.'));
     });
 
     test("renders a macro within the same comment where it's defined", () {
@@ -725,6 +732,8 @@ void main() {
     });
 
     test("a warning is generated for unknown macros", () {
+      // Retrieve documentation first to generate the warning.
+      withUndefinedMacro.documentation;
       expect(
           packageGraph.packageWarningCounter.hasWarning(withUndefinedMacro,
               PackageWarning.unknownMacro, 'ThatDoesNotExist'),

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -852,6 +852,19 @@ class BaseForDocComments {
   String operator [](String key) => "${key}'s value";
 }
 
+/// Verify that we can define and use macros inside accessors.
+enum MacrosFromAccessors {
+  /// Define a macro.
+  /// {@template test_package_docs:accessorMacro}
+  /// This is a macro defined in an Enum accessor.
+  /// {@endtemplate}
+  macroDefinedHere,
+
+  /// Reference a macro.
+  /// {@macro test_package_docs:accessorMacro}
+  macroReferencedHere,
+}
+
 /// Testing if docs for inherited method are correct.
 /// {@category NotSoExcellent}
 class SubForDocComments extends BaseForDocComments {

--- a/testing/test_package_docs/fake/ABaseClass-class.html
+++ b/testing/test_package_docs/fake/ABaseClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs/fake/CovariantMemberParams-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/GenericClass-class.html
+++ b/testing/test_package_docs/fake/GenericClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs/fake/GenericMixin-mixin.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/HasPragma-class.html
+++ b/testing/test_package_docs/fake/HasPragma-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the GenericTypedef property from the fake library, for the Dart programming language.">
-  <title>GenericTypedef typedef - fake library - Dart API</title>
+  <meta name="description" content="API docs for the MacrosFromAccessors enum from the fake library, for the Dart programming language.">
+  <title>MacrosFromAccessors enum - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">GenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</li>
+    <li class="self-crumb">MacrosFromAccessors enum</li>
   </ol>
-  <div class="self-name">GenericTypedef</div>
+  <div class="self-name">MacrosFromAccessors</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -169,25 +169,156 @@
       <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
       <li><a href="fake/Oops-class.html">Oops</a></li>
     </ol>
-  </div><!--/.sidebar-offcanvas-left-->
+  </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>GenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef </h1>
-
-    <section class="multi-line-signature">
-        <span class="returntype">T</span>
-        <span class="name ">GenericTypedef</span>
-(<wbr><span class="parameter" id="GenericTypedef-param-input"><span class="type-annotation">T</span> <span class="parameter-name">input</span></span>)
-    </section>
+    <h1>MacrosFromAccessors enum </h1>
 
     <section class="desc markdown">
-      <p>A typedef with a type parameter.</p>
+      <p>Verify that we can define and use macros inside accessors.</p>
     </section>
-        
+    
+
+    <section class="summary offset-anchor" id="constants">
+      <h2>Constants</h2>
+
+      <dl class="properties">
+        <dt id="macroDefinedHere" class="constant">
+          <span class="name ">macroDefinedHere</span>
+          <span class="signature">&#8594; const <a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span>
+          </dt>
+        <dd>
+          <p>Define a macro.</p>
+          
+  <div>
+            <span class="signature"><code>const MacrosFromAccessors(0)</code></span>
+          </div>
+        </dd>
+        <dt id="macroReferencedHere" class="constant">
+          <span class="name ">macroReferencedHere</span>
+          <span class="signature">&#8594; const <a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span>
+          </dt>
+        <dd>
+          <p>Reference a macro.
+This is a macro defined in an Enum accessor.</p>
+          
+  <div>
+            <span class="signature"><code>const MacrosFromAccessors(1)</code></span>
+          </div>
+        </dd>
+        <dt id="values" class="constant">
+          <span class="name ">values</span>
+          <span class="signature">&#8594; const List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span>&gt;</span></span>
+          </dt>
+        <dd>
+          <p>A constant List of the values in this enum, in order of their declaration.</p>
+          
+  <div>
+            <span class="signature"><code>const List&lt;<wbr><span class="type-parameter">MacrosFromAccessors</span>&gt;</code></span>
+          </div>
+        </dd>
+      </dl>
+    </section>
+
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="index" class="property">
+          <span class="name">index</span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd>
+          <p>The integer index of this enum.</p>
+          <div class="features">final</div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="toString" class="callable">
+          <span class="name"><a href="fake/MacrosFromAccessors/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+          </dt>
+        <dd>
+          
+          <div class="features">override</div>
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    </ol>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs/fake/MacrosFromAccessors/hashCode.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors/hashCode.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>hashCode property - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MacrosFromAccessors/noSuchMethod.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors/noSuchMethod.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>noSuchMethod method - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MacrosFromAccessors/operator_equals.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors/operator_equals.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>operator == method - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MacrosFromAccessors/runtimeType.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors/runtimeType.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>runtimeType property - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MacrosFromAccessors/toString.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors/toString.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>toString method - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+      <div class="features">override</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ModifierClass-class.html
+++ b/testing/test_package_docs/fake/ModifierClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/aCoolVariable.html
+++ b/testing/test_package_docs/fake/aCoolVariable.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/aMixinReturningFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs/fake/bulletDoced-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -937,6 +937,12 @@ default value.
         <dd>
           An <code>enum</code> for ROYGBIV constants.
         </dd>
+        <dt id="MacrosFromAccessors">
+          <span class="name "><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span> 
+        </dt>
+        <dd>
+          Verify that we can define and use macros inside accessors.
+        </dd>
       </dl>
     </section>
 
@@ -1150,6 +1156,7 @@ default value.
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/mustGetThis.html
+++ b/testing/test_package_docs/fake/mustGetThis.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/myMap-constant.html
+++ b/testing/test_package_docs/fake/myMap-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs/fake/thisIsFutureOr.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs/fake/useSomethingInTheSdk.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -7301,6 +7301,72 @@
   }
  },
  {
+  "name": "MacrosFromAccessors",
+  "qualifiedName": "fake.MacrosFromAccessors",
+  "href": "fake/MacrosFromAccessors-class.html",
+  "type": "enum",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.MacrosFromAccessors.==",
+  "href": "fake/MacrosFromAccessors/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.MacrosFromAccessors.hashCode",
+  "href": "fake/MacrosFromAccessors/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.MacrosFromAccessors.noSuchMethod",
+  "href": "fake/MacrosFromAccessors/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.MacrosFromAccessors.runtimeType",
+  "href": "fake/MacrosFromAccessors/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.MacrosFromAccessors.toString",
+  "href": "fake/MacrosFromAccessors/toString.html",
+  "type": "method",
+  "overriddenDepth": 1,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
   "name": "MixMeIn",
   "qualifiedName": "fake.MixMeIn",
   "href": "fake/MixMeIn-class.html",

--- a/testing/test_package_docs_dev/fake/ABaseClass-class.html
+++ b/testing/test_package_docs_dev/fake/ABaseClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Annotation-class.html
+++ b/testing/test_package_docs_dev/fake/Annotation-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs_dev/fake/AnotherInterface-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy2-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Callback2.html
+++ b/testing/test_package_docs_dev/fake/Callback2.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Color-class.html
+++ b/testing/test_package_docs_dev/fake/Color-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ConstantClass-class.html
+++ b/testing/test_package_docs_dev/fake/ConstantClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs_dev/fake/ConstructorTester-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Cool-class.html
+++ b/testing/test_package_docs_dev/fake/Cool-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/DOWN-constant.html
+++ b/testing/test_package_docs_dev/fake/DOWN-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Doh-class.html
+++ b/testing/test_package_docs_dev/fake/Doh-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/FakeProcesses.html
+++ b/testing/test_package_docs_dev/fake/FakeProcesses.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Foo2-class.html
+++ b/testing/test_package_docs_dev/fake/Foo2-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/GenericClass-class.html
+++ b/testing/test_package_docs_dev/fake/GenericClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenerics-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenerics-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/HasPragma-class.html
+++ b/testing/test_package_docs_dev/fake/HasPragma-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Interface-class.html
+++ b/testing/test_package_docs_dev/fake/Interface-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs_dev/fake/LongFirstLine-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEBase-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEBase-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEThing-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEThing-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the GenericTypedef property from the fake library, for the Dart programming language.">
-  <title>GenericTypedef typedef - fake library - Dart API</title>
+  <meta name="description" content="API docs for the MacrosFromAccessors enum from the fake library, for the Dart programming language.">
+  <title>MacrosFromAccessors enum - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">GenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef</li>
+    <li class="self-crumb">MacrosFromAccessors enum</li>
   </ol>
-  <div class="self-name">GenericTypedef</div>
+  <div class="self-name">MacrosFromAccessors</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -169,25 +169,156 @@
       <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
       <li><a href="fake/Oops-class.html">Oops</a></li>
     </ol>
-  </div><!--/.sidebar-offcanvas-left-->
+  </div>
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>GenericTypedef&lt;<wbr><span class="type-parameter">T</span>&gt; typedef </h1>
-
-    <section class="multi-line-signature">
-        <span class="returntype">T</span>
-        <span class="name ">GenericTypedef</span>
-(<wbr><span class="parameter" id="GenericTypedef-param-input"><span class="type-annotation">T</span> <span class="parameter-name">input</span></span>)
-    </section>
+    <h1>MacrosFromAccessors enum </h1>
 
     <section class="desc markdown">
-      <p>A typedef with a type parameter.</p>
+      <p>Verify that we can define and use macros inside accessors.</p>
     </section>
-        
+    
+
+    <section class="summary offset-anchor" id="constants">
+      <h2>Constants</h2>
+
+      <dl class="properties">
+        <dt id="macroDefinedHere" class="constant">
+          <span class="name ">macroDefinedHere</span>
+          <span class="signature">&#8594; const <a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span>
+          </dt>
+        <dd>
+          <p>Define a macro.</p>
+          
+  <div>
+            <span class="signature"><code>const MacrosFromAccessors(0)</code></span>
+          </div>
+        </dd>
+        <dt id="macroReferencedHere" class="constant">
+          <span class="name ">macroReferencedHere</span>
+          <span class="signature">&#8594; const <a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span>
+          </dt>
+        <dd>
+          <p>Reference a macro.
+This is a macro defined in an Enum accessor.</p>
+          
+  <div>
+            <span class="signature"><code>const MacrosFromAccessors(1)</code></span>
+          </div>
+        </dd>
+        <dt id="values" class="constant">
+          <span class="name ">values</span>
+          <span class="signature">&#8594; const List<span class="signature">&lt;<wbr><span class="type-parameter"><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span>&gt;</span></span>
+          </dt>
+        <dd>
+          <p>A constant List of the values in this enum, in order of their declaration.</p>
+          
+  <div>
+            <span class="signature"><code>const List&lt;<wbr><span class="type-parameter">MacrosFromAccessors</span>&gt;</code></span>
+          </div>
+        </dd>
+      </dl>
+    </section>
+
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="index" class="property">
+          <span class="name">index</span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd>
+          <p>The integer index of this enum.</p>
+          <div class="features">final</div>
+</dd>
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="toString" class="callable">
+          <span class="name"><a href="fake/MacrosFromAccessors/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+          </dt>
+        <dd>
+          
+          <div class="features">override</div>
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
 
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    </ol>
   </div><!--/.sidebar-offcanvas-->
 
 </main>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors/hashCode.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors/hashCode.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>hashCode property - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors/noSuchMethod.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors/noSuchMethod.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>noSuchMethod method - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors/operator_equals.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors/operator_equals.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>operator == method - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors/runtimeType.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors/runtimeType.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>runtimeType property - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors/toString.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors/toString.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the MacrosFromAccessors class, for the Dart programming language.">
+  <title>toString method - MacrosFromAccessors class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>MacrosFromAccessors enum</h5>
+    <ol>
+    
+      <li class="section-title">
+        <a href="fake/MacrosFromAccessors-class.html#instance-properties">Properties</a>
+      </li>
+      <li>index</li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#instance-methods">Methods</a></li>
+      <li><a href="fake/MacrosFromAccessors/toString.html">toString</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="fake/MacrosFromAccessors-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/MacrosFromAccessors/operator_equals.html">operator ==</a></li>
+    
+    
+    
+      <li class="section-title"><a href="fake/MacrosFromAccessors-class.html#constants">Constants</a></li>
+      <li>macroDefinedHere</li>
+      <li>macroReferencedHere</li>
+      <li>values</li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+      <div class="features">override</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/MixMeIn-class.html
+++ b/testing/test_package_docs_dev/fake/MixMeIn-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ModifierClass-class.html
+++ b/testing/test_package_docs_dev/fake/ModifierClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/NewGenericTypedef.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/NotAMixin-class.html
+++ b/testing/test_package_docs_dev/fake/NotAMixin-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/Oops-class.html
+++ b/testing/test_package_docs_dev/fake/Oops-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/PI-constant.html
+++ b/testing/test_package_docs_dev/fake/PI-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ReferringClass-class.html
+++ b/testing/test_package_docs_dev/fake/ReferringClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/SpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/SpecialList-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/SubForDocComments-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/UP-constant.html
+++ b/testing/test_package_docs_dev/fake/UP-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/VoidCallback.html
+++ b/testing/test_package_docs_dev/fake/VoidCallback.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/ZERO-constant.html
+++ b/testing/test_package_docs_dev/fake/ZERO-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/aCoolVariable.html
+++ b/testing/test_package_docs_dev/fake/aCoolVariable.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/aVoidParameter.html
+++ b/testing/test_package_docs_dev/fake/aVoidParameter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback.html
+++ b/testing/test_package_docs_dev/fake/addCallback.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback2.html
+++ b/testing/test_package_docs_dev/fake/addCallback2.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs_dev/fake/bulletDoced-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/complicatedReturn.html
+++ b/testing/test_package_docs_dev/fake/complicatedReturn.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/dynamicGetter.html
+++ b/testing/test_package_docs_dev/fake/dynamicGetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/fake-library.html
+++ b/testing/test_package_docs_dev/fake/fake-library.html
@@ -937,6 +937,12 @@ default value.
         <dd>
           An <code>enum</code> for ROYGBIV constants.
         </dd>
+        <dt id="MacrosFromAccessors">
+          <span class="name "><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></span> 
+        </dt>
+        <dd>
+          Verify that we can define and use macros inside accessors.
+        </dd>
       </dl>
     </section>
 
@@ -1150,6 +1156,7 @@ default value.
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/importantComputations.html
+++ b/testing/test_package_docs_dev/fake/importantComputations.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/justGetter.html
+++ b/testing/test_package_docs_dev/fake/justGetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/justSetter.html
+++ b/testing/test_package_docs_dev/fake/justSetter.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/meaningOfLife.html
+++ b/testing/test_package_docs_dev/fake/meaningOfLife.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/mustGetThis.html
+++ b/testing/test_package_docs_dev/fake/mustGetThis.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/myCoolTypedef.html
+++ b/testing/test_package_docs_dev/fake/myCoolTypedef.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/myGenericFunction.html
+++ b/testing/test_package_docs_dev/fake/myGenericFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/myMap-constant.html
+++ b/testing/test_package_docs_dev/fake/myMap-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage1.html
+++ b/testing/test_package_docs_dev/fake/paintImage1.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage2.html
+++ b/testing/test_package_docs_dev/fake/paintImage2.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/required-constant.html
+++ b/testing/test_package_docs_dev/fake/required-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/returningFutureVoid.html
+++ b/testing/test_package_docs_dev/fake/returningFutureVoid.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/setAndGet.html
+++ b/testing/test_package_docs_dev/fake/setAndGet.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/short.html
+++ b/testing/test_package_docs_dev/fake/short.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/simpleProperty.html
+++ b/testing/test_package_docs_dev/fake/simpleProperty.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/soIntense.html
+++ b/testing/test_package_docs_dev/fake/soIntense.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAsync.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOr.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/topLevelFunction.html
+++ b/testing/test_package_docs_dev/fake/topLevelFunction.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
@@ -154,6 +154,7 @@
     
       <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
       <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
       <li><a href="fake/Callback2.html">Callback2</a></li>

--- a/testing/test_package_docs_dev/index.json
+++ b/testing/test_package_docs_dev/index.json
@@ -7312,6 +7312,72 @@
   }
  },
  {
+  "name": "MacrosFromAccessors",
+  "qualifiedName": "fake.MacrosFromAccessors",
+  "href": "fake/MacrosFromAccessors-class.html",
+  "type": "enum",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.MacrosFromAccessors.==",
+  "href": "fake/MacrosFromAccessors/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.MacrosFromAccessors.hashCode",
+  "href": "fake/MacrosFromAccessors/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.MacrosFromAccessors.noSuchMethod",
+  "href": "fake/MacrosFromAccessors/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.MacrosFromAccessors.runtimeType",
+  "href": "fake/MacrosFromAccessors/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.MacrosFromAccessors.toString",
+  "href": "fake/MacrosFromAccessors/toString.html",
+  "type": "method",
+  "overriddenDepth": 1,
+  "enclosedBy": {
+   "name": "MacrosFromAccessors",
+   "type": "enum"
+  }
+ },
+ {
   "name": "MixMeIn",
   "qualifiedName": "fake.MixMeIn",
   "href": "fake/MixMeIn-class.html",

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -674,6 +674,11 @@ Future<List<Map>> _buildFlutterDocs(
     workingDirectory: pathLib.join(flutterPath, 'dev', 'tools'),
   );
   await flutterRepo.launcher.runStreamed(
+    flutterRepo.cachePub,
+    ['get'],
+    workingDirectory: pathLib.join(flutterPath, 'dev', 'snippets'),
+  );
+  await flutterRepo.launcher.runStreamed(
       flutterRepo.cachePub, ['global', 'activate', '-spath', '.'],
       workingDirectory: await futureCwd);
   return await flutterRepo.launcher.runStreamed(


### PR DESCRIPTION
Fixes #1810.

Fix a problem where we need to run pub get in an additional directory to build flutter docs (for the new tools feature being used by Flutter).  Add --enable-asserts to the compare_output_test to find more problems like this in the test package outside of explicit tests.

This also corrects a problem (#1810) where we didn't include accessors in our initial pass to detect macros, and therefore missed picking them up if they're defined there (happens in dart:ui's BoxHeightStyle enum for Flutter).  You can see the result of that bug in Flutter's docs at: https://master-docs-flutter-io.firebaseapp.com/flutter/dart-ui/BoxHeightStyle-class.html, where there is the string "null" because a macro was not resolved correctly.