### PR TITLE
Remove the unneeded ModelFunctionAnonymous and related code

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -39,32 +39,21 @@ abstract class ElementType extends Privacy {
       if (f is FunctionType) {
         assert(f is ParameterizedType);
         if (isGenericTypeAlias) {
-          assert(element is! ModelFunctionAnonymous);
           return CallableGenericTypeAliasElementType(
               f, library, packageGraph, element, returnedFrom);
-        } else {
-          if (element is ModelFunctionAnonymous) {
-            return CallableAnonymousElementType(
-                f, library, packageGraph, element, returnedFrom);
-          } else {
-            assert(element is! ModelFunctionAnonymous);
-            return CallableElementType(
-                f, library, packageGraph, element, returnedFrom);
-          }
         }
+        return CallableElementType(
+            f, library, packageGraph, element, returnedFrom);
       } else if (isGenericTypeAlias) {
         assert(f is TypeParameterType);
-        assert(element is! ModelFunctionAnonymous);
         return GenericTypeAliasElementType(
             f, library, packageGraph, element, returnedFrom);
       }
       if (f is TypeParameterType) {
-        assert(element is! ModelFunctionAnonymous);
         return TypeParameterElementType(
             f, library, packageGraph, element, returnedFrom);
       }
       assert(f is ParameterizedType);
-      assert(element is! ModelFunctionAnonymous);
       return ParameterizedElementType(
           f, library, packageGraph, element, returnedFrom);
     }
@@ -329,10 +318,7 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
           dartTypeArguments = type.typeFormals.map(_legacyTypeParameterType);
         }
       } else {
-        DefinedElementType elementType = returnedFrom as DefinedElementType;
-        if (type.typeFormals.isEmpty &&
-            element is! ModelFunctionAnonymous &&
-            elementType?.element is! ModelFunctionAnonymous) {
+        if (type.typeFormals.isEmpty) {
           dartTypeArguments = type.typeArguments;
         } else if (returnedFrom != null &&
             returnedFrom.type.element is GenericFunctionTypeElement) {
@@ -382,25 +368,6 @@ class CallableElementType extends ParameterizedElementType
   }
 
   String get superLinkedName => super.linkedName;
-}
-
-/// This is an anonymous function using the generic function syntax (declared
-/// literally with "Function").
-class CallableAnonymousElementType extends CallableElementType {
-  CallableAnonymousElementType(FunctionType t, Library library,
-      PackageGraph packageGraph, ModelElement element, ElementType returnedFrom)
-      : super(t, library, packageGraph, element, returnedFrom);
-  @override
-  String get name => 'Function';
-
-  @override
-  String get linkedName {
-    if (_linkedName == null) {
-      _linkedName =
-          CallableAnonymousElementTypeRendererHtml().renderLinkedName(this);
-    }
-    return _linkedName;
-  }
 }
 
 /// Types backed by a [GenericTypeAliasElement] that may or may not be callable.

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -247,22 +247,9 @@ abstract class ModelElement extends Canonicalization
         if (e is FunctionElement) {
           newModelElement = ModelFunction(e, library, packageGraph);
         } else if (e is GenericFunctionTypeElement) {
-          // TODO(scheglov) "e" cannot be both GenericFunctionTypeElement,
-          // and FunctionTypeAliasElement or GenericTypeAliasElement.
-          if (e is FunctionTypeAliasElement) {
-            assert(e.name != '');
-            newModelElement = ModelFunctionTypedef(e, library, packageGraph);
-          } else {
-            if (e.enclosingElement is GenericTypeAliasElement) {
-              assert(e.enclosingElement.name != '');
-              newModelElement = ModelFunctionTypedef(e, library, packageGraph);
-            } else {
-              // Allowing null here is allowed as a workaround for
-              // dart-lang/sdk#32005.
-              assert(e.name == '' || e.name == null);
-              newModelElement = ModelFunctionAnonymous(e, packageGraph);
-            }
-          }
+          assert(e.enclosingElement is GenericTypeAliasElement);
+          assert(e.enclosingElement.name != '');
+          newModelElement = ModelFunctionTypedef(e, library, packageGraph);
         }
         if (e is FunctionTypeAliasElement) {
           newModelElement = Typedef(e, library, packageGraph);

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -60,17 +60,7 @@ class ModelFunctionTypedef extends ModelFunctionTyped {
       : super(element, library, packageGraph);
 
   @override
-  String get name {
-    Element e = element;
-    while (e != null) {
-      if (e is FunctionTypeAliasElement || e is GenericTypeAliasElement) {
-        return e.name;
-      }
-      e = e.enclosingElement;
-    }
-    assert(false);
-    return super.name;
-  }
+  String get name => element.enclosingElement.name;
 }
 
 class ModelFunctionTyped extends ModelElement

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -24,34 +24,6 @@ class ModelFunction extends ModelFunctionTyped with Categorization {
   FunctionElement get _func => (element as FunctionElement);
 }
 
-/// A [ModelElement] for a [FunctionTypedElement] that is an
-/// explicit typedef.
-///
-/// Distinct from ModelFunctionTypedef in that it doesn't
-/// have a name, but we document it as "Function" to match how these are
-/// written in declarations.
-class ModelFunctionAnonymous extends ModelFunctionTyped {
-  ModelFunctionAnonymous(
-      FunctionTypedElement element, PackageGraph packageGraph)
-      : super(element, null, packageGraph);
-
-  @override
-  ModelElement get enclosingElement {
-    // These are not considered to be a part of libraries, so we can simply
-    // blindly instantiate a ModelElement for their enclosing element.
-    return ModelElement.fromElement(element.enclosingElement, packageGraph);
-  }
-
-  @override
-  String get name => 'Function';
-
-  @override
-  String get linkedName => 'Function';
-
-  @override
-  bool get isPublic => false;
-}
-
 /// A [ModelElement] for a [FunctionTypedElement] that is part of an
 /// explicit typedef.
 class ModelFunctionTypedef extends ModelFunctionTyped {

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -93,19 +93,3 @@ class CallableElementTypeRendererHtml
     return buf.toString();
   }
 }
-
-class CallableAnonymousElementTypeRendererHtml
-    extends ElementTypeRenderer<CallableAnonymousElementType> {
-  @override
-  String renderLinkedName(CallableAnonymousElementType elementType) {
-    StringBuffer buf = StringBuffer();
-    buf.write(elementType.returnType.linkedName);
-    buf.write(' ');
-    buf.write(elementType.superLinkedName);
-    buf.write('<span class="signature">(');
-    buf.write(ParameterRendererHtml()
-        .renderLinkedParams(elementType.element.parameters));
-    buf.write(')</span>');
-    return buf.toString();
-  }
-}

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -135,7 +135,6 @@ abstract class ParameterRenderer {
       if (showNames) {
         buf.write(' ${parameterName(param.name)}');
       } else if (paramModelType.isTypedef ||
-          paramModelType is CallableAnonymousElementType ||
           paramModelType.type is FunctionType) {
         buf.write(' ${parameterName(paramModelType.name)}');
       }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -403,8 +403,6 @@ functionUsingMixinReturningFunction() {
   GenericClass<int> using = aMixinReturningFunction();
 }
 
-String Function(int) aFunctionReturningFunction() => (int i) => i.toString();
-
 /// A super class, with many powers. Link to [Apple] from another library.
 @deprecated
 class SuperAwesomeClass {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -403,6 +403,8 @@ functionUsingMixinReturningFunction() {
   GenericClass<int> using = aMixinReturningFunction();
 }
 
+String Function(int) aFunctionReturningFunction() => (int i) => i.toString();
+
 /// A super class, with many powers. Link to [Apple] from another library.
 @deprecated
 class SuperAwesomeClass {


### PR DESCRIPTION
Implements a TODO from @scheglov to strip code that can no longer be reached on modern versions of the analyzer.