### PR TITLE
Include embedder SDK libraries only if the default library is SDK library too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.28.3+3
 * Fix code highlighting in Dart after string interpolation(#1946, #1948) by
-updating the highlightjs dependency.
+  updating the highlightjs dependency.
+* Fix: Include embedded SDK libraries only if the default library is SDK library too.
 
 ## 0.28.3+2
 * Support the latest version of `package:html`.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6013,10 +6013,14 @@ class Package extends LibraryContainer
   /// was not excluded on the command line.
   bool get isLocal {
     if (_isLocal == null) {
-      _isLocal = (packageMeta == packageGraph.packageMeta ||
-              packageGraph.hasEmbedderSdk && packageMeta.isSdk ||
-              packageGraph.config.autoIncludeDependencies) &&
-          !packageGraph.config.isPackageExcluded(name);
+      final isDefault = packageMeta == packageGraph.packageMeta;
+      final partOfEmbedderSdk = packageGraph.hasEmbedderSdk &&
+          packageGraph.packageMeta.isSdk &&
+          packageMeta.isSdk;
+      final autoInclude = packageGraph.config.autoIncludeDependencies;
+      final included = isDefault || partOfEmbedderSdk || autoInclude;
+      final excluded = packageGraph.config.isPackageExcluded(name);
+      _isLocal = included && !excluded;
     }
     return _isLocal;
   }


### PR DESCRIPTION
Good part of the code is refactoring, and the main addition is the `packageGraph.packageMeta.isSdk` condition.

I believe this addresses #1949 and https://github.com/dart-lang/pub-dartlang-dart/issues/2108.
I was able to try and validate it on: a Dart package, on a Flutter package, on the Dart SDK, however, I was not able to verify it on the Flutter SDK (not sure how to generate docs for it).
