### PR TITLE
Fix crash on invalid prefix imports.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2236,7 +2236,8 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
       _prefixToLibrary = {};
       // It is possible to have overlapping prefixes.
       for (ImportElement i in (element as LibraryElement).imports) {
-        if (i.prefix?.name != null) {
+        // Ignore invalid imports.
+        if (i.prefix?.name != null && i.importedLibrary != null) {
           _prefixToLibrary.putIfAbsent(i.prefix?.name, () => new Set());
           _prefixToLibrary[i.prefix?.name].add(
               new ModelElement.from(i.importedLibrary, library, packageGraph));

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -48,6 +48,9 @@ library fake;
 
 import 'dart:async';
 import 'dart:collection';
+// Make sure dartdoc ignores invalid prefixes imports (#1896)
+// ignore: uri_does_not_exist
+import 'dart:json' as invalidPrefix;
 import 'package:meta/meta.dart' show Required;
 import 'csspub.dart' as css;
 import 'csspub.dart' as renamedLib2;


### PR DESCRIPTION
Fixes #1896.

@isoos 

Ideally, we'd be able to use analyzer warnings/errors to put out a nice error message here, but there are a lot of complications and blocking issues for doing that internally to dartdoc.  For now, just drop the invalid prefix import to avoid the crash and assume the fact that the package doesn't work at all will supercede people from caring about minor inaccuracies in the generated docs.