### PR TITLE
More graceful handling of no documentable libraries

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -178,7 +178,7 @@ class Dartdoc extends PackageBuilder {
     DartdocResults dartdocResults = await generateDocsBase();
     if (dartdocResults.packageGraph.publicLibraries.isEmpty) {
       throw new DartdocFailure(
-          "dartdoc could not find any libraries to document. Run `pub get` and try again.");
+          "dartdoc could not find any libraries to document");
     }
 
     final int errorCount =

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6037,7 +6037,7 @@ class Package extends LibraryContainer
 
   /// Is this the package at the top of the list?  We display the first
   /// package specially (with "Libraries" rather than the package name).
-  bool get isFirstPackage => identical(packageGraph.localPackages.first, this);
+  bool get isFirstPackage => packageGraph.localPackages.isNotEmpty && identical(packageGraph.localPackages.first, this);
 
   @override
   bool get isSdk => packageMeta.isSdk;

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -119,7 +119,7 @@
 
       <dl class="constructor-summary-list">
         <dt id="Deprecated" class="callable">
-          <span class="name"><a href="ex/Deprecated/Deprecated.html">Deprecated</a></span><span class="signature">(<span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)</span>
+          <span class="name"><a href="ex/Deprecated/Deprecated.html">Deprecated</a></span><span class="signature">(<span class="parameter" id="-param-message"><span class="type-annotation">String</span> <span class="parameter-name">message</span></span>)</span>
         </dt>
         <dd>
           
@@ -133,7 +133,15 @@
 
       <dl class="properties">
         <dt id="expires" class="property">
-          <span class="name"><a href="ex/Deprecated/expires.html">expires</a></span>
+          <span class="name"><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></span>
+          <span class="signature">&#8594; String</span> 
+        </dt>
+        <dd>
+          
+          <div class="features">@<a href="ex/Deprecated-class.html">Deprecated</a>(&#39;Use `message` instead. Will be removed in Dart 3.0.0&#39;), read-only</div>
+</dd>
+        <dt id="message" class="property">
+          <span class="name"><a href="ex/Deprecated/message.html">message</a></span>
           <span class="signature">&#8594; String</span> 
         </dt>
         <dd>
@@ -211,7 +219,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     
@@ -66,7 +67,7 @@
 
     <section class="multi-line-signature">
       const
-      <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)
+      <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-message"><span class="type-annotation">String</span> <span class="parameter-name">message</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
-    <li class="self-crumb">expires property</li>
+    <li class="self-crumb"><span class="deprecated">expires</span> property</li>
   </ol>
   <div class="self-name">expires</div>
   <form class="search navbar-right" role="search">
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     
@@ -64,13 +65,18 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <h1>expires property</h1>
 
+
+        <section id="getter">
+        
         <section class="multi-line-signature">
           <span class="returntype">String</span>
-          <span class="name ">expires</span>
-          <div class="features">final</div>
-        </section>
-                
-
+          <span class="name deprecated">expires</span>
+  <div class="features">@<a href="ex/Deprecated-class.html">Deprecated</a>(&#39;Use `message` instead. Will be removed in Dart 3.0.0&#39;)</div>
+</section>
+        
+        
+</section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Deprecated/message.html
+++ b/testing/test_package_docs/ex/Deprecated/message.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the hashCode property from the Deprecated class, for the Dart programming language.">
-  <title>hashCode property - Deprecated class - ex library - Dart API</title>
+  <meta name="description" content="API docs for the message property from the Deprecated class, for the Dart programming language.">
+  <title>message property - Deprecated class - ex library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">
 
@@ -26,9 +26,9 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
-    <li class="self-crumb">hashCode property</li>
+    <li class="self-crumb">message property</li>
   </ol>
-  <div class="self-name">hashCode</div>
+  <div class="self-name">message</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -63,20 +63,15 @@
   </div><!--/.sidebar-offcanvas-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>hashCode property</h1>
+    <h1>message property</h1>
 
-
-        <section id="getter">
-        
         <section class="multi-line-signature">
-          <span class="returntype">int</span>
-          <span class="name ">hashCode</span>
-  <div class="features">inherited</div>
-</section>
-        
-        
-</section>
-        
+          <span class="returntype">String</span>
+          <span class="name ">message</span>
+          <div class="features">final</div>
+        </section>
+                
+
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/toString.html
+++ b/testing/test_package_docs/ex/Deprecated/toString.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1057,6 +1057,17 @@
   }
  },
  {
+  "name": "message",
+  "qualifiedName": "ex.Deprecated.message",
+  "href": "ex/Deprecated/message.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Deprecated",
+   "type": "class"
+  }
+ },
+ {
   "name": "noSuchMethod",
   "qualifiedName": "ex.Deprecated.noSuchMethod",
   "href": "ex/Deprecated/noSuchMethod.html",

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,7 +28,6 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
-  PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" pub run grinder build-pub-package
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,6 +28,7 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
+  PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" pub run grinder build-pub-package
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,6 +28,8 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
+  # Negative test for flutter_plugin_tools, make sure right error message is displayed.
+  PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" pub run grinder build-pub-package 2>&1 | grep "Generation failed: dartdoc could not find any libraries to document.$"
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"


### PR DESCRIPTION
Fixes #1833.  Cleans up the error reporting when there is no package that can be documented.