### PR TITLE
Adding youtube directive for embedding YouTube videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.28.3
+* Support a new `{@youtube}` directive in documentation comments to embed
+  YouTubeVideos.
+
 ## 0.28.2
 * Add empty CSS classes in spans around the names of entities so Dashing can pick
   them up.  (flutter/flutter#27654, #1929)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.28.3
 * Support a new `{@youtube}` directive in documentation comments to embed
-  YouTubeVideos.
+  YouTube videos.
 
 ## 0.28.2
 * Add empty CSS classes in spans around the names of entities so Dashing can pick

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.2/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.3/%f%#L%l%'

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4083,7 +4083,7 @@ abstract class ModelElement extends Canonicalization
 
     // Matches YouTube IDs from supported YouTube URLs.
     final RegExp validYouTubeUrlRegExp =
-        new RegExp('https://www\.youtube\.com/watch\\?v=(.+)');
+        new RegExp('https://www\.youtube\.com/watch\\?v=([^&]+)\$');
 
     return rawDocs.replaceAllMapped(basicAnimationRegExp, (basicMatch) {
       final ArgParser parser = new ArgParser();
@@ -4131,7 +4131,7 @@ abstract class ModelElement extends Canonicalization
       return '''
 
 <p>
-  <iframe src="https://www.youtube.com/embed/$youTubeId"
+  <iframe src="https://www.youtube.com/embed/$youTubeId?rel=0"
           width="$width"
           height="$height"
           frameborder="0"

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4106,24 +4106,18 @@ abstract class ModelElement extends Canonicalization
         return '';
       }
 
-      int width;
-      try {
-        width = int.parse(positionalArgs[0]);
-      } on FormatException {
+      final int width = int.tryParse(positionalArgs[0]);
+      if (width == null || width <= 0) {
         warn(PackageWarning.invalidParameter,
             message: 'A @youtube directive has an invalid width, '
-                '"${positionalArgs[0]}". The width must be an integer.');
-        return '';
+                '"${positionalArgs[0]}". The width must be a positive integer.');
       }
 
-      int height;
-      try {
-        height = int.parse(positionalArgs[1]);
-      } on FormatException {
+      final int height = int.tryParse(positionalArgs[1]);
+      if (height == null || height <= 0) {
         warn(PackageWarning.invalidParameter,
             message: 'A @youtube directive has an invalid height, '
-                '"${positionalArgs[1]}". The height must be an integer.');
-        return '';
+                '"${positionalArgs[1]}". The height must be a positive integer.');
       }
 
       final Match url = validYouTubeUrlRegExp.firstMatch(positionalArgs[2]);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4068,13 +4068,16 @@ abstract class ModelElement extends Canonicalization
   ///     &#123;@youtube 560 315 https://www.youtube.com/watch?v=oHg5SJYRHA0&#125;
   ///
   /// Which will embed a YouTube player into the page that plays the specified
-  /// videos.
+  /// video.
   ///
   /// The width and height must be positive integers specifying the dimensions
-  /// of the video in pixels. The video URL must have the following format:
-  /// https://www.youtube.com/watch?v=oHg5SJYRHA0. When viewing a YouTube video
-  /// in a browser, the URL shown in the browser's address bar has the correct
-  /// format and can be copied to be used in this directive.
+  /// of the video in pixels. The height and width are used to calculate the
+  /// aspect ratio of the video; the video is always rendered to take up all
+  /// available horizontal space.
+  ///
+  /// The video URL must have the following format:
+  /// https://www.youtube.com/watch?v=oHg5SJYRHA0. This format can usually be
+  /// found in the address bar of the browser when viewing a YouTube video.
   String _injectYouTube(String rawDocs) {
     // Matches all youtube directives (even some invalid ones). This is so
     // we can give good error messages if the directive is malformed, instead of
@@ -4124,21 +4127,30 @@ abstract class ModelElement extends Canonicalization
         return '';
       }
       final String youTubeId = url.group(url.groupCount);
+      final String aspectRatio = (height / width * 100).toStringAsFixed(2);
 
       // Blank lines before and after, and no indenting at the beginning and end
       // is needed so that Markdown doesn't confuse this with code, so be
       // careful of whitespace here.
       return '''
 
-<p>
+<div style="position: relative;
+            padding-top: $aspectRatio%;">
   <iframe src="https://www.youtube.com/embed/$youTubeId?rel=0"
-          width="$width"
-          height="$height"
           frameborder="0"
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen>
+          allow="accelerometer;
+                 autoplay;
+                 encrypted-media;
+                 gyroscope;
+                 picture-in-picture"
+          allowfullscreen
+          style="position: absolute;
+                 top: 0;
+                 left: 0;
+                 width: 100%;
+                 height: 100%;">
   </iframe>
-</p>
+</div>
 
 '''; // String must end at beginning of line, or following inline text will be
       // indented.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4073,7 +4073,8 @@ abstract class ModelElement extends Canonicalization
   /// The width and height must be positive integers specifying the dimensions
   /// of the video in pixels. The height and width are used to calculate the
   /// aspect ratio of the video; the video is always rendered to take up all
-  /// available horizontal space.
+  /// available horizontal space to accommodate different screen sizes on
+  /// desktop and mobile.
   ///
   /// The video URL must have the following format:
   /// https://www.youtube.com/watch?v=oHg5SJYRHA0. This format can usually be

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4070,16 +4070,11 @@ abstract class ModelElement extends Canonicalization
   /// Which will embed a YouTube player into the page that plays the specified
   /// videos.
   ///
-  /// The width and height must be integers specifying the dimensions of the
-  /// video in pixels.
-  ///
-  /// The following YouTube URL formats are supported:
-  ///
-  ///  * https://www.youtube.com/watch?v=oHg5SJYRHA0 (as shown in the browser's
-  ///    address bar)
-  ///  * https://youtu.be/oHg5SJYRHA0 (as shown in the "Share" dialog)
-  ///  * https://www.youtube.com/embed/oHg5SJYRHA0 (as shown in the "Share ->
-  ///    Embed" dialog)
+  /// The width and height must be positive integers specifying the dimensions
+  /// of the video in pixels. The video URL must have the following format:
+  /// https://www.youtube.com/watch?v=oHg5SJYRHA0. When viewing a YouTube video
+  /// in a browser, the URL shown in the browser's address bar has the correct
+  /// format and can be copied to be used in this directive.
   String _injectYouTube(String rawDocs) {
     // Matches all youtube directives (even some invalid ones). This is so
     // we can give good error messages if the directive is malformed, instead of
@@ -4087,8 +4082,8 @@ abstract class ModelElement extends Canonicalization
     final RegExp basicAnimationRegExp = new RegExp(r'''{@youtube\s+([^}]+)}''');
 
     // Matches YouTube IDs from supported YouTube URLs.
-    final RegExp validYouTubeUrlRegExp = new RegExp(
-        'https://((youtu\.be/)|(www\.youtube\.com/((watch\\?v=)|(embed/))))(.+)');
+    final RegExp validYouTubeUrlRegExp =
+        new RegExp('https://www\.youtube\.com/watch\\?v=(.+)');
 
     return rawDocs.replaceAllMapped(basicAnimationRegExp, (basicMatch) {
       final ArgParser parser = new ArgParser();
@@ -4124,11 +4119,8 @@ abstract class ModelElement extends Canonicalization
       if (url == null) {
         warn(PackageWarning.invalidParameter,
             message: 'A @youtube directive has an invalid URL: '
-                '"${positionalArgs[2]}". Supported YouTube URLs have one of '
-                'the following formats: '
-                'https://www.youtube.com/watch?v=oHg5SJYRHA0, '
-                'https://youtu.be/oHg5SJYRHA0, or '
-                'https://www.youtube.com/embed/oHg5SJYRHA0');
+                '"${positionalArgs[2]}". Supported YouTube URLs have the '
+                'follwing format: https://www.youtube.com/watch?v=oHg5SJYRHA0.');
         return '';
       }
       final String youTubeId = url.group(url.groupCount);

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4134,8 +4134,8 @@ abstract class ModelElement extends Canonicalization
       // careful of whitespace here.
       return '''
 
-<div style="position: relative;
-            padding-top: $aspectRatio%;">
+<p style="position: relative;
+          padding-top: $aspectRatio%;">
   <iframe src="https://www.youtube.com/embed/$youTubeId?rel=0"
           frameborder="0"
           allow="accelerometer;
@@ -4150,7 +4150,7 @@ abstract class ModelElement extends Canonicalization
                  width: 100%;
                  height: 100%;">
   </iframe>
-</div>
+</p>
 
 '''; // String must end at beginning of line, or following inline text will be
       // indented.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4144,13 +4144,15 @@ abstract class ModelElement extends Canonicalization
       // careful of whitespace here.
       return '''
 
-<iframe src="https://www.youtube.com/embed/$youTubeId"
-        width="$width" 
-        height="$height" 
-        frameborder="0"
-        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" 
-        allowfullscreen>
-</iframe>
+<p>
+  <iframe src="https://www.youtube.com/embed/$youTubeId"
+          width="$width"
+          height="$height"
+          frameborder="0"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen>
+  </iframe>
+</p>
 
 '''; // String must end at beginning of line, or following inline text will be
       // indented.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.28.2';
+const packageVersion = '0.28.3';

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -396,6 +396,7 @@ class PackageWarningCounter {
   bool hasWarning(Warnable element, PackageWarning kind, String message) {
     Tuple2<PackageWarning, String> warningData = new Tuple2(kind, message);
     if (countedWarnings.containsKey(element?.element)) {
+      print(countedWarnings[element?.element]);
       return countedWarnings[element?.element].contains(warningData);
     }
     return false;

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -396,7 +396,6 @@ class PackageWarningCounter {
   bool hasWarning(Warnable element, PackageWarning kind, String message) {
     Tuple2<PackageWarning, String> warningData = new Tuple2(kind, message);
     if (countedWarnings.containsKey(element?.element)) {
-      print(countedWarnings[element?.element]);
       return countedWarnings[element?.element].contains(warningData);
     }
     return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.28.2
+version: 0.28.3
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -956,10 +956,8 @@ void main() {
               PackageWarning.invalidParameter,
               'A @youtube directive has an invalid URL: '
               '"http://host/path/to/video.mp4". Supported YouTube URLs have '
-              'one of the following formats: '
-              'https://www.youtube.com/watch?v=oHg5SJYRHA0, '
-              'https://youtu.be/oHg5SJYRHA0, or '
-              'https://www.youtube.com/embed/oHg5SJYRHA0'),
+              'the follwing format: '
+              'https://www.youtube.com/watch?v=oHg5SJYRHA0.'),
           isTrue);
     });
   });
@@ -967,8 +965,6 @@ void main() {
   group('YouTube', () {
     Class dog;
     Method withYouTubeWatchUrl;
-    Method withYouTubeEmbedUrl;
-    Method withYouTubeShortUrl;
     Method withYouTubeInOneLineDoc;
     Method withYouTubeInline;
 
@@ -976,10 +972,6 @@ void main() {
       dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
       withYouTubeWatchUrl = dog.allInstanceMethods
           .firstWhere((m) => m.name == 'withYouTubeWatchUrl');
-      withYouTubeEmbedUrl = dog.allInstanceMethods
-          .firstWhere((m) => m.name == 'withYouTubeEmbedUrl');
-      withYouTubeShortUrl = dog.allInstanceMethods
-          .firstWhere((m) => m.name == 'withYouTubeShortUrl');
       withYouTubeInOneLineDoc = dog.allInstanceMethods
           .firstWhere((m) => m.name == 'withYouTubeInOneLineDoc');
       withYouTubeInline = dog.allInstanceMethods
@@ -988,18 +980,6 @@ void main() {
 
     test("renders a YouTube video within the method documentation", () {
       expect(withYouTubeWatchUrl.documentation,
-          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
-    });
-    test(
-        "renders a YouTube video with embeded URL within the method documentation",
-        () {
-      expect(withYouTubeEmbedUrl.documentation,
-          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
-    });
-    test(
-        "renders a YouTube video with short URL within the method documentation",
-        () {
-      expect(withYouTubeShortUrl.documentation,
           contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
     });
     test("Doesn't place YouTube video in one line doc", () {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -903,6 +903,7 @@ void main() {
     Method withYouTubeBadWidth;
     Method withYouTubeBadHeight;
     Method withYouTubeInvalidUrl;
+    Method withYouTubeUrlWithAdditionalParameters;
 
     setUpAll(() {
       documentationErrors = errorLibrary.classes
@@ -920,6 +921,9 @@ void main() {
       withYouTubeInvalidUrl = documentationErrors.allInstanceMethods
           .firstWhere((m) => m.name == 'withYouTubeInvalidUrl')
             ..documentation;
+      withYouTubeUrlWithAdditionalParameters = documentationErrors.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeUrlWithAdditionalParameters')
+        ..documentation;
     });
 
     test("warns on youtube video with missing parameters", () {
@@ -960,6 +964,17 @@ void main() {
               'https://www.youtube.com/watch?v=oHg5SJYRHA0.'),
           isTrue);
     });
+    test("warns on youtube video with extra parameters in URL", () {
+      expect(
+          packageGraphErrors.packageWarningCounter.hasWarning(
+              withYouTubeUrlWithAdditionalParameters,
+              PackageWarning.invalidParameter,
+              'A @youtube directive has an invalid URL: '
+              '"https://www.youtube.com/watch?v=yI-8QHpGIP4&list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG&index=5". '
+              'Supported YouTube URLs have the follwing format: '
+              'https://www.youtube.com/watch?v=oHg5SJYRHA0.'),
+          isTrue);
+    });
   });
 
   group('YouTube', () {
@@ -980,15 +995,15 @@ void main() {
 
     test("renders a YouTube video within the method documentation", () {
       expect(withYouTubeWatchUrl.documentation,
-          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
+          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0?rel=0"'));
     });
     test("Doesn't place YouTube video in one line doc", () {
       expect(
           withYouTubeInOneLineDoc.oneLineDoc,
           isNot(contains(
-              '<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"')));
+              '<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0?rel=0"')));
       expect(withYouTubeInOneLineDoc.documentation,
-          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
+          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0?rel=0"'));
     });
     test("Handles YouTube video inline properly", () {
       // Make sure it doesn't have a double-space before the continued line,

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -897,6 +897,126 @@ void main() {
     });
   });
 
+  group('YouTube Errors', () {
+    Class documentationErrors;
+    Method withYouTubeWrongParams;
+    Method withYouTubeBadWidth;
+    Method withYouTubeBadHeight;
+    Method withYouTubeInvalidUrl;
+
+    setUpAll(() {
+      documentationErrors = errorLibrary.classes
+          .firstWhere((c) => c.name == 'DocumentationErrors')
+            ..documentation;
+      withYouTubeWrongParams = documentationErrors.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeWrongParams')
+            ..documentation;
+      withYouTubeBadWidth = documentationErrors.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeBadWidth')
+            ..documentation;
+      withYouTubeBadHeight = documentationErrors.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeBadHeight')
+            ..documentation;
+      withYouTubeInvalidUrl = documentationErrors.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeInvalidUrl')
+            ..documentation;
+    });
+
+    test("warns on youtube video with missing parameters", () {
+      expect(
+          packageGraphErrors.packageWarningCounter.hasWarning(
+              withYouTubeWrongParams,
+              PackageWarning.invalidParameter,
+              'Invalid @youtube directive, "{@youtube https://youtu.be/oHg5SJYRHA0}"\n'
+              'YouTube directives must be of the form "{@youtube WIDTH HEIGHT URL}"'),
+          isTrue);
+    });
+    test("warns on youtube video with non-integer width", () {
+      expect(
+          packageGraphErrors.packageWarningCounter.hasWarning(
+              withYouTubeBadWidth,
+              PackageWarning.invalidParameter,
+              'A @youtube directive has an invalid width, "100px". The width '
+              'must be an integer.'),
+          isTrue);
+    });
+    test("warns on youtube video with non-integer height", () {
+      expect(
+          packageGraphErrors.packageWarningCounter.hasWarning(
+              withYouTubeBadHeight,
+              PackageWarning.invalidParameter,
+              'A @youtube directive has an invalid height, "100px". The height '
+              'must be an integer.'),
+          isTrue);
+    });
+    test("warns on youtube video with invalid video URL", () {
+      expect(
+          packageGraphErrors.packageWarningCounter.hasWarning(
+              withYouTubeInvalidUrl,
+              PackageWarning.invalidParameter,
+              'A @youtube directive has an invalid URL: '
+              '"http://host/path/to/video.mp4". Supported YouTube URLs have '
+              'one of the following formats: '
+              'https://www.youtube.com/watch?v=oHg5SJYRHA0, '
+              'https://youtu.be/oHg5SJYRHA0, or '
+              'https://www.youtube.com/embed/oHg5SJYRHA0'),
+          isTrue);
+    });
+  });
+
+  group('YouTube', () {
+    Class dog;
+    Method withYouTubeWatchUrl;
+    Method withYouTubeEmbedUrl;
+    Method withYouTubeShortUrl;
+    Method withYouTubeInOneLineDoc;
+    Method withYouTubeInline;
+
+    setUpAll(() {
+      dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
+      withYouTubeWatchUrl = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeWatchUrl');
+      withYouTubeEmbedUrl = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeEmbedUrl');
+      withYouTubeShortUrl = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeShortUrl');
+      withYouTubeInOneLineDoc = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeInOneLineDoc');
+      withYouTubeInline = dog.allInstanceMethods
+          .firstWhere((m) => m.name == 'withYouTubeInline');
+    });
+
+    test("renders a YouTube video within the method documentation", () {
+      expect(withYouTubeWatchUrl.documentation,
+          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
+    });
+    test(
+        "renders a YouTube video with embeded URL within the method documentation",
+        () {
+      expect(withYouTubeEmbedUrl.documentation,
+          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
+    });
+    test(
+        "renders a YouTube video with short URL within the method documentation",
+        () {
+      expect(withYouTubeShortUrl.documentation,
+          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
+    });
+    test("Doesn't place YouTube video in one line doc", () {
+      expect(
+          withYouTubeInOneLineDoc.oneLineDoc,
+          isNot(contains(
+              '<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"')));
+      expect(withYouTubeInOneLineDoc.documentation,
+          contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0"'));
+    });
+    test("Handles YouTube video inline properly", () {
+      // Make sure it doesn't have a double-space before the continued line,
+      // which would indicate to Markdown to indent the line.
+      expect(withYouTubeInline.documentation, isNot(contains('  works')));
+    });
+  });
+
   group('Animation Errors', () {
     Class documentationErrors;
     Method withInvalidNamedAnimation;
@@ -1790,7 +1910,7 @@ void main() {
     });
 
     test('get methods', () {
-      expect(Dog.publicInstanceMethods, hasLength(19));
+      expect(Dog.publicInstanceMethods, hasLength(24));
     });
 
     test('get operators', () {
@@ -1865,7 +1985,12 @@ void main() {
             'withNamedAnimation',
             'withPrivateMacro',
             'withQuotedNamedAnimation',
-            'withUndefinedMacro'
+            'withUndefinedMacro',
+            'withYouTubeEmbedUrl',
+            'withYouTubeWatchUrl',
+            'withYouTubeInline',
+            'withYouTubeInOneLineDoc',
+            'withYouTubeShortUrl',
           ]));
     });
 

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1890,7 +1890,7 @@ void main() {
     });
 
     test('get methods', () {
-      expect(Dog.publicInstanceMethods, hasLength(24));
+      expect(Dog.publicInstanceMethods, hasLength(22));
     });
 
     test('get operators', () {
@@ -1966,11 +1966,9 @@ void main() {
             'withPrivateMacro',
             'withQuotedNamedAnimation',
             'withUndefinedMacro',
-            'withYouTubeEmbedUrl',
-            'withYouTubeWatchUrl',
             'withYouTubeInline',
             'withYouTubeInOneLineDoc',
-            'withYouTubeShortUrl',
+            'withYouTubeWatchUrl',
           ]));
     });
 

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -993,9 +993,11 @@ void main() {
           .firstWhere((m) => m.name == 'withYouTubeInline');
     });
 
-    test("renders a YouTube video within the method documentation", () {
+    test("renders a YouTube video within the method documentation with correct aspect ratio", () {
       expect(withYouTubeWatchUrl.documentation,
           contains('<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0?rel=0"'));
+      // Video is 560x315, which means height is 56.25% of width.
+      expect(withYouTubeWatchUrl.documentation, contains('padding-top: 56.25%;'));
     });
     test("Doesn't place YouTube video in one line doc", () {
       expect(

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -937,7 +937,7 @@ void main() {
               withYouTubeBadWidth,
               PackageWarning.invalidParameter,
               'A @youtube directive has an invalid width, "100px". The width '
-              'must be an integer.'),
+              'must be a positive integer.'),
           isTrue);
     });
     test("warns on youtube video with non-integer height", () {
@@ -946,7 +946,7 @@ void main() {
               withYouTubeBadHeight,
               PackageWarning.invalidParameter,
               'A @youtube directive has an invalid height, "100px". The height '
-              'must be an integer.'),
+              'must be a positive integer.'),
           isTrue);
     });
     test("warns on youtube video with invalid video URL", () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -356,7 +356,7 @@ class Dog implements Cat, E {
 
   /// YouTube video method
   ///
-  /// {@youtube 100 100 https://www.youtube.com/watch?v=oHg5SJYRHA0}
+  /// {@youtube 560 315 https://www.youtube.com/watch?v=oHg5SJYRHA0}
   /// More docs
   void withYouTubeWatchUrl() {}
 

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -354,6 +354,35 @@ class Dog implements Cat, E {
   /// Don't define this:  {@macro ThatDoesNotExist}
   void withUndefinedMacro() {}
 
+  /// YouTube video method
+  ///
+  /// {@youtube 100 100 https://www.youtube.com/watch?v=oHg5SJYRHA0}
+  /// More docs
+  void withYouTubeWatchUrl() {}
+
+  /// YouTube video method
+  ///
+  /// {@youtube 100 100 https://www.youtube.com/embed/oHg5SJYRHA0}
+  /// More docs
+  void withYouTubeEmbedUrl() {}
+
+  /// YouTube video method
+  ///
+  /// {@youtube 100 100 https://youtu.be/oHg5SJYRHA0}
+  /// More docs
+  void withYouTubeShortUrl() {}
+
+  /// YouTube video in one line doc {@youtube 100 100 https://youtu.be/oHg5SJYRHA0}
+  ///
+  /// This tests to see that we do the right thing if the animation is in
+  /// the one line doc above.
+  void withYouTubeInOneLineDoc() {}
+
+  /// YouTube video inline in text.
+  ///
+  /// Tests to see that an inline {@youtube 100 100 https://youtu.be/oHg5SJYRHA0} works as expected.
+  void withYouTubeInline() {}
+
   /// Animation method
   ///
   /// {@animation 100 100 http://host/path/to/video.mp4}

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -360,19 +360,7 @@ class Dog implements Cat, E {
   /// More docs
   void withYouTubeWatchUrl() {}
 
-  /// YouTube video method
-  ///
-  /// {@youtube 100 100 https://www.youtube.com/embed/oHg5SJYRHA0}
-  /// More docs
-  void withYouTubeEmbedUrl() {}
-
-  /// YouTube video method
-  ///
-  /// {@youtube 100 100 https://youtu.be/oHg5SJYRHA0}
-  /// More docs
-  void withYouTubeShortUrl() {}
-
-  /// YouTube video in one line doc {@youtube 100 100 https://youtu.be/oHg5SJYRHA0}
+  /// YouTube video in one line doc {@youtube 100 100 https://www.youtube.com/watch?v=oHg5SJYRHA0}
   ///
   /// This tests to see that we do the right thing if the animation is in
   /// the one line doc above.
@@ -380,7 +368,7 @@ class Dog implements Cat, E {
 
   /// YouTube video inline in text.
   ///
-  /// Tests to see that an inline {@youtube 100 100 https://youtu.be/oHg5SJYRHA0} works as expected.
+  /// Tests to see that an inline {@youtube 100 100 https://www.youtube.com/watch?v=oHg5SJYRHA0} works as expected.
   void withYouTubeInline() {}
 
   /// Animation method

--- a/testing/test_package_doc_errors/lib/doc_errors.dart
+++ b/testing/test_package_doc_errors/lib/doc_errors.dart
@@ -27,6 +27,11 @@ abstract class DocumentationErrors {
   /// {@youtube 100 100 http://host/path/to/video.mp4}
   void withYouTubeInvalidUrl() {}
 
+  /// YouTube video with extra parameters in URL.
+  ///
+  /// {@youtube 100 100 https://www.youtube.com/watch?v=yI-8QHpGIP4&list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG&index=5}
+  void withYouTubeUrlWithAdditionalParameters() {}
+
   /// Animation method with invalid name
   ///
   /// {@animation 100 100 http://host/path/to/video.mp4 id=2isNot-A-ValidName}

--- a/testing/test_package_doc_errors/lib/doc_errors.dart
+++ b/testing/test_package_doc_errors/lib/doc_errors.dart
@@ -4,6 +4,29 @@ library doc_errors;
 // This is the place to put documentation that has errors in it:
 // This package is expected to fail.
 abstract class DocumentationErrors {
+  /// Malformed YouTube video method with wrong parameters
+  ///
+  /// {@youtube https://youtu.be/oHg5SJYRHA0}
+  /// More docs
+  void withYouTubeWrongParams() {}
+
+  /// Malformed YouTube video method with non-integer width
+  ///
+  /// {@youtube 100px 100 https://youtu.be/oHg5SJYRHA0}
+  /// More docs
+  void withYouTubeBadWidth() {}
+
+  /// Malformed YouTube video method with non-integer height
+  ///
+  /// {@youtube 100 100px https://youtu.be/oHg5SJYRHA0}
+  /// More docs
+  void withYouTubeBadHeight() {}
+
+  /// YouTube video with an invalid URL.
+  ///
+  /// {@youtube 100 100 http://host/path/to/video.mp4}
+  void withYouTubeInvalidUrl() {}
+
   /// Animation method with invalid name
   ///
   /// {@animation 100 100 http://host/path/to/video.mp4 id=2isNot-A-ValidName}


### PR DESCRIPTION
This PR adds an youtube directive that allows embedding YouTube videos. Flutter would like to use this to embed the "Widget of the Week" videos ([example](https://www.youtube.com/watch?v=eI43jkQkrvs)) right into the API docs.

The syntax for adding a YouTube video is:

```
{@youtube 560 315 https://www.youtube.com/watch?v=oHg5SJYRHA0}
```

The integers are the width and height of the video, followed by the YouTube URL of the video. The following YouTube URL format is supported: https://www.youtube.com/watch?v=oHg5SJYRHA0 (as shown in the browser's address bar).