### PR TITLE
Separate documentation parsing and rendering

### DIFF
--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dartdoc/src/dartdoc_options.dart';
-import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartdoc/src/markdown_processor.dart';
+import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/render/documentation_renderer.dart';
+import 'package:dartdoc/src/tuple.dart';
+import 'package:markdown/markdown.dart' as md;
+
+class Documentation {
+  final Canonicalization _element;
+
+  Documentation.forElement(this._element);
+
+  bool _hasExtendedDocs;
+
+  bool get hasExtendedDocs {
+    if (_hasExtendedDocs == null) {
+      _renderDocumentation(_element.isCanonical && _asHtml == null);
+    }
+    return _hasExtendedDocs;
+  }
+
+  String _asHtml;
+
+  String get asHtml {
+    if (_asHtml == null) {
+      assert(_asOneLiner == null || _element.isCanonical);
+      _renderDocumentation(true);
+    }
+    return _asHtml;
+  }
+
+  String _asOneLiner;
+
+  String get asOneLiner {
+    if (_asOneLiner == null) {
+      assert(_asHtml == null);
+      _renderDocumentation(_element.isCanonical);
+    }
+    return _asOneLiner;
+  }
+
+  List<ModelCommentReference> get commentRefs => _element.commentRefs;
+
+  void _renderDocumentation(bool processAllDocs) {
+    Tuple2<List<md.Node>, bool> parseResult =
+        _parseDocumentation(processAllDocs);
+    if (_hasExtendedDocs != null) {
+      assert(_hasExtendedDocs == parseResult.item2);
+    }
+    _hasExtendedDocs = parseResult.item2;
+
+    Tuple2<String, String> renderResult =
+        DocumentationRendererHtml().render(parseResult.item1, processAllDocs);
+
+    if (processAllDocs) {
+      _asHtml = renderResult.item1;
+    }
+    if (_asOneLiner == null) {
+      _asOneLiner = renderResult.item2;
+    }
+  }
+
+  /// Returns a tuple of List<md.Node> and hasExtendedDocs
+  Tuple2<List<md.Node>, bool> _parseDocumentation(bool processFullDocs) {
+    String text = _element.documentation;
+    showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
+    MarkdownDocument document =
+        MarkdownDocument.withElementLinkResolver(_element, commentRefs);
+    return document.parseMarkdownText(text, processFullDocs);
+  }
+}

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -11,6 +11,7 @@ export 'constructor.dart';
 export 'container.dart';
 export 'container_member.dart';
 export 'documentable.dart';
+export 'documentation.dart';
 export 'dynamic.dart';
 export 'enclosed_element.dart';
 export 'enum.dart';

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -23,7 +23,6 @@ import 'package:crypto/crypto.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/logging.dart';
-import 'package:dartdoc/src/markdown_processor.dart' show Documentation;
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as utils;
 import 'package:dartdoc/src/render/parameter_renderer.dart';

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
-import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';

--- a/lib/src/render/documentation_renderer.dart
+++ b/lib/src/render/documentation_renderer.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartdoc/src/tuple.dart';
+import 'package:html/parser.dart' show parse;
+import 'package:markdown/markdown.dart' as md;
+
+abstract class DocumentationRenderer {
+  Tuple2<String, String> render(List<md.Node> nodes, bool processFullDocs);
+}
+
+class DocumentationRendererHtml extends DocumentationRenderer {
+  @override
+  Tuple2<String, String> render(List<md.Node> nodes, bool processFullDocs) {
+    var rawHtml = md.HtmlRenderer().render(nodes);
+    var asHtmlDocument = parse(rawHtml);
+    for (var s in asHtmlDocument.querySelectorAll('script')) {
+      s.remove();
+    }
+    for (var pre in asHtmlDocument.querySelectorAll('pre')) {
+      if (pre.children.isNotEmpty &&
+          pre.children.length != 1 &&
+          pre.children.first.localName != 'code') {
+        continue;
+      }
+
+      if (pre.children.isNotEmpty && pre.children.first.localName == 'code') {
+        var code = pre.children.first;
+        pre.classes
+            .addAll(code.classes.where((name) => name.startsWith('language-')));
+      }
+
+      bool specifiesLanguage = pre.classes.isNotEmpty;
+      // Assume the user intended Dart if there are no other classes present.
+      if (!specifiesLanguage) pre.classes.add('language-dart');
+    }
+    String asHtml;
+    String asOneLiner;
+
+    if (processFullDocs) {
+      // `trim` fixes issue with line ending differences between mac and windows.
+      asHtml = asHtmlDocument.body.innerHtml?.trim();
+    }
+    asOneLiner = asHtmlDocument.body.children.isEmpty
+        ? ''
+        : asHtmlDocument.body.children.first.innerHtml;
+
+    return Tuple2(asHtml, asOneLiner);
+  }
+}


### PR DESCRIPTION
- Move Documentation out of `markdown_processor` and into model package

- Create a renderer class for Documentation