### PR TITLE
Document embedder SDK packages only when they are in the same path as the main package.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6013,8 +6013,14 @@ class Package extends LibraryContainer
   /// was not excluded on the command line.
   bool get isLocal {
     if (_isLocal == null) {
+      // Document embedder SDK packages only when they are in the same path as
+      // the main package.
+      final partOfEmbedderSdk = packageGraph.hasEmbedderSdk &&
+          packageMeta.isSdk &&
+          packageMeta.resolvedDir
+              .startsWith(packageGraph.packageMeta.resolvedDir);
       _isLocal = (packageMeta == packageGraph.packageMeta ||
-              packageGraph.hasEmbedderSdk && packageMeta.isSdk ||
+              partOfEmbedderSdk ||
               packageGraph.config.autoIncludeDependencies) &&
           !packageGraph.config.isPackageExcluded(name);
     }


### PR DESCRIPTION
Running dartdoc on Flutter packages generates docs for the SDK libraries too, and pub site wants to exclude them (pub site issue: https://github.com/dart-lang/pub-dev/issues/2108 ). However using `--exclude` removes the links, e.g. `Future` is not linked to the official SDK docs page.

Restricting the embedder SDK to the direct subdirectories solves the issue for the Flutter packages, and also keeps the option to generate embedder SDK docs if needed.

