### PR TITLE
Do not throw on malformed UTF-8 encodings

### DIFF
--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -4,6 +4,7 @@
 
 library dartdoc.package_meta;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';
@@ -14,6 +15,7 @@ import 'package:yaml/yaml.dart';
 import 'logging.dart';
 
 Map<String, PackageMeta> _packageMetaCache = {};
+Encoding utf8AllowMalformed = new Utf8Codec(allowMalformed: true);
 
 Directory get defaultSdkDir {
   Directory sdkDir = new File(Platform.resolvedExecutable).parent.parent;
@@ -212,7 +214,7 @@ class FileContents {
   factory FileContents(File file) =>
       file == null ? null : new FileContents._(file);
 
-  String get contents => file.readAsStringSync();
+  String get contents => file.readAsStringSync(encoding: utf8AllowMalformed);
 
   bool get isMarkdown => file.path.toLowerCase().endsWith('.md');
 

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -7,6 +7,7 @@ library dartdoc.package_utils_test;
 import 'dart:io';
 
 import 'package:dartdoc/src/package_meta.dart';
+import 'package:path/path.dart' as pathLib;
 import 'package:test/test.dart';
 
 void main() {
@@ -20,6 +21,14 @@ void main() {
 
     test('is not valid', () {
       expect(p, isNull);
+    });
+  });
+
+  group('PackageMeta for the test package', () {
+    PackageMeta p = new PackageMeta.fromDir(new Directory(pathLib.join(Directory.current.path, 'testing', 'test_package')));
+
+    test('readme with corrupt UTF-8 loads without throwing', () {
+      expect(p.getReadmeContents().contents, contains('Here is some messed up UTF-8.\nÃf'));
     });
   });
 

--- a/testing/test_package/README.md
+++ b/testing/test_package/README.md
@@ -5,6 +5,8 @@
 
 This is an amazing package.
 
+## Here is some messed up UTF-8.
+ÃfÃÆ�z�â°
 
 ## Examples
 


### PR DESCRIPTION
Fixes #1889.

For README, CHANGELOG, and other non-critical files, do not require valid UTF-8 encoding.

This may result in corrupted HTML output, but will no longer throw.