### PR TITLE
Create some initial templates for md

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -127,7 +127,7 @@ class Category extends Nameable
   @override
   String get href => isCanonical ? '${package.baseHref}$filePath' : null;
 
-  String get categorization => _categoryRenderer.renderCategoryLabel(this);
+  String get categoryLabel => _categoryRenderer.renderCategoryLabel(this);
 
   String get linkedName => _categoryRenderer.renderLinkedName(this);
 

--- a/lib/templates/html/_categorization.html
+++ b/lib/templates/html/_categorization.html
@@ -1,5 +1,5 @@
 {{#hasCategoryNames}}
   {{#displayedCategories}}
-    {{{categorization}}}
+    {{{categoryLabel}}}
   {{/displayedCategories}}
 {{/hasCategoryNames}}

--- a/lib/templates/md/404error.md
+++ b/lib/templates/md/404error.md
@@ -1,0 +1,6 @@
+# 404
+
+Oops, something's gone wrong :-(
+
+You've tried to visit a page that doesn't exist. Luckily this site has other
+[pages](index.md).

--- a/lib/templates/md/_accessor_getter.md
+++ b/lib/templates/md/_accessor_getter.md
@@ -1,0 +1,7 @@
+{{#getter}}
+{{{ linkedReturnType }}} {{>name_summary}}
+{{>features}}
+
+{{>documentation}}
+{{>source_code}}
+{{/getter}}

--- a/lib/templates/md/_accessor_setter.md
+++ b/lib/templates/md/_accessor_setter.md
@@ -1,0 +1,7 @@
+{{#setter}}
+{{>name_summary}}({{{ linkedParamsNoMetadata }}})
+{{>features}}
+
+{{>documentation}}
+{{>source_code}}
+{{/setter}}

--- a/lib/templates/md/_callable.md
+++ b/lib/templates/md/_callable.md
@@ -1,0 +1,3 @@
+{{#isDeprecated}}~~{{/isDeprecated}}{{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}} {{>categorization}}{{#isDeprecated}}~~{{/isDeprecated}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{>features}}

--- a/lib/templates/md/_callable_multiline.md
+++ b/lib/templates/md/_callable_multiline.md
@@ -1,0 +1,7 @@
+{{#hasAnnotations}}
+{{#annotations}}
+- {{{.}}}
+{{/annotations}}
+{{/hasAnnotations}}
+
+{{{ linkedReturnType }}} {{>name_summary}}{{{genericParameters}}}({{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}})

--- a/lib/templates/md/_categorization.md
+++ b/lib/templates/md/_categorization.md
@@ -1,0 +1,5 @@
+{{#hasCategoryNames}}
+{{#displayedCategories}}
+{{{categoryLabel}}}
+{{/displayedCategories}}
+{{/hasCategoryNames}}

--- a/lib/templates/md/_class.md
+++ b/lib/templates/md/_class.md
@@ -1,0 +1,2 @@
+{{#isDeprecated}}~~{{/isDeprecated}}{{{linkedName}}}{{{linkedGenericParameters}}} {{>categorization}}{{#isDeprecated}}~~{{/isDeprecated}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_constant.md
+++ b/lib/templates/md/_constant.md
@@ -1,0 +1,3 @@
+{{#isDeprecated}}~~{{/isDeprecated}}{{{ linkedName }}} const {{{ linkedReturnType }}} {{>categorization}}{{#isDeprecated}}~~{{/isDeprecated}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{>features}}

--- a/lib/templates/md/_documentation.md
+++ b/lib/templates/md/_documentation.md
@@ -1,0 +1,3 @@
+{{#hasDocumentation}}
+{{{ documentationAsHtml }}}
+{{/hasDocumentation}}

--- a/lib/templates/md/_extension.md
+++ b/lib/templates/md/_extension.md
@@ -1,0 +1,2 @@
+{{#isDeprecated}}~~{{/isDeprecated}}{{{linkedName}}} {{>categorization}}{{#isDeprecated}}~~{{/isDeprecated}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_features.md
+++ b/lib/templates/md/_features.md
@@ -1,0 +1,1 @@
+{{ #featuresAsString.isNotEmpty }}_{{{featuresAsString}}}_{{ /featuresAsString.isNotEmpty }}

--- a/lib/templates/md/_footer.md
+++ b/lib/templates/md/_footer.md
@@ -1,0 +1,3 @@
+{{! markdown has no dedicated footer element, so both placeholders are siblings }}
+{{! footer-text placeholder }}
+{{! footer placeholder }}

--- a/lib/templates/md/_head.md
+++ b/lib/templates/md/_head.md
@@ -1,0 +1,1 @@
+{{! header placeholder }}

--- a/lib/templates/md/_library.md
+++ b/lib/templates/md/_library.md
@@ -1,0 +1,4 @@
+{{{ linkedName }}} ({{>categorization}})
+{{#isDocumented}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{/isDocumented}}

--- a/lib/templates/md/_mixin.md
+++ b/lib/templates/md/_mixin.md
@@ -1,0 +1,2 @@
+{{#isDeprecated}}~~{{/isDeprecated}}{{{linkedName}}}{{{linkedGenericParameters}}} {{>categorization}}{{#isDeprecated}}~~{{/isDeprecated}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_name_summary.md
+++ b/lib/templates/md/_name_summary.md
@@ -1,0 +1,1 @@
+{{#isConst}}const {{/isConst}}{{#isDeprecated}}~~{{/isDeprecated}}{{name}}{{#isDeprecated}}~~{{/isDeprecated}}

--- a/lib/templates/md/_property.md
+++ b/lib/templates/md/_property.md
@@ -1,0 +1,3 @@
+{{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}} {{>categorization}}
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{>features}}

--- a/lib/templates/md/_source_code.md
+++ b/lib/templates/md/_source_code.md
@@ -1,0 +1,7 @@
+{{#hasSourceCode}}
+## Implementation
+
+```dart
+{{{ sourceCode }}}
+```
+{{/hasSourceCode}}

--- a/lib/templates/md/_source_link.md
+++ b/lib/templates/md/_source_link.md
@@ -1,0 +1,3 @@
+{{#hasSourceHref}}
+[source]({{{sourceHref}}})
+{{/hasSourceHref}}

--- a/lib/templates/md/category.md
+++ b/lib/templates/md/category.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{name}} {{kind}}
 
@@ -75,3 +77,5 @@
 {{/publicExceptions}}
 {{/hasPublicExceptions}}
 {{/self}}
+
+{{>footer}}

--- a/lib/templates/md/category.md
+++ b/lib/templates/md/category.md
@@ -1,0 +1,77 @@
+{{#self}}
+# {{name}} {{kind}}
+
+{{>documentation}}
+
+{{#hasPublicLibraries}}
+## Libraries
+
+{{#publicLibraries}}
+{{>library}}
+{{/publicLibraries}}
+{{/hasPublicLibraries}}
+
+{{#hasPublicClasses}}
+## Classes
+
+{{#publicClasses}}
+{{>class}}
+{{/publicClasses}}
+{{/hasPublicClasses}}
+
+{{#hasPublicMixins}}
+## Mixins
+
+{{#publicMixins}}
+{{>mixin}}
+{{/publicMixins}}
+{{/hasPublicMixins}}
+
+{{#hasPublicConstants}}
+## Constants
+
+{{#publicConstants}}
+{{>constant}}
+{{/publicConstants}}
+{{/hasPublicConstants}}
+
+{{#hasPublicProperties}}
+## Properties
+
+{{#publicProperties}}
+{{>property}}
+{{/publicProperties}}
+{{/hasPublicProperties}}
+
+{{#hasPublicFunctions}}
+## Functions
+
+{{#publicFunctions}}
+{{>callable}}
+{{/publicFunctions}}
+{{/hasPublicFunctions}}
+
+{{#hasPublicEnums}}
+## Enums
+
+{{#publicEnums}}
+{{>class}}
+{{/publicEnums}}
+{{/hasPublicEnums}}
+
+{{#hasPublicTypedefs}}
+## Typedefs
+
+{{#publicTypedefs}}
+{{>callable}}
+{{/publicTypedefs}}
+{{/hasPublicTypedefs}}
+
+{{#hasPublicExceptions}}
+## Exceptions / Errors
+
+{{#publicExceptions}}
+{{>class}}
+{{/publicExceptions}}
+{{/hasPublicExceptions}}
+{{/self}}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
 
@@ -53,7 +55,7 @@
 
 {{#hasAnnotations}}
 **Annotations**
-  
+
 {{#annotations}}
 - {{{.}}}
 {{/annotations}}
@@ -118,3 +120,5 @@
 {{/publicConstants}}
 {{/hasPublicConstants}}
 {{/clazz}}
+
+{{>footer}}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -1,0 +1,120 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#clazz}}
+{{>documentation}}
+
+{{#hasModifiers}}
+{{#hasPublicSuperChainReversed}}
+**Inheritance**
+
+- {{{linkedObjectType}}}
+{{#publicSuperChainReversed}}
+- {{{linkedName}}}
+{{/publicSuperChainReversed}}
+- {{{name}}}
+{{/hasPublicSuperChainReversed}}
+
+{{#hasPublicInterfaces}}
+**Implemented types**
+
+{{#publicInterfaces}}
+- {{{linkedName}}}
+{{/publicInterfaces}}
+{{/hasPublicInterfaces}}
+
+{{#hasPublicMixins}}
+**Mixed in types**
+
+{{#publicMixins}}
+- {{{linkedName}}}
+{{/publicMixins}}
+{{/hasPublicMixins}}
+
+{{#hasPublicImplementors}}
+**Implementers**
+
+{{#publicImplementors}}
+- {{{linkedName}}}
+{{/publicImplementors}}
+{{/hasPublicImplementors}}
+
+{{#hasPotentiallyApplicableExtensions}}
+**Available Extensions**
+
+{{#potentiallyApplicableExtensions}}
+- {{{linkedName}}}
+{{/potentiallyApplicableExtensions}}
+{{/hasPotentiallyApplicableExtensions}}
+
+{{#hasAnnotations}}
+**Annotations**
+  
+{{#annotations}}
+- {{{.}}}
+{{/annotations}}
+{{/hasAnnotations}}
+{{/hasModifiers}}
+
+{{#hasPublicConstructors}}
+## Constructors
+
+{{#publicConstructors}}
+{{{linkedName}}} ({{{ linkedParams }}})
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
+{{/publicConstructors}}
+{{/hasPublicConstructors}}
+
+{{#hasPublicProperties}}
+## Properties
+
+{{#allPublicInstanceProperties}}
+{{>property}}
+{{/allPublicInstanceProperties}}
+{{/hasPublicProperties}}
+
+{{#hasPublicMethods}}
+## Methods
+
+{{#allPublicInstanceMethods}}
+{{>callable}}
+{{/allPublicInstanceMethods}}
+{{/hasPublicMethods}}
+
+{{#hasPublicOperators}}
+## Operators
+
+{{#allPublicOperators}}
+{{>callable}}
+{{/allPublicOperators}}
+{{/hasPublicOperators}}
+
+{{#hasPublicStaticProperties}}
+## Static Properties
+
+{{#publicStaticProperties}}
+{{>property}}
+{{/publicStaticProperties}}
+{{/hasPublicStaticProperties}}
+
+{{#hasPublicStaticMethods}}
+## Static Methods
+
+{{#publicStaticMethods}}
+{{>callable}}
+{{/publicStaticMethods}}
+{{/hasPublicStaticMethods}}
+
+{{#hasPublicConstants}}
+## Constants
+
+{{#publicConstants}}
+{{>constant}}
+{{/publicConstants}}
+{{/hasPublicConstants}}
+{{/clazz}}

--- a/lib/templates/md/constant.md
+++ b/lib/templates/md/constant.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{name}}} {{kind}}
 
@@ -10,3 +12,5 @@
 {{>documentation}}
 {{>source_code}}
 {{/property}}
+
+{{>footer}}

--- a/lib/templates/md/constant.md
+++ b/lib/templates/md/constant.md
@@ -1,0 +1,12 @@
+{{#self}}
+# {{{name}}} {{kind}}
+
+{{>source_link}}
+{{/self}}
+
+{{#property}}
+{{{ linkedReturnType }}} {{>name_summary}} = {{{ constantValue }}}
+
+{{>documentation}}
+{{>source_code}}
+{{/property}}

--- a/lib/templates/md/constructor.md
+++ b/lib/templates/md/constructor.md
@@ -1,0 +1,21 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+
+{{>source_link}}
+{{/self}}
+
+{{#constructor}}
+{{#hasAnnotations}}
+{{#annotations}}
+- {{{.}}}
+{{/annotations}}
+{{/hasAnnotations}}
+
+{{#isConst}}const{{/isConst}}
+{{#isDeprecated}}~~{{/isDeprecated}}{{{nameWithGenerics}}}({{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}}){{#isDeprecated}}~~{{/isDeprecated}}
+
+{{>documentation}}
+
+{{>source_code}}
+
+{{/constructor}}

--- a/lib/templates/md/constructor.md
+++ b/lib/templates/md/constructor.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
 
@@ -19,3 +21,5 @@
 {{>source_code}}
 
 {{/constructor}}
+
+{{>footer}}

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -61,7 +61,6 @@
 {{>constant}}
 {{/publicConstants}}
 {{/hasPublicConstants}}
-{{/clazz}}
 
 {{#hasPublicConstructors}}
 ## Constructors

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{name}}} {{kind}}
 
@@ -45,7 +47,7 @@
 
 {{#hasAnnotations}}
 **Annotations**
-  
+
 {{#annotations}}
 - {{{.}}}
 {{/annotations}}
@@ -111,3 +113,5 @@
 {{/publicStaticMethods}}
 {{/hasPublicStaticMethods}}
 {{/eNum}}
+
+{{>footer}}

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -1,0 +1,113 @@
+{{#self}}
+# {{{name}}} {{kind}}
+
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#eNum}}
+{{>documentation}}
+
+{{#hasModifiers}}
+{{#hasPublicSuperChainReversed}}
+**Inheritance**
+
+- {{{linkedObjectType}}}
+{{#publicSuperChainReversed}}
+- {{{linkedName}}}
+{{/publicSuperChainReversed}}
+- {{{name}}}
+{{/hasPublicSuperChainReversed}}
+
+{{#hasPublicInterfaces}}
+**Implemented types**
+
+{{#publicInterfaces}}
+- {{{linkedName}}}
+{{/publicInterfaces}}
+{{/hasPublicInterfaces}}
+
+{{#hasPublicMixins}}
+**Mixed in types**
+
+{{#publicMixins}}
+- {{{linkedName}}}
+{{/publicMixins}}
+{{/hasPublicMixins}}
+
+{{#hasPublicImplementors}}
+**Implementers**
+
+{{#publicImplementors}}
+- {{{linkedName}}}
+{{/publicImplementors}}
+{{/hasPublicImplementors}}
+
+{{#hasAnnotations}}
+**Annotations**
+  
+{{#annotations}}
+- {{{.}}}
+{{/annotations}}
+{{/hasAnnotations}}
+{{/hasModifiers}}
+
+{{#hasPublicConstants}}
+## Constants
+
+{{#publicConstants}}
+{{>constant}}
+{{/publicConstants}}
+{{/hasPublicConstants}}
+{{/clazz}}
+
+{{#hasPublicConstructors}}
+## Constructors
+
+{{#publicConstructors}}
+{{{linkedName}}} ({{{ linkedParams }}})
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
+{{/publicConstructors}}
+{{/hasPublicConstructors}}
+
+{{#hasPublicProperties}}
+## Properties
+
+{{#allPublicInstanceProperties}}
+{{>property}}
+{{/allPublicInstanceProperties}}
+{{/hasPublicProperties}}
+
+{{#hasPublicMethods}}
+## Methods
+
+{{#allPublicInstanceMethods}}
+{{>callable}}
+{{/allPublicInstanceMethods}}
+{{/hasPublicMethods}}
+
+{{#hasPublicOperators}}
+## Operators
+
+{{#allPublicOperators}}
+{{>callable}}
+{{/allPublicOperators}}
+{{/hasPublicOperators}}
+
+{{#hasPublicStaticProperties}}
+## Static Properties
+
+{{#publicStaticProperties}}
+{{>property}}
+{{/publicStaticProperties}}
+{{/hasPublicStaticProperties}}
+
+{{#hasPublicStaticMethods}}
+## Static Methods
+
+{{#publicStaticMethods}}
+{{>callable}}
+{{/publicStaticMethods}}
+{{/hasPublicStaticMethods}}
+{{/eNum}}

--- a/lib/templates/md/extension.md
+++ b/lib/templates/md/extension.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
 
@@ -61,3 +63,5 @@ on
 {{/publicConstants}}
 {{/hasPublicConstants}}
 {{/extension}}
+
+{{>footer}}

--- a/lib/templates/md/extension.md
+++ b/lib/templates/md/extension.md
@@ -1,0 +1,63 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#extension}}
+{{>documentation}}
+
+on
+{{#extendedType}}
+: {{{linkedName}}}
+{{/extendedType}}
+
+{{#hasPublicProperties}}
+## Properties
+
+{{#allPublicInstanceProperties}}
+{{>property}}
+{{/allPublicInstanceProperties}}
+{{/hasPublicProperties}}
+
+{{#hasPublicMethods}}
+## Methods
+
+{{#allPublicInstanceMethods}}
+{{>callable}}
+{{/allPublicInstanceMethods}}
+{{/hasPublicMethods}}
+
+{{#hasPublicOperators}}
+## Operators
+
+{{#allPublicOperators}}
+{{>callable}}
+{{/allPublicOperators}}
+{{/hasPublicOperators}}
+
+{{#hasPublicStaticProperties}}
+## Static Properties
+
+{{#publicStaticProperties}}
+{{>property}}
+{{/publicStaticProperties}}
+{{/hasPublicStaticProperties}}
+
+{{#hasPublicStaticMethods}}
+## Static Methods
+
+{{#publicStaticMethods}}
+{{>callable}}
+{{/publicStaticMethods}}
+{{/hasPublicStaticMethods}}
+
+{{#hasPublicConstants}}
+## Constants
+
+{{#publicConstants}}
+{{>constant}}
+{{/publicConstants}}
+{{/hasPublicConstants}}
+{{/extension}}

--- a/lib/templates/md/function.md
+++ b/lib/templates/md/function.md
@@ -1,0 +1,15 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+ 
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#function}}
+{{>callable_multiline}}
+
+{{>documentation}}
+
+{{>source_code}}
+
+{{/function}}

--- a/lib/templates/md/function.md
+++ b/lib/templates/md/function.md
@@ -1,6 +1,8 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
- 
+
 {{>source_link}}
 {{>categorization}}
 {{/self}}
@@ -13,3 +15,5 @@
 {{>source_code}}
 
 {{/function}}
+
+{{>footer}}

--- a/lib/templates/md/index.md
+++ b/lib/templates/md/index.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 # {{ title }}
 
 {{#packageGraph.defaultPackage}}
@@ -26,3 +28,5 @@
 {{/categoriesWithPublicLibraries}}
 {{/localPackages}}
 {{/packageGraph}}
+
+{{>footer}}

--- a/lib/templates/md/index.md
+++ b/lib/templates/md/index.md
@@ -1,0 +1,28 @@
+# {{ title }}
+
+{{#packageGraph.defaultPackage}}
+{{>documentation}}
+{{/packageGraph.defaultPackage}}
+
+{{#packageGraph}}
+{{#localPackages}}
+{{#isFirstPackage}}
+## Libraries
+{{/isFirstPackage}}
+{{^isFirstPackage}}
+## {{name}}
+{{/isFirstPackage}}
+
+{{#defaultCategory.publicLibraries}}
+{{>library}}
+{{/defaultCategory.publicLibraries}}
+
+{{#categoriesWithPublicLibraries}}
+### {{name}}
+
+{{#publicLibraries}}
+{{>library}}
+{{/publicLibraries}}
+{{/categoriesWithPublicLibraries}}
+{{/localPackages}}
+{{/packageGraph}}

--- a/lib/templates/md/library.md
+++ b/lib/templates/md/library.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{ name }}} {{ kind }}
 
@@ -80,3 +82,5 @@
 {{>class}}
 {{/library.publicExceptions}}
 {{/library.hasPublicExceptions}}
+
+{{>footer}}

--- a/lib/templates/md/library.md
+++ b/lib/templates/md/library.md
@@ -1,0 +1,82 @@
+{{#self}}
+# {{{ name }}} {{ kind }}
+
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#library}}
+{{>documentation}}
+{{/library}}
+
+{{#library.hasPublicClasses}}
+## Classes
+
+{{#library.publicClasses}}
+{{>class}}
+{{/library.publicClasses}}
+{{/library.hasPublicClasses}}
+
+{{#library.hasPublicMixins}}
+## Mixins
+
+{{#library.publicMixins}}
+{{>mixin}}
+{{/library.publicMixins}}
+{{/library.hasPublicMixins}}
+
+{{#library.hasPublicExtensions}}
+## Extensions
+
+{{#library.publicExtensions}}
+{{>extension}}
+{{/library.publicExtensions}}
+{{/library.hasPublicExtensions}}
+
+{{#library.hasPublicConstants}}
+## Constants
+
+{{#library.publicConstants}}
+{{>constant}}
+{{/library.publicConstants}}
+{{/library.hasPublicConstants}}
+
+{{#library.hasPublicProperties}}
+## Properties
+
+{{#library.publicProperties}}
+{{>property}}
+{{/library.publicProperties}}
+{{/library.hasPublicProperties}}
+
+{{#library.hasPublicFunctions}}
+## Functions
+
+{{#library.publicFunctions}}
+{{>callable}}
+{{/library.publicFunctions}}
+{{/library.hasPublicFunctions}}
+
+{{#library.hasPublicEnums}}
+## Enums
+
+{{#library.publicEnums}}
+{{>class}}
+{{/library.publicEnums}}
+{{/library.hasPublicEnums}}
+
+{{#library.hasPublicTypedefs}}
+## Typedefs
+
+{{#library.publicTypedefs}}
+{{>callable}}
+{{/library.publicTypedefs}}
+{{/library.hasPublicTypedefs}}
+
+{{#library.hasPublicExceptions}}
+## Exceptions / Errors
+
+{{#library.publicExceptions}}
+{{>class}}
+{{/library.publicExceptions}}
+{{/library.hasPublicExceptions}}

--- a/lib/templates/md/method.md
+++ b/lib/templates/md/method.md
@@ -1,0 +1,14 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+
+{{>source_link}}
+{{/self}}
+
+{{#method}}
+{{>callable_multiline}}
+{{>features}}
+{{>documentation}}
+
+{{>source_code}}
+
+{{/method}}

--- a/lib/templates/md/method.md
+++ b/lib/templates/md/method.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
 
@@ -12,3 +14,5 @@
 {{>source_code}}
 
 {{/method}}
+
+{{>footer}}

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -1,0 +1,120 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#mixin}}
+{{>documentation}}
+
+{{#hasModifiers}}
+{{#hasPublicSuperclassConstraints}}
+**Superclass Constraints**
+
+{{#publicSuperclassConstraints}}
+- {{{linkedName}}}
+{{/publicSuperclassConstraints}}
+{{/hasPublicSuperclassConstraints}}
+
+{{#hasPublicSuperChainReversed}}
+**Inheritance**
+
+- {{{linkedObjectType}}}
+{{#publicSuperChainReversed}}
+- {{{linkedName}}}
+{{/publicSuperChainReversed}}
+- {{{name}}}
+{{/hasPublicSuperChainReversed}}
+
+{{#hasPublicInterfaces}}
+**Implemented types**
+
+{{#publicInterfaces}}
+- {{{linkedName}}}
+{{/publicInterfaces}}
+{{/hasPublicInterfaces}}
+
+{{#hasPublicMixins}}
+**Mixed in types**
+
+{{#publicMixins}}
+- {{{linkedName}}}
+{{/publicMixins}}
+{{/hasPublicMixins}}
+
+{{#hasPublicImplementors}}
+**Implementers**
+
+{{#publicImplementors}}
+- {{{linkedName}}}
+{{/publicImplementors}}
+{{/hasPublicImplementors}}
+
+{{#hasAnnotations}}
+**Annotations**
+  
+{{#annotations}}
+- {{{.}}}
+{{/annotations}}
+{{/hasAnnotations}}
+{{/hasModifiers}}
+
+{{#hasPublicConstructors}}
+## Constructors
+
+{{#publicConstructors}}
+{{{linkedName}}} ({{{ linkedParams }}})
+: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
+{{/publicConstructors}}
+{{/hasPublicConstructors}}
+
+{{#hasPublicProperties}}
+## Properties
+
+{{#allPublicInstanceProperties}}
+{{>property}}
+{{/allPublicInstanceProperties}}
+{{/hasPublicProperties}}
+
+{{#hasPublicMethods}}
+## Methods
+
+{{#allPublicInstanceMethods}}
+{{>callable}}
+{{/allPublicInstanceMethods}}
+{{/hasPublicMethods}}
+
+{{#hasPublicOperators}}
+## Operators
+
+{{#allPublicOperators}}
+{{>callable}}
+{{/allPublicOperators}}
+{{/hasPublicOperators}}
+
+{{#hasPublicStaticProperties}}
+## Static Properties
+
+{{#publicStaticProperties}}
+{{>property}}
+{{/publicStaticProperties}}
+{{/hasPublicStaticProperties}}
+
+{{#hasPublicStaticMethods}}
+## Static Methods
+
+{{#publicStaticMethods}}
+{{>callable}}
+{{/publicStaticMethods}}
+{{/hasPublicStaticMethods}}
+
+{{#hasPublicConstants}}
+## Constants
+
+{{#publicConstants}}
+{{>constant}}
+{{/publicConstants}}
+{{/hasPublicConstants}}
+{{/mixin}}

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
 
@@ -53,7 +55,7 @@
 
 {{#hasAnnotations}}
 **Annotations**
-  
+
 {{#annotations}}
 - {{{.}}}
 {{/annotations}}
@@ -118,3 +120,5 @@
 {{/publicConstants}}
 {{/hasPublicConstants}}
 {{/mixin}}
+
+{{>footer}}

--- a/lib/templates/md/property.md
+++ b/lib/templates/md/property.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{name}} {{kind}}
 
@@ -23,3 +25,5 @@
 {{/hasSetter}}
 {{/hasGetterOrSetter}}
 {{/self}}
+
+{{>footer}}

--- a/lib/templates/md/property.md
+++ b/lib/templates/md/property.md
@@ -1,0 +1,25 @@
+{{#self}}
+# {{name}} {{kind}}
+
+{{>source_link}}
+{{/self}}
+
+{{#self}}
+{{#hasNoGetterSetter}}
+{{{ linkedReturnType }}} {{>name_summary}}
+{{>features}}
+
+{{>documentation}}
+{{>source_code}}
+{{/hasNoGetterSetter}}
+
+{{#hasGetterOrSetter}}
+{{#hasGetter}}
+{{>accessor_getter}}
+{{/hasGetter}}
+
+{{#hasSetter}}
+{{>accessor_setter}}
+{{/hasSetter}}
+{{/hasGetterOrSetter}}
+{{/self}}

--- a/lib/templates/md/top_level_constant.md
+++ b/lib/templates/md/top_level_constant.md
@@ -1,6 +1,8 @@
+{{>head}}
+
 {{#self}}
 # {{{name}}} {{kind}}
- 
+
 {{>source_link}}
 {{>categorization}}
 
@@ -10,3 +12,5 @@
 {{>documentation}}
 {{>source_code}}
 {{/self}}
+
+{{>footer}}

--- a/lib/templates/md/top_level_constant.md
+++ b/lib/templates/md/top_level_constant.md
@@ -1,0 +1,12 @@
+{{#self}}
+# {{{name}}} {{kind}}
+ 
+{{>source_link}}
+{{>categorization}}
+
+{{>name_summary}} = {{{ constantValue }}}
+{{>features}}
+
+{{>documentation}}
+{{>source_code}}
+{{/self}}

--- a/lib/templates/md/top_level_property.md
+++ b/lib/templates/md/top_level_property.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{name}}} {{kind}}
 
@@ -20,3 +22,5 @@
 {{>accessor_setter}}
 {{/hasExplicitSetter}}
 {{/self}}
+
+{{>footer}}

--- a/lib/templates/md/top_level_property.md
+++ b/lib/templates/md/top_level_property.md
@@ -1,0 +1,22 @@
+{{#self}}
+# {{{name}}} {{kind}}
+
+{{>source_link}}
+{{>categorization}}
+
+{{#hasNoGetterSetter}}
+{{{ linkedReturnType }}} {{>name_summary}}
+{{>features}}
+
+{{>documentation}}
+{{>source_code}}
+{{/hasNoGetterSetter}}
+
+{{#hasExplicitGetter}}
+{{>accessor_getter}}
+{{/hasExplicitGetter}}
+
+{{#hasExplicitSetter}}
+{{>accessor_setter}}
+{{/hasExplicitSetter}}
+{{/self}}

--- a/lib/templates/md/typedef.md
+++ b/lib/templates/md/typedef.md
@@ -1,3 +1,5 @@
+{{>head}}
+
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
 
@@ -11,3 +13,5 @@
 {{>documentation}}
 {{>source_code}}
 {{/typeDef}}
+
+{{>footer}}

--- a/lib/templates/md/typedef.md
+++ b/lib/templates/md/typedef.md
@@ -1,0 +1,13 @@
+{{#self}}
+# {{{nameWithGenerics}}} {{kind}}
+
+{{>source_link}}
+{{>categorization}}
+{{/self}}
+
+{{#typeDef}}
+{{>callable_multiline}}
+
+{{>documentation}}
+{{>source_code}}
+{{/typeDef}}


### PR DESCRIPTION
These are ~~very likely~~ most definitely not perfect, but gets us moving on wiring together a backend for them. They are currently not loaded yet as `--format md` still uses the EmptyGenerator.