### PR TITLE
Replace getBasestElement() with Element.declaration

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -182,9 +182,7 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
               ? t.getGetter(element.name)
               : t.getSetter(element.name);
           if (accessor != null) {
-            if (accessor is Member) {
-              accessor = PackageGraph.getBasestElement(accessor);
-            }
+            accessor = accessor.declaration;
             Class parentClass =
                 ModelElement.fromElement(t.element, packageGraph);
             List<Field> possibleFields = [];

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/special_elements.dart';
 
@@ -41,10 +40,7 @@ mixin Inheritable on ContainerMember {
   @override
   Container computeCanonicalEnclosingContainer() {
     if (isInherited) {
-      Element searchElement = element;
-      searchElement = searchElement is Member
-          ? PackageGraph.getBasestElement(searchElement)
-          : searchElement;
+      Element searchElement = element.declaration;
       // TODO(jcollins-g): generate warning if an inherited element's definition
       // is in an intermediate non-canonical class in the inheritance chain?
       Class previous;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -208,9 +208,8 @@ abstract class ModelElement extends Canonicalization
     // TODO(jcollins-g): Refactor object model to instantiate 'ModelMembers'
     //                   for members?
     if (e is Member) {
-      var basest = PackageGraph.getBasestElement(e);
       originalMember = e;
-      e = basest;
+      e = e.declaration;
     }
     Tuple3<Element, Library, Container> key =
         Tuple3(e, library, enclosingContainer);

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/analysis/driver.dart';
-import 'package:analyzer/src/dart/element/member.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
@@ -672,15 +671,6 @@ class PackageGraph {
     return _canonicalLibraryFor[e];
   }
 
-  // TODO(jcollins-g): Revise when dart-lang/sdk#29600 is fixed.
-  static Element getBasestElement(Element possibleMember) {
-    Element element = possibleMember;
-    while (element is Member) {
-      element = (element as Member).declaration;
-    }
-    return element;
-  }
-
   /// Tries to find a canonical ModelElement for this element.  If we know
   /// this element is related to a particular class, pass preferredClass to
   /// disambiguate.
@@ -715,7 +705,7 @@ class PackageGraph {
     // TODO(jcollins-g): The data structures should be changed to eliminate guesswork
     // with member elements.
     if (e is ClassMemberElement || e is PropertyAccessorElement) {
-      if (e is Member) e = getBasestElement(e);
+      e = e.declaration;
       Set<ModelElement> candidates = Set();
       Tuple2<Element, Library> iKey = Tuple2(e, lib);
       Tuple4<Element, Library, Class, ModelElement> key =


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/29600 was fixed by adding `Element.declaration` and verifying that `Member` is never created around another `Member`.