### PR TITLE
Stop using SdkExtUriResolver.

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -21,7 +21,6 @@ import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
 import 'package:analyzer/src/source/package_map_resolver.dart';
-import 'package:analyzer/src/source/sdk_ext.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/logging.dart';
@@ -118,7 +117,6 @@ class PackageBuilder {
 
   SourceFactory get sourceFactory {
     List<UriResolver> resolvers = [];
-    resolvers.add(SdkExtUriResolver(packageMap));
     final UriResolver packageResolver =
         PackageMapUriResolver(PhysicalResourceProvider.INSTANCE, packageMap);
     UriResolver sdkResolver;


### PR DESCRIPTION
We don't support `_sdkext` anymore, only `_embedder.yaml`.

I'd like to remove `SdkExtUriResolver` in addition to changes done in https://dart-review.googlesource.com/c/sdk/+/128320