### PR TITLE
Prepare for version 0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.29.1
+* Fix edge cases on extension discovery (#2062)
+* Make sure that enum documentation contains unique IDs for animations (#2060)
+
 ## 0.29.0
 * Internal change to our use of FunctionTypeAliasElement for the analyzer
   (#2051).

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.29.0/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.29.1/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.29.0';
+const packageVersion = '0.29.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.29.0
+version: 0.29.1
 description: A documentation generator for Dart.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
Update changelog & version for 0.29.1.  Assumes that #2065, #2060, and #2062 will land.