### PR TITLE
Resolve SDK footer text URI in templates.dart

### DIFF
--- a/lib/resources/sdk_footer_text.md
+++ b/lib/resources/sdk_footer_text.md
@@ -1,0 +1,1 @@
+&bull; [cc license](http://creativecommons.org/licenses/by-sa/4.0/)

--- a/lib/src/html/resources.g.dart
+++ b/lib/src/html/resources.g.dart
@@ -11,6 +11,7 @@ const List<String> resource_names = [
   'package:dartdoc/resources/readme.md',
   'package:dartdoc/resources/script.js',
   'package:dartdoc/resources/sdk_footer_text.html',
+  'package:dartdoc/resources/sdk_footer_text.md',
   'package:dartdoc/resources/styles.css',
   'package:dartdoc/resources/typeahead.bundle.min.js'
 ];

--- a/lib/src/html/templates.dart
+++ b/lib/src/html/templates.dart
@@ -6,6 +6,7 @@ library dartdoc.templates;
 
 import 'dart:async' show Future;
 import 'dart:io' show File, Directory;
+import 'dart:isolate';
 
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/html/resource_loader.dart' as loader;
@@ -149,18 +150,27 @@ class Templates {
   final Template topLevelPropertyTemplate;
   final Template typeDefTemplate;
 
-  static Future<Templates> fromContext(DartdocGeneratorOptionContext context) {
+  static Future<Templates> fromContext(
+      DartdocGeneratorOptionContext context) async {
     String templatesDir = context.templatesDir;
+    String format = context.format;
+    List<String> footerTextPaths = context.footerText;
+    if (context.addSdkFooter) {
+      Uri sdkFooter = await Isolate.resolvePackageUri(
+          Uri.parse('package:dartdoc/resources/sdk_footer_text.$format'));
+      footerTextPaths.add(path.canonicalize(sdkFooter.toFilePath()));
+    }
+
     if (templatesDir != null) {
-      return fromDirectory(Directory(templatesDir), context.format,
+      return fromDirectory(Directory(templatesDir), format,
           headerPaths: context.header,
           footerPaths: context.footer,
-          footerTextPaths: context.footerTextPaths);
+          footerTextPaths: footerTextPaths);
     } else {
-      return createDefault(context.format,
+      return createDefault(format,
           headerPaths: context.header,
           footerPaths: context.footer,
-          footerTextPaths: context.footerTextPaths);
+          footerTextPaths: footerTextPaths);
     }
   }
 


### PR DESCRIPTION
Moves resolution of the SDK footer text since we need to know the
format first and we can't make an await call inside the _compute
function of a DartdocSyntheticOption.