### PR TITLE
Store scroll data by path in sessionStorage

### DIFF
--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -29,20 +29,20 @@ function initSideNav() {
 
 function saveLeftScroll() {
   var leftSidebar = document.getElementById('dartdoc-sidebar-left');
-  sessionStorage.setItem('dartdoc-sidebar-left-scrollt', leftSidebar.scrollTop);
-  sessionStorage.setItem('dartdoc-sidebar-left-scrolll', leftSidebar.scrollLeft);
+  sessionStorage.setItem('dartdoc-sidebar-left-scrollt' + window.location.pathname, leftSidebar.scrollTop);
+  sessionStorage.setItem('dartdoc-sidebar-left-scrolll' + window.location.pathname, leftSidebar.scrollLeft);
 }
 
 function saveMainContentScroll() {
   var mainContent = document.getElementById('dartdoc-main-content');
-  sessionStorage.setItem('dartdoc-main-content-scrollt', mainContent.scrollTop);
-  sessionStorage.setItem('dartdoc-main-content-scrolll', mainContent.scrollLeft);
+  sessionStorage.setItem('dartdoc-main-content-scrollt' + window.location.pathname, mainContent.scrollTop);
+  sessionStorage.setItem('dartdoc-main-content-scrolll' + window.location.pathname, mainContent.scrollLeft);
 }
 
 function saveRightScroll() {
   var rightSidebar = document.getElementById('dartdoc-sidebar-right');
-  sessionStorage.setItem('dartdoc-sidebar-right-scrollt', rightSidebar.scrollTop);
-  sessionStorage.setItem('dartdoc-sidebar-right-scrolll', rightSidebar.scrollLeft);
+  sessionStorage.setItem('dartdoc-sidebar-right-scrollt' + window.location.pathname, rightSidebar.scrollTop);
+  sessionStorage.setItem('dartdoc-sidebar-right-scrolll' + window.location.pathname, rightSidebar.scrollLeft);
 }
 
 function restoreScrolls() {
@@ -51,14 +51,14 @@ function restoreScrolls() {
   var rightSidebar = document.getElementById('dartdoc-sidebar-right');
 
   try {
-    var leftSidebarX = sessionStorage.getItem('dartdoc-sidebar-left-scrolll');
-    var leftSidebarY = sessionStorage.getItem('dartdoc-sidebar-left-scrollt');
+    var leftSidebarX = sessionStorage.getItem('dartdoc-sidebar-left-scrolll' + window.location.pathname);
+    var leftSidebarY = sessionStorage.getItem('dartdoc-sidebar-left-scrollt' + window.location.pathname);
 
-    var mainContentX = sessionStorage.getItem('dartdoc-main-content-scrolll');
-    var mainContentY = sessionStorage.getItem('dartdoc-main-content-scrollt');
+    var mainContentX = sessionStorage.getItem('dartdoc-main-content-scrolll' + window.location.pathname);
+    var mainContentY = sessionStorage.getItem('dartdoc-main-content-scrollt' + window.location.pathname);
 
-    var rightSidebarX = sessionStorage.getItem('dartdoc-sidebar-right-scrolll');
-    var rightSidebarY = sessionStorage.getItem('dartdoc-sidebar-right-scrollt');
+    var rightSidebarX = sessionStorage.getItem('dartdoc-sidebar-right-scrolll' + window.location.pathname);
+    var rightSidebarY = sessionStorage.getItem('dartdoc-sidebar-right-scrollt' + window.location.pathname);
 
     leftSidebar.scrollTo(leftSidebarX, leftSidebarY);
     mainContent.scrollTo(mainContentX, mainContentY);
@@ -78,8 +78,6 @@ function initScrollSave() {
   var rightSidebar = document.getElementById('dartdoc-sidebar-right');
 
   // For portablility, use two different ways of attaching saveLeftScroll to events.
-  // Keep the scroll position from expiring from the cache for a page that's been displayed
-  // a long time but not moved by re-saving its position every hour.
   leftSidebar.onscroll = saveLeftScroll;
   leftSidebar.addEventListener("scroll", saveLeftScroll, true);
   mainContent.onscroll = saveMainContentScroll;


### PR DESCRIPTION
Fixes #1923.

sessionStorage is still origin-wide as is localStorage, rather than local per page.  Reflect this in the keys we store to avoid collisions between different pages.