### PR TITLE
Remove author from pubspec to silence pub complaints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
 version: 0.29.0
-author: Dart Team <misc@dartlang.org>
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
A new version of pub has a new warning.  This fixes:

```
try-publish: |       '-- pubspec.yaml
try-publish: '-- tool
try-publish:     |-- after_failure_travis.sh
try-publish:     |-- builder.dart
try-publish:     |-- doc_packages.dart
try-publish:     |-- grind.dart
try-publish:     |-- install_travis.sh
try-publish:     '-- travis.sh
try-publish: Suggestions:
try-publish: * Your pubspec.yaml includes an "author" section which is no longer used and may be removed.
try-publish:
try-publish: Package has 1 warning.
ProcessException: SubprocessLauncher got non-zero exitCode: 65

```