### PR TITLE
Instantiate enclosing elements for anonymous functions

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3877,7 +3877,8 @@ abstract class ModelElement extends Canonicalization
       return fqName;
     }
 
-    return _buildFullyQualifiedName(e.enclosingElement, '${e.enclosingElement.name}.$fqName');
+    return _buildFullyQualifiedName(
+        e.enclosingElement, '${e.enclosingElement.name}.$fqName');
   }
 
   String _calculateLinkedName() {
@@ -6046,7 +6047,9 @@ class Package extends LibraryContainer
 
   /// Is this the package at the top of the list?  We display the first
   /// package specially (with "Libraries" rather than the package name).
-  bool get isFirstPackage => packageGraph.localPackages.isNotEmpty && identical(packageGraph.localPackages.first, this);
+  bool get isFirstPackage =>
+      packageGraph.localPackages.isNotEmpty &&
+      identical(packageGraph.localPackages.first, this);
 
   @override
   bool get isSdk => packageMeta.isSdk;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3876,8 +3876,7 @@ abstract class ModelElement extends Canonicalization
       return fqName;
     }
 
-    ModelElement parent = (e as EnclosedElement).enclosingElement;
-    return _buildFullyQualifiedName(parent, '${parent.name}.$fqName');
+    return _buildFullyQualifiedName(e.enclosingElement, '${e.enclosingElement.name}.$fqName');
   }
 
   String _calculateLinkedName() {
@@ -4453,6 +4452,13 @@ class ModelFunctionAnonymous extends ModelFunctionTyped {
   ModelFunctionAnonymous(
       FunctionTypedElement element, PackageGraph packageGraph)
       : super(element, null, packageGraph) {}
+
+  @override
+  ModelElement get enclosingElement {
+    // These are not considered to be a part of libraries, so we can simply
+    // blindly instantiate a ModelElement for their enclosing element.
+    return new ModelElement.fromElement(element.enclosingElement, packageGraph);
+  }
 
   @override
   String get name => 'Function';

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -3208,6 +3208,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
         paramFromExportLib,
         methodWithTypedefParam,
         applyCovariantParams;
+    ModelFunction doAComplicatedThing;
     Parameter intNumber, intCheckOptional;
 
     setUpAll(() {
@@ -3231,12 +3232,21 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((m) => m.name == 'methodWithGenericParam');
       methodWithTypedefParam = c.instanceMethods
           .singleWhere((m) => m.name == 'methodWithTypedefParam');
+      doAComplicatedThing = fakeLibrary.publicFunctions
+          .firstWhere((m) => m.name == 'doAComplicatedThing');
     });
 
     test('covariant parameters render correctly', () {
       expect(applyCovariantParams.parameters, hasLength(2));
       expect(applyCovariantParams.linkedParamsLines,
           contains('<span>covariant</span>'));
+    });
+
+    test(
+        'ambiguous reference to function parameter parameters resolves to nothing',
+        () {
+      expect(doAComplicatedThing.documentationAsHtml,
+          contains('<code>aThingParameter</code>'));
     });
 
     test('has parameters', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -97,6 +97,14 @@ class HasGenerics<X, Y, Z> {
   Map<X, Y> convertToMap() => null;
 }
 
+/// Coderef to ambiguous parameter of function parameter should not crash us.
+/// (#1835)
+///
+/// Here is a coderef: [aThingParameter]
+void doAComplicatedThing(int x,
+    {void doSomething(int aThingParameter, String anotherThing),
+    void doSomethingElse(int aThingParameter, double somethingElse)}) {}
+
 /// Bullet point documentation.
 ///
 /// This top level constant has bullet points.

--- a/testing/test_package_docs/fake/ABaseClass-class.html
+++ b/testing/test_package_docs/fake/ABaseClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs/fake/CovariantMemberParams-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/GenericClass-class.html
+++ b/testing/test_package_docs/fake/GenericClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs/fake/GenericMixin-mixin.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation-class.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/HasPragma-class.html
+++ b/testing/test_package_docs/fake/HasPragma-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ModifierClass-class.html
+++ b/testing/test_package_docs/fake/ModifierClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/aCoolVariable.html
+++ b/testing/test_package_docs/fake/aCoolVariable.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/aDynamicAnnotation-constant.html
+++ b/testing/test_package_docs/fake/aDynamicAnnotation-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/aMixinReturningFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/doAComplicatedThing.html
+++ b/testing/test_package_docs/fake/doAComplicatedThing.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the bulletDoced constant from the fake library, for the Dart programming language.">
-  <title>bulletDoced constant - fake library - Dart API</title>
+  <meta name="description" content="API docs for the doAComplicatedThing function from the fake library, for the Dart programming language.">
+  <title>doAComplicatedThing function - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">bulletDoced constant</li>
+    <li class="self-crumb">doAComplicatedThing function</li>
   </ol>
-  <div class="self-name">bulletDoced</div>
+  <div class="self-name">doAComplicatedThing</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -175,21 +175,20 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>bulletDoced top-level constant </h1>
+    <h1>doAComplicatedThing function </h1>
 
     <section class="multi-line-signature">
-      const <span class="name ">bulletDoced</span>
-      =
-      <span class="constant-value">&#39;Foo bar baz&#39;</span>
-      
+        <span class="returntype">void</span>
+        <span class="name ">doAComplicatedThing</span>
+(<wbr><span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, {</span> <span class="parameter" id="doAComplicatedThing-param-doSomething"><span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="doSomething-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomething-param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span>), </span> <span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="doSomethingElse-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomethingElse-param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)</span> })
     </section>
-
     <section class="desc markdown">
-      <p>Bullet point documentation.</p>
-<p>This top level constant has bullet points.</p><ul><li>A bullet point.</li><li>Another even better bullet point.</li><li>A bullet point that wraps onto a second line, without creating a new
-bullet point or paragraph.</li><li>A fourth bullet point.</li></ul>
+      <p>Coderef to ambiguous parameter of function parameter should not crash us.
+(#1835)</p>
+<p>Here is a coderef: <code>aThingParameter</code></p>
     </section>
-        
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -778,6 +778,16 @@ which is a bit redundant.
           This function requires a Future<void> as a parameter</void>
           
 </dd>
+        <dt id="doAComplicatedThing" class="callable">
+          <span class="name"><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></span><span class="signature">(<wbr><span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, {</span> <span class="parameter" id="doAComplicatedThing-param-doSomething"><span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="doSomething-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomething-param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span>), </span> <span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="doSomethingElse-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomethingElse-param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)</span> })
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+          </dt>
+        <dd>
+          Coderef to ambiguous parameter of function parameter should not crash us.
+(#1835) <a href="fake/doAComplicatedThing.html">[...]</a>
+          
+</dd>
         <dt id="functionUsingMixinReturningFunction" class="callable">
           <span class="name"><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; dynamic</span>
@@ -1154,6 +1164,7 @@ default value.
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/mustGetThis.html
+++ b/testing/test_package_docs/fake/mustGetThis.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/myMap-constant.html
+++ b/testing/test_package_docs/fake/myMap-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs/fake/thisIsFutureOr.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs/fake/useSomethingInTheSdk.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -9325,6 +9325,17 @@
   }
  },
  {
+  "name": "doAComplicatedThing",
+  "qualifiedName": "fake.doAComplicatedThing",
+  "href": "fake/doAComplicatedThing.html",
+  "type": "function",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
   "name": "dynamicGetter",
   "qualifiedName": "fake.dynamicGetter",
   "href": "fake/dynamicGetter.html",

--- a/testing/test_package_docs_dev/fake/ABaseClass-class.html
+++ b/testing/test_package_docs_dev/fake/ABaseClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Annotation-class.html
+++ b/testing/test_package_docs_dev/fake/Annotation-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs_dev/fake/AnotherInterface-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy2-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Callback2.html
+++ b/testing/test_package_docs_dev/fake/Callback2.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Color-class.html
+++ b/testing/test_package_docs_dev/fake/Color-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ConstantClass-class.html
+++ b/testing/test_package_docs_dev/fake/ConstantClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs_dev/fake/ConstructorTester-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Cool-class.html
+++ b/testing/test_package_docs_dev/fake/Cool-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/DOWN-constant.html
+++ b/testing/test_package_docs_dev/fake/DOWN-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Doh-class.html
+++ b/testing/test_package_docs_dev/fake/Doh-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/FakeProcesses.html
+++ b/testing/test_package_docs_dev/fake/FakeProcesses.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Foo2-class.html
+++ b/testing/test_package_docs_dev/fake/Foo2-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/GenericClass-class.html
+++ b/testing/test_package_docs_dev/fake/GenericClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/GenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/GenericTypedef.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation-class.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenerics-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenerics-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/HasPragma-class.html
+++ b/testing/test_package_docs_dev/fake/HasPragma-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Interface-class.html
+++ b/testing/test_package_docs_dev/fake/Interface-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs_dev/fake/LongFirstLine-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEBase-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEBase-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEThing-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEThing-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/MixMeIn-class.html
+++ b/testing/test_package_docs_dev/fake/MixMeIn-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ModifierClass-class.html
+++ b/testing/test_package_docs_dev/fake/ModifierClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/NewGenericTypedef.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/NotAMixin-class.html
+++ b/testing/test_package_docs_dev/fake/NotAMixin-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/Oops-class.html
+++ b/testing/test_package_docs_dev/fake/Oops-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/PI-constant.html
+++ b/testing/test_package_docs_dev/fake/PI-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ReferringClass-class.html
+++ b/testing/test_package_docs_dev/fake/ReferringClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/SpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/SpecialList-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/SubForDocComments-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/UP-constant.html
+++ b/testing/test_package_docs_dev/fake/UP-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/VoidCallback.html
+++ b/testing/test_package_docs_dev/fake/VoidCallback.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/ZERO-constant.html
+++ b/testing/test_package_docs_dev/fake/ZERO-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/aCoolVariable.html
+++ b/testing/test_package_docs_dev/fake/aCoolVariable.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/aDynamicAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/aDynamicAnnotation-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/aVoidParameter.html
+++ b/testing/test_package_docs_dev/fake/aVoidParameter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback.html
+++ b/testing/test_package_docs_dev/fake/addCallback.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback2.html
+++ b/testing/test_package_docs_dev/fake/addCallback2.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs_dev/fake/bulletDoced-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/complicatedReturn.html
+++ b/testing/test_package_docs_dev/fake/complicatedReturn.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/doAComplicatedThing.html
+++ b/testing/test_package_docs_dev/fake/doAComplicatedThing.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="API docs for the bulletDoced constant from the fake library, for the Dart programming language.">
-  <title>bulletDoced constant - fake library - Dart API</title>
+  <meta name="description" content="API docs for the doAComplicatedThing function from the fake library, for the Dart programming language.">
+  <title>doAComplicatedThing function - fake library - Dart API</title>
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">
 
@@ -25,9 +25,9 @@
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="index.html">test_package</a></li>
     <li><a href="fake/fake-library.html">fake</a></li>
-    <li class="self-crumb">bulletDoced constant</li>
+    <li class="self-crumb">doAComplicatedThing function</li>
   </ol>
-  <div class="self-name">bulletDoced</div>
+  <div class="self-name">doAComplicatedThing</div>
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
@@ -175,21 +175,20 @@
   </div><!--/.sidebar-offcanvas-left-->
 
   <div class="col-xs-12 col-sm-9 col-md-8 main-content">
-    <h1>bulletDoced top-level constant </h1>
+    <h1>doAComplicatedThing function </h1>
 
     <section class="multi-line-signature">
-      const <span class="name ">bulletDoced</span>
-      =
-      <span class="constant-value">&#39;Foo bar baz&#39;</span>
-      
+        <span class="returntype">void</span>
+        <span class="name ">doAComplicatedThing</span>
+(<wbr><span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, {</span> <span class="parameter" id="doAComplicatedThing-param-doSomething"><span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="doSomething-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomething-param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span>), </span> <span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="doSomethingElse-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomethingElse-param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)</span> })
     </section>
-
     <section class="desc markdown">
-      <p>Bullet point documentation.</p>
-<p>This top level constant has bullet points.</p><ul><li>A bullet point.</li><li>Another even better bullet point.</li><li>A bullet point that wraps onto a second line, without creating a new
-bullet point or paragraph.</li><li>A fourth bullet point.</li></ul>
+      <p>Coderef to ambiguous parameter of function parameter should not crash us.
+(#1835)</p>
+<p>Here is a coderef: <code>aThingParameter</code></p>
     </section>
-        
+    
+    
 
   </div> <!-- /.main-content -->
 

--- a/testing/test_package_docs_dev/fake/dynamicGetter.html
+++ b/testing/test_package_docs_dev/fake/dynamicGetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/fake-library.html
+++ b/testing/test_package_docs_dev/fake/fake-library.html
@@ -778,6 +778,16 @@ which is a bit redundant.
           This function requires a Future<void> as a parameter</void>
           
 </dd>
+        <dt id="doAComplicatedThing" class="callable">
+          <span class="name"><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></span><span class="signature">(<wbr><span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, {</span> <span class="parameter" id="doAComplicatedThing-param-doSomething"><span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="doSomething-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomething-param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span>), </span> <span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="doSomethingElse-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="doSomethingElse-param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)</span> })
+            <span class="returntype parameter">&#8594; void</span>
+          </span>
+          </dt>
+        <dd>
+          Coderef to ambiguous parameter of function parameter should not crash us.
+(#1835) <a href="fake/doAComplicatedThing.html">[...]</a>
+          
+</dd>
         <dt id="functionUsingMixinReturningFunction" class="callable">
           <span class="name"><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; dynamic</span>
@@ -1154,6 +1164,7 @@ default value.
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/importantComputations.html
+++ b/testing/test_package_docs_dev/fake/importantComputations.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/justGetter.html
+++ b/testing/test_package_docs_dev/fake/justGetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/justSetter.html
+++ b/testing/test_package_docs_dev/fake/justSetter.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/meaningOfLife.html
+++ b/testing/test_package_docs_dev/fake/meaningOfLife.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/mustGetThis.html
+++ b/testing/test_package_docs_dev/fake/mustGetThis.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/myCoolTypedef.html
+++ b/testing/test_package_docs_dev/fake/myCoolTypedef.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/myGenericFunction.html
+++ b/testing/test_package_docs_dev/fake/myGenericFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/myMap-constant.html
+++ b/testing/test_package_docs_dev/fake/myMap-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage1.html
+++ b/testing/test_package_docs_dev/fake/paintImage1.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage2.html
+++ b/testing/test_package_docs_dev/fake/paintImage2.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/required-constant.html
+++ b/testing/test_package_docs_dev/fake/required-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/returningFutureVoid.html
+++ b/testing/test_package_docs_dev/fake/returningFutureVoid.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/setAndGet.html
+++ b/testing/test_package_docs_dev/fake/setAndGet.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/short.html
+++ b/testing/test_package_docs_dev/fake/short.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/simpleProperty.html
+++ b/testing/test_package_docs_dev/fake/simpleProperty.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/soIntense.html
+++ b/testing/test_package_docs_dev/fake/soIntense.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAsync.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOr.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/topLevelFunction.html
+++ b/testing/test_package_docs_dev/fake/topLevelFunction.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
@@ -135,6 +135,7 @@
       <li><a href="fake/addCallback2.html">addCallback2</a></li>
       <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
       <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
       <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
       <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
       <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>

--- a/testing/test_package_docs_dev/index.json
+++ b/testing/test_package_docs_dev/index.json
@@ -9325,6 +9325,17 @@
   }
  },
  {
+  "name": "doAComplicatedThing",
+  "qualifiedName": "fake.doAComplicatedThing",
+  "href": "fake/doAComplicatedThing.html",
+  "type": "function",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
   "name": "dynamicGetter",
   "qualifiedName": "fake.dynamicGetter",
   "href": "fake/dynamicGetter.html",

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,6 +28,7 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   else
     PACKAGE_NAME=angular PACKAGE_VERSION=">=5.0.0-beta <5.1.0" DARTDOC_PARAMS="--include=angular,angular.security" pub run grinder build-pub-package
   fi
+  PACKAGE_NAME=access PACKAGE_VERSION=">=1.0.1+2" pub run grinder build-pub-package
   # Negative test for flutter_plugin_tools, make sure right error message is displayed.
   PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" pub run grinder build-pub-package 2>&1 | grep "Generation failed: dartdoc could not find any libraries to document.$"
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package


### PR DESCRIPTION
Fixes #1835.  Even when they're not directly attached to libraries, it's still important to have enclosingElements for comment reference resolution.

To do this properly will require Parameters to be a first-class part of the element tree, but that's blocked on dart-lang/sdk#30146 (forcing Parameter ModelElements to remain uncached)