### PR TITLE
Fix the flutter SDK search box loading on non-root pages with --use-base-href

### DIFF
--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -102,7 +102,7 @@ function initSearch(name) {
 
   var baseHref = '';
   if (!$('body').data('using-base-href')) {
-    // If we aren't using a base-href flag, we will need to add the relative
+    // If dartdoc did not add a base-href tag, we will need to add the relative
     // path ourselves.
     baseHref = $('body').data('base-href');
   }

--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -100,7 +100,12 @@ function initSearch(name) {
     'constructor' : 4
   };
 
-  var baseHref = $('body').data('base-href');
+  var baseHref = '';
+  if (!$('body').data('using-base-href')) {
+    // If we aren't using a base-href flag, we will need to add the relative
+    // path ourselves.
+    baseHref = $('body').data('base-href');
+  }
 
   function findMatches(q) {
     var allMatches = []; // list of matches

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -31,7 +31,8 @@
 </head>
 
 {{! We don't use <base href>, but we do lookup the htmlBase from javascript. }}
-<body data-base-href="{{{htmlBase}}}">
+<body data-base-href="{{{htmlBase}}}"
+      data-using-base-href="{{{useBaseHref}}}">
 
 <div id="overlay-under-drawer"></div>
 


### PR DESCRIPTION
Fixes #2157.

This combines the attempts in #2118 and #2125 into something that works for the case in Flutter where they've changed the directory level of everything except the index to one down (under flutter/), and rewritten the href on the index page accordingly.  I didn't notice this as the `serve-flutter-docs` grinder doesn't do that hack and I didn't stop to think about the implications of that at the time...  Also, `serve-flutter-docs` doesn't use --use-base-href so a manual test verifying the search box worked with that wouldn't have helped in any event.

I'm open to a better way of doing this in javascript, but I have tried several alternatives (including trying to read the base tag directly) and this seems to be the one that works reliably.