### PR TITLE
Update for latest sdk analyzer and work around dart:ffi

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.1.0-dev.9.4 <3.0.0'
 
 dependencies:
-  analyzer: ^0.35.0
+  analyzer: ^0.35.1
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -114,7 +114,7 @@ void main() {
       expect(untypedMap.constantValue, equals('const {}'));
       expect(typedSet.modelType.name, equals('Set'));
       expect(typedSet.modelType.typeArguments.map((a) => a.name).toList(), equals(['String']));
-      expect(typedSet.constantValue, matches(new RegExp(r'const &lt;String&gt;\s+{}')));
+      expect(typedSet.constantValue, matches(new RegExp(r'const &lt;String&gt;\s?{}')));
     });
   });
 
@@ -3043,7 +3043,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('PRETTY_COLORS', () {
       expect(prettyColorsConstant.constantValue, matches(new RegExp(
-          r"const &lt;String&gt;\s+\[COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;\]")));
+          r"const &lt;String&gt;\s?\[COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;\]")));
     });
 
     test('MY_CAT is linked', () {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -114,7 +114,7 @@ void main() {
       expect(untypedMap.constantValue, equals('const {}'));
       expect(typedSet.modelType.name, equals('Set'));
       expect(typedSet.modelType.typeArguments.map((a) => a.name).toList(), equals(['String']));
-      expect(typedSet.constantValue, equals('const &lt;String&gt; {}'));
+      expect(typedSet.constantValue, matches(new RegExp(r'const &lt;String&gt;\s+{}')));
     });
   });
 
@@ -3042,8 +3042,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('PRETTY_COLORS', () {
-      expect(prettyColorsConstant.constantValue,
-          "const &lt;String&gt; [COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;]");
+      expect(prettyColorsConstant.constantValue, matches(new RegExp(
+          r"const &lt;String&gt;\s+\[COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;\]")));
     });
 
     test('MY_CAT is linked', () {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -959,6 +959,8 @@ Future<void> testDartdocFlutterPlugin() async {
 @Task('Validate the SDK doc build.')
 @Depends(buildSdkDocs)
 void validateSdkDocs() {
+  // TODO(jcollins-g): Remove flexibility in library counts once dev build
+  // includes https://dart-review.googlesource.com/c/sdk/+/93160
   const expectedLibCounts = [0, 1];
   const expectedSubLibCount = [19, 20];
   const expectedTotalCount = [19, 20];

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -959,8 +959,9 @@ Future<void> testDartdocFlutterPlugin() async {
 @Task('Validate the SDK doc build.')
 @Depends(buildSdkDocs)
 void validateSdkDocs() {
-  const expectedLibCount = 0;
-  const expectedSubLibCount = 19;
+  const expectedLibCounts = [0, 1];
+  const expectedSubLibCount = [19, 20];
+  const expectedTotalCount = [19, 20];
   File indexHtml = joinFile(sdkDocsDir, ['index.html']);
   if (!indexHtml.existsSync()) {
     fail('no index.html found for SDK docs');
@@ -968,15 +969,15 @@ void validateSdkDocs() {
   log('found index.html');
   String indexContents = indexHtml.readAsStringSync();
   int foundLibs = _findCount(indexContents, '  <li><a href="dart-');
-  if (foundLibs != expectedLibCount) {
+  if (!expectedLibCounts.contains(foundLibs)) {
     fail(
-        'expected $expectedLibCount dart: index.html entries, found $foundLibs');
+        'expected $expectedTotalCount dart: index.html entries, found $foundLibs');
   }
   log('$foundLibs index.html dart: entries found');
 
   int foundSubLibs =
       _findCount(indexContents, '<li class="section-subitem"><a href="dart-');
-  if (foundSubLibs != expectedSubLibCount) {
+  if (!expectedSubLibCount.contains(foundSubLibs)) {
     fail(
         'expected $expectedSubLibCount dart: index.html entries in categories, found $foundSubLibs');
   }
@@ -985,9 +986,9 @@ void validateSdkDocs() {
   // check for the existence of certain files/dirs
   var libsLength =
       sdkDocsDir.listSync().where((fs) => fs.path.contains('dart-')).length;
-  if (libsLength != expectedLibCount + expectedSubLibCount) {
+  if (!expectedTotalCount.contains(libsLength)) {
     fail('docs not generated for all the SDK libraries, '
-        'expected ${expectedLibCount + expectedSubLibCount} directories, generated $libsLength directories');
+        'expected ${expectedTotalCount + expectedTotalCount} directories, generated $libsLength directories');
   }
   log('$libsLength dart: libraries found');
 


### PR DESCRIPTION
Before https://dart-review.googlesource.com/c/sdk/+/93160 lands in a dev build, work around the addition of the library to the libraries list.

Also allow for removing a space after the type in rendered output for set literals.