### PR TITLE
Fix infinite recursion in reexport tagger

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -5011,9 +5011,16 @@ class PackageGraph {
       packages.where((p) => p.documentedWhere != DocumentLocation.missing);
 
   Map<LibraryElement, Set<Library>> _libraryElementReexportedBy = new Map();
+  /// Prevent cycles from breaking our stack.
+  Set<Tuple2<Library, LibraryElement>> _reexportsTagged = new Set();
   void _tagReexportsFor(
       final Library topLevelLibrary, final LibraryElement libraryElement,
       [ExportElement lastExportedElement]) {
+    Tuple2<Library, LibraryElement> key = new Tuple2(topLevelLibrary, libraryElement);
+    if (_reexportsTagged.contains(key)) {
+      return;
+    }
+    _reexportsTagged.add(key);
     if (libraryElement == null) {
       // The first call to _tagReexportFor should not have a null libraryElement.
       assert(lastExportedElement != null);
@@ -5038,6 +5045,7 @@ class PackageGraph {
     if (allLibraries.keys.length != _lastSizeOfAllLibraries) {
       _lastSizeOfAllLibraries = allLibraries.keys.length;
       _libraryElementReexportedBy = new Map<LibraryElement, Set<Library>>();
+      _reexportsTagged = new Set();
       for (Library library in publicLibraries) {
         _tagReexportsFor(library, library.element);
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.33.3+2
+  analyzer: ^0.33.3+1
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.33.1
+  analyzer: ^0.33.3+2
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -57,6 +57,10 @@ import 'two_exports.dart' show BaseClass;
 export 'package:test_package_imported/categoryExporting.dart'
     show IAmAClassWithCategories;
 
+// Explicitly export ourselves, because why not.
+// ignore: uri_does_not_exist
+export 'package:test_package/fake.dart';
+
 abstract class ImplementingThingy implements BaseThingy {}
 
 abstract class BaseThingy {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,6 +28,7 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
+  PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"
   DARTDOC_GRIND_STEP=buildbot-no-publish pub run grinder test-with-analyzer-sdk


### PR DESCRIPTION
Fixes dart-lang/dartdoc#1832.  Explicitly creating reexport cycles via export declarations is allowed in Dart but dartdoc didn't allow for that, and so we overflowed whenever that occurs; this fixes that issue.