### PR TITLE
Add testing for the set literals experiment

### DIFF
--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -88,18 +88,33 @@ void main() {
   // when the feature is enabled by default.
   group('Experiments', () {
     Library main;
-    TopLevelVariable untypedSet, untypedMap, typedSet;
+    TopLevelVariable aComplexSet, inferredTypeSet, specifiedSet, untypedMap, typedSet;
 
     setUpAll(() {
       main = packageGraphExperiments.libraries.firstWhere((lib) => lib.name == 'main');
-      untypedSet = main.constants.firstWhere((v) => v.name == 'untypedSet');
+      aComplexSet = main.constants.firstWhere((v) => v.name == 'aComplexSet');
+      inferredTypeSet = main.constants.firstWhere((v) => v.name == 'inferredTypeSet');
+      specifiedSet = main.constants.firstWhere((v) => v.name == 'specifiedSet');
       untypedMap = main.constants.firstWhere((v) => v.name == 'untypedMap');
       typedSet = main.constants.firstWhere((v) => v.name == 'typedSet');
-
     });
 
     test('Set literals test', () {
-      expect(main, isNotNull);
+      expect(aComplexSet.modelType.name, equals('Set'));
+      expect(aComplexSet.modelType.typeArguments.map((a) => a.name).toList(), equals(['AClassContainingLiterals']));
+      expect(aComplexSet.constantValue, equals('const {const AClassContainingLiterals(3, 5)}'));
+      expect(inferredTypeSet.modelType.name, equals('Set'));
+      expect(inferredTypeSet.modelType.typeArguments.map((a) => a.name).toList(), equals(['num']));
+      expect(inferredTypeSet.constantValue, equals('const {1, 2.5, 3}'));
+      expect(specifiedSet.modelType.name, equals('Set'));
+      expect(specifiedSet.modelType.typeArguments.map((a) => a.name).toList(), equals(['int']));
+      expect(specifiedSet.constantValue, equals('const {}'));
+      expect(untypedMap.modelType.name, equals('Map'));
+      expect(untypedMap.modelType.typeArguments.map((a) => a.name).toList(), equals(['dynamic', 'dynamic']));
+      expect(untypedMap.constantValue, equals('const {}'));
+      expect(typedSet.modelType.name, equals('Set'));
+      expect(typedSet.modelType.typeArguments.map((a) => a.name).toList(), equals(['String']));
+      expect(typedSet.constantValue, equals('const &lt;String&gt; {}'));
     });
   });
 

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -53,6 +53,7 @@ void main() {
   PackageGraph packageGraph;
   PackageGraph packageGraphSmall;
   PackageGraph packageGraphErrors;
+  PackageGraph packageGraphExperiments;
   PackageGraph ginormousPackageGraph;
   Library exLibrary;
   Library fakeLibrary;
@@ -67,6 +68,7 @@ void main() {
     packageGraph = utils.testPackageGraph;
     packageGraphSmall = utils.testPackageGraphSmall;
     packageGraphErrors = utils.testPackageGraphErrors;
+    packageGraphExperiments = utils.testPackageGraphExperiments;
     ginormousPackageGraph = utils.testPackageGraphGinormous;
     exLibrary = packageGraph.libraries.firstWhere((lib) => lib.name == 'ex');
     errorLibrary = packageGraphErrors.libraries
@@ -80,6 +82,25 @@ void main() {
     interceptorsLib = packageGraph.libraries
         .firstWhere((lib) => lib.name == 'dart:_interceptors');
     sdkAsPackageGraph = utils.testPackageGraphSdk;
+  });
+
+  // Experimental features not yet enabled by default.  Move tests out of this block
+  // when the feature is enabled by default.
+  group('Experiments', () {
+    Library main;
+    TopLevelVariable untypedSet, untypedMap, typedSet;
+
+    setUpAll(() {
+      main = packageGraphExperiments.libraries.firstWhere((lib) => lib.name == 'main');
+      untypedSet = main.constants.firstWhere((v) => v.name == 'untypedSet');
+      untypedMap = main.constants.firstWhere((v) => v.name == 'untypedMap');
+      typedSet = main.constants.firstWhere((v) => v.name == 'typedSet');
+
+    });
+
+    test('Set literals test', () {
+      expect(main, isNotNull);
+    });
   });
 
   group('Tools', () {

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -21,6 +21,7 @@ final RegExp observatoryPortRegexp =
 Directory sdkDir;
 PackageMeta sdkPackageMeta;
 PackageGraph testPackageGraph;
+PackageGraph testPackageGraphExperiments;
 PackageGraph testPackageGraphGinormous;
 PackageGraph testPackageGraphSmall;
 PackageGraph testPackageGraphErrors;
@@ -28,6 +29,7 @@ PackageGraph testPackageGraphSdk;
 
 final Directory testPackageBadDir = new Directory('testing/test_package_bad');
 final Directory testPackageDir = new Directory('testing/test_package');
+final Directory testPackageExperimentsDir = new Directory('testing/test_package_experiments');
 final Directory testPackageMinimumDir =
     new Directory('testing/test_package_minimum');
 final Directory testPackageWithEmbedderYaml =
@@ -77,6 +79,11 @@ void init({List<String> additionalArguments}) async {
       'testing/test_package', ['css', 'code_in_commnets', 'excluded'],
       additionalArguments:
           additionalArguments + ['--auto-include-dependencies']);
+
+  testPackageGraphExperiments = await bootBasicPackage(
+      'testing/test_package_experiments', [],
+      additionalArguments: additionalArguments + ['--enable-experiment', 'set-literals']
+  );
 
   testPackageGraphSmall = await bootBasicPackage(
       'testing/test_package_small', [],

--- a/testing/test_package_experiments/lib/main.dart
+++ b/testing/test_package_experiments/lib/main.dart
@@ -1,0 +1,8 @@
+const untypedSet = {1, 2, 3};
+const untypedMap = {};
+final typedSet = <String>{};
+
+class AClassContainingLiterals {
+  final Set<int> inferredSet = {};
+}
+

--- a/testing/test_package_experiments/lib/main.dart
+++ b/testing/test_package_experiments/lib/main.dart
@@ -1,8 +1,16 @@
-const untypedSet = {1, 2, 3};
+const inferredTypeSet = {1, 2.5, 3};
+const Set<int> specifiedSet = const {};
 const untypedMap = {};
-final typedSet = <String>{};
+const typedSet = <String>{};
 
 class AClassContainingLiterals {
-  final Set<int> inferredSet = {};
+  final int value1;
+  final int value2;
+
+  const AClassContainingLiterals(this.value1, this.value2);
+
+  @override
+  bool operator==(Object other) => other is AClassContainingLiterals && value1 == other.value1;
 }
 
+const aComplexSet = {AClassContainingLiterals(3, 5)};

--- a/testing/test_package_experiments/pubspec.yaml
+++ b/testing/test_package_experiments/pubspec.yaml
@@ -1,0 +1,3 @@
+name: test_package_experiments
+version: 0.0.1
+description: Experimental flags are tested here.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -801,7 +801,6 @@ final _generated_files_list = <String>[
 Future<void> checkBuild() async {
   var originalFileContents = new Map<String, String>();
   var differentFiles = <String>[];
-  var launcher = new SubprocessLauncher('check-build');
 
   // Load original file contents into memory before running the builder;
   // it modifies them in place.


### PR DESCRIPTION
Fixes #1826.  Dartdoc support is already adequate for rendering set literals, but this adds tests to make sure we don't regress.  From the new experimental test package:

![screenshot from 2019-02-05 14-20-23](https://user-images.githubusercontent.com/14116827/52308293-cb374e80-2951-11e9-8afd-ac93de971724.png)


