### PR TITLE
Keep default category out of Categorization.categoryNames

### DIFF
--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -42,14 +42,6 @@ abstract class Categorization implements ModelElement {
       return '';
     });
 
-    if (_categorySet.isEmpty) {
-      // All objects are in the default category if not specified.
-      _categorySet.add(null);
-    }
-    if (_subCategorySet.isEmpty) {
-      // All objects are in the default subcategory if not specified.
-      _subCategorySet.add(null);
-    }
     _categoryNames = _categorySet.toList()..sort();
     _subCategoryNames = _subCategorySet.toList()..sort();
     _image ??= '';
@@ -57,8 +49,7 @@ abstract class Categorization implements ModelElement {
     return rawDocs;
   }
 
-  bool get hasSubCategoryNames =>
-      subCategoryNames.length > 1 || subCategoryNames.first != null;
+  bool get hasSubCategoryNames => subCategoryNames.isNotEmpty;
   List<String> _subCategoryNames;
 
   /// Either a set of strings containing all declared subcategories for this symbol,
@@ -70,8 +61,7 @@ abstract class Categorization implements ModelElement {
   }
 
   @override
-  bool get hasCategoryNames =>
-      categoryNames.length > 1 || categoryNames.first != null;
+  bool get hasCategoryNames => categoryNames.isNotEmpty;
   List<String> _categoryNames;
 
   /// Either a set of strings containing all declared categories for this symbol,

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -270,8 +270,13 @@ class Package extends LibraryContainer
       _nameToCategory[null] = Category(null, this, config);
       for (Categorization c in libraries.expand(
           (l) => l.allCanonicalModelElements.whereType<Categorization>())) {
-        for (String category in c.categoryNames) {
-          categoryFor(category).addItem(c);
+        if (c.hasCategoryNames) {
+          for (String category in c.categoryNames) {
+            categoryFor(category).addItem(c);
+          }
+        } else {
+          // Add to the default category.
+          categoryFor(null).addItem(c);
         }
       }
     }

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -89,11 +89,11 @@ void main() {
       });
 
       test('includeExternal and showUndocumentedCategories', () async {
-        Class Something = p.allCanonicalModelElements
+        Class withUndocumentedCategory = p.allCanonicalModelElements
             .whereType<Class>()
-            .firstWhere((ModelElement c) => c.name == 'Something');
-        expect(Something.isPublic, isTrue);
-        expect(Something.displayedCategories, isNotEmpty);
+            .firstWhere((ModelElement c) => c.name == 'UseAnExampleHere');
+        expect(withUndocumentedCategory.isPublic, isTrue);
+        expect(withUndocumentedCategory.displayedCategories, isNotEmpty);
       });
     });
 


### PR DESCRIPTION
Prevents CategoryRenderer from having to deal with `null` names.