### PR TITLE
Bump markdown dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.28.3+2
 * Support the latest version of `package:html`.
+* Use latest version of the markdown package.
 
 ## 0.28.3+1
 * Fix scroll physics and behavior for Safari on iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   http_parser: '>=3.0.3 <4.0.0'
   logging: ^0.11.3+1
   process: ^3.0.5
-  markdown: ^2.0.0
+  markdown: ^2.0.3
   mustache: ^1.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0


### PR DESCRIPTION
This  markdown release properly escapes Fenced Code Block info strings.