### PR TITLE
Breakdown comment reference handling further and tweak performance

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -18,12 +18,15 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
   DartdocProgramOptionContext(DartdocOptionSet optionSet, Directory dir)
       : super(optionSet, dir);
 
+  bool get asyncStackTraces => optionSet['asyncStackTraces'].valueAt(context);
   bool get help => optionSet['help'].valueAt(context);
   bool get version => optionSet['version'].valueAt(context);
 }
 
 Future<List<DartdocOption>> createDartdocProgramOptions() async {
   return <DartdocOption>[
+    new DartdocOptionArgOnly<bool>('asyncStackTraces', false,
+        help: 'Display coordinated asynchronous stack traces (slow)', negatable: true),
     new DartdocOptionArgOnly<bool>('help', false,
         abbr: 'h', help: 'Show command help.', negatable: false),
     new DartdocOptionArgOnly<bool>('version', false,
@@ -88,7 +91,7 @@ void main(List<String> arguments) async {
         stderr.writeln('\nGeneration failed: ${e}\n${chain.terse}');
         exit(255);
       }
-    });
+    }, when: config.asyncStackTraces);
   } finally {
     // Clear out any cached tool snapshots.
     SnapshotCache.instance.dispose();

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -26,7 +26,8 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
 Future<List<DartdocOption>> createDartdocProgramOptions() async {
   return <DartdocOption>[
     new DartdocOptionArgOnly<bool>('asyncStackTraces', false,
-        help: 'Display coordinated asynchronous stack traces (slow)', negatable: true),
+        help: 'Display coordinated asynchronous stack traces (slow)',
+        negatable: true),
     new DartdocOptionArgOnly<bool>('help', false,
         abbr: 'h', help: 'Show command help.', negatable: false),
     new DartdocOptionArgOnly<bool>('version', false,

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -577,7 +577,9 @@ class _MarkdownCommentReference {
         // might make no sense.  Instead, use the enclosing class from the
         // element in [packageGraph.findRefElementCache], because that element's
         // enclosing class will be preferred from [codeRefChomped]'s perspective.
-        _addCanonicalResult(modelElement, modelElement.enclosingElement is Class
+        _addCanonicalResult(
+            modelElement,
+            modelElement.enclosingElement is Class
                 ? modelElement.enclosingElement
                 : null);
       }
@@ -637,8 +639,7 @@ class _MarkdownCommentReference {
 
   // Add a result, but make it canonical.
   void _addCanonicalResult(ModelElement modelElement, Class tryClass) {
-    results.add(packageGraph.findCanonicalModelElementFor(
-        modelElement.element,
+    results.add(packageGraph.findCanonicalModelElementFor(modelElement.element,
         preferredClass: tryClass));
   }
 
@@ -679,18 +680,24 @@ class _MarkdownCommentReference {
   /// true if we found something.
   void _getResultsForSuperChainElement(Class c, Class tryClass) {
     Iterable<ModelElement> membersToCheck;
-    membersToCheck = (c.allModelElementsByNamePart[codeRefChomped] ?? []).where((m) => _ConsiderIfConstructor(m));
+    membersToCheck = (c.allModelElementsByNamePart[codeRefChomped] ?? [])
+        .where((m) => _ConsiderIfConstructor(m));
     for (final ModelElement modelElement in membersToCheck) {
       // [thing], a member of this class
       _addCanonicalResult(modelElement, tryClass);
     }
-    membersToCheck = (c.allModelElementsByNamePart[codeRefChompedParts.last] ?? <ModelElement>[]).where((m) => _ConsiderIfConstructor(m));
+    membersToCheck = (c.allModelElementsByNamePart[codeRefChompedParts.last] ??
+            <ModelElement>[])
+        .where((m) => _ConsiderIfConstructor(m));
     if (codeRefChompedParts.first == c.name) {
       // [Foo...thing], a member of this class (possibly a parameter).
       membersToCheck.map((m) => _addCanonicalResult(m, tryClass));
-    } else if (codeRefChompedParts.length > 1 && codeRefChompedParts[codeRefChompedParts.length - 2] == c.name) {
+    } else if (codeRefChompedParts.length > 1 &&
+        codeRefChompedParts[codeRefChompedParts.length - 2] == c.name) {
       // [....Foo.thing], a member of this class partially specified.
-      membersToCheck.whereType<Constructor>().map((m) => _addCanonicalResult(m, tryClass));
+      membersToCheck
+          .whereType<Constructor>()
+          .map((m) => _addCanonicalResult(m, tryClass));
     }
     results.remove(null);
     if (results.isNotEmpty) return;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -692,14 +692,16 @@ class Class extends ModelElement
     return _allElements;
   }
 
-
   Map<String, List<ModelElement>> _allModelElementsByNamePart;
+
   /// Helper for [_MarkdownCommentReference._getResultsForClass].
   Map<String, List<ModelElement>> get allModelElementsByNamePart {
     if (_allModelElementsByNamePart == null) {
       _allModelElementsByNamePart = {};
       for (ModelElement me in allModelElements) {
-        _allModelElementsByNamePart.update(me.namePart, (List<ModelElement> v) => v..add(me), ifAbsent: () => <ModelElement>[me]);
+        _allModelElementsByNamePart.update(
+            me.namePart, (List<ModelElement> v) => v..add(me),
+            ifAbsent: () => <ModelElement>[me]);
       }
     }
     return _allModelElementsByNamePart;
@@ -4654,6 +4656,7 @@ abstract class Nameable {
   }
 
   String _namePart;
+
   /// Utility getter/cache for [_MarkdownCommentReference._getResultsForClass].
   String get namePart {
     // TODO(jcollins-g): This should really be the same as 'name', but isn't


### PR DESCRIPTION
Minor improvement to comment reference handling; this now makes comment reference handling overall negligible for performance (~ 5 seconds spent on a flutter run now) and hopefully reduces further the amount of cut-and-pastyness going on in the reference handling.  It should make it easier when we go in to rewrite that to understand what the current code does.

In addition, disable by default the high quality stack traces inside the `Chain.capture()` call.  This has a more significant performance impact.