### PR TITLE
Prepare for 0.28.1+1 (fix hamburger icon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.28.1+1
+* Make hamburger menu appear in Chrome 72.
+
 ## 0.28.1
 * Reenable three-pane scrolling in Chrome 72 (#1922, #1921)
 * A new version of the highlightjs pack supports syntax highlighting for

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.1/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.1+1/%f%#L%l%'

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -755,7 +755,7 @@ button {
 @media screen and (max-width:768px) {
   #sidenav-left-toggle {
     display: inline;
-    background: no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='#111' d='M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z'/></svg>");
+    background: no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='%23111' d='M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z'/></svg>");
     background-position: center;
     width: 24px;
     height: 24px;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.28.1';
+const packageVersion = '0.28.1+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.28.1
+version: 0.28.1+1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc


### PR DESCRIPTION
Fix for #1918 wasn't complete and the hamburger icon suffered the same fate as the greater-than symbols.  Publish a new version to fix the hamburger icon as well.