### PR TITLE
Stop checking for ElementHandle, it is not used anymore, we are removing it.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -31,7 +31,6 @@ import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer/src/dart/analysis/file_state.dart';
 import 'package:analyzer/src/dart/analysis/performance_logger.dart';
 import 'package:analyzer/src/dart/element/element.dart';
-import 'package:analyzer/src/dart/element/handle.dart';
 import 'package:analyzer/src/dart/element/inheritance_manager3.dart';
 import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member, ParameterMember;
@@ -3131,11 +3130,6 @@ abstract class ModelElement extends Canonicalization
         e is TypeParameterElement ||
         e is GenericFunctionTypeElementImpl ||
         e.kind == ElementKind.DYNAMIC);
-    // With AnalysisDriver, we sometimes get ElementHandles when building
-    // docs for the SDK, seen via [Library.importedExportedLibraries].  Why?
-    if (e is ElementHandle) {
-      e = (e as ElementHandle).actualElement;
-    }
 
     Member originalMember;
     // TODO(jcollins-g): Refactor object model to instantiate 'ModelMembers'


### PR DESCRIPTION
Handles were used with summary1, and summary2 uses resolved, always available ASTNode(s)