### PR TITLE
Fix a crash when using --no-generate-docs

### DIFF
--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -45,6 +45,12 @@ class Documentation {
   List<ModelCommentReference> get commentRefs => _element.commentRefs;
 
   void _renderDocumentation(bool processAllDocs) {
+    if (!_element.hasDocumentation) {
+      _asHtml = '';
+      _asOneLiner = '';
+      _hasExtendedDocs = false;
+      return;
+    }
     Tuple2<List<md.Node>, bool> parseResult =
         _parseDocumentation(processAllDocs);
     if (_hasExtendedDocs != null) {

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -45,12 +45,6 @@ class Documentation {
   List<ModelCommentReference> get commentRefs => _element.commentRefs;
 
   void _renderDocumentation(bool processAllDocs) {
-    if (!_element.hasDocumentation) {
-      _asHtml = '';
-      _asOneLiner = '';
-      _hasExtendedDocs = false;
-      return;
-    }
     Tuple2<List<md.Node>, bool> parseResult =
         _parseDocumentation(processAllDocs);
     if (_hasExtendedDocs != null) {
@@ -71,6 +65,9 @@ class Documentation {
 
   /// Returns a tuple of List<md.Node> and hasExtendedDocs
   Tuple2<List<md.Node>, bool> _parseDocumentation(bool processFullDocs) {
+    if (!_element.hasDocumentation) {
+      return Tuple2([], false);
+    }
     String text = _element.documentation;
     showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
     MarkdownDocument document =

--- a/lib/src/render/documentation_renderer.dart
+++ b/lib/src/render/documentation_renderer.dart
@@ -13,6 +13,9 @@ abstract class DocumentationRenderer {
 class DocumentationRendererHtml extends DocumentationRenderer {
   @override
   Tuple2<String, String> render(List<md.Node> nodes, bool processFullDocs) {
+    if (nodes.isEmpty) {
+      return Tuple2('', '');
+    }
     var rawHtml = md.HtmlRenderer().render(nodes);
     var asHtmlDocument = parse(rawHtml);
     for (var s in asHtmlDocument.querySelectorAll('script')) {


### PR DESCRIPTION
Fixes a crash when accessing `documentationAsHtml` directly. Most usages first check `hasDocumentation`, but nothing enforces this. Notably, `EmptyGenerator` accesses this property without checking first (you can reproduce the crash by passing `--no-generate-docs`).