### PR TITLE
Allow annotations returning the dynamic type

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3107,7 +3107,7 @@ abstract class ModelElement extends Canonicalization
       if (annotationElement is ExecutableElement) {
         annotationElement = (annotationElement as ExecutableElement)
             .returnType
-            .element as ClassElement;
+            .element;
       }
       if (annotationElement is ClassElement) {
         annotationClassElement = annotationElement;
@@ -3117,7 +3117,7 @@ abstract class ModelElement extends Canonicalization
       // annotationElement can be null if the element can't be resolved.
       Class annotationClass = packageGraph
           .findCanonicalModelElementFor(annotationClassElement) as Class;
-      if (annotationClass == null && annotationElement != null) {
+      if (annotationClass == null && annotationElement != null && annotationClassElement != null) {
         annotationClass =
             new ModelElement.fromElement(annotationClassElement, packageGraph)
                 as Class;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3105,9 +3105,8 @@ abstract class ModelElement extends Canonicalization
 
       ClassElement annotationClassElement;
       if (annotationElement is ExecutableElement) {
-        annotationElement = (annotationElement as ExecutableElement)
-            .returnType
-            .element;
+        annotationElement =
+            (annotationElement as ExecutableElement).returnType.element;
       }
       if (annotationElement is ClassElement) {
         annotationClassElement = annotationElement;
@@ -3117,7 +3116,9 @@ abstract class ModelElement extends Canonicalization
       // annotationElement can be null if the element can't be resolved.
       Class annotationClass = packageGraph
           .findCanonicalModelElementFor(annotationClassElement) as Class;
-      if (annotationClass == null && annotationElement != null && annotationClassElement != null) {
+      if (annotationClass == null &&
+          annotationElement != null &&
+          annotationClassElement != null) {
         annotationClass =
             new ModelElement.fromElement(annotationClassElement, packageGraph)
                 as Class;
@@ -5037,12 +5038,14 @@ class PackageGraph {
       packages.where((p) => p.documentedWhere != DocumentLocation.missing);
 
   Map<LibraryElement, Set<Library>> _libraryElementReexportedBy = new Map();
+
   /// Prevent cycles from breaking our stack.
   Set<Tuple2<Library, LibraryElement>> _reexportsTagged = new Set();
   void _tagReexportsFor(
       final Library topLevelLibrary, final LibraryElement libraryElement,
       [ExportElement lastExportedElement]) {
-    Tuple2<Library, LibraryElement> key = new Tuple2(topLevelLibrary, libraryElement);
+    Tuple2<Library, LibraryElement> key =
+        new Tuple2(topLevelLibrary, libraryElement);
     if (_reexportsTagged.contains(key)) {
       return;
     }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -112,10 +112,10 @@ const String bulletDoced = 'Foo bar baz';
 @pragma('Hello world')
 class HasPragma {}
 
-
 const dynamic aDynamicAnnotation = 4;
 
 @aDynamicAnnotation
+
 /// This class has a dynamic annotation.
 class HasDynamicAnnotation {}
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -112,6 +112,13 @@ const String bulletDoced = 'Foo bar baz';
 @pragma('Hello world')
 class HasPragma {}
 
+
+const dynamic aDynamicAnnotation = 4;
+
+@aDynamicAnnotation
+/// This class has a dynamic annotation.
+class HasDynamicAnnotation {}
+
 /// This is a class with a table.
 ///
 /// It has multiple sentences before the table.  Because testing is a good

--- a/testing/test_package_docs/ex/Deprecated-class.html
+++ b/testing/test_package_docs/ex/Deprecated-class.html
@@ -119,7 +119,7 @@
 
       <dl class="constructor-summary-list">
         <dt id="Deprecated" class="callable">
-          <span class="name"><a href="ex/Deprecated/Deprecated.html">Deprecated</a></span><span class="signature">(<span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)</span>
+          <span class="name"><a href="ex/Deprecated/Deprecated.html">Deprecated</a></span><span class="signature">(<span class="parameter" id="-param-message"><span class="type-annotation">String</span> <span class="parameter-name">message</span></span>)</span>
         </dt>
         <dd>
           
@@ -133,7 +133,15 @@
 
       <dl class="properties">
         <dt id="expires" class="property">
-          <span class="name"><a href="ex/Deprecated/expires.html">expires</a></span>
+          <span class="name"><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></span>
+          <span class="signature">&#8594; String</span> 
+        </dt>
+        <dd>
+          
+          <div class="features">@<a href="ex/Deprecated-class.html">Deprecated</a>(&#39;Use `message` instead. Will be removed in Dart 3.0.0&#39;), read-only</div>
+</dd>
+        <dt id="message" class="property">
+          <span class="name"><a href="ex/Deprecated/message.html">message</a></span>
           <span class="signature">&#8594; String</span> 
         </dt>
         <dd>
@@ -211,7 +219,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/Deprecated.html
+++ b/testing/test_package_docs/ex/Deprecated/Deprecated.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     
@@ -66,7 +67,7 @@
 
     <section class="multi-line-signature">
       const
-      <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-expires"><span class="type-annotation">String</span> <span class="parameter-name">expires</span></span>)
+      <span class="name ">Deprecated</span>(<wbr><span class="parameter" id="-param-message"><span class="type-annotation">String</span> <span class="parameter-name">message</span></span>)
     </section>
 
     

--- a/testing/test_package_docs/ex/Deprecated/expires.html
+++ b/testing/test_package_docs/ex/Deprecated/expires.html
@@ -26,7 +26,7 @@
     <li><a href="index.html">test_package</a></li>
     <li><a href="ex/ex-library.html">ex</a></li>
     <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
-    <li class="self-crumb">expires property</li>
+    <li class="self-crumb"><span class="deprecated">expires</span> property</li>
   </ol>
   <div class="self-name">expires</div>
   <form class="search navbar-right" role="search">
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     
@@ -64,13 +65,18 @@
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
     <h1>expires property</h1>
 
+
+        <section id="getter">
+        
         <section class="multi-line-signature">
           <span class="returntype">String</span>
-          <span class="name ">expires</span>
-          <div class="features">final</div>
-        </section>
-                
-
+          <span class="name deprecated">expires</span>
+  <div class="features">@<a href="ex/Deprecated-class.html">Deprecated</a>(&#39;Use `message` instead. Will be removed in Dart 3.0.0&#39;)</div>
+</section>
+        
+        
+</section>
+        
   </div> <!-- /.main-content -->
 
   <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">

--- a/testing/test_package_docs/ex/Deprecated/hashCode.html
+++ b/testing/test_package_docs/ex/Deprecated/hashCode.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/message.html
+++ b/testing/test_package_docs/ex/Deprecated/message.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the message property from the Deprecated class, for the Dart programming language.">
+  <title>message property - Deprecated class - ex library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="ex/ex-library.html">ex</a></li>
+    <li><a href="ex/Deprecated-class.html">Deprecated</a></li>
+    <li class="self-crumb">message property</li>
+  </ol>
+  <div class="self-name">message</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>Deprecated class</h5>
+    <ol>
+      <li class="section-title"><a href="ex/Deprecated-class.html#constructors">Constructors</a></li>
+      <li><a href="ex/Deprecated/Deprecated.html">Deprecated</a></li>
+    
+      <li class="section-title">
+        <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
+      <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="ex/Deprecated-class.html#instance-methods">Methods</a></li>
+      <li><a href="ex/Deprecated/toString.html">toString</a></li>
+      <li class="inherited"><a href="ex/Deprecated/noSuchMethod.html">noSuchMethod</a></li>
+    
+      <li class="section-title inherited"><a href="ex/Deprecated-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="ex/Deprecated/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>message property</h1>
+
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">message</span>
+          <div class="features">final</div>
+        </section>
+                
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
+++ b/testing/test_package_docs/ex/Deprecated/noSuchMethod.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/operator_equals.html
+++ b/testing/test_package_docs/ex/Deprecated/operator_equals.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/runtimeType.html
+++ b/testing/test_package_docs/ex/Deprecated/runtimeType.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/ex/Deprecated/toString.html
+++ b/testing/test_package_docs/ex/Deprecated/toString.html
@@ -45,7 +45,8 @@
       <li class="section-title">
         <a href="ex/Deprecated-class.html#instance-properties">Properties</a>
       </li>
-      <li><a href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a class="deprecated" href="ex/Deprecated/expires.html">expires</a></li>
+      <li><a href="ex/Deprecated/message.html">message</a></li>
       <li class="inherited"><a href="ex/Deprecated/hashCode.html">hashCode</a></li>
       <li class="inherited"><a href="ex/Deprecated/runtimeType.html">runtimeType</a></li>
     

--- a/testing/test_package_docs/fake/ABaseClass-class.html
+++ b/testing/test_package_docs/fake/ABaseClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs/fake/CovariantMemberParams-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/GenericClass-class.html
+++ b/testing/test_package_docs/fake/GenericClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs/fake/GenericMixin-mixin.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation-class.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation-class.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the HasDynamicAnnotation class from the fake library, for the Dart programming language.">
+  <title>HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">HasDynamicAnnotation class</li>
+  </ol>
+  <div class="self-name">HasDynamicAnnotation</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/ABaseClass-class.html">ABaseClass</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassUsingNewStyleMixin-class.html">AClassUsingNewStyleMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a></li>
+      <li><a href="fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/CovariantMemberParams-class.html">CovariantMemberParams</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
+      <li><a href="categoriesExported/IAmAClassWithCategories-class.html">IAmAClassWithCategories</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/ModifierClass-class.html">ModifierClass</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/TypedefUsingClass-class.html">TypedefUsingClass</a></li>
+      <li><a href="fake/TypeInferenceMixedIn-class.html">TypeInferenceMixedIn</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#mixins">Mixins</a></li>
+      <li><a href="fake/GenericMixin-mixin.html">GenericMixin</a></li>
+      <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/myMap-constant.html">myMap</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/mustGetThis.html">mustGetThis</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+      <li><a href="fake/useSomethingInAnotherPackage.html">useSomethingInAnotherPackage</a></li>
+      <li><a href="fake/useSomethingInTheSdk.html">useSomethingInTheSdk</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
+      <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></li>
+      <li><a href="fake/returningFutureVoid.html">returningFutureVoid</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a href="fake/thisIsFutureOr.html">thisIsFutureOr</a></li>
+      <li><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></li>
+      <li><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+      <li><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <h1>HasDynamicAnnotation class </h1>
+
+    <section class="desc markdown">
+      <p>This class has a dynamic annotation.</p>
+    </section>
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+
+        <dt>Annotations</dt>
+        <dd><ul class="annotation-list clazz-relationships">
+          <li>@aDynamicAnnotation</li>
+        </ul></dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="HasDynamicAnnotation" class="callable">
+          <span class="name"><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation/HasDynamicAnnotation.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation/HasDynamicAnnotation.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the HasDynamicAnnotation constructor from the Class HasDynamicAnnotation class from the fake library, for the Dart programming language.">
+  <title>HasDynamicAnnotation constructor - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">HasDynamicAnnotation constructor</li>
+  </ol>
+  <div class="self-name">HasDynamicAnnotation</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>HasDynamicAnnotation constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">HasDynamicAnnotation</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation/hashCode.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation/hashCode.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>hashCode property - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>noSuchMethod method - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation/operator_equals.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>operator == method - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation/runtimeType.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation/runtimeType.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>runtimeType property - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation/toString.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>toString method - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/HasPragma-class.html
+++ b/testing/test_package_docs/fake/HasPragma-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ModifierClass-class.html
+++ b/testing/test_package_docs/fake/ModifierClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/aCoolVariable.html
+++ b/testing/test_package_docs/fake/aCoolVariable.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/aDynamicAnnotation-constant.html
+++ b/testing/test_package_docs/fake/aDynamicAnnotation-constant.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aDynamicAnnotation constant from the fake library, for the Dart programming language.">
+  <title>aDynamicAnnotation constant - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">aDynamicAnnotation constant</li>
+  </ol>
+  <div class="self-name">aDynamicAnnotation</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/ABaseClass-class.html">ABaseClass</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassUsingNewStyleMixin-class.html">AClassUsingNewStyleMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a></li>
+      <li><a href="fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/CovariantMemberParams-class.html">CovariantMemberParams</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
+      <li><a href="categoriesExported/IAmAClassWithCategories-class.html">IAmAClassWithCategories</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/ModifierClass-class.html">ModifierClass</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/TypedefUsingClass-class.html">TypedefUsingClass</a></li>
+      <li><a href="fake/TypeInferenceMixedIn-class.html">TypeInferenceMixedIn</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#mixins">Mixins</a></li>
+      <li><a href="fake/GenericMixin-mixin.html">GenericMixin</a></li>
+      <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/myMap-constant.html">myMap</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/mustGetThis.html">mustGetThis</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+      <li><a href="fake/useSomethingInAnotherPackage.html">useSomethingInAnotherPackage</a></li>
+      <li><a href="fake/useSomethingInTheSdk.html">useSomethingInTheSdk</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
+      <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></li>
+      <li><a href="fake/returningFutureVoid.html">returningFutureVoid</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a href="fake/thisIsFutureOr.html">thisIsFutureOr</a></li>
+      <li><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></li>
+      <li><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+      <li><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>aDynamicAnnotation top-level constant </h1>
+
+    <section class="multi-line-signature">
+      const <span class="name ">aDynamicAnnotation</span>
+      =
+      <span class="constant-value">4</span>
+      
+    </section>
+
+        
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/aMixinReturningFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs/fake/bulletDoced-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -226,6 +226,12 @@ Don't ask questions.</p>
         <dd>
           A generic class for testing type inference.
         </dd>
+        <dt id="HasDynamicAnnotation">
+          <span class="name "><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></span> 
+        </dt>
+        <dd>
+          This class has a dynamic annotation.
+        </dd>
         <dt id="HasGenerics">
           <span class="name "><a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></span> 
         </dt>
@@ -425,6 +431,17 @@ class still takes precedence (#1561).
       <h2>Constants</h2>
 
       <dl class="properties">
+        <dt id="aDynamicAnnotation" class="constant">
+          <span class="name "><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></span>
+          <span class="signature">&#8594; const dynamic</span>
+          </dt>
+        <dd>
+          
+          
+  <div>
+            <span class="signature"><code>4</code></span>
+          </div>
+        </dd>
         <dt id="bulletDoced" class="constant">
           <span class="name "><a href="fake/bulletDoced-constant.html">bulletDoced</a></span>
           <span class="signature">&#8594; const String</span>
@@ -1063,6 +1080,7 @@ default value.
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -1097,6 +1115,7 @@ default value.
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/mustGetThis.html
+++ b/testing/test_package_docs/fake/mustGetThis.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/myMap-constant.html
+++ b/testing/test_package_docs/fake/myMap-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs/fake/thisIsFutureOr.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs/fake/useSomethingInTheSdk.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -1057,6 +1057,17 @@
   }
  },
  {
+  "name": "message",
+  "qualifiedName": "ex.Deprecated.message",
+  "href": "ex/Deprecated/message.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "Deprecated",
+   "type": "class"
+  }
+ },
+ {
   "name": "noSuchMethod",
   "qualifiedName": "ex.Deprecated.noSuchMethod",
   "href": "ex/Deprecated/noSuchMethod.html",
@@ -6080,6 +6091,83 @@
   }
  },
  {
+  "name": "HasDynamicAnnotation",
+  "qualifiedName": "fake.HasDynamicAnnotation",
+  "href": "fake/HasDynamicAnnotation-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "HasDynamicAnnotation",
+  "qualifiedName": "fake.HasDynamicAnnotation",
+  "href": "fake/HasDynamicAnnotation/HasDynamicAnnotation.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.HasDynamicAnnotation.==",
+  "href": "fake/HasDynamicAnnotation/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.HasDynamicAnnotation.hashCode",
+  "href": "fake/HasDynamicAnnotation/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.HasDynamicAnnotation.noSuchMethod",
+  "href": "fake/HasDynamicAnnotation/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.HasDynamicAnnotation.runtimeType",
+  "href": "fake/HasDynamicAnnotation/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.HasDynamicAnnotation.toString",
+  "href": "fake/HasDynamicAnnotation/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
   "name": "HasGenericWithExtends",
   "qualifiedName": "fake.HasGenericWithExtends",
   "href": "fake/HasGenericWithExtends-class.html",
@@ -9153,6 +9241,17 @@
   "qualifiedName": "fake.aCoolVariable",
   "href": "fake/aCoolVariable.html",
   "type": "top-level property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "aDynamicAnnotation",
+  "qualifiedName": "fake.aDynamicAnnotation",
+  "href": "fake/aDynamicAnnotation-constant.html",
+  "type": "top-level constant",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",

--- a/testing/test_package_docs_dev/fake/ABaseClass-class.html
+++ b/testing/test_package_docs_dev/fake/ABaseClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Annotation-class.html
+++ b/testing/test_package_docs_dev/fake/Annotation-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs_dev/fake/AnotherInterface-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy2-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Callback2.html
+++ b/testing/test_package_docs_dev/fake/Callback2.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Color-class.html
+++ b/testing/test_package_docs_dev/fake/Color-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ConstantClass-class.html
+++ b/testing/test_package_docs_dev/fake/ConstantClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs_dev/fake/ConstructorTester-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Cool-class.html
+++ b/testing/test_package_docs_dev/fake/Cool-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/DOWN-constant.html
+++ b/testing/test_package_docs_dev/fake/DOWN-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Doh-class.html
+++ b/testing/test_package_docs_dev/fake/Doh-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/FakeProcesses.html
+++ b/testing/test_package_docs_dev/fake/FakeProcesses.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Foo2-class.html
+++ b/testing/test_package_docs_dev/fake/Foo2-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/GenericClass-class.html
+++ b/testing/test_package_docs_dev/fake/GenericClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/GenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/GenericTypedef.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation-class.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation-class.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the HasDynamicAnnotation class from the fake library, for the Dart programming language.">
+  <title>HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">HasDynamicAnnotation class</li>
+  </ol>
+  <div class="self-name">HasDynamicAnnotation</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/ABaseClass-class.html">ABaseClass</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassUsingNewStyleMixin-class.html">AClassUsingNewStyleMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a></li>
+      <li><a href="fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/CovariantMemberParams-class.html">CovariantMemberParams</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
+      <li><a href="categoriesExported/IAmAClassWithCategories-class.html">IAmAClassWithCategories</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/ModifierClass-class.html">ModifierClass</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/TypedefUsingClass-class.html">TypedefUsingClass</a></li>
+      <li><a href="fake/TypeInferenceMixedIn-class.html">TypeInferenceMixedIn</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#mixins">Mixins</a></li>
+      <li><a href="fake/GenericMixin-mixin.html">GenericMixin</a></li>
+      <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/myMap-constant.html">myMap</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/mustGetThis.html">mustGetThis</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+      <li><a href="fake/useSomethingInAnotherPackage.html">useSomethingInAnotherPackage</a></li>
+      <li><a href="fake/useSomethingInTheSdk.html">useSomethingInTheSdk</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
+      <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></li>
+      <li><a href="fake/returningFutureVoid.html">returningFutureVoid</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a href="fake/thisIsFutureOr.html">thisIsFutureOr</a></li>
+      <li><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></li>
+      <li><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+      <li><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <h1>HasDynamicAnnotation class </h1>
+
+    <section class="desc markdown">
+      <p>This class has a dynamic annotation.</p>
+    </section>
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+
+        <dt>Annotations</dt>
+        <dd><ul class="annotation-list clazz-relationships">
+          <li>@aDynamicAnnotation</li>
+        </ul></dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="HasDynamicAnnotation" class="callable">
+          <span class="name"><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation/HasDynamicAnnotation.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation/HasDynamicAnnotation.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the HasDynamicAnnotation constructor from the Class HasDynamicAnnotation class from the fake library, for the Dart programming language.">
+  <title>HasDynamicAnnotation constructor - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">HasDynamicAnnotation constructor</li>
+  </ol>
+  <div class="self-name">HasDynamicAnnotation</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>HasDynamicAnnotation constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">HasDynamicAnnotation</span>(<wbr>)
+    </section>
+
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation/hashCode.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation/hashCode.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>hashCode property - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation/noSuchMethod.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>noSuchMethod method - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation/operator_equals.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>operator == method - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation/runtimeType.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation/runtimeType.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>runtimeType property - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation/toString.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the HasDynamicAnnotation class, for the Dart programming language.">
+  <title>toString method - HasDynamicAnnotation class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>HasDynamicAnnotation class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/HasDynamicAnnotation-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/HasDynamicAnnotation/HasDynamicAnnotation.html">HasDynamicAnnotation</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/HasDynamicAnnotation-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/HasDynamicAnnotation-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/HasDynamicAnnotation/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenerics-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenerics-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/HasPragma-class.html
+++ b/testing/test_package_docs_dev/fake/HasPragma-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Interface-class.html
+++ b/testing/test_package_docs_dev/fake/Interface-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs_dev/fake/LongFirstLine-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEBase-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEBase-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEThing-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEThing-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/MixMeIn-class.html
+++ b/testing/test_package_docs_dev/fake/MixMeIn-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ModifierClass-class.html
+++ b/testing/test_package_docs_dev/fake/ModifierClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/NewGenericTypedef.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/NotAMixin-class.html
+++ b/testing/test_package_docs_dev/fake/NotAMixin-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/Oops-class.html
+++ b/testing/test_package_docs_dev/fake/Oops-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/PI-constant.html
+++ b/testing/test_package_docs_dev/fake/PI-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ReferringClass-class.html
+++ b/testing/test_package_docs_dev/fake/ReferringClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/SpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/SpecialList-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/SubForDocComments-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/UP-constant.html
+++ b/testing/test_package_docs_dev/fake/UP-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/VoidCallback.html
+++ b/testing/test_package_docs_dev/fake/VoidCallback.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/ZERO-constant.html
+++ b/testing/test_package_docs_dev/fake/ZERO-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/aCoolVariable.html
+++ b/testing/test_package_docs_dev/fake/aCoolVariable.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/aDynamicAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/aDynamicAnnotation-constant.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the aDynamicAnnotation constant from the fake library, for the Dart programming language.">
+  <title>aDynamicAnnotation constant - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">aDynamicAnnotation constant</li>
+  </ol>
+  <div class="self-name">aDynamicAnnotation</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/ABaseClass-class.html">ABaseClass</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassUsingNewStyleMixin-class.html">AClassUsingNewStyleMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a></li>
+      <li><a href="fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/CovariantMemberParams-class.html">CovariantMemberParams</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
+      <li><a href="categoriesExported/IAmAClassWithCategories-class.html">IAmAClassWithCategories</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/ModifierClass-class.html">ModifierClass</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/TypedefUsingClass-class.html">TypedefUsingClass</a></li>
+      <li><a href="fake/TypeInferenceMixedIn-class.html">TypeInferenceMixedIn</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#mixins">Mixins</a></li>
+      <li><a href="fake/GenericMixin-mixin.html">GenericMixin</a></li>
+      <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/myMap-constant.html">myMap</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/mustGetThis.html">mustGetThis</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+      <li><a href="fake/useSomethingInAnotherPackage.html">useSomethingInAnotherPackage</a></li>
+      <li><a href="fake/useSomethingInTheSdk.html">useSomethingInTheSdk</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
+      <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></li>
+      <li><a href="fake/returningFutureVoid.html">returningFutureVoid</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a href="fake/thisIsFutureOr.html">thisIsFutureOr</a></li>
+      <li><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></li>
+      <li><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+      <li><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>aDynamicAnnotation top-level constant </h1>
+
+    <section class="multi-line-signature">
+      const <span class="name ">aDynamicAnnotation</span>
+      =
+      <span class="constant-value">4</span>
+      
+    </section>
+
+        
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/aVoidParameter.html
+++ b/testing/test_package_docs_dev/fake/aVoidParameter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback.html
+++ b/testing/test_package_docs_dev/fake/addCallback.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback2.html
+++ b/testing/test_package_docs_dev/fake/addCallback2.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs_dev/fake/bulletDoced-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/complicatedReturn.html
+++ b/testing/test_package_docs_dev/fake/complicatedReturn.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/dynamicGetter.html
+++ b/testing/test_package_docs_dev/fake/dynamicGetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/fake-library.html
+++ b/testing/test_package_docs_dev/fake/fake-library.html
@@ -226,6 +226,12 @@ Don't ask questions.</p>
         <dd>
           A generic class for testing type inference.
         </dd>
+        <dt id="HasDynamicAnnotation">
+          <span class="name "><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></span> 
+        </dt>
+        <dd>
+          This class has a dynamic annotation.
+        </dd>
         <dt id="HasGenerics">
           <span class="name "><a href="fake/HasGenerics-class.html">HasGenerics</a><span class="signature">&lt;<wbr><span class="type-parameter">X</span>, <span class="type-parameter">Y</span>, <span class="type-parameter">Z</span>&gt;</span></span> 
         </dt>
@@ -425,6 +431,17 @@ class still takes precedence (#1561).
       <h2>Constants</h2>
 
       <dl class="properties">
+        <dt id="aDynamicAnnotation" class="constant">
+          <span class="name "><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></span>
+          <span class="signature">&#8594; const dynamic</span>
+          </dt>
+        <dd>
+          
+          
+  <div>
+            <span class="signature"><code>4</code></span>
+          </div>
+        </dd>
         <dt id="bulletDoced" class="constant">
           <span class="name "><a href="fake/bulletDoced-constant.html">bulletDoced</a></span>
           <span class="signature">&#8594; const String</span>
@@ -1063,6 +1080,7 @@ default value.
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -1097,6 +1115,7 @@ default value.
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/importantComputations.html
+++ b/testing/test_package_docs_dev/fake/importantComputations.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/justGetter.html
+++ b/testing/test_package_docs_dev/fake/justGetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/justSetter.html
+++ b/testing/test_package_docs_dev/fake/justSetter.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/meaningOfLife.html
+++ b/testing/test_package_docs_dev/fake/meaningOfLife.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/mustGetThis.html
+++ b/testing/test_package_docs_dev/fake/mustGetThis.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/myCoolTypedef.html
+++ b/testing/test_package_docs_dev/fake/myCoolTypedef.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/myGenericFunction.html
+++ b/testing/test_package_docs_dev/fake/myGenericFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/myMap-constant.html
+++ b/testing/test_package_docs_dev/fake/myMap-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage1.html
+++ b/testing/test_package_docs_dev/fake/paintImage1.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage2.html
+++ b/testing/test_package_docs_dev/fake/paintImage2.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/required-constant.html
+++ b/testing/test_package_docs_dev/fake/required-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/returningFutureVoid.html
+++ b/testing/test_package_docs_dev/fake/returningFutureVoid.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/setAndGet.html
+++ b/testing/test_package_docs_dev/fake/setAndGet.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/short.html
+++ b/testing/test_package_docs_dev/fake/short.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/simpleProperty.html
+++ b/testing/test_package_docs_dev/fake/simpleProperty.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/soIntense.html
+++ b/testing/test_package_docs_dev/fake/soIntense.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAsync.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOr.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/topLevelFunction.html
+++ b/testing/test_package_docs_dev/fake/topLevelFunction.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
@@ -61,6 +61,7 @@
       <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
       <li><a href="fake/Foo2-class.html">Foo2</a></li>
       <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
       <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
       <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
       <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
@@ -95,6 +96,7 @@
       <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
     
       <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
       <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
       <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
       <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>

--- a/testing/test_package_docs_dev/index.json
+++ b/testing/test_package_docs_dev/index.json
@@ -6091,6 +6091,83 @@
   }
  },
  {
+  "name": "HasDynamicAnnotation",
+  "qualifiedName": "fake.HasDynamicAnnotation",
+  "href": "fake/HasDynamicAnnotation-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "HasDynamicAnnotation",
+  "qualifiedName": "fake.HasDynamicAnnotation",
+  "href": "fake/HasDynamicAnnotation/HasDynamicAnnotation.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.HasDynamicAnnotation.==",
+  "href": "fake/HasDynamicAnnotation/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.HasDynamicAnnotation.hashCode",
+  "href": "fake/HasDynamicAnnotation/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.HasDynamicAnnotation.noSuchMethod",
+  "href": "fake/HasDynamicAnnotation/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.HasDynamicAnnotation.runtimeType",
+  "href": "fake/HasDynamicAnnotation/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.HasDynamicAnnotation.toString",
+  "href": "fake/HasDynamicAnnotation/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "HasDynamicAnnotation",
+   "type": "class"
+  }
+ },
+ {
   "name": "HasGenericWithExtends",
   "qualifiedName": "fake.HasGenericWithExtends",
   "href": "fake/HasGenericWithExtends-class.html",
@@ -9164,6 +9241,17 @@
   "qualifiedName": "fake.aCoolVariable",
   "href": "fake/aCoolVariable.html",
   "type": "top-level property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "aDynamicAnnotation",
+  "qualifiedName": "fake.aDynamicAnnotation",
+  "href": "fake/aDynamicAnnotation-constant.html",
+  "type": "top-level constant",
   "overriddenDepth": 0,
   "enclosedBy": {
    "name": "fake",

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,6 +28,7 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
+  PACKAGE_NAME=kernel PACKAGE_VERSION=">=0.3.6+4" pub run grinder build-pub-package
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,7 +28,6 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
-  PACKAGE_NAME=kernel PACKAGE_VERSION=">=0.3.6+4" pub run grinder build-pub-package
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running main dartdoc bot against the SDK analyzer"


### PR DESCRIPTION
Fixes #1834.  We can't add kernel to the packages test because it is malformed (has invalid dev_dependencies), but added the problem to the test_package so we don't regress.