### PR TITLE
Prepare for dartdoc 0.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.30.2
+* Fix the broken search box with --use-base-href in Flutter (#2158).
+* More internal changes preparing for markdown output
+  (#2145, #2150, #2151, #2153).
+
 ## 0.30.1
 * A more complete fix for the broken search box. (#2125, #2124)
 * Fix the "--rel-canonical-prefix" flag post `base href`. (#2126, #2122) 

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.30.1/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.30.2/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.30.1';
+const packageVersion = '0.30.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.30.1
+version: 0.30.2
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
Update pubspec and changelog for a new release.  This should enable Flutter to get back up to speed with the latest dartdoc.