### PR TITLE
Fix constructor resolution regression and add test

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -690,13 +690,13 @@ class _MarkdownCommentReference {
         .where((m) => _ConsiderIfConstructor(m));
     if (codeRefChompedParts.first == c.name) {
       // [Foo...thing], a member of this class (possibly a parameter).
-      membersToCheck.map((m) => _addCanonicalResult(m, tryClass));
+      membersToCheck.forEach((m) => _addCanonicalResult(m, tryClass));
     } else if (codeRefChompedParts.length > 1 &&
         codeRefChompedParts[codeRefChompedParts.length - 2] == c.name) {
       // [....Foo.thing], a member of this class partially specified.
       membersToCheck
           .whereType<Constructor>()
-          .map((m) => _addCanonicalResult(m, tryClass));
+          .forEach((m) => _addCanonicalResult(m, tryClass));
     }
     results.remove(null);
     if (results.isNotEmpty) return;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4134,8 +4134,10 @@ abstract class ModelElement extends Canonicalization
         // Count the number of invocations of tools in this dartdoc block,
         // so that tools can differentiate different blocks from each other.
         invocationIndex++;
-        return await config.tools.runner.run(args,
-            (String message) async => warn(PackageWarning.toolError, message: message),
+        return await config.tools.runner.run(
+            args,
+            (String message) async =>
+                warn(PackageWarning.toolError, message: message),
             content: basicMatch[2],
             environment: {
               'SOURCE_LINE': lineAndColumn?.item1?.toString(),

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -25,17 +25,19 @@ final MultiFutureTracker _toolTracker = new MultiFutureTracker(4);
 class ToolTempFileTracker {
   final Directory temporaryDirectory;
 
-  ToolTempFileTracker._() : temporaryDirectory = Directory.systemTemp.createTempSync('dartdoc_tools_');
+  ToolTempFileTracker._()
+      : temporaryDirectory =
+            Directory.systemTemp.createTempSync('dartdoc_tools_');
 
   static ToolTempFileTracker _instance;
-  static ToolTempFileTracker get instance => _instance ??= ToolTempFileTracker._();
+  static ToolTempFileTracker get instance =>
+      _instance ??= ToolTempFileTracker._();
 
   int _temporaryFileCount = 0;
   Future<File> createTemporaryFile() async {
     _temporaryFileCount++;
     File tempFile = new File(pathLib.join(
-        temporaryDirectory.absolute.path,
-        'input_$_temporaryFileCount'));
+        temporaryDirectory.absolute.path, 'input_$_temporaryFileCount'));
     await tempFile.create(recursive: true);
     return tempFile;
   }
@@ -60,7 +62,9 @@ class ToolRunner {
   final ToolConfiguration toolConfiguration;
 
   void _runSetup(
-      String name, ToolDefinition tool, Map<String, String> environment,
+      String name,
+      ToolDefinition tool,
+      Map<String, String> environment,
       ToolErrorCallback toolErrorCallback) async {
     bool isDartSetup = ToolDefinition.isDartExecutable(tool.setupCommand[0]);
     var args = tool.setupCommand.toList();
@@ -71,12 +75,17 @@ class ToolRunner {
     } else {
       commandPath = args.removeAt(0);
     }
-    await _runProcess(name, '', commandPath, args, environment, toolErrorCallback);
+    await _runProcess(
+        name, '', commandPath, args, environment, toolErrorCallback);
     tool.setupComplete = true;
   }
 
-  Future<String> _runProcess(String name, String content, String commandPath,
-      List<String> args, Map<String, String> environment,
+  Future<String> _runProcess(
+      String name,
+      String content,
+      String commandPath,
+      List<String> args,
+      Map<String, String> environment,
       ToolErrorCallback toolErrorCallback) async {
     String commandString() => ([commandPath] + args).join(' ');
     try {
@@ -113,7 +122,8 @@ class ToolRunner {
     Future runner;
     // Prevent too many tools from running simultaneously.
     await _toolTracker.addFutureFromClosure(() {
-      runner = _run(args, toolErrorCallback, content: content, environment: environment);
+      runner = _run(args, toolErrorCallback,
+          content: content, environment: environment);
       return runner;
     });
     return runner;
@@ -127,7 +137,8 @@ class ToolRunner {
     environment ??= <String, String>{};
     var tool = args.removeAt(0);
     if (!toolConfiguration.tools.containsKey(tool)) {
-      toolErrorCallback('Unable to find definition for tool "$tool" in tool map. '
+      toolErrorCallback(
+          'Unable to find definition for tool "$tool" in tool map. '
           'Did you add it to dartdoc_options.yaml?');
       return '';
     }
@@ -193,12 +204,12 @@ class ToolRunner {
     }
 
     if (callCompleter != null) {
-      return _runProcess(
-              tool, content, commandPath, argsWithInput, envWithInput, toolErrorCallback)
+      return _runProcess(tool, content, commandPath, argsWithInput,
+              envWithInput, toolErrorCallback)
           .whenComplete(callCompleter);
     } else {
-      return _runProcess(
-          tool, content, commandPath, argsWithInput, envWithInput, toolErrorCallback);
+      return _runProcess(tool, content, commandPath, argsWithInput,
+          envWithInput, toolErrorCallback);
     }
   }
 }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -2919,7 +2919,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     Constructor appleDefaultConstructor, constCatConstructor;
     Constructor appleConstructorFromString;
     Constructor constructorTesterDefault, constructorTesterFromSomething;
-    Class apple, constCat, constructorTester;
+    Class apple, constCat, constructorTester, referToADefaultConstructor;
     setUpAll(() {
       apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
       constCat = exLibrary.classes.firstWhere((c) => c.name == 'ConstantCat');
@@ -2934,6 +2934,20 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((c) => c.name == 'ConstructorTester');
       constructorTesterFromSomething = constructorTester.constructors
           .firstWhere((c) => c.name == 'ConstructorTester.fromSomething');
+      referToADefaultConstructor = fakeLibrary.classes
+          .firstWhere((c) => c.name == 'ReferToADefaultConstructor');
+    });
+
+    test('calculates comment references to classes vs. constructors correctly',
+        () {
+      expect(
+          referToADefaultConstructor.documentationAsHtml,
+          contains(
+              '<a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a>'));
+      expect(
+          referToADefaultConstructor.documentationAsHtml,
+          contains(
+              '<a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor.ReferToADefaultConstructor</a>'));
     });
 
     test('displays generic parameters correctly', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -926,6 +926,15 @@ void paintImage2(String fooParam,
   // nothing to do here -
 }
 
+/// This is to test referring to a constructor.
+///
+/// This should refer to a class: [ReferToADefaultConstructor].
+/// This should refer to the constructor: [ReferToADefaultConstructor.ReferToADefaultConstructor].
+class ReferToADefaultConstructor {
+  /// A default constructor.
+  ReferToADefaultConstructor();
+}
+
 /// Test operator references: [OperatorReferenceClass.==].
 class OperatorReferenceClass {
   OperatorReferenceClass();

--- a/testing/test_package_docs/fake/ABaseClass-class.html
+++ b/testing/test_package_docs/fake/ABaseClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingASuperMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs/fake/AClassUsingNewStyleMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs/fake/AClassWithFancyProperties-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs/fake/AMixinCallingSuper-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs/fake/ATypeTakingClassMixedIn-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Annotation-class.html
+++ b/testing/test_package_docs/fake/Annotation-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs/fake/AnotherInterface-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs/fake/BaseForDocComments-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/BaseThingy-class.html
+++ b/testing/test_package_docs/fake/BaseThingy-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs/fake/BaseThingy2-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Callback2.html
+++ b/testing/test_package_docs/fake/Callback2.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs/fake/ClassWithUnusualProperties-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Color-class.html
+++ b/testing/test_package_docs/fake/Color-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ConstantClass-class.html
+++ b/testing/test_package_docs/fake/ConstantClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs/fake/ConstructorTester-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Cool-class.html
+++ b/testing/test_package_docs/fake/Cool-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs/fake/CovariantMemberParams-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/DOWN-constant.html
+++ b/testing/test_package_docs/fake/DOWN-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs/fake/DocumentWithATable-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Doh-class.html
+++ b/testing/test_package_docs/fake/Doh-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ExtendsFutureVoid-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs/fake/ExtraSpecialList-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/FakeProcesses.html
+++ b/testing/test_package_docs/fake/FakeProcesses.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Foo2-class.html
+++ b/testing/test_package_docs/fake/Foo2-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/GenericClass-class.html
+++ b/testing/test_package_docs/fake/GenericClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs/fake/GenericMixin-mixin.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/GenericTypedef.html
+++ b/testing/test_package_docs/fake/GenericTypedef.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/HasDynamicAnnotation-class.html
+++ b/testing/test_package_docs/fake/HasDynamicAnnotation-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs/fake/HasGenericWithExtends-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/HasGenerics-class.html
+++ b/testing/test_package_docs/fake/HasGenerics-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/HasPragma-class.html
+++ b/testing/test_package_docs/fake/HasPragma-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs/fake/ImplementingThingy2-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs/fake/ImplementsFutureVoid-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs/fake/ImplicitProperties-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs/fake/InheritingClassOne-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs/fake/InheritingClassTwo-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Interface-class.html
+++ b/testing/test_package_docs/fake/Interface-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs/fake/LongFirstLine-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs/fake/LotsAndLotsOfParameters.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MIEEBase-class.html
+++ b/testing/test_package_docs/fake/MIEEBase-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs/fake/MIEEMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs/fake/MIEEMixinWithOverride-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MIEEThing-class.html
+++ b/testing/test_package_docs/fake/MIEEThing-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs/fake/MacrosFromAccessors-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/MixMeIn-class.html
+++ b/testing/test_package_docs/fake/MixMeIn-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ModifierClass-class.html
+++ b/testing/test_package_docs/fake/ModifierClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs/fake/NewGenericTypedef.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs/fake/NewStyleMixinCallingSuper-mixin.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/NotAMixin-class.html
+++ b/testing/test_package_docs/fake/NotAMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/Oops-class.html
+++ b/testing/test_package_docs/fake/Oops-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs/fake/OperatorReferenceClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs/fake/OtherGenericsThing-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/PI-constant.html
+++ b/testing/test_package_docs/fake/PI-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor-class.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor-class.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ReferToADefaultConstructor class from the fake library, for the Dart programming language.">
+  <title>ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">ReferToADefaultConstructor class</li>
+  </ol>
+  <div class="self-name">ReferToADefaultConstructor</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/ABaseClass-class.html">ABaseClass</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassUsingNewStyleMixin-class.html">AClassUsingNewStyleMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a></li>
+      <li><a href="fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/CovariantMemberParams-class.html">CovariantMemberParams</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
+      <li><a href="categoriesExported/IAmAClassWithCategories-class.html">IAmAClassWithCategories</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/ModifierClass-class.html">ModifierClass</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/TypedefUsingClass-class.html">TypedefUsingClass</a></li>
+      <li><a href="fake/TypeInferenceMixedIn-class.html">TypeInferenceMixedIn</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#mixins">Mixins</a></li>
+      <li><a href="fake/GenericMixin-mixin.html">GenericMixin</a></li>
+      <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/myMap-constant.html">myMap</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/mustGetThis.html">mustGetThis</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+      <li><a href="fake/useSomethingInAnotherPackage.html">useSomethingInAnotherPackage</a></li>
+      <li><a href="fake/useSomethingInTheSdk.html">useSomethingInTheSdk</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
+      <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
+      <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></li>
+      <li><a href="fake/returningFutureVoid.html">returningFutureVoid</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a href="fake/thisIsFutureOr.html">thisIsFutureOr</a></li>
+      <li><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></li>
+      <li><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+      <li><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <h1>ReferToADefaultConstructor class </h1>
+
+    <section class="desc markdown">
+      <p>This is to test referring to a constructor.</p>
+<p>This should refer to a class: <a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a>.
+This should refer to the constructor: <a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor.ReferToADefaultConstructor</a>.</p>
+    </section>
+    
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ReferToADefaultConstructor" class="callable">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          A default constructor.
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ReferToADefaultConstructor constructor from the Class ReferToADefaultConstructor class from the fake library, for the Dart programming language.">
+  <title>ReferToADefaultConstructor constructor - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">ReferToADefaultConstructor constructor</li>
+  </ol>
+  <div class="self-name">ReferToADefaultConstructor</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>ReferToADefaultConstructor constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">ReferToADefaultConstructor</span>(<wbr>)
+    </section>
+
+    <section class="desc markdown">
+      <p>A default constructor.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor/hashCode.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor/hashCode.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>hashCode property - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor/noSuchMethod.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>noSuchMethod method - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor/operator_equals.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>operator == method - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor/runtimeType.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor/runtimeType.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>runtimeType property - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferToADefaultConstructor/toString.html
+++ b/testing/test_package_docs/fake/ReferToADefaultConstructor/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>toString method - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs/fake/ReferringClass-class.html
+++ b/testing/test_package_docs/fake/ReferringClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/SpecialList-class.html
+++ b/testing/test_package_docs/fake/SpecialList-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs/fake/SubForDocComments-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs/fake/SuperAwesomeClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs/fake/TypeInferenceMixedIn-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs/fake/TypedefUsingClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/UP-constant.html
+++ b/testing/test_package_docs/fake/UP-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/VoidCallback.html
+++ b/testing/test_package_docs/fake/VoidCallback.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs/fake/WithGetterAndSetter-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/ZERO-constant.html
+++ b/testing/test_package_docs/fake/ZERO-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/aCoolVariable.html
+++ b/testing/test_package_docs/fake/aCoolVariable.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/aDynamicAnnotation-constant.html
+++ b/testing/test_package_docs/fake/aDynamicAnnotation-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/aMixinReturningFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/aVoidParameter.html
+++ b/testing/test_package_docs/fake/aVoidParameter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/addCallback.html
+++ b/testing/test_package_docs/fake/addCallback.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/addCallback2.html
+++ b/testing/test_package_docs/fake/addCallback2.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs/fake/bulletDoced-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/complicatedReturn.html
+++ b/testing/test_package_docs/fake/complicatedReturn.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/doAComplicatedThing.html
+++ b/testing/test_package_docs/fake/doAComplicatedThing.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/dynamicGetter.html
+++ b/testing/test_package_docs/fake/dynamicGetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/fake-library.html
+++ b/testing/test_package_docs/fake/fake-library.html
@@ -369,6 +369,12 @@ class still takes precedence (#1561).
         <dd>
           
         </dd>
+        <dt id="ReferToADefaultConstructor">
+          <span class="name "><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></span> 
+        </dt>
+        <dd>
+          This is to test referring to a constructor. <a href="fake/ReferToADefaultConstructor-class.html">[...]</a>
+        </dd>
         <dt id="SpecialList">
           <span class="name "><a href="fake/SpecialList-class.html">SpecialList</a><span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> 
         </dt>
@@ -1113,6 +1119,7 @@ default value.
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs/fake/functionUsingMixinReturningFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs/fake/functionWithFunctionParameters.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocGetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs/fake/getterSetterNodocSetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatAnnotation-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs/fake/greatestAnnotation-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/importantComputations.html
+++ b/testing/test_package_docs/fake/importantComputations.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs/fake/incorrectDocReference-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/justGetter.html
+++ b/testing/test_package_docs/fake/justGetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/justSetter.html
+++ b/testing/test_package_docs/fake/justSetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs/fake/mapWithDynamicKeys.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/meaningOfLife.html
+++ b/testing/test_package_docs/fake/meaningOfLife.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/mustGetThis.html
+++ b/testing/test_package_docs/fake/mustGetThis.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/myCoolTypedef.html
+++ b/testing/test_package_docs/fake/myCoolTypedef.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/myGenericFunction.html
+++ b/testing/test_package_docs/fake/myGenericFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/myMap-constant.html
+++ b/testing/test_package_docs/fake/myMap-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs/fake/onlyPositionalWithNoDefaultNoType.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paintImage1.html
+++ b/testing/test_package_docs/fake/paintImage1.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paintImage2.html
+++ b/testing/test_package_docs/fake/paintImage2.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs/fake/paramFromAnotherLib.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs/fake/paramOfFutureOrNull.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/required-constant.html
+++ b/testing/test_package_docs/fake/required-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/returningFutureVoid.html
+++ b/testing/test_package_docs/fake/returningFutureVoid.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/setAndGet.html
+++ b/testing/test_package_docs/fake/setAndGet.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/short.html
+++ b/testing/test_package_docs/fake/short.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/simpleProperty.html
+++ b/testing/test_package_docs/fake/simpleProperty.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/soIntense.html
+++ b/testing/test_package_docs/fake/soIntense.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs/fake/thisIsAlsoAsync.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsAsync.html
+++ b/testing/test_package_docs/fake/thisIsAsync.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs/fake/thisIsFutureOr.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrNull.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs/fake/thisIsFutureOrT.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/topLevelFunction.html
+++ b/testing/test_package_docs/fake/topLevelFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs/fake/typeParamOfFutureOr.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs/fake/useSomethingInAnotherPackage.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs/fake/useSomethingInTheSdk.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs/index.json
+++ b/testing/test_package_docs/index.json
@@ -8038,6 +8038,83 @@
   }
  },
  {
+  "name": "ReferToADefaultConstructor",
+  "qualifiedName": "fake.ReferToADefaultConstructor",
+  "href": "fake/ReferToADefaultConstructor-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ReferToADefaultConstructor",
+  "qualifiedName": "fake.ReferToADefaultConstructor",
+  "href": "fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.ReferToADefaultConstructor.==",
+  "href": "fake/ReferToADefaultConstructor/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.ReferToADefaultConstructor.hashCode",
+  "href": "fake/ReferToADefaultConstructor/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.ReferToADefaultConstructor.noSuchMethod",
+  "href": "fake/ReferToADefaultConstructor/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.ReferToADefaultConstructor.runtimeType",
+  "href": "fake/ReferToADefaultConstructor/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.ReferToADefaultConstructor.toString",
+  "href": "fake/ReferToADefaultConstructor/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
   "name": "ReferringClass",
   "qualifiedName": "fake.ReferringClass",
   "href": "fake/ReferringClass-class.html",

--- a/testing/test_package_docs_dev/fake/ABaseClass-class.html
+++ b/testing/test_package_docs_dev/fake/ABaseClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingASuperMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
+++ b/testing/test_package_docs_dev/fake/AClassUsingNewStyleMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
+++ b/testing/test_package_docs_dev/fake/AClassWithFancyProperties-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
+++ b/testing/test_package_docs_dev/fake/AMixinCallingSuper-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/ATypeTakingClassMixedIn-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Annotation-class.html
+++ b/testing/test_package_docs_dev/fake/Annotation-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/AnotherInterface-class.html
+++ b/testing/test_package_docs_dev/fake/AnotherInterface-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/BaseForDocComments-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/BaseThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/BaseThingy2-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
+++ b/testing/test_package_docs_dev/fake/CUSTOM_CLASS_PRIVATE-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Callback2.html
+++ b/testing/test_package_docs_dev/fake/Callback2.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ClassWithUnusualProperties-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Color-class.html
+++ b/testing/test_package_docs_dev/fake/Color-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ConstantClass-class.html
+++ b/testing/test_package_docs_dev/fake/ConstantClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ConstructorTester-class.html
+++ b/testing/test_package_docs_dev/fake/ConstructorTester-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Cool-class.html
+++ b/testing/test_package_docs_dev/fake/Cool-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
+++ b/testing/test_package_docs_dev/fake/CovariantMemberParams-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/DOWN-constant.html
+++ b/testing/test_package_docs_dev/fake/DOWN-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
+++ b/testing/test_package_docs_dev/fake/DocumentWithATable-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Doh-class.html
+++ b/testing/test_package_docs_dev/fake/Doh-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ExtendsFutureVoid-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/ExtraSpecialList-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/FakeProcesses.html
+++ b/testing/test_package_docs_dev/fake/FakeProcesses.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Foo2-class.html
+++ b/testing/test_package_docs_dev/fake/Foo2-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/GenericClass-class.html
+++ b/testing/test_package_docs_dev/fake/GenericClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
+++ b/testing/test_package_docs_dev/fake/GenericMixin-mixin.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/GenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/GenericTypedef.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/HasDynamicAnnotation-class.html
+++ b/testing/test_package_docs_dev/fake/HasDynamicAnnotation-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenericWithExtends-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/HasGenerics-class.html
+++ b/testing/test_package_docs_dev/fake/HasGenerics-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/HasPragma-class.html
+++ b/testing/test_package_docs_dev/fake/HasPragma-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementingThingy2-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
+++ b/testing/test_package_docs_dev/fake/ImplementsFutureVoid-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
+++ b/testing/test_package_docs_dev/fake/ImplicitProperties-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassOne-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
+++ b/testing/test_package_docs_dev/fake/InheritingClassTwo-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Interface-class.html
+++ b/testing/test_package_docs_dev/fake/Interface-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/LongFirstLine-class.html
+++ b/testing/test_package_docs_dev/fake/LongFirstLine-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
+++ b/testing/test_package_docs_dev/fake/LotsAndLotsOfParameters.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEBase-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEBase-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixin-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEMixinWithOverride-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/MIEEThing-class.html
+++ b/testing/test_package_docs_dev/fake/MIEEThing-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
+++ b/testing/test_package_docs_dev/fake/MacrosFromAccessors-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/MixMeIn-class.html
+++ b/testing/test_package_docs_dev/fake/MixMeIn-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ModifierClass-class.html
+++ b/testing/test_package_docs_dev/fake/ModifierClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_SINGLEUNDERSCORE-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
+++ b/testing/test_package_docs_dev/fake/NAME_WITH_TWO_UNDERSCORES-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/NewGenericTypedef.html
+++ b/testing/test_package_docs_dev/fake/NewGenericTypedef.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
+++ b/testing/test_package_docs_dev/fake/NewStyleMixinCallingSuper-mixin.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/NotAMixin-class.html
+++ b/testing/test_package_docs_dev/fake/NotAMixin-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/Oops-class.html
+++ b/testing/test_package_docs_dev/fake/Oops-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
+++ b/testing/test_package_docs_dev/fake/OperatorReferenceClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
+++ b/testing/test_package_docs_dev/fake/OtherGenericsThing-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/PI-constant.html
+++ b/testing/test_package_docs_dev/fake/PI-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor-class.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor-class.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ReferToADefaultConstructor class from the fake library, for the Dart programming language.">
+  <title>ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li class="self-crumb">ReferToADefaultConstructor class</li>
+  </ol>
+  <div class="self-name">ReferToADefaultConstructor</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>fake library</h5>
+    <ol>
+      <li class="section-title"><a href="fake/fake-library.html#classes">Classes</a></li>
+      <li><a href="fake/ABaseClass-class.html">ABaseClass</a></li>
+      <li><a href="fake/AClassUsingASuperMixin-class.html">AClassUsingASuperMixin</a></li>
+      <li><a href="fake/AClassUsingNewStyleMixin-class.html">AClassUsingNewStyleMixin</a></li>
+      <li><a href="fake/AClassWithFancyProperties-class.html">AClassWithFancyProperties</a></li>
+      <li><a href="fake/AMixinCallingSuper-class.html">AMixinCallingSuper</a></li>
+      <li><a href="fake/Annotation-class.html">Annotation</a></li>
+      <li><a href="fake/AnotherInterface-class.html">AnotherInterface</a></li>
+      <li><a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a></li>
+      <li><a href="fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a></li>
+      <li><a href="fake/BaseForDocComments-class.html">BaseForDocComments</a></li>
+      <li><a href="fake/BaseThingy-class.html">BaseThingy</a></li>
+      <li><a href="fake/BaseThingy2-class.html">BaseThingy2</a></li>
+      <li><a href="fake/ClassWithUnusualProperties-class.html">ClassWithUnusualProperties</a></li>
+      <li><a href="fake/ConstantClass-class.html">ConstantClass</a></li>
+      <li><a href="fake/ConstructorTester-class.html">ConstructorTester</a></li>
+      <li><a href="fake/Cool-class.html">Cool</a></li>
+      <li><a href="fake/CovariantMemberParams-class.html">CovariantMemberParams</a></li>
+      <li><a href="fake/DocumentWithATable-class.html">DocumentWithATable</a></li>
+      <li><a href="fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a></li>
+      <li><a href="fake/ExtraSpecialList-class.html">ExtraSpecialList</a></li>
+      <li><a href="fake/Foo2-class.html">Foo2</a></li>
+      <li><a href="fake/GenericClass-class.html">GenericClass</a></li>
+      <li><a href="fake/HasDynamicAnnotation-class.html">HasDynamicAnnotation</a></li>
+      <li><a href="fake/HasGenerics-class.html">HasGenerics</a></li>
+      <li><a href="fake/HasGenericWithExtends-class.html">HasGenericWithExtends</a></li>
+      <li><a href="fake/HasPragma-class.html">HasPragma</a></li>
+      <li><a href="categoriesExported/IAmAClassWithCategories-class.html">IAmAClassWithCategories</a></li>
+      <li><a href="fake/ImplementingThingy-class.html">ImplementingThingy</a></li>
+      <li><a href="fake/ImplementingThingy2-class.html">ImplementingThingy2</a></li>
+      <li><a href="fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a></li>
+      <li><a href="fake/ImplicitProperties-class.html">ImplicitProperties</a></li>
+      <li><a href="fake/InheritingClassOne-class.html">InheritingClassOne</a></li>
+      <li><a href="fake/InheritingClassTwo-class.html">InheritingClassTwo</a></li>
+      <li><a href="fake/Interface-class.html">Interface</a></li>
+      <li><a href="fake/LongFirstLine-class.html">LongFirstLine</a></li>
+      <li><a href="fake/MIEEBase-class.html">MIEEBase</a></li>
+      <li><a href="fake/MIEEMixin-class.html">MIEEMixin</a></li>
+      <li><a href="fake/MIEEMixinWithOverride-class.html">MIEEMixinWithOverride</a></li>
+      <li><a href="fake/MIEEThing-class.html">MIEEThing</a></li>
+      <li><a href="fake/MixMeIn-class.html">MixMeIn</a></li>
+      <li><a href="fake/ModifierClass-class.html">ModifierClass</a></li>
+      <li><a href="fake/NotAMixin-class.html">NotAMixin</a></li>
+      <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
+      <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
+      <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+      <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
+      <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
+      <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>
+      <li><a href="fake/TypedefUsingClass-class.html">TypedefUsingClass</a></li>
+      <li><a href="fake/TypeInferenceMixedIn-class.html">TypeInferenceMixedIn</a></li>
+      <li><a href="fake/WithGetterAndSetter-class.html">WithGetterAndSetter</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#mixins">Mixins</a></li>
+      <li><a href="fake/GenericMixin-mixin.html">GenericMixin</a></li>
+      <li><a href="fake/NewStyleMixinCallingSuper-mixin.html">NewStyleMixinCallingSuper</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#constants">Constants</a></li>
+      <li><a href="fake/aDynamicAnnotation-constant.html">aDynamicAnnotation</a></li>
+      <li><a href="fake/bulletDoced-constant.html">bulletDoced</a></li>
+      <li><a href="fake/CUSTOM_CLASS-constant.html">CUSTOM_CLASS</a></li>
+      <li><a href="fake/CUSTOM_CLASS_PRIVATE-constant.html">CUSTOM_CLASS_PRIVATE</a></li>
+      <li><a class="deprecated" href="fake/DOWN-constant.html">DOWN</a></li>
+      <li><a href="fake/greatAnnotation-constant.html">greatAnnotation</a></li>
+      <li><a href="fake/greatestAnnotation-constant.html">greatestAnnotation</a></li>
+      <li><a href="fake/incorrectDocReference-constant.html">incorrectDocReference</a></li>
+      <li><a href="fake/myMap-constant.html">myMap</a></li>
+      <li><a href="fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a></li>
+      <li><a href="fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a></li>
+      <li><a href="fake/PI-constant.html">PI</a></li>
+      <li><a href="fake/required-constant.html">required</a></li>
+      <li><a href="fake/testingCodeSyntaxInOneLiners-constant.html">testingCodeSyntaxInOneLiners</a></li>
+      <li><a href="fake/UP-constant.html">UP</a></li>
+      <li><a href="fake/ZERO-constant.html">ZERO</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#properties">Properties</a></li>
+      <li><a href="fake/aCoolVariable.html">aCoolVariable</a></li>
+      <li><a href="fake/complicatedReturn.html">complicatedReturn</a></li>
+      <li><a href="fake/dynamicGetter.html">dynamicGetter</a></li>
+      <li><a href="fake/getterSetterNodocGetter.html">getterSetterNodocGetter</a></li>
+      <li><a href="fake/getterSetterNodocSetter.html">getterSetterNodocSetter</a></li>
+      <li><a href="fake/importantComputations.html">importantComputations</a></li>
+      <li><a href="fake/justGetter.html">justGetter</a></li>
+      <li><a href="fake/justSetter.html">justSetter</a></li>
+      <li><a href="fake/mapWithDynamicKeys.html">mapWithDynamicKeys</a></li>
+      <li><a class="deprecated" href="fake/meaningOfLife.html">meaningOfLife</a></li>
+      <li><a href="fake/mustGetThis.html">mustGetThis</a></li>
+      <li><a href="fake/setAndGet.html">setAndGet</a></li>
+      <li><a href="fake/simpleProperty.html">simpleProperty</a></li>
+      <li><a href="fake/useSomethingInAnotherPackage.html">useSomethingInAnotherPackage</a></li>
+      <li><a href="fake/useSomethingInTheSdk.html">useSomethingInTheSdk</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#functions">Functions</a></li>
+      <li><a href="fake/addCallback.html">addCallback</a></li>
+      <li><a href="fake/addCallback2.html">addCallback2</a></li>
+      <li><a href="fake/aMixinReturningFunction.html">aMixinReturningFunction</a></li>
+      <li><a href="fake/aVoidParameter.html">aVoidParameter</a></li>
+      <li><a href="fake/doAComplicatedThing.html">doAComplicatedThing</a></li>
+      <li><a href="fake/functionUsingMixinReturningFunction.html">functionUsingMixinReturningFunction</a></li>
+      <li><a href="fake/functionWithFunctionParameters.html">functionWithFunctionParameters</a></li>
+      <li><a href="fake/myGenericFunction.html">myGenericFunction</a></li>
+      <li><a href="fake/onlyPositionalWithNoDefaultNoType.html">onlyPositionalWithNoDefaultNoType</a></li>
+      <li><a href="fake/paintImage1.html">paintImage1</a></li>
+      <li><a href="fake/paintImage2.html">paintImage2</a></li>
+      <li><a href="fake/paramFromAnotherLib.html">paramFromAnotherLib</a></li>
+      <li><a href="fake/paramOfFutureOrNull.html">paramOfFutureOrNull</a></li>
+      <li><a href="fake/returningFutureVoid.html">returningFutureVoid</a></li>
+      <li><a href="fake/short.html">short</a></li>
+      <li><a href="fake/soIntense.html">soIntense</a></li>
+      <li><a href="fake/thisIsAlsoAsync.html">thisIsAlsoAsync</a></li>
+      <li><a href="fake/thisIsAsync.html">thisIsAsync</a></li>
+      <li><a href="fake/thisIsFutureOr.html">thisIsFutureOr</a></li>
+      <li><a href="fake/thisIsFutureOrNull.html">thisIsFutureOrNull</a></li>
+      <li><a href="fake/thisIsFutureOrT.html">thisIsFutureOrT</a></li>
+      <li><a class="deprecated" href="fake/topLevelFunction.html">topLevelFunction</a></li>
+      <li><a href="fake/typeParamOfFutureOr.html">typeParamOfFutureOr</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#enums">Enums</a></li>
+      <li><a href="fake/Color-class.html">Color</a></li>
+      <li><a href="fake/MacrosFromAccessors-class.html">MacrosFromAccessors</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#typedefs">Typedefs</a></li>
+      <li><a href="fake/Callback2.html">Callback2</a></li>
+      <li><a class="deprecated" href="fake/FakeProcesses.html">FakeProcesses</a></li>
+      <li><a href="fake/GenericTypedef.html">GenericTypedef</a></li>
+      <li><a href="fake/LotsAndLotsOfParameters.html">LotsAndLotsOfParameters</a></li>
+      <li><a href="fake/myCoolTypedef.html">myCoolTypedef</a></li>
+      <li><a href="fake/NewGenericTypedef.html">NewGenericTypedef</a></li>
+      <li><a href="fake/VoidCallback.html">VoidCallback</a></li>
+    
+      <li class="section-title"><a href="fake/fake-library.html#exceptions">Exceptions</a></li>
+      <li><a class="deprecated" href="fake/Doh-class.html">Doh</a></li>
+      <li><a href="fake/Oops-class.html">Oops</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <h1>ReferToADefaultConstructor class </h1>
+
+    <section class="desc markdown">
+      <p>This is to test referring to a constructor.</p>
+<p>This should refer to a class: <a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a>.
+This should refer to the constructor: <a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor.ReferToADefaultConstructor</a>.</p>
+    </section>
+    
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="ReferToADefaultConstructor" class="callable">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></span><span class="signature">()</span>
+        </dt>
+        <dd>
+          A default constructor.
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span> 
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toString" class="callable inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor inherited" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable inherited">
+          <span class="name"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+          </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the ReferToADefaultConstructor constructor from the Class ReferToADefaultConstructor class from the fake library, for the Dart programming language.">
+  <title>ReferToADefaultConstructor constructor - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">ReferToADefaultConstructor constructor</li>
+  </ol>
+  <div class="self-name">ReferToADefaultConstructor</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>ReferToADefaultConstructor constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">ReferToADefaultConstructor</span>(<wbr>)
+    </section>
+
+    <section class="desc markdown">
+      <p>A default constructor.</p>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/hashCode.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/hashCode.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the hashCode property from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>hashCode property - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">hashCode property</li>
+  </ol>
+  <div class="self-name">hashCode</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>hashCode property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">int</span>
+          <span class="name ">hashCode</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/noSuchMethod.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/noSuchMethod.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the noSuchMethod method from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>noSuchMethod method - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">noSuchMethod method</li>
+  </ol>
+  <div class="self-name">noSuchMethod</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>noSuchMethod method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">dynamic</span>
+      <span class="name ">noSuchMethod</span>
+(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/operator_equals.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/operator_equals.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the operator == method from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>operator == method - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">operator == method</li>
+  </ol>
+  <div class="self-name">operator ==</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>operator == method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">bool</span>
+      <span class="name ">operator ==</span>
+(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">dynamic</span> <span class="parameter-name">other</span></span>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/runtimeType.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/runtimeType.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the runtimeType property from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>runtimeType property - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">runtimeType property</li>
+  </ol>
+  <div class="self-name">runtimeType</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>runtimeType property</h1>
+
+
+        <section id="getter">
+        
+        <section class="multi-line-signature">
+          <span class="returntype">Type</span>
+          <span class="name ">runtimeType</span>
+  <div class="features">inherited</div>
+</section>
+        
+        
+</section>
+        
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/toString.html
+++ b/testing/test_package_docs_dev/fake/ReferToADefaultConstructor/toString.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the toString method from the ReferToADefaultConstructor class, for the Dart programming language.">
+  <title>toString method - ReferToADefaultConstructor class - fake library - Dart API</title>
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">test_package</a></li>
+    <li><a href="fake/fake-library.html">fake</a></li>
+    <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
+    <li class="self-crumb">toString method</li>
+  </ol>
+  <div class="self-name">toString</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>ReferToADefaultConstructor class</h5>
+    <ol>
+      <li class="section-title"><a href="fake/ReferToADefaultConstructor-class.html#constructors">Constructors</a></li>
+      <li><a href="fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor</a></li>
+    
+      <li class="section-title inherited">
+        <a href="fake/ReferToADefaultConstructor-class.html#instance-properties">Properties</a>
+      </li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/hashCode.html">hashCode</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#instance-methods">Methods</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/toString.html">toString</a></li>
+    
+      <li class="section-title inherited"><a href="fake/ReferToADefaultConstructor-class.html#operators">Operators</a></li>
+      <li class="inherited"><a href="fake/ReferToADefaultConstructor/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>toString method</h1>
+
+    <section class="multi-line-signature">
+      <span class="returntype">String</span>
+      <span class="name ">toString</span>
+(<wbr>)
+      <div class="features">inherited</div>
+    </section>
+    
+    
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    test_package 0.0.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/testing/test_package_docs_dev/fake/ReferringClass-class.html
+++ b/testing/test_package_docs_dev/fake/ReferringClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/SpecialList-class.html
+++ b/testing/test_package_docs_dev/fake/SpecialList-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/SubForDocComments-class.html
+++ b/testing/test_package_docs_dev/fake/SubForDocComments-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
+++ b/testing/test_package_docs_dev/fake/SuperAwesomeClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
+++ b/testing/test_package_docs_dev/fake/TypeInferenceMixedIn-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
+++ b/testing/test_package_docs_dev/fake/TypedefUsingClass-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/UP-constant.html
+++ b/testing/test_package_docs_dev/fake/UP-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/VoidCallback.html
+++ b/testing/test_package_docs_dev/fake/VoidCallback.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
+++ b/testing/test_package_docs_dev/fake/WithGetterAndSetter-class.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/ZERO-constant.html
+++ b/testing/test_package_docs_dev/fake/ZERO-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/aCoolVariable.html
+++ b/testing/test_package_docs_dev/fake/aCoolVariable.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/aDynamicAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/aDynamicAnnotation-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/aMixinReturningFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/aVoidParameter.html
+++ b/testing/test_package_docs_dev/fake/aVoidParameter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback.html
+++ b/testing/test_package_docs_dev/fake/addCallback.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/addCallback2.html
+++ b/testing/test_package_docs_dev/fake/addCallback2.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/bulletDoced-constant.html
+++ b/testing/test_package_docs_dev/fake/bulletDoced-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/complicatedReturn.html
+++ b/testing/test_package_docs_dev/fake/complicatedReturn.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/doAComplicatedThing.html
+++ b/testing/test_package_docs_dev/fake/doAComplicatedThing.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/dynamicGetter.html
+++ b/testing/test_package_docs_dev/fake/dynamicGetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/fake-library.html
+++ b/testing/test_package_docs_dev/fake/fake-library.html
@@ -369,6 +369,12 @@ class still takes precedence (#1561).
         <dd>
           
         </dd>
+        <dt id="ReferToADefaultConstructor">
+          <span class="name "><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></span> 
+        </dt>
+        <dd>
+          This is to test referring to a constructor. <a href="fake/ReferToADefaultConstructor-class.html">[...]</a>
+        </dd>
         <dt id="SpecialList">
           <span class="name "><a href="fake/SpecialList-class.html">SpecialList</a><span class="signature">&lt;<wbr><span class="type-parameter">E</span>&gt;</span></span> 
         </dt>
@@ -1113,6 +1119,7 @@ default value.
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
+++ b/testing/test_package_docs_dev/fake/functionUsingMixinReturningFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
+++ b/testing/test_package_docs_dev/fake/functionWithFunctionParameters.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocGetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
+++ b/testing/test_package_docs_dev/fake/getterSetterNodocSetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatAnnotation-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
+++ b/testing/test_package_docs_dev/fake/greatestAnnotation-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/importantComputations.html
+++ b/testing/test_package_docs_dev/fake/importantComputations.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
+++ b/testing/test_package_docs_dev/fake/incorrectDocReference-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/justGetter.html
+++ b/testing/test_package_docs_dev/fake/justGetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/justSetter.html
+++ b/testing/test_package_docs_dev/fake/justSetter.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
+++ b/testing/test_package_docs_dev/fake/mapWithDynamicKeys.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/meaningOfLife.html
+++ b/testing/test_package_docs_dev/fake/meaningOfLife.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/mustGetThis.html
+++ b/testing/test_package_docs_dev/fake/mustGetThis.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/myCoolTypedef.html
+++ b/testing/test_package_docs_dev/fake/myCoolTypedef.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/myGenericFunction.html
+++ b/testing/test_package_docs_dev/fake/myGenericFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/myMap-constant.html
+++ b/testing/test_package_docs_dev/fake/myMap-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
+++ b/testing/test_package_docs_dev/fake/onlyPositionalWithNoDefaultNoType.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage1.html
+++ b/testing/test_package_docs_dev/fake/paintImage1.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/paintImage2.html
+++ b/testing/test_package_docs_dev/fake/paintImage2.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
+++ b/testing/test_package_docs_dev/fake/paramFromAnotherLib.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/paramOfFutureOrNull.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/required-constant.html
+++ b/testing/test_package_docs_dev/fake/required-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/returningFutureVoid.html
+++ b/testing/test_package_docs_dev/fake/returningFutureVoid.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/setAndGet.html
+++ b/testing/test_package_docs_dev/fake/setAndGet.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/short.html
+++ b/testing/test_package_docs_dev/fake/short.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/simpleProperty.html
+++ b/testing/test_package_docs_dev/fake/simpleProperty.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/soIntense.html
+++ b/testing/test_package_docs_dev/fake/soIntense.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
+++ b/testing/test_package_docs_dev/fake/testingCodeSyntaxInOneLiners-constant.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAlsoAsync.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsAsync.html
+++ b/testing/test_package_docs_dev/fake/thisIsAsync.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOr.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOr.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrNull.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
+++ b/testing/test_package_docs_dev/fake/thisIsFutureOrT.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/topLevelFunction.html
+++ b/testing/test_package_docs_dev/fake/topLevelFunction.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
+++ b/testing/test_package_docs_dev/fake/typeParamOfFutureOr.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInAnotherPackage.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
+++ b/testing/test_package_docs_dev/fake/useSomethingInTheSdk.html
@@ -84,6 +84,7 @@
       <li><a href="fake/OperatorReferenceClass-class.html">OperatorReferenceClass</a></li>
       <li><a href="fake/OtherGenericsThing-class.html">OtherGenericsThing</a></li>
       <li><a href="fake/ReferringClass-class.html">ReferringClass</a></li>
+      <li><a href="fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a></li>
       <li><a href="fake/SpecialList-class.html">SpecialList</a></li>
       <li><a href="fake/SubForDocComments-class.html">SubForDocComments</a></li>
       <li><a class="deprecated" href="fake/SuperAwesomeClass-class.html">SuperAwesomeClass</a></li>

--- a/testing/test_package_docs_dev/index.json
+++ b/testing/test_package_docs_dev/index.json
@@ -8038,6 +8038,83 @@
   }
  },
  {
+  "name": "ReferToADefaultConstructor",
+  "qualifiedName": "fake.ReferToADefaultConstructor",
+  "href": "fake/ReferToADefaultConstructor-class.html",
+  "type": "class",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "fake",
+   "type": "library"
+  }
+ },
+ {
+  "name": "ReferToADefaultConstructor",
+  "qualifiedName": "fake.ReferToADefaultConstructor",
+  "href": "fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html",
+  "type": "constructor",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "operator ==",
+  "qualifiedName": "fake.ReferToADefaultConstructor.==",
+  "href": "fake/ReferToADefaultConstructor/operator_equals.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "hashCode",
+  "qualifiedName": "fake.ReferToADefaultConstructor.hashCode",
+  "href": "fake/ReferToADefaultConstructor/hashCode.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "noSuchMethod",
+  "qualifiedName": "fake.ReferToADefaultConstructor.noSuchMethod",
+  "href": "fake/ReferToADefaultConstructor/noSuchMethod.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "runtimeType",
+  "qualifiedName": "fake.ReferToADefaultConstructor.runtimeType",
+  "href": "fake/ReferToADefaultConstructor/runtimeType.html",
+  "type": "property",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
+  "name": "toString",
+  "qualifiedName": "fake.ReferToADefaultConstructor.toString",
+  "href": "fake/ReferToADefaultConstructor/toString.html",
+  "type": "method",
+  "overriddenDepth": 0,
+  "enclosedBy": {
+   "name": "ReferToADefaultConstructor",
+   "type": "class"
+  }
+ },
+ {
   "name": "ReferringClass",
   "qualifiedName": "fake.ReferringClass",
   "href": "fake/ReferringClass-class.html",


### PR DESCRIPTION
Use 'forEach' instead of 'map' when intending to always run the closures.  Fixes 4 unresolved links introduced since 0.25.0 in Flutter. 