### PR TITLE
Revert #2048 and upgrade analyzer version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.3
+  analyzer: ^0.39.0
   args: '>=1.5.0 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -225,7 +225,7 @@ void analyze() async {
 }
 
 @Task('analyze, test, and self-test dartdoc')
-@Depends(analyze, test, testDartdoc)
+@Depends(analyze, checkBuild, test, testDartdoc)
 void buildbotNoPublish() => null;
 
 @Task('analyze, test, and self-test dartdoc')


### PR DESCRIPTION
With the publish of build 1.2.1, we can upgrade the analyzer version in pubspec to 0.39.0 and restore the check-build step of the sdk analyzer bot.