### PR TITLE
Improve package description and add brief example reference

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,28 @@
+# dartdoc examples
+
+Dartdoc is typically used as a command line utility to support generating
+documentation served on websites.  In the future this directory may contain
+direct examples, but for now, here are pointers to the main users of dartdoc
+in the Dart ecosystem.
+
+## Dart SDK
+
+The Dart team builds docs for the [Dart API reference](https://api.dart.dev/)
+with each new version of the SDK, via
+[this script](https://github.com/dart-lang/sdk/blob/master/tools/bots/dart_sdk.py).
+Look for `BuildDartdocAPIDocs`.
+
+## pub
+
+The [pub package website](https://pub.dev) automatically builds Dart
+[API documentation](https://pub.dev/documentation/dartdoc/latest/)
+for [uploaded packages](https://pub.dev/packages/dartdoc).   Unlike the other two
+examples, dartdoc is used as a library.  See [this script](https://github.com/dart-lang/pub-dev/blob/master/pkg/pub_dartdoc/bin/pub_dartdoc.dart)
+for the entry point.
+
+## Flutter
+
+The Flutter team builds [API documentation for the Flutter SDK](https://api.flutter.dev)
+automatically.  A [shell script](https://github.com/flutter/flutter/blob/master/dev/bots/docs.sh)
+wraps a [small dart program](https://github.com/flutter/flutter/blob/master/dev/tools/dartdoc.dart)
+that manages the process. 

--- a/example/README.md
+++ b/example/README.md
@@ -12,17 +12,22 @@ with each new version of the SDK, via
 [this script](https://github.com/dart-lang/sdk/blob/master/tools/bots/dart_sdk.py).
 Look for `BuildDartdocAPIDocs`.
 
-## pub
-
-The [pub package website](https://pub.dev) automatically builds Dart
-[API documentation](https://pub.dev/documentation/dartdoc/latest/)
-for [uploaded packages](https://pub.dev/packages/dartdoc).   Unlike the other two
-examples, dartdoc is used as a library.  See [this script](https://github.com/dart-lang/pub-dev/blob/master/pkg/pub_dartdoc/bin/pub_dartdoc.dart)
-for the entry point.
-
 ## Flutter
 
 The Flutter team builds [API documentation for the Flutter SDK](https://api.flutter.dev)
 automatically.  A [shell script](https://github.com/flutter/flutter/blob/master/dev/bots/docs.sh)
 wraps a [small dart program](https://github.com/flutter/flutter/blob/master/dev/tools/dartdoc.dart)
-that manages the process. 
+that manages the process.
+
+## pub
+
+The [pub package website](https://pub.dev) automatically builds Dart
+[API documentation](https://pub.dev/documentation/dartdoc/latest/)
+for [uploaded packages](https://pub.dev/packages/dartdoc).
+
+Note, unlike the other two examples, here dartdoc is used as a library.  While we make some
+effort not to regularly break simple uses of the library interface, we strongly recommend
+you use the command line and focus our semantic versioning around that case.   However, if
+that doesn't work for your case, the pub site usage may be of interest.  See
+[this script](https://github.com/dart-lang/pub-dev/blob/master/pkg/pub_dartdoc/bin/pub_dartdoc.dart)
+for the entry point.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dartdoc
 # Run `grind build` after updating.
 version: 0.29.1
 author: Dart Team <misc@dartlang.org>
-description: A documentation generator for Dart.
+description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=2.6.0 <3.0.0'

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('has a description', () {
-      expect(p.description, equals('A documentation generator for Dart.'));
+      expect(p.description, equals('A non-interactive HTML documentation generator for Dart source code.'));
     });
 
     test('has a homepage', () {

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -46,7 +46,10 @@ void main() {
     });
 
     test('has a description', () {
-      expect(p.description, equals('A non-interactive HTML documentation generator for Dart source code.'));
+      expect(
+          p.description,
+          equals(
+              'A non-interactive HTML documentation generator for Dart source code.'));
     });
 
     test('has a homepage', () {


### PR DESCRIPTION
A long overdue update that adds references to exemplars of dartdoc usage.