### PR TITLE
Eliminate accidental multiple snapshot creation and update analyzer to 0.34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ dart:
   - stable
   - "dev/raw/latest"
 env:
-  - DARTDOC_BOT=flutter
   - DARTDOC_BOT=sdk-analyzer
   - DARTDOC_BOT=main
-  - DARTDOC_BOT=sdk-docs
+  - DARTDOC_BOT=flutter
   - DARTDOC_BOT=packages
+  - DARTDOC_BOT=sdk-docs
 script: ./tool/travis.sh
 
 os:

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -212,10 +212,7 @@ class Snapshot {
   }
 
   Future<void> snapshotValid() => _snapshotCompleter.future;
-  void snapshotCompleted() {
-    assert(snapshotFile.existsSync());
-    _snapshotCompleter.complete();
-  }
+  void snapshotCompleted() => _snapshotCompleter.complete();
 }
 
 /// A singleton that keeps track of cached snapshot files. The [dispose]

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -194,11 +194,13 @@ class Snapshot {
       _snapshotFile = File(toolPath);
       snapshotCompleted();
     } else {
-      _snapshotFile = File(pathLib.join(snapshotCache.absolute.path, 'snapshot_$serial'));
+      _snapshotFile =
+          File(pathLib.join(snapshotCache.absolute.path, 'snapshot_$serial'));
     }
   }
 
   bool _needsSnapshot = true;
+
   /// Will return true precisely once, unless [toolPath] was already a snapshot.
   /// In that case, will always return false.
   bool get needsSnapshot {
@@ -215,7 +217,6 @@ class Snapshot {
     _snapshotCompleter.complete();
   }
 }
-
 
 /// A singleton that keeps track of cached snapshot files. The [dispose]
 /// function must be called before process exit to clean up snapshots in the
@@ -268,7 +269,6 @@ class DartToolDefinition extends ToolDefinition {
     File snapshotFile = snapshot.snapshotFile;
     bool needsSnapshot = snapshot.needsSnapshot;
     if (needsSnapshot) {
-      print('creating snapshot');
       args.insertAll(0, [
         '--snapshot=${snapshotFile.absolute.path}',
         '--snapshot_kind=app-jit'
@@ -285,7 +285,6 @@ class DartToolDefinition extends ToolDefinition {
   DartToolDefinition(
       List<String> command, List<String> setupCommand, String description)
       : super(command, setupCommand, description);
-
 }
 
 /// A configuration class that can interpret [ToolDefinition]s from a YAML map.

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -168,6 +168,55 @@ class ToolDefinition {
   }
 }
 
+/// Manages the creation of a single snapshot file in a context where multiple
+/// async functions could be trying to use and/or create it.
+///
+/// To use:
+///
+/// var s = new Snapshot(...);
+///
+/// if (s.needsSnapshot) {
+///   // create s.snapshotFile, then call:
+///   s.snapshotCompleted();
+/// } else {
+///   await snapshotValid();
+///   // use existing s.snapshotFile;
+/// }
+///
+class Snapshot {
+  File _snapshotFile;
+  File get snapshotFile => _snapshotFile;
+  final Completer _snapshotCompleter = Completer();
+
+  Snapshot(Directory snapshotCache, String toolPath, int serial) {
+    if (toolPath.endsWith('.snapshot')) {
+      _needsSnapshot = false;
+      _snapshotFile = File(toolPath);
+      snapshotCompleted();
+    } else {
+      _snapshotFile = File(pathLib.join(snapshotCache.absolute.path, 'snapshot_$serial'));
+    }
+  }
+
+  bool _needsSnapshot = true;
+  /// Will return true precisely once, unless [toolPath] was already a snapshot.
+  /// In that case, will always return false.
+  bool get needsSnapshot {
+    if (_needsSnapshot == true) {
+      _needsSnapshot = false;
+      return true;
+    }
+    return _needsSnapshot;
+  }
+
+  Future<void> snapshotValid() => _snapshotCompleter.future;
+  void snapshotCompleted() {
+    assert(snapshotFile.existsSync());
+    _snapshotCompleter.complete();
+  }
+}
+
+
 /// A singleton that keeps track of cached snapshot files. The [dispose]
 /// function must be called before process exit to clean up snapshots in the
 /// cache.
@@ -175,7 +224,7 @@ class SnapshotCache {
   static SnapshotCache _instance;
 
   Directory snapshotCache;
-  final Map<String, File> snapshots = {};
+  final Map<String, Snapshot> snapshots = {};
   int _serial = 0;
 
   SnapshotCache._()
@@ -187,15 +236,13 @@ class SnapshotCache {
     return _instance;
   }
 
-  File getSnapshot(String toolPath) {
+  Snapshot getSnapshot(String toolPath) {
     if (snapshots.containsKey(toolPath)) {
       return snapshots[toolPath];
     }
-    File snapshot =
-        File(pathLib.join(snapshotCache.absolute.path, 'snapshot_$_serial'));
+    snapshots[toolPath] = new Snapshot(snapshotCache, toolPath, _serial);
     _serial++;
-    snapshots[toolPath] = snapshot;
-    return snapshot;
+    return snapshots[toolPath];
   }
 
   void dispose() {
@@ -217,43 +264,28 @@ class DartToolDefinition extends ToolDefinition {
     assert(args[0] == command.first);
     // Set up flags to create a new snapshot, if needed, and use the first run as the training
     // run.
-    File snapshotFile = await getSnapshotFile();
-    if (snapshotFile.existsSync()) {
-      // replace the first argument with the path to the snapshot.
-      args[0] = snapshotFile.absolute.path;
-    } else {
+    Snapshot snapshot = SnapshotCache.instance.getSnapshot(command.first);
+    File snapshotFile = snapshot.snapshotFile;
+    bool needsSnapshot = snapshot.needsSnapshot;
+    if (needsSnapshot) {
+      print('creating snapshot');
       args.insertAll(0, [
         '--snapshot=${snapshotFile.absolute.path}',
         '--snapshot_kind=app-jit'
       ]);
+    } else {
+      await snapshot.snapshotValid();
+      // replace the first argument with the path to the snapshot.
+      args[0] = snapshotFile.absolute.path;
     }
     return new Tuple2(Platform.resolvedExecutable,
-        _snapshotCompleter.isCompleted ? null : _snapshotCompleter.complete);
+        needsSnapshot ? snapshot.snapshotCompleted : null);
   }
 
   DartToolDefinition(
       List<String> command, List<String> setupCommand, String description)
-      : super(command, setupCommand, description) {
-    // If the dart tool is already a snapshot, then we just use that.
-    if (command[0].endsWith('.snapshot')) {
-      _snapshotPath = File(command[0]);
-      _snapshotCompleter.complete();
-    }
-  }
+      : super(command, setupCommand, description);
 
-  final Completer _snapshotCompleter = new Completer();
-
-  /// If the tool has a pre-built snapshot, it will be stored here.
-  File _snapshotPath;
-
-  Future<File> getSnapshotFile() async {
-    if (_snapshotPath == null) {
-      _snapshotPath = SnapshotCache.instance.getSnapshot(command.first);
-    } else {
-      await _snapshotCompleter.future;
-    }
-    return _snapshotPath;
-  }
 }
 
 /// A configuration class that can interpret [ToolDefinition]s from a YAML map.

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -104,7 +104,7 @@ class ToolRunner {
         return result.stdout;
       }
     } on ProcessException catch (exception) {
-      _error('Failed to run tool "$name" '
+      _error('Failed to run tool "$name" as '
           '"${commandString()}": $exception\n'
           'Input to $name was:\n'
           '$content');

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -19,8 +19,6 @@ typedef FakeResultCallback = String Function(String tool,
 /// limiting both parallelization and the number of open temporary files.
 final MultiFutureTracker _toolTracker = new MultiFutureTracker(4);
 
-int toolCounter = 0;
-
 /// A helper class for running external tools.
 class ToolRunner {
   /// Creates a new ToolRunner.
@@ -90,15 +88,12 @@ class ToolRunner {
 
   Future<String> _runProcess(String name, String content, String commandPath,
       List<String> args, Map<String, String> environment) async {
-    int toolCounterValue = toolCounter++;
     String commandString() => ([commandPath] + args).join(' ');
     try {
-      print ('Tool "$name" starting (#$toolCounterValue), run as: ${commandString()}');
-      print ('from: ${Directory.current}');
       ProcessResult result =
           await Process.run(commandPath, args, environment: environment);
       if (result.exitCode != 0) {
-        _error('Tool "$name" (#$toolCounterValue) returned non-zero exit code '
+        _error('Tool "$name" returned non-zero exit code '
             '(${result.exitCode}) when run as '
             '"${commandString()}" from ${Directory.current}\n'
             'Input to $name was:\n'
@@ -109,13 +104,11 @@ class ToolRunner {
         return result.stdout;
       }
     } on ProcessException catch (exception) {
-      _error('Failed to run tool "$name" (#$toolCounterValue) '
+      _error('Failed to run tool "$name" '
           '"${commandString()}": $exception\n'
           'Input to $name was:\n'
           '$content');
       return '';
-    } finally {
-      print('Tool "$name" (#$toolCounterValue complete, run as ${commandString()}');
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.1.0-dev.9.4 <3.0.0'
 
 dependencies:
-  analyzer: ^0.33.6
+  analyzer: ^0.34.0
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6

--- a/testing/test_package_docs/ex/deprecated-constant.html
+++ b/testing/test_package_docs/ex/deprecated-constant.html
@@ -115,7 +115,7 @@
     <section class="multi-line-signature">
       const <span class="name ">deprecated</span>
       =
-      <span class="constant-value">const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&#39;next release&#39;)</span>
+      <span class="constant-value">const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&quot;next release&quot;)</span>
       
     </section>
 

--- a/testing/test_package_docs/ex/ex-library.html
+++ b/testing/test_package_docs/ex/ex-library.html
@@ -316,7 +316,7 @@ that has some operators
           
           
   <div>
-            <span class="signature"><code>const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&#39;next release&#39;)</code></span>
+            <span class="signature"><code>const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&quot;next release&quot;)</code></span>
           </div>
         </dd>
         <dt id="incorrectDocReference" class="constant">

--- a/testing/test_package_docs_dev/ex/deprecated-constant.html
+++ b/testing/test_package_docs_dev/ex/deprecated-constant.html
@@ -115,7 +115,7 @@
     <section class="multi-line-signature">
       const <span class="name ">deprecated</span>
       =
-      <span class="constant-value">const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&#39;next release&#39;)</span>
+      <span class="constant-value">const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&quot;next release&quot;)</span>
       
     </section>
 

--- a/testing/test_package_docs_dev/ex/ex-library.html
+++ b/testing/test_package_docs_dev/ex/ex-library.html
@@ -316,7 +316,7 @@ that has some operators
           
           
   <div>
-            <span class="signature"><code>const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&#39;next release&#39;)</code></span>
+            <span class="signature"><code>const <a href="ex/Deprecated/Deprecated.html">Deprecated</a>(&quot;next release&quot;)</code></span>
           </div>
         </dd>
         <dt id="incorrectDocReference" class="constant">


### PR DESCRIPTION
Fixes #1861.

Track snapshot creation via children of the SnapshotCache rather than the ToolDefinition, since the latter is not global.   This gains us a surprising amount of time on travis so shuffle around the tasks so that the slowest launches first again, and update analyzer to the latest version.