### PR TITLE
Add config option for output format

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -88,7 +88,7 @@ Future<void> main(List<String> arguments) async {
   startLogging(config);
 
   Dartdoc dartdoc = config.generateDocs
-      ? await Dartdoc.withDefaultGenerators(config)
+      ? await Dartdoc.fromContext(config)
       : await Dartdoc.withEmptyGenerator(config);
   dartdoc.onCheckProgress.listen(logProgress);
   try {

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -109,7 +109,7 @@ class Dartdoc extends PackageBuilder {
 
   /// An asynchronous factory method that builds Dartdoc's file writers
   /// and returns a Dartdoc object with them.
-  @deprecated
+  @Deprecated('Prefer withContext() instead')
   static Future<Dartdoc> withDefaultGenerators(
       DartdocGeneratorOptionContext config) async {
     return Dartdoc._(config, await initHtmlGenerator(config));

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -107,6 +107,14 @@ class Dartdoc extends PackageBuilder {
     outputDir = Directory(config.output)..createSync(recursive: true);
   }
 
+  /// An asynchronous factory method that builds Dartdoc's file writers
+  /// and returns a Dartdoc object with them.
+  @deprecated
+  static Future<Dartdoc> withDefaultGenerators(
+      DartdocGeneratorOptionContext config) async {
+    return Dartdoc._(config, await initHtmlGenerator(config));
+  }
+
   /// Asynchronous factory method that builds Dartdoc with an empty generator.
   static Future<Dartdoc> withEmptyGenerator(DartdocOptionContext config) async {
     return Dartdoc._(config, await initEmptyGenerator(config));
@@ -117,7 +125,7 @@ class Dartdoc extends PackageBuilder {
   static Future<Dartdoc> fromContext(
       DartdocGeneratorOptionContext context) async {
     Generator generator;
-    switch (context.outputFormat) {
+    switch (context.format) {
       case 'html':
         generator = await initHtmlGenerator(context);
         break;
@@ -126,8 +134,7 @@ class Dartdoc extends PackageBuilder {
         generator = await initEmptyGenerator(context);
         break;
       default:
-        throw DartdocFailure(
-            'Unsupported output format: ${context.outputFormat}');
+        throw DartdocFailure('Unsupported output format: ${context.format}');
     }
     return Dartdoc._(context, generator);
   }

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -107,16 +107,29 @@ class Dartdoc extends PackageBuilder {
     outputDir = Directory(config.output)..createSync(recursive: true);
   }
 
-  /// An asynchronous factory method that builds Dartdoc's file writers
-  /// and returns a Dartdoc object with them.
-  static Future<Dartdoc> withDefaultGenerators(
-      DartdocGeneratorOptionContext config) async {
-    return Dartdoc._(config, await initHtmlGenerator(config));
-  }
-
-  /// An asynchronous factory method that builds
+  /// Asynchronous factory method that builds Dartdoc with an empty generator.
   static Future<Dartdoc> withEmptyGenerator(DartdocOptionContext config) async {
     return Dartdoc._(config, await initEmptyGenerator(config));
+  }
+
+  /// Asynchronous factory method that builds Dartdoc with a generator
+  /// determined by the given context.
+  static Future<Dartdoc> fromContext(
+      DartdocGeneratorOptionContext context) async {
+    Generator generator;
+    switch (context.outputFormat) {
+      case 'html':
+        generator = await initHtmlGenerator(context);
+        break;
+      case 'md':
+        // TODO(jdkoren): use a real generator
+        generator = await initEmptyGenerator(context);
+        break;
+      default:
+        throw DartdocFailure(
+            'Unsupported output format: ${context.outputFormat}');
+    }
+    return Dartdoc._(context, generator);
   }
 
   Stream<String> get onCheckProgress => _onCheckProgress.stream;

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -56,7 +56,8 @@ mixin GeneratorContext on DartdocOptionContextBase {
 
   String get templatesDir => optionSet['templatesDir'].valueAt(context);
 
-  String get outputFormat => optionSet['format'].valueAt(context);
+  /// Output format, e.g. 'html', 'md'
+  String get format => optionSet['format'].valueAt(context);
 
   // TODO(jdkoren): duplicated temporarily so that GeneratorContext is enough for configuration.
   bool get useBaseHref => optionSet['useBaseHref'].valueAt(context);

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -56,6 +56,8 @@ mixin GeneratorContext on DartdocOptionContextBase {
 
   String get templatesDir => optionSet['templatesDir'].valueAt(context);
 
+  String get outputFormat => optionSet['format'].valueAt(context);
+
   // TODO(jdkoren): duplicated temporarily so that GeneratorContext is enough for configuration.
   bool get useBaseHref => optionSet['useBaseHref'].valueAt(context);
 }
@@ -137,6 +139,8 @@ Future<List<DartdocOption>> createGeneratorOptions() async {
             'top_level_property, typedef. Partial templates are supported; '
             'they must begin with an underscore, and references to them must '
             'omit the leading underscore (e.g. use {{>foo}} to reference the '
-            'partial template _foo.html).'),
+            'partial template named _foo).'),
+    // TODO(jdkoren): Unhide when we have good support for another format.
+    DartdocOptionArgOnly<String>('format', 'html', hide: true),
   ];
 }

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -427,7 +427,7 @@ void main() {
 
     test('generate docs with bad output format', () async {
       try {
-        await buildDartdoc(['--format', 'bad'], testPackageMinimumDir, tempDir);
+        await buildDartdoc(['--format', 'bad'], testPackageDir, tempDir);
         fail('dartdoc should fail with bad output format');
       } catch (e) {
         expect(e is DartdocFailure, isTrue);

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -45,9 +45,8 @@ void main() {
 
     Future<Dartdoc> buildDartdoc(
         List<String> argv, Directory packageRoot, Directory tempDir) async {
-      return await Dartdoc.withDefaultGenerators(await generatorContextFromArgv(
-          argv
-            ..addAll(['--input', packageRoot.path, '--output', tempDir.path])));
+      return await Dartdoc.fromContext(await generatorContextFromArgv(argv
+        ..addAll(['--input', packageRoot.path, '--output', tempDir.path])));
     }
 
     group('Option handling', () {
@@ -424,6 +423,17 @@ void main() {
       expect(level2.existsSync(), isTrue);
       expect(level2.readAsStringSync(),
           contains('<link rel="canonical" href="$prefix/ex/Apple/m.html">'));
+    });
+
+    test('generate docs with bad output format', () async {
+      try {
+        await buildDartdoc(['--format', 'bad'], testPackageMinimumDir, tempDir);
+        fail('dartdoc should fail with bad output format');
+      } catch (e) {
+        expect(e is DartdocFailure, isTrue);
+        expect((e as DartdocFailure).message,
+            startsWith('Unsupported output format'));
+      }
     });
   }, timeout: Timeout.factor(8));
 }


### PR DESCRIPTION
Defaults to 'html', but also supports 'md' (using empty generator).
Option is hidden for now until a real generator for 'md' is wired up.