### PR TITLE
Avoid relying on literal version for meta package

### DIFF
--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -365,8 +365,8 @@ void main() {
       expect(meta.documentedWhere, equals(DocumentLocation.remote));
       expect(
           useSomethingInAnotherPackage.modelType.linkedName,
-          startsWith(
-              '<a href=\"https://pub.dartlang.org/documentation/meta/1.1.6/meta/Required-class.html\">Required</a>'));
+          matches(
+              '<a href=\"https://pub.dartlang.org/documentation/meta/[^\"]*/meta/Required-class.html\">Required</a>'));
       RegExp stringLink = new RegExp(
           'https://api.dartlang.org/(dev|stable|edge|be)/${Platform.version.split(' ').first}/dart-core/String-class.html">String</a>');
       expect(useSomethingInTheSdk.modelType.linkedName, contains(stringLink));


### PR DESCRIPTION
This should not have been hardcoded, oops.