### PR TITLE
Extend timeouts to make travis happier

### DIFF
--- a/test/dartdoc_integration_test.dart
+++ b/test/dartdoc_integration_test.dart
@@ -248,5 +248,5 @@ void main() {
       RegExp version = RegExp(r'(\d+\.)?(\d+\.)?(\*|\d+)');
       expect(version.hasMatch(m.group(0)), false);
     });
-  }, timeout: Timeout.factor(4));
+  }, timeout: Timeout.factor(8));
 }


### PR DESCRIPTION
Stretch our timeouts in the integration test, as travis has highly variable performance.