### PR TITLE
Update pubspec.yaml and tryPublish check for Dart 2.7

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
 version: 0.29.2
-author: Dart Team <misc@dartlang.org>
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -876,12 +876,8 @@ Future<void> checkBuild() async {
 @Task('Dry run of publish to pub.dartlang')
 @Depends(checkChangelogHasVersion)
 Future<void> tryPublish() async {
-  if (Platform.version.contains('dev')) {
-    log('Skipping publish check -- requires a stable version of the SDK');
-  } else {
-    var launcher = SubprocessLauncher('try-publish');
-    await launcher.runStreamed(sdkBin('pub'), ['publish', '-n']);
-  }
+  var launcher = SubprocessLauncher('try-publish');
+  await launcher.runStreamed(sdkBin('pub'), ['publish', '-n']);
 }
 
 @Task('Run a smoke test, only')


### PR DESCRIPTION
With Dart 2.7 stable we need to update our pubspec.yaml to publish without warnings (and fix the test that checks whether we can).