### PR TITLE
Decouple href and from a model's filename

### DIFF
--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -289,7 +289,7 @@ class HtmlGeneratorInstance {
     TemplateData data =
         CategoryTemplateData(_options, packageGraph, _templateHelper, category);
 
-    _build(category.href, _templates.categoryTemplate, data);
+    _build(category.filePath, _templates.categoryTemplate, data);
   }
 
   void generateLibrary(PackageGraph packageGraph, Library lib) {
@@ -301,26 +301,26 @@ class HtmlGeneratorInstance {
     TemplateData data =
         LibraryTemplateData(_options, packageGraph, _templateHelper, lib);
 
-    _build(lib.href, _templates.libraryTemplate, data);
+    _build(lib.filePath, _templates.libraryTemplate, data);
   }
 
   void generateClass(PackageGraph packageGraph, Library lib, Class clazz) {
     TemplateData data =
         ClassTemplateData(_options, packageGraph, _templateHelper, lib, clazz);
-    _build(clazz.href, _templates.classTemplate, data);
+    _build(clazz.filePath, _templates.classTemplate, data);
   }
 
   void generateExtension(
       PackageGraph packageGraph, Library lib, Extension extension) {
     TemplateData data = ExtensionTemplateData(
         _options, packageGraph, _templateHelper, lib, extension);
-    _build(extension.href, _templates.extensionTemplate, data);
+    _build(extension.filePath, _templates.extensionTemplate, data);
   }
 
   void generateMixins(PackageGraph packageGraph, Library lib, Mixin mixin) {
     TemplateData data =
         MixinTemplateData(_options, packageGraph, _templateHelper, lib, mixin);
-    _build(mixin.href, _templates.mixinTemplate, data);
+    _build(mixin.filePath, _templates.mixinTemplate, data);
   }
 
   void generateConstructor(PackageGraph packageGraph, Library lib, Class clazz,
@@ -328,14 +328,14 @@ class HtmlGeneratorInstance {
     TemplateData data = ConstructorTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, constructor);
 
-    _build(constructor.href, _templates.constructorTemplate, data);
+    _build(constructor.filePath, _templates.constructorTemplate, data);
   }
 
   void generateEnum(PackageGraph packageGraph, Library lib, Enum eNum) {
     TemplateData data =
         EnumTemplateData(_options, packageGraph, _templateHelper, lib, eNum);
 
-    _build(eNum.href, _templates.enumTemplate, data);
+    _build(eNum.filePath, _templates.enumTemplate, data);
   }
 
   void generateFunction(
@@ -343,7 +343,7 @@ class HtmlGeneratorInstance {
     TemplateData data = FunctionTemplateData(
         _options, packageGraph, _templateHelper, lib, function);
 
-    _build(function.href, _templates.functionTemplate, data);
+    _build(function.filePath, _templates.functionTemplate, data);
   }
 
   void generateMethod(
@@ -351,7 +351,7 @@ class HtmlGeneratorInstance {
     TemplateData data = MethodTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, method);
 
-    _build(method.href, _templates.methodTemplate, data);
+    _build(method.filePath, _templates.methodTemplate, data);
   }
 
   void generateConstant(
@@ -359,7 +359,7 @@ class HtmlGeneratorInstance {
     TemplateData data = ConstantTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, property);
 
-    _build(property.href, _templates.constantTemplate, data);
+    _build(property.filePath, _templates.constantTemplate, data);
   }
 
   void generateProperty(
@@ -367,7 +367,7 @@ class HtmlGeneratorInstance {
     TemplateData data = PropertyTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, property);
 
-    _build(property.href, _templates.propertyTemplate, data);
+    _build(property.filePath, _templates.propertyTemplate, data);
   }
 
   void generateTopLevelProperty(
@@ -375,7 +375,7 @@ class HtmlGeneratorInstance {
     TemplateData data = TopLevelPropertyTemplateData(
         _options, packageGraph, _templateHelper, lib, property);
 
-    _build(property.href, _templates.topLevelPropertyTemplate, data);
+    _build(property.filePath, _templates.topLevelPropertyTemplate, data);
   }
 
   void generateTopLevelConstant(
@@ -383,7 +383,7 @@ class HtmlGeneratorInstance {
     TemplateData data = TopLevelConstTemplateData(
         _options, packageGraph, _templateHelper, lib, property);
 
-    _build(property.href, _templates.topLevelConstantTemplate, data);
+    _build(property.filePath, _templates.topLevelConstantTemplate, data);
   }
 
   void generateTypeDef(
@@ -391,7 +391,7 @@ class HtmlGeneratorInstance {
     TemplateData data = TypedefTemplateData(
         _options, packageGraph, _templateHelper, lib, typeDef);
 
-    _build(typeDef.href, _templates.typeDefTemplate, data);
+    _build(typeDef.filePath, _templates.typeDefTemplate, data);
   }
 
   // TODO: change this to use resource_loader

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -279,7 +279,7 @@ class HtmlGeneratorInstance {
         PackageTemplateData(_options, packageGraph, _templateHelper, package);
     logInfo('documenting ${package.name}');
 
-    _build('index.html', _templates.indexTemplate, data);
+    _build(package.filePath, _templates.indexTemplate, data);
     _build('__404error.html', _templates.errorTemplate, data);
   }
 

--- a/lib/src/html/html_generator_instance.dart
+++ b/lib/src/html/html_generator_instance.dart
@@ -289,8 +289,7 @@ class HtmlGeneratorInstance {
     TemplateData data =
         CategoryTemplateData(_options, packageGraph, _templateHelper, category);
 
-    _build(path.joinAll(category.href.split('/')), _templates.categoryTemplate,
-        data);
+    _build(category.href, _templates.categoryTemplate, data);
   }
 
   void generateLibrary(PackageGraph packageGraph, Library lib) {
@@ -302,28 +301,26 @@ class HtmlGeneratorInstance {
     TemplateData data =
         LibraryTemplateData(_options, packageGraph, _templateHelper, lib);
 
-    _build(path.join(lib.dirName, '${lib.fileName}'),
-        _templates.libraryTemplate, data);
+    _build(lib.href, _templates.libraryTemplate, data);
   }
 
   void generateClass(PackageGraph packageGraph, Library lib, Class clazz) {
     TemplateData data =
         ClassTemplateData(_options, packageGraph, _templateHelper, lib, clazz);
-    _build(path.joinAll(clazz.href.split('/')), _templates.classTemplate, data);
+    _build(clazz.href, _templates.classTemplate, data);
   }
 
   void generateExtension(
-      PackageGraph packageGraph, Library lib, Extension ext) {
+      PackageGraph packageGraph, Library lib, Extension extension) {
     TemplateData data = ExtensionTemplateData(
-        _options, packageGraph, _templateHelper, lib, ext);
-    _build(
-        path.joinAll(ext.href.split('/')), _templates.extensionTemplate, data);
+        _options, packageGraph, _templateHelper, lib, extension);
+    _build(extension.href, _templates.extensionTemplate, data);
   }
 
   void generateMixins(PackageGraph packageGraph, Library lib, Mixin mixin) {
     TemplateData data =
         MixinTemplateData(_options, packageGraph, _templateHelper, lib, mixin);
-    _build(path.joinAll(mixin.href.split('/')), _templates.mixinTemplate, data);
+    _build(mixin.href, _templates.mixinTemplate, data);
   }
 
   void generateConstructor(PackageGraph packageGraph, Library lib, Class clazz,
@@ -331,15 +328,14 @@ class HtmlGeneratorInstance {
     TemplateData data = ConstructorTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, constructor);
 
-    _build(path.joinAll(constructor.href.split('/')),
-        _templates.constructorTemplate, data);
+    _build(constructor.href, _templates.constructorTemplate, data);
   }
 
   void generateEnum(PackageGraph packageGraph, Library lib, Enum eNum) {
     TemplateData data =
         EnumTemplateData(_options, packageGraph, _templateHelper, lib, eNum);
 
-    _build(path.joinAll(eNum.href.split('/')), _templates.enumTemplate, data);
+    _build(eNum.href, _templates.enumTemplate, data);
   }
 
   void generateFunction(
@@ -347,8 +343,7 @@ class HtmlGeneratorInstance {
     TemplateData data = FunctionTemplateData(
         _options, packageGraph, _templateHelper, lib, function);
 
-    _build(path.joinAll(function.href.split('/')), _templates.functionTemplate,
-        data);
+    _build(function.href, _templates.functionTemplate, data);
   }
 
   void generateMethod(
@@ -356,8 +351,7 @@ class HtmlGeneratorInstance {
     TemplateData data = MethodTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, method);
 
-    _build(
-        path.joinAll(method.href.split('/')), _templates.methodTemplate, data);
+    _build(method.href, _templates.methodTemplate, data);
   }
 
   void generateConstant(
@@ -365,8 +359,7 @@ class HtmlGeneratorInstance {
     TemplateData data = ConstantTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, property);
 
-    _build(path.joinAll(property.href.split('/')), _templates.constantTemplate,
-        data);
+    _build(property.href, _templates.constantTemplate, data);
   }
 
   void generateProperty(
@@ -374,8 +367,7 @@ class HtmlGeneratorInstance {
     TemplateData data = PropertyTemplateData(
         _options, packageGraph, _templateHelper, lib, clazz, property);
 
-    _build(path.joinAll(property.href.split('/')), _templates.propertyTemplate,
-        data);
+    _build(property.href, _templates.propertyTemplate, data);
   }
 
   void generateTopLevelProperty(
@@ -383,8 +375,7 @@ class HtmlGeneratorInstance {
     TemplateData data = TopLevelPropertyTemplateData(
         _options, packageGraph, _templateHelper, lib, property);
 
-    _build(path.joinAll(property.href.split('/')),
-        _templates.topLevelPropertyTemplate, data);
+    _build(property.href, _templates.topLevelPropertyTemplate, data);
   }
 
   void generateTopLevelConstant(
@@ -392,8 +383,7 @@ class HtmlGeneratorInstance {
     TemplateData data = TopLevelConstTemplateData(
         _options, packageGraph, _templateHelper, lib, property);
 
-    _build(path.joinAll(property.href.split('/')),
-        _templates.topLevelConstantTemplate, data);
+    _build(property.href, _templates.topLevelConstantTemplate, data);
   }
 
   void generateTypeDef(
@@ -401,8 +391,7 @@ class HtmlGeneratorInstance {
     TemplateData data = TypedefTemplateData(
         _options, packageGraph, _templateHelper, lib, typeDef);
 
-    _build(path.joinAll(typeDef.href.split('/')), _templates.typeDefTemplate,
-        data);
+    _build(typeDef.href, _templates.typeDefTemplate, data);
   }
 
   // TODO: change this to use resource_loader
@@ -420,9 +409,11 @@ class HtmlGeneratorInstance {
   }
 
   void _build(String filename, Template template, TemplateData data) {
+    // Replaces '/' separators with proper separators for the platform.
+    String outFile = path.joinAll(filename.split('/'));
     String content = template.renderString(data);
 
-    _writer(filename, content);
+    _writer(outFile, content);
     if (data.self is Indexable) _indexedElements.add(data.self as Indexable);
   }
 }

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -90,9 +90,7 @@ class Accessor extends ModelElement implements EnclosedElement {
   }
 
   @override
-  String get filePath {
-    return enclosingCombo.filePath;
-  }
+  String get filePath => enclosingCombo.filePath;
 
   @override
   bool get isCanonical => enclosingCombo.isCanonical;

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -90,6 +90,11 @@ class Accessor extends ModelElement implements EnclosedElement {
   }
 
   @override
+  String get filePath {
+    return enclosingCombo.filePath;
+  }
+
+  @override
   bool get isCanonical => enclosingCombo.isCanonical;
 
   @override

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -120,6 +120,8 @@ class Category extends Nameable
   @override
   String get fullyQualifiedName => name;
 
+  String get filePath => 'topics/${name}-topic.html';
+
   @override
   String get href =>
       isCanonical ? '${package.baseHref}topics/${name}-topic.html' : null;

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -123,8 +123,7 @@ class Category extends Nameable
   String get filePath => 'topics/${name}-topic.html';
 
   @override
-  String get href =>
-      isCanonical ? '${package.baseHref}topics/${name}-topic.html' : null;
+  String get href => isCanonical ? '${package.baseHref}$filePath' : null;
 
   String get categorization => _renderer.renderCategoryLabel(this);
 

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -252,7 +252,7 @@ class Class extends Container
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${library.dirName}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   /// Returns all the implementors of this class.

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -201,6 +201,16 @@ class Class extends Container
   @override
   String get fileName => "${name}-class.html";
 
+  @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
+  }
+
   String get fullkind {
     if (isAbstract) return 'abstract $kind';
     return kind;

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -202,14 +202,7 @@ class Class extends Container
   String get fileName => "${name}-class.html";
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${library.dirName}/$fileName';
-  }
+  String get filePath => '${library.dirName}/$fileName';
 
   String get fullkind {
     if (isAbstract) return 'abstract $kind';

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -57,7 +57,7 @@ class Constructor extends ModelElement
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   @override

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -34,6 +34,16 @@ class Constructor extends ModelElement
   ModelElement get enclosingElement =>
       ModelElement.from(_constructor.enclosingElement, library, packageGraph);
 
+  @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name.html';
+  }
+
   String get fullKind {
     if (isConst) return 'const $kind';
     if (isFactory) return 'factory $kind';

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -35,14 +35,8 @@ class Constructor extends ModelElement
       ModelElement.from(_constructor.enclosingElement, library, packageGraph);
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name.html';
-  }
+  String get filePath =>
+      '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
 
   String get fullKind {
     if (isConst) return 'const $kind';
@@ -63,7 +57,7 @@ class Constructor extends ModelElement
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.name}/$name.html';
+    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
   }
 
   @override

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -27,4 +27,7 @@ class Dynamic extends ModelElement {
 
   @override
   String get linkedName => 'dynamic';
+
+  @override
+  String get filePath => null;
 }

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -144,6 +144,16 @@ class Extension extends Container
   }
 
   @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
+  }
+
+  @override
   String get href {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -144,14 +144,7 @@ class Extension extends Container
   }
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${library.dirName}/$fileName';
-  }
+  String get filePath => '${library.dirName}/$fileName';
 
   @override
   String get href {

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -153,6 +153,6 @@ class Extension extends Container
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${library.dirName}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 }

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -65,6 +65,17 @@ class Field extends ModelElement
   }
 
   @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalEnclosingContainer == enclosingElement);
+    assert(canonicalLibrary == library);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
+  }
+
+  @override
   String get href {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -65,15 +65,8 @@ class Field extends ModelElement
   }
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalEnclosingContainer == enclosingElement);
-    assert(canonicalLibrary == library);
-    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
-  }
+  String get filePath =>
+      '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
 
   @override
   String get href {

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -76,7 +76,7 @@ class Field extends ModelElement
     assert(canonicalLibrary != null);
     assert(canonicalEnclosingContainer == enclosingElement);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   @override

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -375,6 +375,14 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   @override
   String get fileName => '$dirName-library.html';
 
+  @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    return '${library.dirName}/$fileName';
+  }
+
   List<ModelFunction> _functions;
 
   @override

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -397,7 +397,7 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;
     }
-    return '${package.baseHref}${library.dirName}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   InheritanceManager3 _inheritanceManager;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -376,12 +376,7 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   String get fileName => '$dirName-library.html';
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    return '${library.dirName}/$fileName';
-  }
+  String get filePath => '${library.dirName}/$fileName';
 
   List<ModelFunction> _functions;
 

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -59,15 +59,8 @@ class Method extends ModelElement
   }
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(!(canonicalLibrary == null || canonicalEnclosingContainer == null));
-    assert(canonicalLibrary == library);
-    assert(canonicalEnclosingContainer == enclosingElement);
-    return '${enclosingElement.library.dirName}/${enclosingElement.name}/${fileName}';
-  }
+  String get filePath =>
+      '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
 
   String get fullkind {
     if (_method.isAbstract) return 'abstract $kind';

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -58,6 +58,17 @@ class Method extends ModelElement
     return _enclosingContainer;
   }
 
+  @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(!(canonicalLibrary == null || canonicalEnclosingContainer == null));
+    assert(canonicalLibrary == library);
+    assert(canonicalEnclosingContainer == enclosingElement);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/${fileName}';
+  }
+
   String get fullkind {
     if (_method.isAbstract) return 'abstract $kind';
     return kind;

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -75,7 +75,7 @@ class Method extends ModelElement
     assert(!(canonicalLibrary == null || canonicalEnclosingContainer == null));
     assert(canonicalLibrary == library);
     assert(canonicalEnclosingContainer == enclosingElement);
-    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.name}/${fileName}';
+    return '${package.baseHref}$filePath';
   }
 
   @override

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -791,6 +791,8 @@ abstract class ModelElement extends Canonicalization
 
   String get fileName => "${name}.html";
 
+  String get filePath;
+
   /// Returns the fully qualified name.
   ///
   /// For example: libraryName.className.methodName

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -57,6 +57,16 @@ class ModelFunctionTyped extends ModelElement
   ModelElement get enclosingElement => library;
 
   @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
+  }
+
+  @override
   String get href {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -66,7 +66,7 @@ class ModelFunctionTyped extends ModelElement
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${library.dirName}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   @override

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -57,14 +57,7 @@ class ModelFunctionTyped extends ModelElement
   ModelElement get enclosingElement => library;
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${library.dirName}/$fileName';
-  }
+  String get filePath => '${library.dirName}/$fileName';
 
   @override
   String get href {

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -170,6 +170,8 @@ class Package extends LibraryContainer
   @override
   String get enclosingName => packageGraph.defaultPackageName;
 
+  String get filePath => 'index.html';
+
   @override
   String get fullyQualifiedName => 'package:$name';
 
@@ -211,7 +213,7 @@ class Package extends LibraryContainer
   }
 
   @override
-  String get href => '${baseHref}index.html';
+  String get href => '$baseHref$filePath';
 
   @override
   String get location => path.toUri(packageMeta.resolvedDir).toString();

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -28,6 +28,11 @@ class Parameter extends ModelElement implements EnclosedElement {
   }
 
   @override
+  String get filePath {
+    throw StateError('filePath not implemented for parameters');
+  }
+
+  @override
   String get href {
     throw StateError('href not implemented for parameters');
   }

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -54,7 +54,7 @@ class TopLevelVariable extends ModelElement
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${library.dirName}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   @override

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -45,6 +45,16 @@ class TopLevelVariable extends ModelElement
   ModelElement get enclosingElement => library;
 
   @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
+  }
+
+  @override
   String get href {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -45,14 +45,7 @@ class TopLevelVariable extends ModelElement
   ModelElement get enclosingElement => library;
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${library.dirName}/$fileName';
-  }
+  String get filePath => '${library.dirName}/$fileName';
 
   @override
   String get href {

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -28,7 +28,7 @@ class TypeParameter extends ModelElement {
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.name}/$name';
+    return '${package.baseHref}$filePath';
   }
 
   @override

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -18,6 +18,16 @@ class TypeParameter extends ModelElement {
       : null;
 
   @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name';
+  }
+
+  @override
   String get href {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -18,14 +18,8 @@ class TypeParameter extends ModelElement {
       : null;
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${enclosingElement.library.dirName}/${enclosingElement.name}/$name';
-  }
+  String get filePath =>
+      '${enclosingElement.library.dirName}/${enclosingElement.name}/$name';
 
   @override
   String get href {

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -40,7 +40,7 @@ class Typedef extends ModelElement
     }
     assert(canonicalLibrary != null);
     assert(canonicalLibrary == library);
-    return '${package.baseHref}${library.dirName}/$fileName';
+    return '${package.baseHref}$filePath';
   }
 
   // Food for mustache.

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -31,6 +31,16 @@ class Typedef extends ModelElement
   }
 
   @override
+  String get filePath {
+    if (!identical(canonicalModelElement, this)) {
+      return canonicalModelElement?.filePath;
+    }
+    assert(canonicalLibrary != null);
+    assert(canonicalLibrary == library);
+    return '${library.dirName}/$fileName';
+  }
+
+  @override
   String get href {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -31,14 +31,7 @@ class Typedef extends ModelElement
   }
 
   @override
-  String get filePath {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.filePath;
-    }
-    assert(canonicalLibrary != null);
-    assert(canonicalLibrary == library);
-    return '${library.dirName}/$fileName';
-  }
+  String get filePath => '${library.dirName}/$fileName';
 
   @override
   String get href {


### PR DESCRIPTION
Currently a model's href is also used to determine the filename where Dartdoc generates documentation. This change separates the two usages so that hrefs could be relative and include parts that should not be in a file path, such a `..`.

See #2090