### PR TITLE
Work around head bot failure

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -225,7 +225,7 @@ void analyze() async {
 }
 
 @Task('analyze, test, and self-test dartdoc')
-@Depends(analyze, checkBuild, test, testDartdoc)
+@Depends(analyze, test, testDartdoc)
 void buildbotNoPublish() => null;
 
 @Task('analyze, test, and self-test dartdoc')


### PR DESCRIPTION
Disable 'check-build' until a new build package is published and we can upgrade the analyzer version.

The build package doesn't support analyzer 0.39.0 yet.  Attempting to run a pass to verify that dartdoc's build script works while force overriding the dependencies to use the sdk analyzer therefore can not work.   So I am deleting the build check from the group of tests run with the sdk analyzer.  This is a stopgap until a new build package is published.