### PR TITLE
Fix return type calculation for typedefs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ dart:
 env:
   - DARTDOC_BOT=main
   - DARTDOC_BOT=flutter
-  # Disable pending #2036
-  #- DARTDOC_BOT=sdk-analyzer
+  - DARTDOC_BOT=sdk-analyzer
   - DARTDOC_BOT=packages
   - DARTDOC_BOT=sdk-docs
 script: ./tool/travis.sh

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -447,7 +447,7 @@ class CallableGenericTypeAliasElementType extends ParameterizedElementType
   ElementType get returnType {
     if (_returnType == null) {
       _returnType = ElementType.from(
-          returnElement.modelType.type, library, packageGraph, this);
+          type.returnType, library, packageGraph, this);
     }
     return _returnType;
   }


### PR DESCRIPTION
Fixes #2036.

Dartdoc was doing something wrong that happened to work before https://dart-review.googlesource.com/c/sdk/+/119823, but no longer does.  With this change, dartdoc can work with and without @scheglov's fix.