### PR TITLE
Minimize number of tool execution runs

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2263,7 +2263,7 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   Set<String> get canonicalFor {
     if (_canonicalFor == null) {
       // TODO(jcollins-g): restructure to avoid using side effects.
-      documentation;
+      _buildDocumentationAddition(documentationComment);
     }
     return _canonicalFor;
   }
@@ -2273,14 +2273,14 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   ///
   /// Example:
   ///   {@canonicalFor libname.ClassName}
-  String _setCanonicalFor(String rawDocs) {
-    if (_canonicalFor == null) {
-      _canonicalFor = new Set();
-    }
+  @override
+  String _buildDocumentationAddition(String rawDocs) {
+    rawDocs = super._buildDocumentationAddition(rawDocs);
+    Set<String> newCanonicalFor = new Set();
     Set<String> notFoundInAllModelElements = new Set();
     final canonicalRegExp = new RegExp(r'{@canonicalFor\s([^}]+)}');
     rawDocs = rawDocs.replaceAllMapped(canonicalRegExp, (Match match) {
-      canonicalFor.add(match.group(1));
+      newCanonicalFor.add(match.group(1));
       notFoundInAllModelElements.add(match.group(1));
       return '';
     });
@@ -2290,16 +2290,12 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     for (String notFound in notFoundInAllModelElements) {
       warn(PackageWarning.ignoredCanonicalFor, message: notFound);
     }
-    return rawDocs;
-  }
-
-  String _libraryDocs;
-  @override
-  String get documentation {
-    if (_libraryDocs == null) {
-      _libraryDocs = _setCanonicalFor(super.documentation);
+    // TODO(jcollins-g): warn if a macro/tool _does_ generate an unexpected
+    // canonicalFor?
+    if (_canonicalFor == null) {
+      _canonicalFor = newCanonicalFor;
     }
-    return _libraryDocs;
+    return rawDocs;
   }
 
   /// Libraries are not enclosed by anything.
@@ -3256,7 +3252,7 @@ abstract class ModelElement extends Canonicalization
   String _buildDocumentationBaseSync() {
     assert(_rawDocs == null);
     // Do not use the sync method if we need to evaluate tools or templates.
-    assert(packageGraph._localDocumentationBuilt);
+    assert(!needsPrecacheRegExp.hasMatch(documentationComment ?? ''));
     if (config.dropTextFrom.contains(element.library.name)) {
       _rawDocs = '';
     } else {
@@ -4692,6 +4688,11 @@ class PackageGraph {
   /// Generate a list of futures for any docs that actually require precaching.
   Iterable<Future> precacheLocalDocs() sync* {
     for (ModelElement m in allModelElements) {
+      // Skip if there is a canonicalModelElement somewhere else we can run this
+      // for.  Not the same as allCanonicalModelElements since we need to run
+      // for any ModelElement that might not have a canonical ModelElement,
+      // too.
+      if (m.canonicalModelElement != null && !m.isCanonical) continue;
       if (m.documentationComment != null &&
           needsPrecacheRegExp.hasMatch(m.documentationComment)) {
         yield m._precacheLocalDocs();

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1297,10 +1297,10 @@ abstract class Documentable extends Nameable {
 }
 
 /// Mixin implementing dartdoc categorization for ModelElements.
-mixin Categorization on ModelElement {
+abstract class Categorization implements ModelElement {
   @override
   String _buildDocumentationAddition(String rawDocs) =>
-      _stripAndSetDartdocCategories(super._buildDocumentationAddition(rawDocs));
+      _stripAndSetDartdocCategories(rawDocs ??= '');
 
   /// Parse {@category ...} and related information in API comments, stripping
   /// out that information from the given comments and returning the stripped

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3250,8 +3250,7 @@ abstract class ModelElement extends Canonicalization
 
   /// Separate from _buildDocumentationLocal for overriding.
   String _buildDocumentationBaseSync() {
-    // Prevent reentrancy.
-    assert(_rawDocs == null);
+    assert(_rawDocs == null, 'reentrant calls to _buildDocumentation* not allowed');
     // Do not use the sync method if we need to evaluate tools or templates.
     assert(!isCanonical ||
         !needsPrecacheRegExp.hasMatch(documentationComment ?? ''));
@@ -3271,8 +3270,7 @@ abstract class ModelElement extends Canonicalization
   /// Separate from _buildDocumentationLocal for overriding.  Can only be
   /// used as part of [PackageGraph.setUpPackageGraph].
   Future<String> _buildDocumentationBase() async {
-    // Prevent reentrancy.
-    assert(_rawDocs == null);
+    assert(_rawDocs == null, 'reentrant calls to _buildDocumentation* not allowed');
     // Do not use the sync method if we need to evaluate tools or templates.
     if (config.dropTextFrom.contains(element.library.name)) {
       _rawDocs = '';

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3253,7 +3253,8 @@ abstract class ModelElement extends Canonicalization
     // Prevent reentrancy.
     assert(_rawDocs == null);
     // Do not use the sync method if we need to evaluate tools or templates.
-    assert(!isCanonical || !needsPrecacheRegExp.hasMatch(documentationComment ?? ''));
+    assert(!isCanonical ||
+        !needsPrecacheRegExp.hasMatch(documentationComment ?? ''));
     if (config.dropTextFrom.contains(element.library.name)) {
       _rawDocs = '';
     } else {
@@ -4034,7 +4035,8 @@ abstract class ModelElement extends Canonicalization
               'LIBRARY_NAME': library?.fullyQualifiedName,
               'ELEMENT_NAME': fullyQualifiedNameWithoutLibrary,
               'INVOCATION_INDEX': invocationIndex.toString(),
-              'PACKAGE_INVOCATION_INDEX': (package.toolInvocationIndex++).toString(),
+              'PACKAGE_INVOCATION_INDEX':
+                  (package.toolInvocationIndex++).toString(),
             }..removeWhere((key, value) => value == null));
       });
     } else {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -92,32 +92,47 @@ void main() {
     Method invokeToolPrivateLibrary, invokeToolPrivateLibraryOriginal;
 
     setUpAll(() {
-      _NonCanonicalToolUser = fakeLibrary.allClasses.firstWhere((c) => c.name == '_NonCanonicalToolUser');
-      CanonicalToolUser = fakeLibrary.allClasses.firstWhere((c) => c.name == 'CanonicalToolUser');
-      PrivateLibraryToolUser = fakeLibrary.allClasses.firstWhere((c) => c.name == 'PrivateLibraryToolUser');
+      _NonCanonicalToolUser = fakeLibrary.allClasses
+          .firstWhere((c) => c.name == '_NonCanonicalToolUser');
+      CanonicalToolUser = fakeLibrary.allClasses
+          .firstWhere((c) => c.name == 'CanonicalToolUser');
+      PrivateLibraryToolUser = fakeLibrary.allClasses
+          .firstWhere((c) => c.name == 'PrivateLibraryToolUser');
       toolUser = exLibrary.classes.firstWhere((c) => c.name == 'ToolUser');
       invokeTool =
           toolUser.allInstanceMethods.firstWhere((m) => m.name == 'invokeTool');
-      invokeToolNonCanonical = _NonCanonicalToolUser.allInstanceMethods.firstWhere((m) => m.name == 'invokeToolNonCanonical');
-      invokeToolNonCanonicalSubclass = CanonicalToolUser.allInstanceMethods.firstWhere((m) => m.name == 'invokeToolNonCanonical');
+      invokeToolNonCanonical = _NonCanonicalToolUser.allInstanceMethods
+          .firstWhere((m) => m.name == 'invokeToolNonCanonical');
+      invokeToolNonCanonicalSubclass = CanonicalToolUser.allInstanceMethods
+          .firstWhere((m) => m.name == 'invokeToolNonCanonical');
       invokeToolNoInput = toolUser.allInstanceMethods
           .firstWhere((m) => m.name == 'invokeToolNoInput');
       invokeToolMultipleSections = toolUser.allInstanceMethods
           .firstWhere((m) => m.name == 'invokeToolMultipleSections');
       invokeToolPrivateLibrary = PrivateLibraryToolUser.allInstanceMethods
           .firstWhere((m) => m.name == 'invokeToolPrivateLibrary');
-      invokeToolPrivateLibraryOriginal = (invokeToolPrivateLibrary.definingEnclosingElement as Class).allInstanceMethods.firstWhere((m) => m.name == 'invokeToolPrivateLibrary');
+      invokeToolPrivateLibraryOriginal =
+          (invokeToolPrivateLibrary.definingEnclosingElement as Class)
+              .allInstanceMethods
+              .firstWhere((m) => m.name == 'invokeToolPrivateLibrary');
       packageGraph.allLocalModelElements.forEach((m) => m.documentation);
     });
 
     test('does _not_ invoke a tool multiple times unnecessarily', () {
-      RegExp packageInvocationIndexRegexp = new RegExp(r'PACKAGE_INVOCATION_INDEX: (\d+)');
+      RegExp packageInvocationIndexRegexp =
+          new RegExp(r'PACKAGE_INVOCATION_INDEX: (\d+)');
       expect(invokeToolNonCanonical.isCanonical, isFalse);
       expect(invokeToolNonCanonicalSubclass.isCanonical, isTrue);
-      expect(packageInvocationIndexRegexp.firstMatch(invokeToolNonCanonical.documentation).group(1),
-             equals(packageInvocationIndexRegexp.firstMatch(invokeToolNonCanonicalSubclass.documentation).group(1)));
+      expect(
+          packageInvocationIndexRegexp
+              .firstMatch(invokeToolNonCanonical.documentation)
+              .group(1),
+          equals(packageInvocationIndexRegexp
+              .firstMatch(invokeToolNonCanonicalSubclass.documentation)
+              .group(1)));
       expect(invokeToolPrivateLibrary.documentation, isNot(contains('{@tool')));
-      expect(invokeToolPrivateLibraryOriginal.documentation, contains('{@tool'));
+      expect(
+          invokeToolPrivateLibraryOriginal.documentation, contains('{@tool'));
     });
 
     test('can invoke a tool and pass args and environment', () {

--- a/testing/test_package/bin/drill.dart
+++ b/testing/test_package/bin/drill.dart
@@ -36,6 +36,7 @@ void main(List<String> argList) {
     'LIBRARY_NAME',
     'ELEMENT_NAME',
     'INVOCATION_INDEX',
+    'PACKAGE_INVOCATION_INDEX',
   ]);
   Map<String, String> env = <String, String>{}..addAll(Platform.environment);
   env.removeWhere((String key, String value) => !variableNames.contains(key));

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -60,6 +60,8 @@ import 'two_exports.dart' show BaseClass;
 export 'package:test_package_imported/categoryExporting.dart'
     show IAmAClassWithCategories;
 
+export 'src/tool.dart';
+
 // Explicitly export ourselves, because why not.
 // ignore: uri_does_not_exist
 export 'package:test_package/fake.dart';
@@ -1004,3 +1006,15 @@ abstract class MIEEMixin<K, V> implements MIEEThing<K, V> {
 abstract class MIEEThing<K, V> {
   void operator []=(K key, V value);
 }
+
+
+abstract class _NonCanonicalToolUser {
+  /// Invokes a tool without the $INPUT token or args.
+  ///
+  /// {@tool drill}
+  /// Some text in the drill that references [noInvokeTool].
+  /// {@end-tool}
+  void invokeToolNonCanonical();
+}
+
+abstract class CanonicalToolUser extends _NonCanonicalToolUser {}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1007,7 +1007,6 @@ abstract class MIEEThing<K, V> {
   void operator []=(K key, V value);
 }
 
-
 abstract class _NonCanonicalToolUser {
   /// Invokes a tool without the $INPUT token or args.
   ///

--- a/testing/test_package/lib/src/tool.dart
+++ b/testing/test_package/lib/src/tool.dart
@@ -1,0 +1,12 @@
+library test_package.tool;
+
+
+
+abstract class PrivateLibraryToolUser {
+  /// Invokes a tool from a private library.
+  ///
+  /// {@tool drill}
+  /// Some text in the drill.
+  /// {@end-tool}
+  void invokeToolPrivateLibrary();
+}

--- a/testing/test_package/lib/src/tool.dart
+++ b/testing/test_package/lib/src/tool.dart
@@ -1,7 +1,5 @@
 library test_package.tool;
 
-
-
 abstract class PrivateLibraryToolUser {
   /// Invokes a tool from a private library.
   ///


### PR DESCRIPTION
Make `@canonicalFor` no longer able to be detected from macros or tools, but in so doing restrict tool executions to only documentation that will be used (dartdoc-canonical ModelElement instances, or ModelElements that have no canonicalization).

As an aside, this seems to improve dartdoc's overall performance on flutter by about 15%.

