### PR TITLE
Use template comment syntax for header & footer placeholders

### DIFF
--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -60,9 +60,9 @@ const _requiredTemplates = <String>[
   'typedef.html',
 ];
 
-const String _headerPlaceholder = '<!-- header placeholder -->';
-const String _footerPlaceholder = '<!-- footer placeholder -->';
-const String _footerTextPlaceholder = '<!-- footer-text placeholder -->';
+const String _headerPlaceholder = '{{! header placeholder }}';
+const String _footerPlaceholder = '{{! footer placeholder }}';
+const String _footerTextPlaceholder = '{{! footer-text placeholder }}';
 
 Future<Map<String, String>> _loadPartials(
     _TemplatesLoader templatesLoader,

--- a/lib/templates/_footer.html
+++ b/lib/templates/_footer.html
@@ -8,7 +8,7 @@
     {{/packageGraph.hasFooterVersion}}
   </span>
 
-  <!-- footer-text placeholder -->
+  {{! footer-text placeholder }}
 </footer>
 
 {{! TODO(jdkoren): unwrap ^useBaseHref sections when the option is removed.}}
@@ -17,7 +17,8 @@
 <script src="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/highlight.pack.js"></script>
 <script src="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/URI.js"></script>
 <script src="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/script.js"></script>
-<!-- footer placeholder -->
+
+{{! footer placeholder }}
 
 </body>
 

--- a/lib/templates/_head.html
+++ b/lib/templates/_head.html
@@ -26,7 +26,8 @@
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/github.css">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/styles.css">
   <link rel="icon" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/favicon.png">
-  <!-- header placeholder -->
+
+  {{! header placeholder }}
 </head>
 
 {{! We don't use <base href>, but we do lookup the htmlBase from javascript. }}

--- a/testing/test_package_custom_templates/templates/_footer.html
+++ b/testing/test_package_custom_templates/templates/_footer.html
@@ -6,9 +6,9 @@
     {{packageGraph.defaultPackage.name}} {{packageGraph.defaultPackage.version}}
   </p>
 
-  <!-- footer-text placeholder -->
+  {{! footer-text placeholder }}
 </footer>
 
-<!-- footer placeholder -->
+{{! footer placeholder }}
 </body>
 </html>

--- a/testing/test_package_custom_templates/templates/_head.html
+++ b/testing/test_package_custom_templates/templates/_head.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <title>{{ title }}</title>
-  <!-- header placeholder -->
+  {{! header placeholder }}
 </head>
 
 <body>


### PR DESCRIPTION
Different formats have different comment syntax, so use template comment syntax for these placeholders instead of html syntax. If no content is passed to replace them, the placeholders will not appear in the output files.