### PR TITLE
Enforce the unused import lint on presubmit via analysis warnings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,9 @@
 include: package:pedantic/analysis_options.1.8.0.yaml
 
 analyzer:
+  errors:
+    unused_import: warning
+    unused_shown_name: warning
   exclude:
     - 'doc/**'
     - 'lib/src/third_party/pkg/**'

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/html/html_generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/tool_runner.dart';
 import 'package:stack_trace/stack_trace.dart';

--- a/lib/src/empty_generator.dart
+++ b/lib/src/empty_generator.dart
@@ -7,7 +7,6 @@ import 'package:dartdoc/src/generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
-import 'package:dartdoc/src/warnings.dart';
 
 /// A generator that does not generate files, but does traverse the [PackageGraph]
 /// and access [ModelElement.documentationAsHtml] for every element as though

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -5,7 +5,7 @@
 /// A library containing an abstract documentation generator.
 library dartdoc.generator;
 
-import 'dart:async' show Stream, Future;
+import 'dart:async' show Future;
 import 'dart:io' show Directory;
 import 'dart:isolate';
 

--- a/lib/src/generator_frontend.dart
+++ b/lib/src/generator_frontend.dart
@@ -3,14 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show File;
 
 import 'package:dartdoc/src/generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/warnings.dart';
-import 'package:path/path.dart' as path;
 
 /// [Generator] that delegates rendering to a [GeneratorBackend] and delegates
 /// file creation to a [FileWriter].

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -10,7 +10,6 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/html/html_generator.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;


### PR DESCRIPTION
Just what it says, this should help us avoid collecting more of them.