### PR TITLE
Add telemetry to package overrides for sdk bot

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -427,6 +427,8 @@ dependency_overrides:
     path: '${sdkClone.path}/pkg/kernel'
   _fe_analyzer_shared:
     path: '${sdkClone.path}/pkg/_fe_analyzer_shared'
+  telemetry:
+    path: '${sdkClone.path}/pkg/telemetry'
 ''', mode: FileMode.append);
   await launcher.runStreamed(sdkBin('pub'), ['get'],
       workingDirectory: dartdocSdk.path);


### PR DESCRIPTION
Fixes the sdk bot after the telemetry package was added to analyzer's dependencies.