### PR TITLE
Fix iOS scroll physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.28.3+1
+* Fix scroll physics and behavior for Safari on iOS.
+
 ## 0.28.3
 * Support a new `{@youtube}` directive in documentation comments to embed
   YouTube videos.
@@ -137,7 +140,7 @@
 ## 0.22.0
 * Documentation updates. (#1760)
 * Fix incompatibility with head analyzer (endsWith exception). (#1768)
-* Added the ability to run external tools on a section of documentation and 
+* Added the ability to run external tools on a section of documentation and
   replace it with the output of the tool.
 
 ## 0.21.1

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.3/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.3+1/%f%#L%l%'

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -28,7 +28,7 @@ body {
 body {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  -webkit-overflow-scrolling: touch;
 }
 
 header {
@@ -88,7 +88,6 @@ main {
 ::-webkit-scrollbar-thumb{ background-color: #CCC; }
 ::-webkit-scrollbar-thumb:hover{ background-color: #CCC; }
 ::-webkit-scrollbar{ width: 4px; }
-::-webkit-overflow-scrolling: touch;
 
 .main-content::-webkit-scrollbar{ width: 8px; }
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.28.3';
+const packageVersion = '0.28.3+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.28.3
+version: 0.28.3+1
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc


### PR DESCRIPTION
`-webkit-overflow-scrolling` doesn't seem to be a pseudo selector. Instead, it has to be applied directly to the scrolling container (or inherited to it from a parent as in this fix).

Additionally, the `min-height: 100vh` is causing trouble on iOS because on this platform Safari is actually reporting a viewport size that's larger than what's visible. Despite what one may think, this statement therefore caused the dartdocs page to be bigger than what's visible, which is introducing extra awkward scrollbars on the whole page. Removing the statement fixes the issue without breaking anything else.