### PR TITLE
Create renderer for Category

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
+import 'package:dartdoc/src/render/category_renderer.dart';
 import 'package:dartdoc/src/warnings.dart';
 
 /// A category is a subcategory of a package, containing libraries tagged
@@ -123,27 +124,23 @@ class Category extends Nameable
   String get href =>
       isCanonical ? '${package.baseHref}topics/${name}-topic.html' : null;
 
-  String get linkedName {
-    String unbrokenCategoryName = name.replaceAll(' ', '&nbsp;');
-    if (isDocumented) {
-      return '<a href="$href">$unbrokenCategoryName</a>';
-    } else {
-      return unbrokenCategoryName;
-    }
+  String get categorization {
+    return CategoryRendererHtml().renderCategoryLabel(this);
   }
 
-  String _categoryNumberClass;
+  String get linkedName {
+    return CategoryRendererHtml().renderLinkedName(this);
+  }
+
+  int _categoryIndex;
 
   /// The position in the container order for this category.
-  String get categoryNumberClass {
-    if (_categoryNumberClass == null) {
-      _categoryNumberClass = "cp-${package.categories.indexOf(this)}";
+  int get categoryIndex {
+    if (_categoryIndex == null) {
+      _categoryIndex = package.categories.indexOf(this);
     }
-    return _categoryNumberClass;
+    return _categoryIndex;
   }
-
-  /// Category name used in template as part of the class.
-  String get spanClass => name.split(' ').join('-').toLowerCase();
 
   CategoryDefinition get categoryDefinition =>
       config.categories.categoryDefinitions[sortKey];

--- a/lib/src/render/category_renderer.dart
+++ b/lib/src/render/category_renderer.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartdoc/src/model/category.dart';
+
+abstract class CategoryRenderer {
+  String renderCategoryLabel(Category category);
+  String renderLinkedName(Category category);
+}
+
+class CategoryRendererHtml extends CategoryRenderer {
+  static final CategoryRendererHtml _instance = CategoryRendererHtml._();
+
+  factory CategoryRendererHtml() {
+    return _instance;
+  }
+
+  CategoryRendererHtml._();
+
+  @override
+  String renderCategoryLabel(Category category) {
+    List<String> spanClasses = [];
+    spanClasses.add('category');
+    spanClasses.add(category.name.split(' ').join('-').toLowerCase());
+    spanClasses.add('cp-${category.categoryIndex}');
+    if (category.isDocumented) {
+      spanClasses.add('linked');
+    }
+    var spanTitle = "This is part of the ${category.name} ${category.kind}.";
+
+    StringBuffer buf = StringBuffer();
+    buf.write('<span class="${spanClasses.join(' ')}" title="$spanTitle">');
+    buf.write(category.linkedName);
+    buf.write('</span>');
+    return buf.toString();
+  }
+
+  @override
+  String renderLinkedName(Category category) {
+    String unbrokenName = category.name.replaceAll(' ', '&nbsp;');
+    if (category.isDocumented) {
+      return '<a href="${category.href}">$unbrokenName</a>';
+    } else {
+      return unbrokenName;
+    }
+  }
+}

--- a/lib/templates/_categorization.html
+++ b/lib/templates/_categorization.html
@@ -1,5 +1,5 @@
 {{#hasCategoryNames}}
   {{#displayedCategories}}
-  <span class="category {{spanClass}} {{categoryNumberClass}} {{#isDocumented}}linked{{/isDocumented}}" title="This is part of the {{name}} {{kind}}.">{{{linkedName}}}</span>
+    {{{categorization}}}
   {{/displayedCategories}}
 {{/hasCategoryNames}}

--- a/test/model_special_cases_test.dart
+++ b/test/model_special_cases_test.dart
@@ -256,8 +256,7 @@ void main() {
       expect(IAmAClassWithCategoriesReexport.displayedCategories, isNotEmpty);
       Category category =
           IAmAClassWithCategoriesReexport.displayedCategories.first;
-      expect(category.spanClass, equals('superb'));
-      expect(category.categoryNumberClass, equals('cp-0'));
+      expect(category.categoryIndex, equals(0));
       expect(category.isDocumented, isTrue);
     });
 

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
+import 'package:dartdoc/src/render/category_renderer.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:test/test.dart';
 
@@ -360,6 +361,22 @@ void main() {
               .localPackages.first.defaultCategory.publicLibraries.length,
           // Only 5 libraries have categories, the rest belong in default.
           equals(utils.kTestPackagePublicLibraries - 5));
+    });
+
+    test('CategoryRendererHtml renders category label', () {
+      Category category = packageGraph.publicPackages.first.categories.first;
+      CategoryRendererHtml renderer = CategoryRendererHtml();
+      expect(
+          renderer.renderCategoryLabel(category),
+          '<span class="category superb cp-0 linked" title="This is part of the Superb Topic.">'
+          '<a href="topics/Superb-topic.html">Superb</a></span>');
+    });
+
+    test('CategoryRendererHtml renders linkedName', () {
+      Category category = packageGraph.publicPackages.first.categories.first;
+      CategoryRendererHtml renderer = CategoryRendererHtml();
+      expect(renderer.renderLinkedName(category),
+          '<a href="topics/Superb-topic.html">Superb</a>');
     });
   });
 


### PR DESCRIPTION
Moves html-specific rendering out of the model and into a helper class. Later the helper could be changed via a factory.