### PR TITLE
Do not allow tools to run in compare_output_test

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1286,6 +1286,7 @@ class DartdocOptionContext {
 
   // All values defined in createDartdocOptions should be exposed here.
   bool get addCrossdart => optionSet['addCrossdart'].valueAt(context);
+  bool get allowTools => optionSet['allowTools'].valueAt(context);
   double get ambiguousReexportScorerMinConfidence =>
       optionSet['ambiguousReexportScorerMinConfidence'].valueAt(context);
   bool get autoIncludeDependencies =>
@@ -1346,6 +1347,9 @@ Future<List<DartdocOption>> createDartdocOptions() async {
   return <DartdocOption>[
     new DartdocOptionArgOnly<bool>('addCrossdart', false,
         help: 'Add Crossdart links to the source code pieces.',
+        negatable: true),
+    new DartdocOptionArgOnly<bool>('allowTools', true,
+        help: 'Execute user-defined tools to fill in @tool directives.',
         negatable: true),
     new DartdocOptionArgFile<double>(
         'ambiguousReexportScorerMinConfidence', 0.1,

--- a/test/compare_output_test.dart
+++ b/test/compare_output_test.dart
@@ -89,6 +89,7 @@ void main() {
       var args = <String>[
         '--enable-asserts',
         dartdocBin,
+        '--no-allow-tools',
         '--auto-include-dependencies',
         '--example-path-prefix',
         'examples',

--- a/testing/test_package_docs/ex/HtmlInjection/injectHtmlFromTool.html
+++ b/testing/test_package_docs/ex/HtmlInjection/injectHtmlFromTool.html
@@ -73,18 +73,12 @@
     </section>
     <section class="desc markdown">
       <p>Invokes more than one tool in the same comment block, and injects HTML.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: HtmlInjection.injectHtmlFromTool, INVOCATION_INDEX: 1}
-Script location is in dartdoc tree.
-Args: <code>--file=&lt;INPUT_FILE&gt;, --html</code></p>
-<h2 id="this-text-should-appear-in-the-output"><code>This text should appear in the output.</code></h2>
-<p>{@inject-html}</p><div class="title">Title</div>{@end-inject-html}<p></p>
-<p>This text should appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: HtmlInjection.injectHtmlFromTool, INVOCATION_INDEX: 2}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;, --html</code></p>
-<h2 id="this-text-should-also-appear-in-the-output"><code>This text should also appear in the output.</code></h2>
-<p>{@inject-html}</p><div class="title">Title</div>{@end-inject-html}<p></p>
-<p>This text should also appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
+<p>{@tool drill --file=$INPUT --html}
+This text should appear in the output.
+{@end-tool}
+{@tool drill --file=$INPUT --html}
+This text should also appear in the output.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/ToolUser/invokeTool.html
+++ b/testing/test_package_docs/ex/ToolUser/invokeTool.html
@@ -74,13 +74,10 @@
     </section>
     <section class="desc markdown">
       <p>Invokes a tool.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeTool, INVOCATION_INDEX: 1}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;, --source=lib/example.dart_546_8, --package-path=&lt;PACKAGE_PATH&gt;, --package-name=test_package, --library-name=ex, --element-name=ToolUser.invokeTool, --special= |[</code>!@#"'$%^&amp;*()_+]</p>
-<h2 id="yes-it-is-a-dog"><code>Yes it is a [Dog]!</code></h2>
-<p>Yes it is a <a href="ex/Dog-class.html">Dog</a>! Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
-<h2 id="ok-fine-it-isnt"><code>Ok, fine it isn't.</code></h2>
-<p>Ok, fine it isn't. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
+<p>{@tool drill --file="$INPUT" --source="$(SOURCE_PATH)<em>$(SOURCE_LINE)</em>$SOURCE_COLUMN" --package-path=$PACKAGE_PATH --package-name=$PACKAGE_NAME --library-name=$LIBRARY_NAME --element-name=$(ELEMENT_NAME) --special=" |[]!@#"'$%^&amp;*()_+"}
+Yes it is a <a href="ex/Dog-class.html">Dog</a>!
+Ok, fine it isn't.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/ToolUser/invokeToolMultipleSections.html
+++ b/testing/test_package_docs/ex/ToolUser/invokeToolMultipleSections.html
@@ -74,16 +74,12 @@
     </section>
     <section class="desc markdown">
       <p>Invokes more than one tool in the same comment block.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeToolMultipleSections, INVOCATION_INDEX: 1}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;</code></p>
-<h2 id="this-text-should-appear-in-the-output"><code>This text should appear in the output.</code></h2>
-<p>This text should appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeToolMultipleSections, INVOCATION_INDEX: 2}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;</code></p>
-<h2 id="this-text-should-also-appear-in-the-output"><code>This text should also appear in the output.</code></h2>
-<p>This text should also appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
+<p>{@tool drill --file=$INPUT}
+This text should appear in the output.
+{@end-tool}
+{@tool drill --file=$INPUT}
+This text should also appear in the output.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs/ex/ToolUser/invokeToolNoInput.html
+++ b/testing/test_package_docs/ex/ToolUser/invokeToolNoInput.html
@@ -74,9 +74,9 @@
     </section>
     <section class="desc markdown">
       <p>Invokes a tool without the $INPUT token or args.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeToolNoInput, INVOCATION_INDEX: 1}
-Script location is in snapshot cache.
-Args: []</p>
+<p>{@tool drill}
+This text should not appear in the output, even if it references <a href="ex/Dog-class.html">Dog</a>.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs_dev/ex/HtmlInjection/injectHtmlFromTool.html
+++ b/testing/test_package_docs_dev/ex/HtmlInjection/injectHtmlFromTool.html
@@ -73,18 +73,12 @@
     </section>
     <section class="desc markdown">
       <p>Invokes more than one tool in the same comment block, and injects HTML.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: HtmlInjection.injectHtmlFromTool, INVOCATION_INDEX: 1}
-Script location is in dartdoc tree.
-Args: <code>--file=&lt;INPUT_FILE&gt;, --html</code></p>
-<h2 id="this-text-should-appear-in-the-output"><code>This text should appear in the output.</code></h2>
-<p>{@inject-html}</p><div class="title">Title</div>{@end-inject-html}<p></p>
-<p>This text should appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: HtmlInjection.injectHtmlFromTool, INVOCATION_INDEX: 2}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;, --html</code></p>
-<h2 id="this-text-should-also-appear-in-the-output"><code>This text should also appear in the output.</code></h2>
-<p>{@inject-html}</p><div class="title">Title</div>{@end-inject-html}<p></p>
-<p>This text should also appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
+<p>{@tool drill --file=$INPUT --html}
+This text should appear in the output.
+{@end-tool}
+{@tool drill --file=$INPUT --html}
+This text should also appear in the output.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs_dev/ex/ToolUser/invokeTool.html
+++ b/testing/test_package_docs_dev/ex/ToolUser/invokeTool.html
@@ -74,13 +74,10 @@
     </section>
     <section class="desc markdown">
       <p>Invokes a tool.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeTool, INVOCATION_INDEX: 1}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;, --source=lib/example.dart_546_8, --package-path=&lt;PACKAGE_PATH&gt;, --package-name=test_package, --library-name=ex, --element-name=ToolUser.invokeTool, --special= |[</code>!@#"'$%^&amp;*()_+]</p>
-<h2 id="yes-it-is-a-dog"><code>Yes it is a [Dog]!</code></h2>
-<p>Yes it is a <a href="ex/Dog-class.html">Dog</a>! Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
-<h2 id="ok-fine-it-isnt"><code>Ok, fine it isn't.</code></h2>
-<p>Ok, fine it isn't. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
+<p>{@tool drill --file="$INPUT" --source="$(SOURCE_PATH)<em>$(SOURCE_LINE)</em>$SOURCE_COLUMN" --package-path=$PACKAGE_PATH --package-name=$PACKAGE_NAME --library-name=$LIBRARY_NAME --element-name=$(ELEMENT_NAME) --special=" |[]!@#"'$%^&amp;*()_+"}
+Yes it is a <a href="ex/Dog-class.html">Dog</a>!
+Ok, fine it isn't.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs_dev/ex/ToolUser/invokeToolMultipleSections.html
+++ b/testing/test_package_docs_dev/ex/ToolUser/invokeToolMultipleSections.html
@@ -74,16 +74,12 @@
     </section>
     <section class="desc markdown">
       <p>Invokes more than one tool in the same comment block.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeToolMultipleSections, INVOCATION_INDEX: 1}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;</code></p>
-<h2 id="this-text-should-appear-in-the-output"><code>This text should appear in the output.</code></h2>
-<p>This text should appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeToolMultipleSections, INVOCATION_INDEX: 2}
-Script location is in snapshot cache.
-Args: <code>--file=&lt;INPUT_FILE&gt;</code></p>
-<h2 id="this-text-should-also-appear-in-the-output"><code>This text should also appear in the output.</code></h2>
-<p>This text should also appear in the output. Is not a <a href="ex/ToolUser-class.html">ToolUser</a>.</p>
+<p>{@tool drill --file=$INPUT}
+This text should appear in the output.
+{@end-tool}
+{@tool drill --file=$INPUT}
+This text should also appear in the output.
+{@end-tool}</p>
     </section>
     
     

--- a/testing/test_package_docs_dev/ex/ToolUser/invokeToolNoInput.html
+++ b/testing/test_package_docs_dev/ex/ToolUser/invokeToolNoInput.html
@@ -74,9 +74,9 @@
     </section>
     <section class="desc markdown">
       <p>Invokes a tool without the $INPUT token or args.</p>
-<p>Env: {INPUT: &lt;INPUT_FILE&gt;, SOURCE_COLUMN: 8, SOURCE_PATH: lib/example.dart, PACKAGE_PATH: &lt;PACKAGE_PATH&gt;, PACKAGE_NAME: test_package, LIBRARY_NAME: ex, ELEMENT_NAME: ToolUser.invokeToolNoInput, INVOCATION_INDEX: 1}
-Script location is in snapshot cache.
-Args: []</p>
+<p>{@tool drill}
+This text should not appear in the output, even if it references <a href="ex/Dog-class.html">Dog</a>.
+{@end-tool}</p>
     </section>
     
     

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -968,6 +968,7 @@ Future<void> updateTestPackageDocs() async {
       [
         '--enable-asserts',
         pathLib.join('..', '..', 'bin', 'dartdoc.dart'),
+        '--no-allow-tools',
         '--auto-include-dependencies',
         '--example-path-prefix',
         'examples',


### PR DESCRIPTION
Since tool-running is asynchronous now, which tool run is from the snapshot cache can vary and so the output changes depending on random events.  Eliminate this by adding a flag to disable tool execution and using it in the compare_output_test when validating HTML output.