### PR TITLE
WIP: Make dartdoc sort of work with new analyzer

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,3 +44,11 @@ dev_dependencies:
 
 executables:
   dartdoc: null
+
+dependency_overrides:
+  analyzer:
+    path: '../sdk/sdk/pkg/analyzer'
+  front_end:
+    path: '../sdk/sdk/pkg/front_end'
+  kernel:
+    path: '../sdk/sdk/pkg/kernel'


### PR DESCRIPTION
Do Not Land.

This breaks crossdart (not important), but also breaks the "Implementation" section for displayed source code and breaks or makes worse a lot of comment reference resolution.  But it does run without crashing with the analyzer branch at https://github.com/dart-lang/sdk/tree/analyzer, and even manages to produce somewhat readable docs for the Dart SDK.