### PR TITLE
Make sure that enum documentation contains unique IDs for animations

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4452,13 +4452,17 @@ abstract class ModelElement extends Canonicalization
     // Matches valid javascript identifiers.
     final RegExp validIdRegExp = RegExp(r'^[a-zA-Z_]\w*$');
 
-    final Set<String> uniqueIds = Set<String>();
+    // Make sure we have a set to keep track of used IDs for this href.
+    package.usedAnimationIdsByHref[href] ??= {};
+
     String getUniqueId(String base) {
-      int count = 1;
-      String id = '$base$count';
-      while (uniqueIds.contains(id)) {
-        count++;
-        id = '$base$count';
+      int animationIdCount = 1;
+      String id = '$base$animationIdCount';
+      // We check for duplicate IDs so that we make sure not to collide with
+      // user-supplied ids on the same page.
+      while (package.usedAnimationIdsByHref[href].contains(id)) {
+        animationIdCount++;
+        id = '$base$animationIdCount';
       }
       return id;
     }
@@ -4476,7 +4480,7 @@ abstract class ModelElement extends Canonicalization
       bool wasDeprecated = false;
       if (positionalArgs.length == 4) {
         // Supports the original form of the animation tag for backward
-        // compatibility.
+        // compatibility.`
         uniqueId = positionalArgs.removeAt(0);
         wasDeprecated = true;
       } else if (positionalArgs.length == 3) {
@@ -4496,13 +4500,13 @@ abstract class ModelElement extends Canonicalization
                 'and must not begin with a number.');
         return '';
       }
-      if (uniqueIds.contains(uniqueId)) {
+      if (package.usedAnimationIdsByHref[href].contains(uniqueId)) {
         warn(PackageWarning.invalidParameter,
             message: 'An animation has a non-unique identifier, "$uniqueId". '
                 'Animation identifiers must be unique.');
         return '';
       }
-      uniqueIds.add(uniqueId);
+      package.usedAnimationIdsByHref[href].add(uniqueId);
 
       int width;
       try {
@@ -4552,7 +4556,8 @@ abstract class ModelElement extends Canonicalization
 
 <div style="position: relative;">
   <div id="${overlayId}"
-       onclick="if ($uniqueId.paused) {
+       onclick="var $uniqueId = document.getElementById('$uniqueId');
+                if ($uniqueId.paused) {
                   $uniqueId.play();
                   this.style.display = 'none';
                 } else {
@@ -4569,7 +4574,8 @@ abstract class ModelElement extends Canonicalization
   </div>
   <video id="$uniqueId"
          style="width:${width}px; height:${height}px;"
-         onclick="if (this.paused) {
+         onclick="var $overlayId = document.getElementById('$overlayId');
+                  if (this.paused) {
                     this.play();
                     $overlayId.style.display = 'none';
                   } else {
@@ -6293,6 +6299,10 @@ class Package extends LibraryContainer
 
   /// Number of times we have invoked a tool for this package.
   int toolInvocationIndex = 0;
+
+  // The animation IDs that have already been used, indexed by the [href] of the
+  // object that contains them.
+  Map<String, Set<String>> usedAnimationIdsByHref = {};
 
   /// Pieces of the location split by [locationSplitter] (removing package: and
   /// slashes).

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -4480,7 +4480,7 @@ abstract class ModelElement extends Canonicalization
       bool wasDeprecated = false;
       if (positionalArgs.length == 4) {
         // Supports the original form of the animation tag for backward
-        // compatibility.`
+        // compatibility.
         uniqueId = positionalArgs.removeAt(0);
         wasDeprecated = true;
       } else if (positionalArgs.length == 3) {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1176,8 +1176,16 @@ void main() {
     Method withAnimationInOneLineDoc;
     Method withAnimationInline;
     Method withAnimationOutOfOrder;
+    Enum enumWithAnimation;
+    EnumField enumValue1;
+    EnumField enumValue2;
 
     setUpAll(() {
+      enumWithAnimation = exLibrary.enums.firstWhere((c) => c.name == 'EnumWithAnimation');
+      enumValue1 = enumWithAnimation.constants
+          .firstWhere((m) => m.name == 'value1');
+      enumValue2 = enumWithAnimation.constants
+          .firstWhere((m) => m.name == 'value2');
       dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
       withAnimation =
           dog.allInstanceMethods.firstWhere((m) => m.name == 'withAnimation');
@@ -1236,6 +1244,14 @@ void main() {
     test("Out of order arguments work.", () {
       expect(withAnimationOutOfOrder.documentation,
           contains('<video id="outOfOrder"'));
+    });
+    test("Enum field animation identifiers are unique.", () {
+      expect(enumValue1.documentationAsHtml, contains('<video id="animation_1"'));
+      expect(enumValue1.documentationAsHtml, contains('<video id="animation_2"'));
+      expect(enumValue2.documentationAsHtml, isNot(contains('<video id="animation_1"')));
+      expect(enumValue2.documentationAsHtml, isNot(contains('<video id="animation_2"')));
+      expect(enumValue2.documentationAsHtml, contains('<video id="animation_3"'));
+      expect(enumValue2.documentationAsHtml, contains('<video id="animation_4"'));
     });
   });
 

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -452,6 +452,23 @@ class Dog implements Cat, E {
   void abstractMethod() {}
 }
 
+/// Animation in an enum
+enum EnumWithAnimation {
+  /// Animation enum value1
+  ///
+  /// {@animation 100 100 http://host/path/to/video1.mp4}
+  /// {@animation 100 100 http://host/path/to/video2.mp4}
+  /// More docs
+  value1,
+
+  /// Animation enum value2
+  ///
+  /// {@animation 100 100 http://host/path/to/video1.mp4}
+  /// {@animation 100 100 http://host/path/to/video2.mp4}
+  /// More docs
+  value2,
+}
+
 abstract class E {}
 
 class F<T extends String> extends Dog with _PrivateAbstractClass {


### PR DESCRIPTION
Currently, on pages like [this](https://api.flutter.dev/flutter/dart-ui/StrokeJoin-class.html), the animations produced don't have unique IDs, because for enum fields, their `oneLineDoc` contains the entire documentation, so that they all appear in the Constants list on the enum's class page.

The way we tried to generate unique values in the past was to assume that each element would appear on its own page, and so be unique, but that's not true for enums.

This change creates a package-level `Map<String, Set<String>` that contains a mapping from `Element.href` to a set of animation IDs that have been already used for that href.  We then generate new ids, making sure that each new ID is unique for the href.  This should assure that there are no non-unique IDs on a single output page, including checking to make sure that user-supplied IDs are unique per page.

Also added a test that should make sure this is the case.