### PR TITLE
Prepare for dartdoc 0.29.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
+## 0.29.3
+* More refactoring changes to rendering (#2085, #2086).
+* Internal changes to stop using newly deprecated analyzer interfaces (#2091, #2093).
+
 ## 0.29.2
-* Many refactoring changes to rendering and tests (#2084, #2081, #2080, #2078, #2077, #2076, #2068, #2067)
-* Add 'required' for required named parameters with NNBD enabled (#2075)
-* Rewrite parameter handling and fix problems with brackets (#2075, #2059, #2052, #2082)
-* Add 'late' as a feature for final variables with NNBD enabled (#2071)
-* Add presubmit grinder and dartfmt check for dartdoc development (#2070)
-* Initial implementation of NNBD support (with --enable-experiment flag) (#2069)
+* Many refactoring changes to rendering and tests (#2084, #2081, #2080, #2078, #2077, #2076, #2068, #2067).
+* Add 'required' for required named parameters with NNBD enabled (#2075).
+* Rewrite parameter handling and fix problems with brackets (#2075, #2059, #2052, #2082).
+* Add 'late' as a feature for final variables with NNBD enabled (#2071).
+* Add presubmit grinder and dartfmt check for dartdoc development (#2070).
+* Initial implementation of NNBD support (with --enable-experiment flag) (#2069).
 
 ## 0.29.1
-* Fix edge cases on extension discovery (#2062)
-* Make sure that enum documentation contains unique IDs for animations (#2060)
+* Fix edge cases on extension discovery (#2062).
+* Make sure that enum documentation contains unique IDs for animations (#2060).
 
 ## 0.29.0
 * Internal change to our use of FunctionTypeAliasElement for the analyzer

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.29.2/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.29.3/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.29.2';
+const packageVersion = '0.29.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.29.2
+version: 0.29.3
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
Assumes #2093 will land first.