### PR TITLE
Enable using summary2 for analysis

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -334,16 +334,17 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
   // TODO(jcollins-g): Rewrite this and improve object model so this doesn't
   // require type checking everywhere.
   Iterable<ElementType> get typeArguments {
-    DefinedElementType elementType = returnedFrom as DefinedElementType;
     if (_typeArguments == null) {
       Iterable<DartType> dartTypeArguments;
       if (type.typeFormals.isEmpty &&
           element is! ModelFunctionAnonymous &&
-          elementType?.element is! ModelFunctionAnonymous) {
+          (returnedFrom is DefinedElementType &&
+              (returnedFrom as DefinedElementType)?.element
+                  is! ModelFunctionAnonymous)) {
         dartTypeArguments = type.typeArguments;
       } else if (returnedFrom != null &&
           returnedFrom.type.element is GenericFunctionTypeElement) {
-        _typeArguments = elementType.typeArguments;
+        _typeArguments = (returnedFrom as DefinedElementType).typeArguments;
       } else {
         dartTypeArguments = type.typeFormals.map((f) => f.type);
       }

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -6,6 +6,7 @@
 library dartdoc.element_type;
 
 import 'dart:collection';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/model.dart';
@@ -121,7 +122,7 @@ class UndefinedElementType extends ElementType {
   String get name => type.name ?? '';
 }
 
-// A FunctionType that does not have an underpinning Element.
+/// A FunctionType that does not have an underpinning Element.
 class FunctionTypeElementType extends UndefinedElementType {
   FunctionTypeElementType(DartType f, Library library,
       PackageGraph packageGraph, ElementType returnedFrom)

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -336,17 +336,24 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
   Iterable<ElementType> get typeArguments {
     if (_typeArguments == null) {
       Iterable<DartType> dartTypeArguments;
-      if (type.typeFormals.isEmpty &&
-          element is! ModelFunctionAnonymous &&
-          (returnedFrom is DefinedElementType &&
-              (returnedFrom as DefinedElementType)?.element
-                  is! ModelFunctionAnonymous)) {
-        dartTypeArguments = type.typeArguments;
-      } else if (returnedFrom != null &&
-          returnedFrom.type.element is GenericFunctionTypeElement) {
-        _typeArguments = (returnedFrom as DefinedElementType).typeArguments;
+      if (returnedFrom is FunctionTypeElementType) {
+        if (type.typeFormals.isEmpty) {
+          dartTypeArguments = type.typeArguments;
+        } else {
+          dartTypeArguments = type.typeFormals.map((f) => f.type);
+        }
       } else {
-        dartTypeArguments = type.typeFormals.map((f) => f.type);
+        DefinedElementType elementType = returnedFrom as DefinedElementType;
+        if (type.typeFormals.isEmpty &&
+            element is! ModelFunctionAnonymous &&
+            elementType?.element is! ModelFunctionAnonymous) {
+          dartTypeArguments = type.typeArguments;
+        } else if (returnedFrom != null &&
+            returnedFrom.type.element is GenericFunctionTypeElement) {
+          _typeArguments = (returnedFrom as DefinedElementType).typeArguments;
+        } else {
+          dartTypeArguments = type.typeFormals.map((f) => f.type);
+        }
       }
       if (dartTypeArguments != null) {
         _typeArguments = dartTypeArguments

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6952,6 +6952,8 @@ class PackageBuilder {
       // TODO(jcollins-g): Make use of currently not existing API for managing
       //                   many AnalysisDrivers
       // TODO(jcollins-g): make use of DartProject isApi()
+      // TODO(keertip): Use summary 2 after fixing #2017
+      AnalysisDriver.useSummary2 = false;
       _driver = AnalysisDriver(
           scheduler,
           log,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -56,7 +56,7 @@ import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/line_number_cache.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/markdown_processor.dart' show Documentation;
-import 'package:dartdoc/src/model_utils.dart';
+import 'package:dartdoc/src/model_utils.dart' as utils;
 import 'package:dartdoc/src/package_meta.dart' show PackageMeta, FileContents;
 import 'package:dartdoc/src/source_linker.dart';
 import 'package:dartdoc/src/special_elements.dart';
@@ -574,7 +574,7 @@ class Mixin extends Class {
       _superclassConstraints = (element as ClassElement)
           .superclassConstraints
           .map<ParameterizedElementType>(
-              (InterfaceType i) => ElementType.from(i, packageGraph))
+              (InterfaceType i) => ElementType.from(i, library, packageGraph))
           .toList();
     }
     return _superclassConstraints;
@@ -584,7 +584,7 @@ class Mixin extends Class {
       publicSuperclassConstraints.isNotEmpty;
 
   Iterable<ParameterizedElementType> get publicSuperclassConstraints =>
-      filterNonPublic(superclassConstraints);
+      utils.filterNonPublic(superclassConstraints);
 
   @override
   bool get hasModifiers => super.hasModifiers || hasPublicSuperclassConstraints;
@@ -628,10 +628,11 @@ abstract class Container extends ModelElement {
     return _instanceMethods;
   }
 
-  bool get hasPublicMethods => filterNonPublic(instanceMethods).isNotEmpty;
+  bool get hasPublicMethods =>
+      utils.filterNonPublic(instanceMethods).isNotEmpty;
 
   Iterable<Method> get allPublicInstanceMethods =>
-      filterNonPublic(instanceMethods);
+      utils.filterNonPublic(instanceMethods);
 
   List<Method> get staticMethods {
     if (_staticMethods != null) return _staticMethods;
@@ -642,9 +643,11 @@ abstract class Container extends ModelElement {
     return _staticMethods;
   }
 
-  bool get hasPublicStaticMethods => filterNonPublic(staticMethods).isNotEmpty;
+  bool get hasPublicStaticMethods =>
+      utils.filterNonPublic(staticMethods).isNotEmpty;
 
-  Iterable<Method> get publicStaticMethods => filterNonPublic(staticMethods);
+  Iterable<Method> get publicStaticMethods =>
+      utils.filterNonPublic(staticMethods);
 
   List<Operator> get operators {
     if (_operators != null) return _operators;
@@ -660,9 +663,10 @@ abstract class Container extends ModelElement {
 
   bool get hasPublicOperators => publicOperators.isNotEmpty;
 
-  Iterable<Operator> get allPublicOperators => filterNonPublic(allOperators);
+  Iterable<Operator> get allPublicOperators =>
+      utils.filterNonPublic(allOperators);
 
-  Iterable<Operator> get publicOperators => filterNonPublic(operators);
+  Iterable<Operator> get publicOperators => utils.filterNonPublic(operators);
 
   List<Field> get _allFields => [];
 
@@ -677,7 +681,7 @@ abstract class Container extends ModelElement {
   }
 
   Iterable<Field> get publicStaticProperties =>
-      filterNonPublic(staticProperties);
+      utils.filterNonPublic(staticProperties);
 
   bool get hasPublicStaticProperties => publicStaticProperties.isNotEmpty;
 
@@ -692,14 +696,14 @@ abstract class Container extends ModelElement {
   }
 
   Iterable<Field> get publicInstanceProperties =>
-      filterNonPublic(instanceProperties);
+      utils.filterNonPublic(instanceProperties);
 
   bool get hasPublicProperties => publicInstanceProperties.isNotEmpty;
 
   Iterable<Field> get allInstanceFields => instanceProperties;
 
   Iterable<Field> get allPublicInstanceProperties =>
-      filterNonPublic(allInstanceFields);
+      utils.filterNonPublic(allInstanceFields);
 
   bool isInheritingFrom(Container other) => false;
 
@@ -711,7 +715,7 @@ abstract class Container extends ModelElement {
     return _constants;
   }
 
-  Iterable<Field> get publicConstants => filterNonPublic(constants);
+  Iterable<Field> get publicConstants => utils.filterNonPublic(constants);
 
   bool get hasPublicConstants => publicConstants.isNotEmpty;
 
@@ -737,18 +741,19 @@ class Class extends Container
     packageGraph.specialClasses.addSpecial(this);
     _mixins = _cls.mixins
         .map((f) {
-          DefinedElementType t = ElementType.from(f, packageGraph);
+          DefinedElementType t = ElementType.from(f, library, packageGraph);
           return t;
         })
         .where((mixin) => mixin != null)
         .toList(growable: false);
 
     if (_cls.supertype != null && _cls.supertype.element.supertype != null) {
-      supertype = ElementType.from(_cls.supertype, packageGraph);
+      supertype = ElementType.from(_cls.supertype, library, packageGraph);
     }
 
     _interfaces = _cls.interfaces
-        .map((f) => ElementType.from(f, packageGraph) as DefinedElementType)
+        .map((f) =>
+            ElementType.from(f, library, packageGraph) as DefinedElementType)
         .toList(growable: false);
   }
 
@@ -767,7 +772,7 @@ class Class extends Container
 
   @override
   Iterable<Method> get allPublicInstanceMethods =>
-      filterNonPublic(allInstanceMethods);
+      utils.filterNonPublic(allInstanceMethods);
 
   bool get allPublicInstanceMethodsInherited =>
       instanceMethods.every((f) => f.isInherited);
@@ -886,7 +891,8 @@ class Class extends Container
     return _constructors;
   }
 
-  Iterable<Constructor> get publicConstructors => filterNonPublic(constructors);
+  Iterable<Constructor> get publicConstructors =>
+      utils.filterNonPublic(constructors);
 
   /// Returns the library that encloses this element.
   @override
@@ -947,7 +953,7 @@ class Class extends Container
 
   /// Returns all the implementors of this class.
   Iterable<Class> get publicImplementors {
-    return filterNonPublic(findCanonicalFor(
+    return utils.filterNonPublic(utils.findCanonicalFor(
         packageGraph.implementors[href] != null
             ? packageGraph.implementors[href]
             : []));
@@ -976,7 +982,8 @@ class Class extends Container
     return _inheritedMethods;
   }
 
-  Iterable get publicInheritedMethods => filterNonPublic(inheritedMethods);
+  Iterable get publicInheritedMethods =>
+      utils.filterNonPublic(inheritedMethods);
 
   bool get hasPublicInheritedMethods => publicInheritedMethods.isNotEmpty;
 
@@ -1002,7 +1009,7 @@ class Class extends Container
   }
 
   Iterable<Operator> get publicInheritedOperators =>
-      filterNonPublic(inheritedOperators);
+      utils.filterNonPublic(inheritedOperators);
 
   List<Field> get inheritedProperties {
     if (_inheritedProperties == null) {
@@ -1013,14 +1020,14 @@ class Class extends Container
   }
 
   Iterable<Field> get publicInheritedProperties =>
-      filterNonPublic(inheritedProperties);
+      utils.filterNonPublic(inheritedProperties);
 
   Iterable<Method> get publicInstanceMethods => instanceMethods;
 
   List<DefinedElementType> get interfaces => _interfaces;
 
   Iterable<DefinedElementType> get publicInterfaces =>
-      filterNonPublic(interfaces);
+      utils.filterNonPublic(interfaces);
 
   bool get isAbstract => _cls.isAbstract;
 
@@ -1049,7 +1056,8 @@ class Class extends Container
 
   List<DefinedElementType> get mixins => _mixins;
 
-  Iterable<DefinedElementType> get publicMixins => filterNonPublic(mixins);
+  Iterable<DefinedElementType> get publicMixins =>
+      utils.filterNonPublic(mixins);
 
   @override
   DefinedElementType get modelType => super.modelType;
@@ -1095,7 +1103,7 @@ class Class extends Container
           parent = null;
         } else {
           parent = ElementType.from(
-              (parent.type as InterfaceType).superclass, packageGraph);
+              (parent.type as InterfaceType).superclass, library, packageGraph);
         }
       } else {
         parent = (parent.element as Class).supertype;
@@ -1105,7 +1113,7 @@ class Class extends Container
   }
 
   Iterable<DefinedElementType> get publicSuperChain =>
-      filterNonPublic(superChain);
+      utils.filterNonPublic(superChain);
 
   Iterable<DefinedElementType> get publicSuperChainReversed =>
       publicSuperChain.toList().reversed;
@@ -1277,7 +1285,8 @@ class Extension extends Container
   Extension(
       ExtensionElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph) {
-    extendedType = ElementType.from(_extension.extendedType, packageGraph);
+    extendedType =
+        ElementType.from(_extension.extendedType, library, packageGraph);
   }
 
   @override
@@ -1639,7 +1648,7 @@ class ModelNode {
   }
 
   String get sourceCode {
-    String contents = getFileContentsFor(element);
+    String contents = utils.getFileContentsFor(element);
     if (_sourceOffset != null) {
       // Find the start of the line, so that we can line up all the indents.
       int i = _sourceOffset;
@@ -1656,8 +1665,8 @@ class ModelNode {
       String source = contents.substring(start, _sourceEnd);
 
       source = const HtmlEscape().convert(source);
-      source = stripIndentFromSource(source);
-      source = stripDartdocCommentsFromSource(source);
+      source = utils.stripIndentFromSource(source);
+      source = utils.stripDartdocCommentsFromSource(source);
 
       return source.trim();
     } else {
@@ -3361,9 +3370,9 @@ abstract class ModelElement extends Canonicalization
       } else {
         String docComment = documentationComment;
         if (docComment == null) {
-          _isPublic = hasPublicName(element);
+          _isPublic = utils.hasPublicName(element);
         } else {
-          _isPublic = hasPublicName(element) &&
+          _isPublic = utils.hasPublicName(element) &&
               !(docComment.contains('@nodoc') ||
                   docComment.contains('<nodoc>'));
         }
@@ -3590,7 +3599,7 @@ abstract class ModelElement extends Canonicalization
 
       // Privately named elements can never have a canonical library, so
       // just shortcut them out.
-      if (!hasPublicName(element)) {
+      if (!utils.hasPublicName(element)) {
         _canonicalLibrary = null;
       } else if (!packageGraph.localPublicLibraries.contains(definingLibrary)) {
         List<Library> candidateLibraries = definingLibrary.exportedInLibraries
@@ -3840,12 +3849,16 @@ abstract class ModelElement extends Canonicalization
     return _linkedName;
   }
 
-  String get linkedParamsLines => linkedParams().trim();
+  String get linkedParams => utils.linkedParams(parameters);
 
-  String get linkedParamsNoMetadata => linkedParams(showMetadata: false);
+  String get linkedParamsLines => utils.linkedParams(parameters).trim();
+
+  String get linkedParamsNoMetadata =>
+      utils.linkedParams(parameters, showMetadata: false);
 
   String get linkedParamsNoMetadataOrNames {
-    return linkedParams(showMetadata: false, showNames: false);
+    return utils.linkedParams(parameters,
+        showMetadata: false, showNames: false);
   }
 
   ElementType get modelType {
@@ -3856,18 +3869,21 @@ abstract class ModelElement extends Canonicalization
               _originalMember is ParameterMember)) {
         if (_originalMember is ExecutableMember) {
           _modelType = ElementType.from(
-              (_originalMember as ExecutableMember).type, packageGraph);
+              (_originalMember as ExecutableMember).type,
+              library,
+              packageGraph);
         } else {
           // ParameterMember
           _modelType = ElementType.from(
-              (_originalMember as ParameterMember).type, packageGraph);
+              (_originalMember as ParameterMember).type, library, packageGraph);
         }
       } else if (element is ExecutableElement ||
           element is FunctionTypedElement ||
           element is ParameterElement ||
           element is TypeDefiningElement ||
           element is PropertyInducingElement) {
-        _modelType = ElementType.from((element as dynamic).type, packageGraph);
+        _modelType =
+            ElementType.from((element as dynamic).type, library, packageGraph);
       }
     }
     return _modelType;
@@ -3921,8 +3937,9 @@ abstract class ModelElement extends Canonicalization
         recursedParameters.addAll(newParameters);
         newParameters.clear();
         for (Parameter p in recursedParameters) {
-          newParameters.addAll(p.modelType.parameters
-              .where((p) => !recursedParameters.contains(p)));
+          var l = p.modelType.parameters
+              .where((pm) => !recursedParameters.contains(pm));
+          newParameters.addAll(l);
         }
       }
       _allParameters = recursedParameters.toList();
@@ -4009,124 +4026,7 @@ abstract class ModelElement extends Canonicalization
       return 0;
     }
   }
-
-  String renderParam(
-      Parameter param, String suffix, bool showMetadata, bool showNames) {
-    StringBuffer buf = StringBuffer();
-    ElementType paramModelType = param.modelType;
-
-    buf.write('<span class="parameter" id="${param.htmlId}">');
-    if (showMetadata && param.hasAnnotations) {
-      param.annotations.forEach((String annotation) {
-        buf.write('<span>$annotation</span> ');
-      });
-    }
-    if (param.isCovariant) {
-      buf.write('<span>covariant</span> ');
-    }
-    if (paramModelType is CallableElementTypeMixin) {
-      String returnTypeName;
-      if (paramModelType.isTypedef) {
-        returnTypeName = paramModelType.linkedName;
-      } else {
-        returnTypeName = paramModelType.createLinkedReturnTypeName();
-      }
-      buf.write('<span class="type-annotation">${returnTypeName}</span>');
-      if (showNames) {
-        buf.write(' <span class="parameter-name">${param.name}</span>');
-      } else if (paramModelType.isTypedef ||
-          paramModelType is CallableAnonymousElementType) {
-        buf.write(
-            ' <span class="parameter-name">${paramModelType.name}</span>');
-      }
-      if (!paramModelType.isTypedef) {
-        buf.write('(');
-        buf.write(paramModelType.element
-            .linkedParams(showNames: showNames, showMetadata: showMetadata));
-        buf.write(')');
-      }
-    } else if (param.modelType != null) {
-      String typeName = paramModelType.linkedName;
-      if (typeName.isNotEmpty) {
-        buf.write('<span class="type-annotation">$typeName</span>');
-      }
-      if (typeName.isNotEmpty && showNames && param.name.isNotEmpty) {
-        buf.write(' ');
-      }
-      if (showNames && param.name.isNotEmpty) {
-        buf.write('<span class="parameter-name">${param.name}</span>');
-      }
-    }
-
-    if (param.hasDefaultValue) {
-      if (param.isOptionalNamed) {
-        buf.write(': ');
-      } else {
-        buf.write(' = ');
-      }
-      buf.write('<span class="default-value">${param.defaultValue}</span>');
-    }
-    buf.write('${suffix}</span>');
-    return buf.toString();
-  }
-
-  String linkedParams(
-      {bool showMetadata = true,
-      bool showNames = true,
-      String separator = ', '}) {
-    List<Parameter> requiredParams =
-        parameters.where((Parameter p) => !p.isOptional).toList();
-    List<Parameter> positionalParams =
-        parameters.where((Parameter p) => p.isOptionalPositional).toList();
-    List<Parameter> namedParams =
-        parameters.where((Parameter p) => p.isOptionalNamed).toList();
-
-    StringBuffer builder = StringBuffer();
-
-    // prefix
-    if (requiredParams.isEmpty && positionalParams.isNotEmpty) {
-      builder.write('[');
-    } else if (requiredParams.isEmpty && namedParams.isNotEmpty) {
-      builder.write('{');
-    }
-
-    // index over params
-    for (Parameter param in requiredParams) {
-      bool isLast = param == requiredParams.last;
-      String ext;
-      if (isLast && positionalParams.isNotEmpty) {
-        ext = ', [';
-      } else if (isLast && namedParams.isNotEmpty) {
-        ext = ', {';
-      } else {
-        ext = isLast ? '' : ', ';
-      }
-      builder.write(renderParam(param, ext, showMetadata, showNames));
-      builder.write(' ');
-    }
-    for (Parameter param in positionalParams) {
-      bool isLast = param == positionalParams.last;
-      builder.write(
-          renderParam(param, isLast ? '' : ', ', showMetadata, showNames));
-      builder.write(' ');
-    }
-    for (Parameter param in namedParams) {
-      bool isLast = param == namedParams.last;
-      builder.write(
-          renderParam(param, isLast ? '' : ', ', showMetadata, showNames));
-      builder.write(' ');
-    }
-
-    // suffix
-    if (namedParams.isNotEmpty) {
-      builder.write('}');
-    } else if (positionalParams.isNotEmpty) {
-      builder.write(']');
-    }
-
-    return builder.toString().trim();
-  }
-
+  
   @override
   String toString() => '$runtimeType $name';
 
@@ -5104,8 +5004,10 @@ class PackageGraph {
 
   void _populateModelNodeFor(
       Element element, Map<String, CompilationUnit> compilationUnitMap) {
-    _modelNodes.putIfAbsent(element,
-        () => ModelNode(getAstNode(element, compilationUnitMap), element));
+    _modelNodes.putIfAbsent(
+        element,
+        () =>
+            ModelNode(utils.getAstNode(element, compilationUnitMap), element));
   }
 
   ModelNode _getModelNodeFor(Element element) => _modelNodes[element];
@@ -5128,7 +5030,7 @@ class PackageGraph {
       assert(packageGraph.allLibrariesAdded);
       _findRefElementCache = Map();
       for (final modelElement
-          in filterNonDocumented(packageGraph.allLocalModelElements)) {
+          in utils.filterNonDocumented(packageGraph.allLocalModelElements)) {
         _findRefElementCache.putIfAbsent(
             modelElement.fullyQualifiedNameWithoutLibrary, () => Set());
         _findRefElementCache.putIfAbsent(
@@ -5550,7 +5452,7 @@ class PackageGraph {
   Iterable<Library> get publicLibraries {
     if (_publicLibraries == null) {
       assert(allLibrariesAdded);
-      _publicLibraries = filterNonPublic(libraries).toList();
+      _publicLibraries = utils.filterNonPublic(libraries).toList();
     }
     return _publicLibraries;
   }
@@ -5571,7 +5473,7 @@ class PackageGraph {
   Iterable<Library> get localPublicLibraries {
     if (_localPublicLibraries == null) {
       assert(allLibrariesAdded);
-      _localPublicLibraries = filterNonPublic(localLibraries).toList();
+      _localPublicLibraries = utils.filterNonPublic(localLibraries).toList();
     }
     return _localPublicLibraries;
   }
@@ -5934,24 +5836,26 @@ abstract class TopLevelContainer implements Nameable {
 
   bool get hasPublicTypedefs => publicTypedefs.isNotEmpty;
 
-  Iterable<Class> get publicClasses => filterNonPublic(classes);
+  Iterable<Class> get publicClasses => utils.filterNonPublic(classes);
 
-  Iterable<Extension> get publicExtensions => filterNonPublic(extensions);
+  Iterable<Extension> get publicExtensions => utils.filterNonPublic(extensions);
 
-  Iterable<TopLevelVariable> get publicConstants => filterNonPublic(constants);
+  Iterable<TopLevelVariable> get publicConstants =>
+      utils.filterNonPublic(constants);
 
-  Iterable<Enum> get publicEnums => filterNonPublic(enums);
+  Iterable<Enum> get publicEnums => utils.filterNonPublic(enums);
 
-  Iterable<Class> get publicExceptions => filterNonPublic(exceptions);
+  Iterable<Class> get publicExceptions => utils.filterNonPublic(exceptions);
 
-  Iterable<ModelFunction> get publicFunctions => filterNonPublic(functions);
+  Iterable<ModelFunction> get publicFunctions =>
+      utils.filterNonPublic(functions);
 
-  Iterable<Mixin> get publicMixins => filterNonPublic(mixins);
+  Iterable<Mixin> get publicMixins => utils.filterNonPublic(mixins);
 
   Iterable<TopLevelVariable> get publicProperties =>
-      filterNonPublic(properties);
+      utils.filterNonPublic(properties);
 
-  Iterable<Typedef> get publicTypedefs => filterNonPublic(typedefs);
+  Iterable<Typedef> get publicTypedefs => utils.filterNonPublic(typedefs);
 }
 
 /// A set of libraries, initialized after construction by accessing [_libraries].
@@ -5965,7 +5869,7 @@ abstract class LibraryContainer
 
   PackageGraph get packageGraph;
 
-  Iterable<Library> get publicLibraries => filterNonPublic(libraries);
+  Iterable<Library> get publicLibraries => utils.filterNonPublic(libraries);
 
   bool get hasPublicLibraries => publicLibraries.isNotEmpty;
 
@@ -6566,20 +6470,31 @@ class Parameter extends ModelElement implements EnclosedElement {
 
   @override
   String get htmlId {
-    String enclosingName = _parameter.enclosingElement.name;
-    if (_parameter.enclosingElement is GenericFunctionTypeElement) {
-      // TODO(jcollins-g): Drop when GenericFunctionTypeElement populates name.
-      // Also, allowing null here is allowed as a workaround for
-      // dart-lang/sdk#32005.
-      for (Element e = _parameter.enclosingElement;
-          e.enclosingElement != null;
-          e = e.enclosingElement) {
-        enclosingName = e.name;
-        if (enclosingName != null && enclosingName.isNotEmpty) break;
+    if (_parameter.enclosingElement != null) {
+      String enclosingName = _parameter.enclosingElement.name;
+      if (_parameter.enclosingElement is GenericFunctionTypeElement) {
+        // TODO(jcollins-g): Drop when GenericFunctionTypeElement populates name.
+        // Also, allowing null here is allowed as a workaround for
+        // dart-lang/sdk#32005.
+        for (Element e = _parameter.enclosingElement;
+            e.enclosingElement != null;
+            e = e.enclosingElement) {
+          enclosingName = e.name;
+          if (enclosingName != null && enclosingName.isNotEmpty) break;
+        }
       }
+      return '${enclosingName}-param-${name}';
+    } else {
+      return 'param-${name}';
     }
-    return '${enclosingName}-param-${name}';
   }
+
+  @override
+  int get hashCode => _element == null ? 0 : _element.hashCode;
+
+  @override
+  bool operator ==(Object object) =>
+      object is Parameter && (_parameter.type == object._parameter.type);
 
   bool get isCovariant => _parameter.isCovariant;
 
@@ -6777,8 +6692,9 @@ class TypeParameter extends ModelElement {
       : super(element, library, packageGraph, null);
 
   @override
-  ModelElement get enclosingElement =>
-      ModelElement.from(element.enclosingElement, library, packageGraph);
+  ModelElement get enclosingElement => (element.enclosingElement != null)
+      ? ModelElement.from(element.enclosingElement, library, packageGraph)
+      : null;
 
   @override
   String get href {
@@ -6799,7 +6715,7 @@ class TypeParameter extends ModelElement {
     if (_boundType == null) {
       var bound = _typeParameter.bound;
       if (bound != null) {
-        _boundType = ElementType.from(bound, packageGraph);
+        _boundType = ElementType.from(bound, library, packageGraph);
       }
     }
     return _boundType;
@@ -6953,7 +6869,7 @@ class PackageBuilder {
       //                   many AnalysisDrivers
       // TODO(jcollins-g): make use of DartProject isApi()
       // TODO(keertip): Use summary 2 after fixing #2017
-      AnalysisDriver.useSummary2 = false;
+      AnalysisDriver.useSummary2 = true;
       _driver = AnalysisDriver(
           scheduler,
           log,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -35,7 +35,7 @@ import 'package:analyzer/src/dart/element/handle.dart';
 import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member, ParameterMember;
 import 'package:analyzer/src/dart/sdk/sdk.dart';
-import 'package:analyzer/src/generated/engine.dart' hide AnalysisResult;
+import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/java_io.dart';
 import 'package:analyzer/src/generated/resolver.dart'
     show
@@ -6869,8 +6869,6 @@ class PackageBuilder {
       // TODO(jcollins-g): Make use of currently not existing API for managing
       //                   many AnalysisDrivers
       // TODO(jcollins-g): make use of DartProject isApi()
-      // TODO(keertip): Use summary 2 after fixing #2017
-      AnalysisDriver.useSummary2 = true;
       _driver = AnalysisDriver(
           scheduler,
           log,

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4026,7 +4026,7 @@ abstract class ModelElement extends Canonicalization
       return 0;
     }
   }
-  
+
   @override
   String toString() => '$runtimeType $name';
 
@@ -4034,7 +4034,7 @@ abstract class ModelElement extends Canonicalization
     e ??= this;
     fqName ??= e.name;
 
-    if (e is! EnclosedElement) {
+    if (e is! EnclosedElement || e.enclosingElement == null) {
       return fqName;
     }
 
@@ -6455,8 +6455,9 @@ class Parameter extends ModelElement implements EnclosedElement {
   }
 
   @override
-  ModelElement get enclosingElement =>
-      ModelElement.from(_parameter.enclosingElement, library, packageGraph);
+  ModelElement get enclosingElement => (_parameter.enclosingElement != null)
+      ? ModelElement.from(_parameter.enclosingElement, library, packageGraph)
+      : null;
 
   bool get hasDefaultValue {
     return _parameter.defaultValueCode != null &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.2
+  analyzer: ^0.38.3
   args: '>=1.4.1 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ^0.38.3
-  args: '>=1.4.1 <2.0.0'
+  args: '>=1.5.0 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6
   html: '>=0.12.1 <0.15.0'

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:test/test.dart';
@@ -2233,6 +2234,7 @@ void main() {
     ModelFunction thisIsFutureOrT;
     ModelFunction topLevelFunction;
     ModelFunction typeParamOfFutureOr;
+    ModelFunction doAComplicatedThing;
 
     setUpAll(() {
       f1 = exLibrary.functions.first;
@@ -2252,6 +2254,8 @@ void main() {
           fakeLibrary.functions.firstWhere((f) => f.name == 'topLevelFunction');
       typeParamOfFutureOr = fakeLibrary.functions
           .firstWhere((f) => f.name == 'typeParamOfFutureOr');
+      doAComplicatedThing = fakeLibrary.functions
+          .firstWhere((f) => f.name == 'doAComplicatedThing');
     });
 
     test('has a fully qualified name', () {
@@ -2279,7 +2283,7 @@ void main() {
     });
 
     test('handles dynamic parameters correctly', () {
-      expect(f1.linkedParams(), contains('lastParam'));
+      expect(linkedParams(f1.parameters), contains('lastParam'));
     });
 
     test('async function', () {
@@ -2318,7 +2322,7 @@ void main() {
 
     test('function with a parameter having type FutureOr<Null>', () {
       expect(
-          paramOfFutureOrNull.linkedParams(),
+          linkedParams(paramOfFutureOrNull.parameters),
           equals(
               '<span class="parameter" id="paramOfFutureOrNull-param-future"><span class="type-annotation">FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span></span> <span class="parameter-name">future</span></span>'));
     });
@@ -2346,7 +2350,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('typedef params have proper signature', () {
       ModelFunction function =
           fakeLibrary.functions.firstWhere((f) => f.name == 'addCallback');
-      String params = function.linkedParams();
+      String params = linkedParams(function.parameters);
       expect(
           params,
           '<span class="parameter" id="addCallback-param-callback">'
@@ -2355,7 +2359,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
       function =
           fakeLibrary.functions.firstWhere((f) => f.name == 'addCallback2');
-      params = function.linkedParams();
+      params = linkedParams(function.parameters);
       expect(
           params,
           '<span class="parameter" id="addCallback2-param-callback">'
@@ -2366,6 +2370,12 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('supports generic methods', () {
       expect(genericFunction.nameWithGenerics,
           'genericFunction&lt;<wbr><span class="type-parameter">T</span>&gt;');
+    });
+
+    test('can resolve functions as parameters', () {
+      String params = linkedParams(doAComplicatedThing.parameters);
+      expect(params,
+          '<span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, {</span> <span class="parameter" id="doAComplicatedThing-param-doSomething"><span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span>), </span> <span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span> <span class="parameter" id="param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)</span> }');
     });
   });
 
@@ -2385,7 +2395,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       // TODO(jcollins-g): really, these shouldn't be called "parameters" in
       // the span class.
       expect(explicitSetter.linkedReturnType,
-          '<span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="f-param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="f-param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="f-param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span></span>)</span>');
+          '<span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="param-bar"><span class="type-annotation">int</span>, </span> <span class="parameter" id="param-baz"><span class="type-annotation"><a href="fake/Cool-class.html">Cool</a></span>, </span> <span class="parameter" id="param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span></span>)</span>');
     });
 
     test('parameterized type from field is correctly displayed', () {
@@ -2481,7 +2491,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((m) => m.name == 'operator +');
       expect(aInheritedAdditionOperator.linkedReturnType,
           '<a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
-      expect(aInheritedAdditionOperator.linkedParams(),
+      expect(linkedParams(aInheritedAdditionOperator.parameters),
           '<span class="parameter" id="+-param-other"><span class="type-annotation"><a href="ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">other</span></span>');
     });
 
@@ -2541,7 +2551,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           getAFunctionReturningVoid.linkedReturnType,
           equals(
-              'void Function<span class="signature">(<span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningVoid-param-"><span class="type-annotation">T2</span></span>)</span>'));
+              'void Function<span class="signature">(<span class="parameter" id="param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="param-"><span class="type-annotation">T2</span></span>)</span>'));
     });
 
     test(
@@ -2550,7 +2560,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           getAFunctionReturningBool.linkedReturnType,
           equals(
-              'bool Function<span class="signature">&lt;<wbr><span class="type-parameter">T4</span>&gt;</span><span class="signature">(<span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="getAFunctionReturningBool-param-"><span class="type-annotation">T4</span></span>)</span>'));
+              'bool Function&lt;<wbr><span class="type-parameter">T4</span>&gt;<span class="signature">(<span class="parameter" id="param-"><span class="type-annotation">String</span>, </span> <span class="parameter" id="param-"><span class="type-annotation">T1</span>, </span> <span class="parameter" id="param-"><span class="type-annotation">T4</span></span>)</span>'));
     });
 
     test('has a fully qualified name', () {
@@ -3105,19 +3115,18 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'Verify that a map containing anonymous functions as values works correctly',
         () {
-      Iterable<CallableElementType> typeArguments =
+      Iterable<ElementType> typeArguments =
           (importantComputations.modelType.returnType as DefinedElementType)
-              .typeArguments
-              .cast<CallableElementType>();
+              .typeArguments;
       expect(typeArguments, isNotEmpty);
       expect(
           typeArguments.last.linkedName,
           equals(
-              '(<span class="parameter" id="null-param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span></span>) → dynamic'));
+              'dynamic Function<span class="signature">(<span class="parameter" id="param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span> <span class="parameter-name">a</span></span>)</span>'));
       expect(
           importantComputations.linkedReturnType,
           equals(
-              'Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">(<span class="parameter" id="null-param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span></span>) → dynamic</span>&gt;</span>'));
+              'Map<span class="signature">&lt;<wbr><span class="type-parameter">int</span>, <span class="type-parameter">dynamic Function<span class="signature">(<span class="parameter" id="param-a"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">num</span>&gt;</span></span> <span class="parameter-name">a</span></span>)</span></span>&gt;</span>'));
     });
 
     test(
@@ -3126,7 +3135,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           complicatedReturn.linkedReturnType,
           equals(
-              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="-param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span>'));
+              '<a href="fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span>'));
     });
 
     test('@nodoc on simple property works', () {
@@ -3388,7 +3397,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('a function requiring a Future<void> parameter', () {
       expect(
-          aVoidParameter.linkedParams(showMetadata: true, showNames: true),
+          linkedParams(aVoidParameter.parameters,
+              showMetadata: true, showNames: true),
           equals(
               '<span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">p1</span></span>'));
     });
@@ -3470,7 +3480,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
         () {
       Constructor theConstructor = TypedefUsingClass.constructors.first;
       expect(
-          theConstructor.linkedParams(),
+          linkedParams(theConstructor.parameters),
           equals(
               '<span class="parameter" id="-param-x"><span class="type-annotation"><a href="ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span> <span class="parameter-name">x</span></span>'));
     });
@@ -3489,7 +3499,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           aComplexTypedef.linkedReturnType,
           equals(
-              'void Function<span class="signature">(<span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="aComplexTypedef-param-"><span class="type-annotation">A3</span></span>)</span>'));
+              'void Function<span class="signature">(<span class="parameter" id="param-"><span class="type-annotation">A1</span>, </span> <span class="parameter" id="param-"><span class="type-annotation">A2</span>, </span> <span class="parameter" id="param-"><span class="type-annotation">A3</span></span>)</span>'));
       expect(
           aComplexTypedef.linkedParamsLines,
           equals(
@@ -3613,21 +3623,21 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('param with generics', () {
-      var params = methodWithGenericParam.linkedParams();
+      var params = linkedParams(methodWithGenericParam.parameters);
       expect(params.contains('List') && params.contains('Apple'), isTrue);
     });
 
     test('commas on same param line', () {
       ModelFunction method =
           fakeLibrary.functions.firstWhere((f) => f.name == 'paintImage1');
-      String params = method.linkedParams();
+      String params = linkedParams(method.parameters);
       expect(params, contains(', </span>'));
     });
 
     test('param with annotations', () {
       ModelFunction method =
           fakeLibrary.functions.firstWhere((f) => f.name == 'paintImage1');
-      String params = method.linkedParams();
+      String params = linkedParams(method.parameters);
       expect(params, contains('@required'));
     });
 
@@ -3638,7 +3648,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('typedef param is linked and does not include types', () {
-      var params = methodWithTypedefParam.linkedParams();
+      var params = linkedParams(methodWithTypedefParam.parameters);
       expect(
           params,
           equals(


### PR DESCRIPTION
Refactor to use summary2 as sometimes FunctionType's are not backed by elements, we have use the type to get the information.


