### PR TITLE
Generator backend for Markdown

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -16,6 +16,7 @@ import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/generator/empty_generator.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/generator/html_generator.dart';
+import 'package:dartdoc/src/generator/markdown_generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -109,7 +110,7 @@ class Dartdoc extends PackageBuilder {
 
   /// An asynchronous factory method that builds Dartdoc's file writers
   /// and returns a Dartdoc object with them.
-  @Deprecated('Prefer withContext() instead')
+  @Deprecated('Prefer fromContext() instead')
   static Future<Dartdoc> withDefaultGenerators(
       DartdocGeneratorOptionContext config) async {
     return Dartdoc._(config, await initHtmlGenerator(config));
@@ -130,8 +131,7 @@ class Dartdoc extends PackageBuilder {
         generator = await initHtmlGenerator(context);
         break;
       case 'md':
-        // TODO(jdkoren): use a real generator
-        generator = await initEmptyGenerator(context);
+        generator = await initMarkdownGenerator(context);
         break;
       default:
         throw DartdocFailure('Unsupported output format: ${context.format}');

--- a/lib/src/generator/markdown_generator.dart
+++ b/lib/src/generator/markdown_generator.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartdoc/dartdoc.dart';
+import 'package:dartdoc/src/generator/dartdoc_generator_backend.dart';
+import 'package:dartdoc/src/generator/generator.dart';
+import 'package:dartdoc/src/generator/generator_frontend.dart';
+import 'package:dartdoc/src/generator/template_data.dart';
+import 'package:dartdoc/src/generator/templates.dart';
+import 'package:dartdoc/src/model/package.dart';
+import 'package:dartdoc/src/model/package_graph.dart';
+
+Future<Generator> initMarkdownGenerator(
+    DartdocGeneratorOptionContext context) async {
+  var templates = await Templates.fromContext(context);
+  var options = DartdocGeneratorBackendOptions.fromContext(context);
+  var backend = MarkdownGeneratorBackend(options, templates);
+  return GeneratorFrontEnd(backend);
+}
+
+/// Generator backend for markdown output.
+class MarkdownGeneratorBackend extends DartdocGeneratorBackend {
+  MarkdownGeneratorBackend(
+      DartdocGeneratorBackendOptions options, Templates templates)
+      : super(options, templates);
+
+  @override
+  void generatePackage(FileWriter writer, PackageGraph graph, Package package) {
+    super.generatePackage(writer, graph, package);
+    // We have to construct the data again. This only happens once per package.
+    TemplateData data = PackageTemplateData(options, graph, package);
+    render(writer, '__404error.md', templates.errorTemplate, data);
+  }
+}


### PR DESCRIPTION
This wires up the Markdown backend, but using the existing HTML renderers (Markdown renderers to follow in another change set).