### PR TITLE
Prepare for dartdoc 0.28.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.28.7
-* Remove obsolete references to Element.type and ElementHandle (#2028, #2031)
+* Remove obsolete references to Element.type and ElementHandle (#2028, #2031).
+* Fix problem with return values for typedefs with analyzer 0.38.5 (#2036).
 
 ## 0.28.6
 * Support for 0.38.3 version of `package:analyzer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.28.7
+* Remove obsolete references to Element.type and ElementHandle (#2028, #2031)
+
 ## 0.28.6
 * Support for 0.38.3 version of `package:analyzer`.
 * Support generating docs for extension methods (#2001).

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.6/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.7/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.28.6';
+const packageVersion = '0.28.7';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.28.6
+version: 0.28.7
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc


### PR DESCRIPTION
Release a new version of dartdoc with some obsolete analyzer references removed, thanks to @scheglov.