### PR TITLE
Handle reexports of extensions in dartdoc

### DIFF
--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -171,7 +171,7 @@ class HtmlGeneratorInstance {
           }
         }
 
-        for (var extension in filterNonPublic(lib.extensions)) {
+        for (var extension in filterNonDocumented(lib.extensions)) {
           generateExtension(_packageGraph, lib, extension);
 
           for (var constant in filterNonDocumented(extension.constants)) {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -2114,11 +2114,20 @@ void main() {
 
   group('Extension', () {
     Extension ext, fancyList;
+    Extension documentOnceReexportOne, documentOnceReexportTwo;
+    Library reexportOneLib, reexportTwoLib;
     Class extensionReferencer;
     Method doSomeStuff, doStuff, s;
     List<Extension> extensions;
 
     setUpAll(() {
+      reexportOneLib = packageGraph.libraries
+          .firstWhere((lib) => lib.name == 'reexport_one');
+      reexportTwoLib = packageGraph.libraries
+          .firstWhere((lib) => lib.name == 'reexport_two');
+      documentOnceReexportOne = reexportOneLib.extensions.firstWhere((e) => e.name == 'DocumentThisExtensionOnce');
+      documentOnceReexportTwo = reexportTwoLib.extensions.firstWhere((e) => e.name == 'DocumentThisExtensionOnce');
+
       ext = exLibrary.extensions.firstWhere((e) => e.name == 'AppleExtension');
       extensionReferencer = exLibrary.classes.firstWhere((c) => c.name == 'ExtensionReferencer');
       fancyList = exLibrary.extensions.firstWhere((e) => e.name == 'FancyList');
@@ -2127,6 +2136,12 @@ void main() {
       doStuff = exLibrary.extensions.firstWhere((e) => e.name == 'SimpleStringExtension')
           .instanceMethods.firstWhere((m) => m.name == 'doStuff');
       extensions = exLibrary.publicExtensions.toList();
+    });
+
+    test('basic canonicalization for extensions', () {
+      expect(documentOnceReexportOne.isCanonical, isFalse);
+      expect(documentOnceReexportOne.href, equals(documentOnceReexportTwo.href));
+      expect(documentOnceReexportTwo.isCanonical, isTrue);
     });
 
     // TODO(jcollins-g): implement feature and update tests
@@ -2143,6 +2158,7 @@ void main() {
       expect(extensionReferencer.documentationAsHtml, contains('<code>_Shhh</code>'));
       expect(extensionReferencer.documentationAsHtml, contains('<a href="ex/FancyList.html">FancyList</a>'));
       expect(extensionReferencer.documentationAsHtml, contains('<a href="ex/AnExtension/call.html">AnExtension.call</a>'));
+      expect(extensionReferencer.documentationAsHtml, contains('<a href="reexport_two/DocumentThisExtensionOnce.html">DocumentThisExtensionOnce</a>'));
     });
 
     test('has a fully qualified name', () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -677,4 +677,5 @@ extension on Object {
 
 /// This class has nothing to do with [_Shhh], [FancyList], or [AnExtension.call],
 /// but should not crash because we referenced them.
+/// We should be able to find [DocumentThisExtensionOnce], too.
 class ExtensionReferencer {}

--- a/testing/test_package/lib/reexport_two.dart
+++ b/testing/test_package/lib/reexport_two.dart
@@ -1,6 +1,7 @@
 /// {@canonicalFor reexport.somelib.SomeClass}
 /// {@canonicalFor reexport.somelib.AUnicornClass}
 /// {@canonicalFor something.ThatDoesntExist}
+/// {@canonicalFor reexport.somelib.DocumentThisExtensionOnce}
 /// {@category Unreal}
 library reexport_two;
 

--- a/testing/test_package/lib/src/somelib.dart
+++ b/testing/test_package/lib/src/somelib.dart
@@ -7,3 +7,19 @@ class SomeOtherClass {}
 class YetAnotherClass {}
 
 class AUnicornClass {}
+
+
+/// A private extension.
+extension _Unseen on Object {
+  void doYouSeeMe() { }
+}
+
+/// An extension without a name
+extension on List {
+  void somethingNew() { }
+}
+
+/// [_Unseen] is not seen, but [DocumentMe] is.
+extension DocumentThisExtensionOnce on String {
+  String get reportOnString => '$this is wonderful';
+}


### PR DESCRIPTION
Fixes #2032.  

This implements canonicalization with export handling for extensions, but not yet their methods. (All methods of extensions are assumed canonical with their extension, which is usually the case.)  Largely based on the class handling for the same problem, which has also been cleaned up a bit.