### PR TITLE
Reenable scrolling with workaround to chromium issue 927066

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -72,6 +72,7 @@ main {
   display: flex;
   flex-direction: row;
   padding: 20px;
+  min-height: 0;
 }
 
 .sidebar-offcanvas-left {


### PR DESCRIPTION
Fixes #1921.

Uses the workaround at https://bugs.chromium.org/p/chromium/issues/detail?id=927066#c10 to reenable independent column scrolling.