### PR TITLE
use an older version of pedantic

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:pedantic/analysis_options.1.5.0.yaml
 
 analyzer:
   exclude:


### PR DESCRIPTION
- use an older version of pedantic; I'll open an issue to move to the latest version and resolve the resulting analysis issues

This is related to https://github.com/dart-lang/dartdoc/pull/1972.

@keertip for review

@davidmorgan - thanks much for adding the multiple versions to `package:pedantic`! very useful
