### PR TITLE
Prepare for 0.28.1+2 and fix search box alignment in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.28.1+2
+* Fix alignment of search box text in Safari (#1926).
+
 ## 0.28.1+1
 * Make hamburger menu appear in Chrome 72.
 

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.1+1/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.1+2/%f%#L%l%'

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -847,8 +847,8 @@ button {
 .tt-hint {
   width: 200px;
   height: 20px;
-  padding: 4px 12px;
-  line-height: 30px;
+  padding: 2px 7px 1px 7px;
+  line-height: 20px;
   outline: none;
 }
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.28.1+1';
+const packageVersion = '0.28.1+2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Also update the `version` field in lib/dartdoc.dart.
-version: 0.28.1+1
+version: 0.28.1+2
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc


### PR DESCRIPTION
Fixes #1926 and verified that Firefox / Chrome are not impacted.  Will publish as a second patch release on 0.28.1.

Before:

<img width="456" alt="safari-old" src="https://user-images.githubusercontent.com/14116827/52293085-e2167a80-292a-11e9-87a5-4a2ecb4b9ae2.png">

After:

<img width="463" alt="safari-new" src="https://user-images.githubusercontent.com/14116827/52293112-f490b400-292a-11e9-9fdf-1ea8ba7bf2c4.png">
