### PR TITLE
Prepare for dartdoc 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.29.0
+* Internal change to use of FunctionTypeAliasElement (#2051).
+* Analyzer version to 0.29+ (#2049).
+* Refactor element discovery and fix extension discovery to work with imports
+ (#2050).
+* Bugfix for corrupt location reporting in many cases (#2043).
+* Add a list of extensions to applicable class pages (#2053).
+
 ## 0.28.8
 * Use analyzer line number library, fixing crash on empty file (#2034, #1938).
 * Fix crash on resolving comment references inside extension methods (#2040, #2033).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.29.0
-* Internal change to use of FunctionTypeAliasElement (#2051).
+* Internal change to our use of FunctionTypeAliasElement for the analyzer
+  (#2051).
 * Analyzer version to 0.29+ (#2049).
 * Refactor element discovery and fix extension discovery to work with imports
- (#2050).
+  (#2050).
 * Bugfix for corrupt location reporting in many cases (#2043).
 * Add a list of extensions to applicable class pages (#2053).
 

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.28.8/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.29.0/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.28.8';
+const packageVersion = '0.29.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.28.8
+version: 0.29.0
 author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc


### PR DESCRIPTION
Get ready for a 0.29.0 release of dartdoc.  Minor version update as dartdoc will (after #2053 lands) no longer even try to run on Dart versions below 2.2.