### PR TITLE
Look up code references within libraries by map rather than traversing a list

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -368,6 +368,7 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
   }
 
   results.remove(null);
+  // This could be local to the class, look there first.
   _findWithinTryClasses(results, preferredClass, element, codeRefChomped, codeRef, packageGraph);
 
   // We now need the ref element cache to keep from repeatedly searching [Package.allModelElements].

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -368,117 +368,23 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
   }
 
   results.remove(null);
-  if (results.isEmpty) {
-    // Maybe this is local to a class.
-    // TODO(jcollins-g): tryClasses is a strict subset of the superclass chain.  Optimize.
-    List<Class> tryClasses = [preferredClass];
-    Class realClass = tryClasses.first;
-    if (element is Inheritable) {
-      Inheritable overriddenElement = element.overriddenElement;
-      while (overriddenElement != null) {
-        tryClasses.add(
-            (element.overriddenElement as EnclosedElement).enclosingElement);
-        overriddenElement = overriddenElement.overriddenElement;
-      }
-    }
-
-    for (Class tryClass in tryClasses) {
-      if (tryClass != null) {
-        _getResultsForClass(
-            tryClass, codeRefChomped, results, codeRef, packageGraph);
-      }
-      results.remove(null);
-      if (results.isNotEmpty) break;
-    }
-
-    if (results.isEmpty && realClass != null) {
-      for (Class superClass
-          in realClass.publicSuperChain.map((et) => et.element as Class)) {
-        if (!tryClasses.contains(superClass)) {
-          _getResultsForClass(
-              superClass, codeRefChomped, results, codeRef, packageGraph);
-        }
-        results.remove(null);
-        if (results.isNotEmpty) break;
-      }
-    }
-  }
-  results.remove(null);
+  _findWithinTryClasses(results, preferredClass, element, codeRefChomped, codeRef, packageGraph);
 
   // We now need the ref element cache to keep from repeatedly searching [Package.allModelElements].
   // But if not, look for a fully qualified match.  (That only makes sense
   // if the codeRef might be qualified, and contains periods.)
-  if (results.isEmpty &&
-      codeRefChomped.contains('.') &&
-      packageGraph.findRefElementCache.containsKey(codeRefChomped)) {
-    for (final ModelElement modelElement
-        in packageGraph.findRefElementCache[codeRefChomped]) {
-      if (!_ConsiderIfConstructor(codeRef, modelElement)) continue;
-      // For fully qualified matches, the original preferredClass passed
-      // might make no sense.  Instead, use the enclosing class from the
-      // element in [_findRefElementCache], because that element's enclosing
-      // class will be preferred from [codeRefChomped]'s perspective.
-      results.add(packageGraph.findCanonicalModelElementFor(
-          modelElement.element,
-          preferredClass: modelElement.enclosingElement is Class
-              ? modelElement.enclosingElement
-              : null));
-    }
-  }
-  results.remove(null);
+  _findWithinRefElementCache(results, codeRefChomped, packageGraph, codeRef);
 
   // Only look for partially qualified matches if we didn't find a fully qualified one.
-  if (results.isEmpty) {
-    for (final modelElement in library.allModelElements) {
-      if (!_ConsiderIfConstructor(codeRef, modelElement)) continue;
-      if (codeRefChomped == modelElement.fullyQualifiedNameWithoutLibrary) {
-        results.add(packageGraph.findCanonicalModelElementFor(
-            modelElement.element,
-            preferredClass: preferredClass));
-      }
-    }
-  }
-  results.remove(null);
+  _findPartiallyQualifiedMatches(results, library, codeRef, codeRefChomped, packageGraph, preferredClass);
 
   // And if we still haven't found anything, just search the whole ball-of-wax.
-  if (results.isEmpty &&
-      packageGraph.findRefElementCache.containsKey(codeRefChomped)) {
-    for (final modelElement
-        in packageGraph.findRefElementCache[codeRefChomped]) {
-      if (codeRefChomped == modelElement.fullyQualifiedNameWithoutLibrary ||
-          (modelElement is Library &&
-              codeRefChomped == modelElement.fullyQualifiedName)) {
-        results.add(
-            packageGraph.findCanonicalModelElementFor(modelElement.element));
-      }
-    }
-  }
-  results.remove(null);
+  _findGlobalWithinRefElementCache(results, packageGraph, codeRefChomped);
 
   // This could conceivably be a reference to an enum member.  They don't show up in allModelElements.
   // TODO(jcollins-g): Put enum members in allModelElements with useful hrefs without blowing up other assumptions about what that means.
   // TODO(jcollins-g): This doesn't provide good warnings if an enum and class have the same name in different libraries in the same package.  Fix that.
-  if (results.isEmpty) {
-    List<String> codeRefChompedParts = codeRefChomped.split('.');
-    if (codeRefChompedParts.length >= 2) {
-      String maybeEnumName = codeRefChompedParts
-          .sublist(0, codeRefChompedParts.length - 1)
-          .join('.');
-      String maybeEnumMember = codeRefChompedParts.last;
-      if (packageGraph.findRefElementCache.containsKey(maybeEnumName)) {
-        for (final modelElement
-            in packageGraph.findRefElementCache[maybeEnumName]) {
-          if (modelElement is Enum) {
-            if (modelElement.constants.any((e) => e.name == maybeEnumMember)) {
-              results.add(modelElement);
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-  results.remove(null);
+  _findEnumReferences(results, codeRefChomped, packageGraph);
 
   if (results.length > 1) {
     // If this name could refer to a class or a constructor, prefer the class.
@@ -558,6 +464,122 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
     result = results.first;
   }
   return result;
+}
+
+void _findEnumReferences(Set<ModelElement> results, String codeRefChomped, PackageGraph packageGraph) {
+  if (results.isEmpty) {
+    List<String> codeRefChompedParts = codeRefChomped.split('.');
+    if (codeRefChompedParts.length >= 2) {
+      String maybeEnumName = codeRefChompedParts
+          .sublist(0, codeRefChompedParts.length - 1)
+          .join('.');
+      String maybeEnumMember = codeRefChompedParts.last;
+      if (packageGraph.findRefElementCache.containsKey(maybeEnumName)) {
+        for (final modelElement
+            in packageGraph.findRefElementCache[maybeEnumName]) {
+          if (modelElement is Enum) {
+            if (modelElement.constants.any((e) => e.name == maybeEnumMember)) {
+              results.add(modelElement);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+  results.remove(null);
+}
+
+void _findGlobalWithinRefElementCache(Set<ModelElement> results, PackageGraph packageGraph, String codeRefChomped) {
+  if (results.isEmpty &&
+      packageGraph.findRefElementCache.containsKey(codeRefChomped)) {
+    for (final modelElement
+        in packageGraph.findRefElementCache[codeRefChomped]) {
+      if (codeRefChomped == modelElement.fullyQualifiedNameWithoutLibrary ||
+          (modelElement is Library &&
+              codeRefChomped == modelElement.fullyQualifiedName)) {
+        results.add(
+            packageGraph.findCanonicalModelElementFor(modelElement.element));
+      }
+    }
+  }
+  results.remove(null);
+}
+
+void _findPartiallyQualifiedMatches(Set<ModelElement> results, Library library, String codeRef, String codeRefChomped, PackageGraph packageGraph, Class preferredClass) {
+  // Only look for partially qualified matches if we didn't find a fully qualified one.
+  if (results.isEmpty && library.modelElementsNameMap.containsKey(codeRefChomped)) {
+    for (final modelElement in library.modelElementsNameMap[codeRefChomped]) {
+      if (!_ConsiderIfConstructor(codeRef, modelElement)) continue;
+      results.add(packageGraph.findCanonicalModelElementFor(
+          modelElement.element,
+          preferredClass: preferredClass));
+    }
+  }
+  results.remove(null);
+}
+
+void _findWithinRefElementCache(Set<ModelElement> results, String codeRefChomped, PackageGraph packageGraph, String codeRef) {
+  // We now need the ref element cache to keep from repeatedly searching [Package.allModelElements].
+  // But if not, look for a fully qualified match.  (That only makes sense
+  // if the codeRef might be qualified, and contains periods.)
+  if (results.isEmpty &&
+      codeRefChomped.contains('.') &&
+      packageGraph.findRefElementCache.containsKey(codeRefChomped)) {
+    for (final ModelElement modelElement
+        in packageGraph.findRefElementCache[codeRefChomped]) {
+      if (!_ConsiderIfConstructor(codeRef, modelElement)) continue;
+      // For fully qualified matches, the original preferredClass passed
+      // might make no sense.  Instead, use the enclosing class from the
+      // element in [_findRefElementCache], because that element's enclosing
+      // class will be preferred from [codeRefChomped]'s perspective.
+      results.add(packageGraph.findCanonicalModelElementFor(
+          modelElement.element,
+          preferredClass: modelElement.enclosingElement is Class
+              ? modelElement.enclosingElement
+              : null));
+    }
+  }
+  results.remove(null);
+}
+
+void _findWithinTryClasses(Set<ModelElement> results, Class preferredClass, Warnable element, String codeRefChomped, String codeRef, PackageGraph packageGraph) {
+  if (results.isEmpty) {
+    // Maybe this is local to a class.
+    // TODO(jcollins-g): tryClasses is a strict subset of the superclass chain.  Optimize.
+    List<Class> tryClasses = [preferredClass];
+    Class realClass = tryClasses.first;
+    if (element is Inheritable) {
+      Inheritable overriddenElement = element.overriddenElement;
+      while (overriddenElement != null) {
+        tryClasses.add(
+            (element.overriddenElement as EnclosedElement).enclosingElement);
+        overriddenElement = overriddenElement.overriddenElement;
+      }
+    }
+
+    for (Class tryClass in tryClasses) {
+      if (tryClass != null) {
+        _getResultsForClass(
+            tryClass, codeRefChomped, results, codeRef, packageGraph);
+      }
+      results.remove(null);
+      if (results.isNotEmpty) break;
+    }
+
+    if (results.isEmpty && realClass != null) {
+      for (Class superClass
+          in realClass.publicSuperChain.map((et) => et.element as Class)) {
+        if (!tryClasses.contains(superClass)) {
+          _getResultsForClass(
+              superClass, codeRefChomped, results, codeRef, packageGraph);
+        }
+        results.remove(null);
+        if (results.isNotEmpty) break;
+      }
+    }
+  }
+  results.remove(null);
 }
 
 // _getResultsForClass assumes codeRefChomped might be a member of tryClass (inherited or not)

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -333,6 +333,9 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
         newCodeRef, element, commentRefs, preferredClass);
   }
 
+  // Remove any "null" objects after each step of trying to add to results.
+  // TODO(jcollins-g): Eliminate all situations where nulls can be added
+  // to the results set.
   results.remove(null);
   // Oh, and someone might have some type parameters or other garbage.
   if (results.isEmpty && codeRef.contains(trailingIgnoreStuff)) {
@@ -366,26 +369,31 @@ ModelElement _findRefElementInLibrary(String codeRef, Warnable element,
           p.name == codeRefChomped || codeRefChomped.startsWith("${p.name}.")));
     }
   }
-
   results.remove(null);
+
   // This could be local to the class, look there first.
   _findWithinTryClasses(results, preferredClass, element, codeRefChomped, codeRef, packageGraph);
+  results.remove(null);
 
   // We now need the ref element cache to keep from repeatedly searching [Package.allModelElements].
   // But if not, look for a fully qualified match.  (That only makes sense
   // if the codeRef might be qualified, and contains periods.)
   _findWithinRefElementCache(results, codeRefChomped, packageGraph, codeRef);
+  results.remove(null);
 
   // Only look for partially qualified matches if we didn't find a fully qualified one.
   _findPartiallyQualifiedMatches(results, library, codeRef, codeRefChomped, packageGraph, preferredClass);
+  results.remove(null);
 
   // And if we still haven't found anything, just search the whole ball-of-wax.
   _findGlobalWithinRefElementCache(results, packageGraph, codeRefChomped);
+  results.remove(null);
 
   // This could conceivably be a reference to an enum member.  They don't show up in allModelElements.
   // TODO(jcollins-g): Put enum members in allModelElements with useful hrefs without blowing up other assumptions about what that means.
   // TODO(jcollins-g): This doesn't provide good warnings if an enum and class have the same name in different libraries in the same package.  Fix that.
   _findEnumReferences(results, codeRefChomped, packageGraph);
+  results.remove(null);
 
   if (results.length > 1) {
     // If this name could refer to a class or a constructor, prefer the class.
@@ -488,7 +496,6 @@ void _findEnumReferences(Set<ModelElement> results, String codeRefChomped, Packa
       }
     }
   }
-  results.remove(null);
 }
 
 void _findGlobalWithinRefElementCache(Set<ModelElement> results, PackageGraph packageGraph, String codeRefChomped) {
@@ -504,7 +511,6 @@ void _findGlobalWithinRefElementCache(Set<ModelElement> results, PackageGraph pa
       }
     }
   }
-  results.remove(null);
 }
 
 void _findPartiallyQualifiedMatches(Set<ModelElement> results, Library library, String codeRef, String codeRefChomped, PackageGraph packageGraph, Class preferredClass) {
@@ -517,7 +523,6 @@ void _findPartiallyQualifiedMatches(Set<ModelElement> results, Library library, 
           preferredClass: preferredClass));
     }
   }
-  results.remove(null);
 }
 
 void _findWithinRefElementCache(Set<ModelElement> results, String codeRefChomped, PackageGraph packageGraph, String codeRef) {
@@ -541,7 +546,6 @@ void _findWithinRefElementCache(Set<ModelElement> results, String codeRefChomped
               : null));
     }
   }
-  results.remove(null);
 }
 
 void _findWithinTryClasses(Set<ModelElement> results, Class preferredClass, Warnable element, String codeRefChomped, String codeRef, PackageGraph packageGraph) {
@@ -580,7 +584,6 @@ void _findWithinTryClasses(Set<ModelElement> results, Class preferredClass, Warn
       }
     }
   }
-  results.remove(null);
 }
 
 // _getResultsForClass assumes codeRefChomped might be a member of tryClass (inherited or not)

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2533,14 +2533,18 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   }
 
   Map<String, Set<ModelElement>> _modelElementsNameMap;
+  /// Map of [fullyQualifiedNameWithoutLibrary] to all matching [ModelElement]s
+  /// in this library.  Used for code reference lookups.
   Map<String, Set<ModelElement>> get modelElementsNameMap {
     if (_modelElementsNameMap == null) {
-      // TODO(jcollins-g): avoid side effects?
-      modelElementsMap;
+      _modelElementsNameMap = new Map<String, Set<ModelElement>>();
+      allModelElements.forEach((ModelElement modelElement) {
+        _modelElementsNameMap.putIfAbsent(modelElement.fullyQualifiedNameWithoutLibrary, () => new Set());
+        _modelElementsNameMap[modelElement.fullyQualifiedNameWithoutLibrary].add(modelElement);
+      });
     }
     return _modelElementsNameMap;
   }
-
 
   Map<Element, Set<ModelElement>> _modelElementsMap;
   Map<Element, Set<ModelElement>> get modelElementsMap {
@@ -2568,12 +2572,9 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
       });
 
       _modelElementsMap = new Map<Element, Set<ModelElement>>();
-      _modelElementsNameMap = new Map<String, Set<ModelElement>>();
       results.forEach((modelElement) {
         _modelElementsMap.putIfAbsent(modelElement.element, () => new Set());
-        _modelElementsNameMap.putIfAbsent(modelElement.fullyQualifiedNameWithoutLibrary, () => new Set());
         _modelElementsMap[modelElement.element].add(modelElement);
-        _modelElementsNameMap[modelElement.fullyQualifiedNameWithoutLibrary].add(modelElement);
       });
       _modelElementsMap.putIfAbsent(element, () => new Set());
       _modelElementsMap[element].add(this);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2532,6 +2532,16 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     return name;
   }
 
+  Map<String, Set<ModelElement>> _modelElementsNameMap;
+  Map<String, Set<ModelElement>> get modelElementsNameMap {
+    if (_modelElementsNameMap == null) {
+      // TODO(jcollins-g): avoid side effects?
+      modelElementsMap;
+    }
+    return _modelElementsNameMap;
+  }
+
+
   Map<Element, Set<ModelElement>> _modelElementsMap;
   Map<Element, Set<ModelElement>> get modelElementsMap {
     if (_modelElementsMap == null) {
@@ -2558,9 +2568,12 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
       });
 
       _modelElementsMap = new Map<Element, Set<ModelElement>>();
+      _modelElementsNameMap = new Map<String, Set<ModelElement>>();
       results.forEach((modelElement) {
         _modelElementsMap.putIfAbsent(modelElement.element, () => new Set());
+        _modelElementsNameMap.putIfAbsent(modelElement.fullyQualifiedNameWithoutLibrary, () => new Set());
         _modelElementsMap[modelElement.element].add(modelElement);
+        _modelElementsNameMap[modelElement.fullyQualifiedNameWithoutLibrary].add(modelElement);
       });
       _modelElementsMap.putIfAbsent(element, () => new Set());
       _modelElementsMap[element].add(this);


### PR DESCRIPTION
Fairly low hanging fruit to improve generator performance, but more risky than #1828.    Especially good on heavily code-referenced codebases like Flutter's, around 20% runtime reduction in the generator stage.

Checked with compare-flutter-warnings to make sure it didn't impact generation for Flutter.

Also extracts a few functions to make looking around in the profiler easier.