### PR TITLE
Don't use 'Element.type'.

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -8,6 +8,7 @@ library dartdoc.element_type;
 import 'dart:collection';
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
@@ -341,7 +342,7 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
         if (type.typeFormals.isEmpty) {
           dartTypeArguments = type.typeArguments;
         } else {
-          dartTypeArguments = type.typeFormals.map((f) => f.type);
+          dartTypeArguments = type.typeFormals.map(_legacyTypeParameterType);
         }
       } else {
         DefinedElementType elementType = returnedFrom as DefinedElementType;
@@ -353,7 +354,7 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
             returnedFrom.type.element is GenericFunctionTypeElement) {
           _typeArguments = (returnedFrom as DefinedElementType).typeArguments;
         } else {
-          dartTypeArguments = type.typeFormals.map((f) => f.type);
+          dartTypeArguments = type.typeFormals.map(_legacyTypeParameterType);
         }
       }
       if (dartTypeArguments != null) {
@@ -363,6 +364,20 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
       }
     }
     return _typeArguments;
+  }
+
+  /// Return the [TypeParameterType] with the legacy nullability for the given
+  /// type parameter [element].
+  ///
+  /// TODO(scheglov) This method is a work around that fact that DartDoc
+  /// currently represents both type formals and uses of them as actual types,
+  /// as [TypeParameterType]s. This was not perfect, but worked before NNBD.
+  /// With NNBD types have nullability suffixes, but type formals should not.
+  /// Eventually we should separate models for type formals and types.
+  static TypeParameterType _legacyTypeParameterType(
+    TypeParameterElement element,
+  ) {
+    return element.instantiate(nullabilitySuffix: NullabilitySuffix.star);
   }
 }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1033,15 +1033,15 @@ class Class extends Container
   bool get isCanonical => super.isCanonical && isPublic;
 
   bool get isErrorOrException {
-    bool _doCheck(InterfaceType type) {
-      return (type.element.library.isDartCore &&
-          (type.name == 'Exception' || type.name == 'Error'));
+    bool _doCheck(ClassElement element) {
+      return (element.library.isDartCore &&
+          (element.name == 'Exception' || element.name == 'Error'));
     }
 
     // if this class is itself Error or Exception, return true
-    if (_doCheck(_cls.type)) return true;
+    if (_doCheck(_cls)) return true;
 
-    return _cls.allSupertypes.any(_doCheck);
+    return _cls.allSupertypes.map((t) => t.element).any(_doCheck);
   }
 
   /// Returns true if [other] is a parent class for this class.
@@ -1121,12 +1121,12 @@ class Class extends Container
   List<ExecutableElement> get _inheritedElements {
     if (__inheritedElements == null) {
       var classElement = element as ClassElement;
-      var classType = classElement.type;
-      if (classType.isObject) {
+      if (classElement.isDartCoreObject) {
         return __inheritedElements = <ExecutableElement>[];
       }
 
       var inheritance = definingLibrary.inheritanceManager;
+      var classType = classElement.thisType;
       var cmap = inheritance.getInheritedConcreteMap(classType);
       var imap = inheritance.getInheritedMap(classType);
 
@@ -4049,8 +4049,7 @@ abstract class ModelElement extends Canonicalization
     // If we're calling this with an empty name, we probably have the wrong
     // element associated with a ModelElement or there's an analysis bug.
     assert(name.isNotEmpty ||
-        (this.element is TypeDefiningElement &&
-            (this.element as TypeDefiningElement).type.name == "dynamic") ||
+        this.element?.kind == ElementKind.DYNAMIC ||
         this is ModelFunction);
 
     if (href == null) {


### PR DESCRIPTION
For most elements `.type` should be considered deprecated.

Specifically, for `ClassElement`, `GenericFunctionTypeElement`, and `TypeParameterElement`.
These elements don't have external types per se, but can be used to construct a type.
Before NNBD to construct a type from them you needed to provide type arguments.
Now you need to provide type arguments, and also the nullability suffix.

I have never been fond of using raw InterfaceType(s) as workpieces for actual types.
But with NNBD this just gets out of hand, especially with type parameters.
So, it is time for a clean-up.