### PR TITLE
Fix package_meta test for latest SDK changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - master
 
 install:
-  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/raw/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/release/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - cmd: del dart-sdk.zip

--- a/test/model_special_cases_test.dart
+++ b/test/model_special_cases_test.dart
@@ -325,7 +325,7 @@ void main() {
 
       test('sdk description', () {
         expect(sdkAsPackageGraph.defaultPackage.documentation,
-            startsWith('Welcome to the Dart API reference doc'));
+            startsWith('Welcome'));
       });
     });
 

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -112,7 +112,7 @@ void main() {
     test('has a readme', () {
       expect(p.getReadmeContents(), isNotNull);
       expect(p.getReadmeContents().contents,
-          startsWith('Welcome to the Dart API reference documentation'));
+          startsWith('Welcome'));
     });
 
     test('does not have a license', () {

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -111,8 +111,7 @@ void main() {
 
     test('has a readme', () {
       expect(p.getReadmeContents(), isNotNull);
-      expect(p.getReadmeContents().contents,
-          startsWith('Welcome'));
+      expect(p.getReadmeContents().contents, startsWith('Welcome'));
     });
 
     test('does not have a license', () {


### PR DESCRIPTION
Changes to the documentation have rendered a sanity check in package_meta obsolete.

Also, synchronize appveyor so we're testing the same version of the package on Windows as well as LInux (latest dev release, not raw).