### PR TITLE
Remove the use of AnalysisDriver.addFile

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6590,7 +6590,6 @@ class PackageBuilder {
     do {
       lastPass = _packageMetasForFiles(files);
       files.difference(addedFiles).forEach((filename) {
-        driver.addFile(filename);
         addedFiles.add(filename);
       });
       await Future.wait(


### PR DESCRIPTION
@scheglov assures me that this isn't necessary, and that this is likely what's causing the analysis session to be invalidated. The larger set of changes isn't currently working, but this passes all the tests, so I thought it was worth getting it committed separately.