### PR TITLE
Disable sdk-analyzer bot and extend timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ dart:
 env:
   - DARTDOC_BOT=main
   - DARTDOC_BOT=flutter
-  - DARTDOC_BOT=sdk-analyzer
+  # Disable pending #2036
+  #- DARTDOC_BOT=sdk-analyzer
   - DARTDOC_BOT=packages
   - DARTDOC_BOT=sdk-docs
 script: ./tool/travis.sh

--- a/test/dartdoc_integration_test.dart
+++ b/test/dartdoc_integration_test.dart
@@ -69,7 +69,7 @@ void main() {
       expect(outputLines, contains(matches('^  warning:')));
       expect(outputLines.last, matches(r'^found \d+ warnings and \d+ errors'));
       expect(outputDir.listSync(), isNotEmpty);
-    });
+    }, timeout: new Timeout.factor(2));
 
     test('invalid parameters return non-zero and print a fatal-error',
         () async {


### PR DESCRIPTION
Pending #2036, disable the sdk-analyzer bot so other work can continue and be reviewed/tested.  Also extend a timeout that was resulting in a flaky test.