### PR TITLE
Fix style to avoid deprecation warning

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -545,7 +545,7 @@ footer a, footer a:hover {
 }
 
 .gt-separated li:before {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='#DDDDDD' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='%23DDDDDD' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
   background-position: center;
   content: "\00a0";
   margin: 0 6px 0 4px;
@@ -553,7 +553,7 @@ footer a, footer a:hover {
 }
 
 .gt-separated.dark li:before {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='#727272' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill='%23727272' d='M6.7,4L5.7,4.9L8.8,8l-3.1,3.1L6.7,12l4-4L6.7,4z'/></svg>");
 }
 
 .gt-separated li:first-child:before {


### PR DESCRIPTION
Fixes #1918.

Discovered that this particular style was responsible for the warnings due to two unescaped `#`s.  Escaping it seems to work without breaking anything -- header still looks correct on generated pages.

