### PR TITLE
Markdown template tweaks

### DIFF
--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -114,6 +114,8 @@ abstract class Categorization implements ModelElement {
     return categories.where((c) => c.isDocumented);
   }
 
+  bool get hasDisplayedCategories => displayedCategories.isNotEmpty;
+
   /// True if categories, subcategories, a documentation icon, or samples were
   /// declared.
   bool get hasCategorization {

--- a/lib/src/render/type_parameters_renderer.dart
+++ b/lib/src/render/type_parameters_renderer.dart
@@ -49,6 +49,6 @@ class TypeParametersRendererMd extends TypeParametersRenderer {
       return '';
     }
     var joined = typeParameters.map(mapfn).join(', ');
-    return '<${joined}>';
+    return '&lt;${joined}>';
   }
 }

--- a/lib/templates/md/_accessor_getter.md
+++ b/lib/templates/md/_accessor_getter.md
@@ -1,5 +1,5 @@
 {{#getter}}
-{{{ linkedReturnType }}} {{>name_summary}}
+{{{ linkedReturnType }}} {{>name_summary}}  {{!two spaces intentional}}
 {{>features}}
 
 {{>documentation}}

--- a/lib/templates/md/_accessor_getter.md
+++ b/lib/templates/md/_accessor_getter.md
@@ -3,5 +3,6 @@
 {{>features}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/getter}}

--- a/lib/templates/md/_accessor_setter.md
+++ b/lib/templates/md/_accessor_setter.md
@@ -3,5 +3,6 @@
 {{>features}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/setter}}

--- a/lib/templates/md/_accessor_setter.md
+++ b/lib/templates/md/_accessor_setter.md
@@ -1,5 +1,5 @@
 {{#setter}}
-{{>name_summary}}({{{ linkedParamsNoMetadata }}})
+{{>name_summary}}({{{ linkedParamsNoMetadata }}})  {{!two spaces intentional}}
 {{>features}}
 
 {{>documentation}}

--- a/lib/templates/md/_callable.md
+++ b/lib/templates/md/_callable.md
@@ -1,3 +1,4 @@
 {{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}} {{>categorization}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
 {{>features}}

--- a/lib/templates/md/_callable.md
+++ b/lib/templates/md/_callable.md
@@ -1,4 +1,4 @@
-{{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}}
+##### {{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}}
 {{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}

--- a/lib/templates/md/_callable.md
+++ b/lib/templates/md/_callable.md
@@ -1,4 +1,5 @@
-{{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}} {{>categorization}}
+{{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}}
+{{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
 {{>features}}

--- a/lib/templates/md/_callable.md
+++ b/lib/templates/md/_callable.md
@@ -1,4 +1,4 @@
 {{{linkedName}}}{{{linkedGenericParameters}}}({{{ linkedParamsNoMetadata }}}) {{{ linkedReturnType }}} {{>categorization}}
 
-{{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
 {{>features}}

--- a/lib/templates/md/_categorization.md
+++ b/lib/templates/md/_categorization.md
@@ -1,5 +1,6 @@
-{{#hasCategoryNames}}
+{{#hasDisplayedCategories}}
+Categories:
 {{#displayedCategories}}
 {{{categoryLabel}}}
 {{/displayedCategories}}
-{{/hasCategoryNames}}
+{{/hasDisplayedCategories}}

--- a/lib/templates/md/_class.md
+++ b/lib/templates/md/_class.md
@@ -1,2 +1,3 @@
 {{{linkedName}}}{{{linkedGenericParameters}}} {{>categorization}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_class.md
+++ b/lib/templates/md/_class.md
@@ -1,3 +1,4 @@
-{{{linkedName}}}{{{linkedGenericParameters}}} {{>categorization}}
+{{{linkedName}}}{{{linkedGenericParameters}}}
+{{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_class.md
+++ b/lib/templates/md/_class.md
@@ -1,4 +1,4 @@
-{{{linkedName}}}{{{linkedGenericParameters}}}
+##### {{{linkedName}}}{{{linkedGenericParameters}}}
 {{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_constant.md
+++ b/lib/templates/md/_constant.md
@@ -1,4 +1,4 @@
-{{{ linkedName }}} const {{{ linkedReturnType }}}
+##### {{{ linkedName }}} const {{{ linkedReturnType }}}
 {{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}

--- a/lib/templates/md/_constant.md
+++ b/lib/templates/md/_constant.md
@@ -1,4 +1,4 @@
 {{{ linkedName }}} const {{{ linkedReturnType }}} {{>categorization}}
 
-{{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
 {{>features}}

--- a/lib/templates/md/_constant.md
+++ b/lib/templates/md/_constant.md
@@ -1,3 +1,4 @@
 {{{ linkedName }}} const {{{ linkedReturnType }}} {{>categorization}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
 {{>features}}

--- a/lib/templates/md/_constant.md
+++ b/lib/templates/md/_constant.md
@@ -1,4 +1,5 @@
-{{{ linkedName }}} const {{{ linkedReturnType }}} {{>categorization}}
+{{{ linkedName }}} const {{{ linkedReturnType }}}
+{{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
 {{>features}}

--- a/lib/templates/md/_extension.md
+++ b/lib/templates/md/_extension.md
@@ -1,3 +1,4 @@
-{{{linkedName}}} {{>categorization}}
+{{{linkedName}}}
+{{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_extension.md
+++ b/lib/templates/md/_extension.md
@@ -1,4 +1,4 @@
-{{{linkedName}}}
+##### {{{linkedName}}}
 {{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_extension.md
+++ b/lib/templates/md/_extension.md
@@ -1,2 +1,3 @@
 {{{linkedName}}} {{>categorization}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_library.md
+++ b/lib/templates/md/_library.md
@@ -1,4 +1,5 @@
 {{{ linkedName }}} ({{>categorization}})
 {{#isDocumented}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
 {{/isDocumented}}

--- a/lib/templates/md/_library.md
+++ b/lib/templates/md/_library.md
@@ -1,4 +1,4 @@
-{{{ linkedName }}} ({{>categorization}})
+{{{ linkedName }}}
 {{#isDocumented}}
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}
 

--- a/lib/templates/md/_library.md
+++ b/lib/templates/md/_library.md
@@ -1,4 +1,4 @@
-{{{ linkedName }}}
+##### {{{ linkedName }}}
 {{#isDocumented}}
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}
 

--- a/lib/templates/md/_mixin.md
+++ b/lib/templates/md/_mixin.md
@@ -1,2 +1,3 @@
 {{{linkedName}}}{{{linkedGenericParameters}}} {{>categorization}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_mixin.md
+++ b/lib/templates/md/_mixin.md
@@ -1,3 +1,4 @@
-{{{linkedName}}}{{{linkedGenericParameters}}} {{>categorization}}
+{{{linkedName}}}{{{linkedGenericParameters}}}
+{{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_mixin.md
+++ b/lib/templates/md/_mixin.md
@@ -1,4 +1,4 @@
-{{{linkedName}}}{{{linkedGenericParameters}}}
+##### {{{linkedName}}}{{{linkedGenericParameters}}}
 {{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}

--- a/lib/templates/md/_property.md
+++ b/lib/templates/md/_property.md
@@ -1,3 +1,4 @@
 {{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}} {{>categorization}}
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
 {{>features}}

--- a/lib/templates/md/_property.md
+++ b/lib/templates/md/_property.md
@@ -1,4 +1,4 @@
-{{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}}
+##### {{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}}
 {{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}

--- a/lib/templates/md/_property.md
+++ b/lib/templates/md/_property.md
@@ -1,4 +1,4 @@
 {{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}} {{>categorization}}
 
-{{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
 {{>features}}

--- a/lib/templates/md/_property.md
+++ b/lib/templates/md/_property.md
@@ -1,4 +1,5 @@
-{{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}} {{>categorization}}
+{{{linkedName}}} {{{ arrow }}} {{{ linkedReturnType }}}
+{{>categorization}}
 
 {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
 {{>features}}

--- a/lib/templates/md/_source_link.md
+++ b/lib/templates/md/_source_link.md
@@ -1,3 +1,3 @@
 {{#hasSourceHref}}
-[source]({{{sourceHref}}})
+[view source]({{{sourceHref}}})
 {{/hasSourceHref}}

--- a/lib/templates/md/category.md
+++ b/lib/templates/md/category.md
@@ -10,6 +10,7 @@
 
 {{#publicLibraries}}
 {{>library}}
+
 {{/publicLibraries}}
 {{/hasPublicLibraries}}
 
@@ -18,6 +19,7 @@
 
 {{#publicClasses}}
 {{>class}}
+
 {{/publicClasses}}
 {{/hasPublicClasses}}
 
@@ -26,6 +28,7 @@
 
 {{#publicMixins}}
 {{>mixin}}
+
 {{/publicMixins}}
 {{/hasPublicMixins}}
 
@@ -34,6 +37,7 @@
 
 {{#publicConstants}}
 {{>constant}}
+
 {{/publicConstants}}
 {{/hasPublicConstants}}
 
@@ -42,6 +46,7 @@
 
 {{#publicProperties}}
 {{>property}}
+
 {{/publicProperties}}
 {{/hasPublicProperties}}
 
@@ -50,6 +55,7 @@
 
 {{#publicFunctions}}
 {{>callable}}
+
 {{/publicFunctions}}
 {{/hasPublicFunctions}}
 
@@ -58,6 +64,7 @@
 
 {{#publicEnums}}
 {{>class}}
+
 {{/publicEnums}}
 {{/hasPublicEnums}}
 
@@ -66,6 +73,7 @@
 
 {{#publicTypedefs}}
 {{>callable}}
+
 {{/publicTypedefs}}
 {{/hasPublicTypedefs}}
 
@@ -74,6 +82,7 @@
 
 {{#publicExceptions}}
 {{>class}}
+
 {{/publicExceptions}}
 {{/hasPublicExceptions}}
 {{/self}}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -67,7 +67,8 @@
 
 {{#publicConstructors}}
 {{{linkedName}}} ({{{ linkedParams }}})
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
 {{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
 {{/publicConstructors}}
 {{/hasPublicConstructors}}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -68,8 +68,9 @@
 {{#publicConstructors}}
 {{{linkedName}}} ({{{ linkedParams }}})
 
-{{{ oneLineDoc }}} {{{ extendedDocLink }}}
-{{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
+{{#isConst}}_const_{{/isConst}} {{#isFactory}}_factory_{{/isFactory}}
+
 {{/publicConstructors}}
 {{/hasPublicConstructors}}
 

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -77,6 +77,7 @@
 
 {{#allPublicInstanceProperties}}
 {{>property}}
+
 {{/allPublicInstanceProperties}}
 {{/hasPublicProperties}}
 
@@ -85,6 +86,7 @@
 
 {{#allPublicInstanceMethods}}
 {{>callable}}
+
 {{/allPublicInstanceMethods}}
 {{/hasPublicMethods}}
 
@@ -93,6 +95,7 @@
 
 {{#allPublicOperators}}
 {{>callable}}
+
 {{/allPublicOperators}}
 {{/hasPublicOperators}}
 
@@ -101,6 +104,7 @@
 
 {{#publicStaticProperties}}
 {{>property}}
+
 {{/publicStaticProperties}}
 {{/hasPublicStaticProperties}}
 
@@ -109,6 +113,7 @@
 
 {{#publicStaticMethods}}
 {{>callable}}
+
 {{/publicStaticMethods}}
 {{/hasPublicStaticMethods}}
 
@@ -117,6 +122,7 @@
 
 {{#publicConstants}}
 {{>constant}}
+
 {{/publicConstants}}
 {{/hasPublicConstants}}
 {{/clazz}}

--- a/lib/templates/md/constant.md
+++ b/lib/templates/md/constant.md
@@ -10,6 +10,7 @@
 {{{ linkedReturnType }}} {{>name_summary}} = {{{ constantValue }}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/property}}
 

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -69,8 +69,9 @@
 {{#publicConstructors}}
 {{{linkedName}}}({{{ linkedParams }}})
 
-{{{ oneLineDoc }}} {{{ extendedDocLink }}}
-{{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
+{{#isConst}}_const_{{/isConst}} {{#isFactory}}_factory_{{/isFactory}}
+
 {{/publicConstructors}}
 {{/hasPublicConstructors}}
 

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -67,8 +67,9 @@
 ## Constructors
 
 {{#publicConstructors}}
-{{{linkedName}}} ({{{ linkedParams }}})
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{linkedName}}}({{{ linkedParams }}})
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
 {{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
 {{/publicConstructors}}
 {{/hasPublicConstructors}}

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -59,6 +59,7 @@
 
 {{#publicConstants}}
 {{>constant}}
+
 {{/publicConstants}}
 {{/hasPublicConstants}}
 
@@ -77,6 +78,7 @@
 
 {{#allPublicInstanceProperties}}
 {{>property}}
+
 {{/allPublicInstanceProperties}}
 {{/hasPublicProperties}}
 
@@ -85,6 +87,7 @@
 
 {{#allPublicInstanceMethods}}
 {{>callable}}
+
 {{/allPublicInstanceMethods}}
 {{/hasPublicMethods}}
 
@@ -93,6 +96,7 @@
 
 {{#allPublicOperators}}
 {{>callable}}
+
 {{/allPublicOperators}}
 {{/hasPublicOperators}}
 
@@ -101,6 +105,7 @@
 
 {{#publicStaticProperties}}
 {{>property}}
+
 {{/publicStaticProperties}}
 {{/hasPublicStaticProperties}}
 
@@ -109,6 +114,7 @@
 
 {{#publicStaticMethods}}
 {{>callable}}
+
 {{/publicStaticMethods}}
 {{/hasPublicStaticMethods}}
 {{/eNum}}

--- a/lib/templates/md/extension.md
+++ b/lib/templates/md/extension.md
@@ -4,6 +4,7 @@
 # {{{nameWithGenerics}}} {{kind}}
 
 {{>source_link}}
+
 {{>categorization}}
 {{/self}}
 
@@ -20,6 +21,7 @@ on
 
 {{#allPublicInstanceProperties}}
 {{>property}}
+
 {{/allPublicInstanceProperties}}
 {{/hasPublicProperties}}
 
@@ -28,6 +30,7 @@ on
 
 {{#allPublicInstanceMethods}}
 {{>callable}}
+
 {{/allPublicInstanceMethods}}
 {{/hasPublicMethods}}
 
@@ -36,6 +39,7 @@ on
 
 {{#allPublicOperators}}
 {{>callable}}
+
 {{/allPublicOperators}}
 {{/hasPublicOperators}}
 
@@ -44,6 +48,7 @@ on
 
 {{#publicStaticProperties}}
 {{>property}}
+
 {{/publicStaticProperties}}
 {{/hasPublicStaticProperties}}
 
@@ -52,6 +57,7 @@ on
 
 {{#publicStaticMethods}}
 {{>callable}}
+
 {{/publicStaticMethods}}
 {{/hasPublicStaticMethods}}
 
@@ -60,6 +66,7 @@ on
 
 {{#publicConstants}}
 {{>constant}}
+
 {{/publicConstants}}
 {{/hasPublicConstants}}
 {{/extension}}

--- a/lib/templates/md/extension.md
+++ b/lib/templates/md/extension.md
@@ -2,6 +2,7 @@
 
 {{#self}}
 # {{{nameWithGenerics}}} {{kind}}
+on {{#extendedType}}{{{linkedName}}}{{/extendedType}}
 
 {{>source_link}}
 
@@ -10,11 +11,6 @@
 
 {{#extension}}
 {{>documentation}}
-
-on
-{{#extendedType}}
-: {{{linkedName}}}
-{{/extendedType}}
 
 {{#hasPublicProperties}}
 ## Properties

--- a/lib/templates/md/index.md
+++ b/lib/templates/md/index.md
@@ -20,7 +20,7 @@
 {{/defaultCategory.publicLibraries}}
 
 {{#categoriesWithPublicLibraries}}
-### {{name}}
+### Category {{{categoryLabel}}}
 
 {{#publicLibraries}}
 {{>library}}

--- a/lib/templates/md/library.md
+++ b/lib/templates/md/library.md
@@ -16,6 +16,7 @@
 
 {{#library.publicClasses}}
 {{>class}}
+
 {{/library.publicClasses}}
 {{/library.hasPublicClasses}}
 
@@ -24,6 +25,7 @@
 
 {{#library.publicMixins}}
 {{>mixin}}
+
 {{/library.publicMixins}}
 {{/library.hasPublicMixins}}
 
@@ -32,6 +34,7 @@
 
 {{#library.publicExtensions}}
 {{>extension}}
+
 {{/library.publicExtensions}}
 {{/library.hasPublicExtensions}}
 
@@ -40,6 +43,7 @@
 
 {{#library.publicConstants}}
 {{>constant}}
+
 {{/library.publicConstants}}
 {{/library.hasPublicConstants}}
 
@@ -48,6 +52,7 @@
 
 {{#library.publicProperties}}
 {{>property}}
+
 {{/library.publicProperties}}
 {{/library.hasPublicProperties}}
 
@@ -56,6 +61,7 @@
 
 {{#library.publicFunctions}}
 {{>callable}}
+
 {{/library.publicFunctions}}
 {{/library.hasPublicFunctions}}
 
@@ -64,6 +70,7 @@
 
 {{#library.publicEnums}}
 {{>class}}
+
 {{/library.publicEnums}}
 {{/library.hasPublicEnums}}
 
@@ -72,6 +79,7 @@
 
 {{#library.publicTypedefs}}
 {{>callable}}
+
 {{/library.publicTypedefs}}
 {{/library.hasPublicTypedefs}}
 
@@ -80,6 +88,7 @@
 
 {{#library.publicExceptions}}
 {{>class}}
+
 {{/library.publicExceptions}}
 {{/library.hasPublicExceptions}}
 

--- a/lib/templates/md/method.md
+++ b/lib/templates/md/method.md
@@ -9,6 +9,7 @@
 {{#method}}
 {{>callable_multiline}}
 {{>features}}
+
 {{>documentation}}
 
 {{>source_code}}

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -77,6 +77,7 @@
 
 {{#allPublicInstanceProperties}}
 {{>property}}
+
 {{/allPublicInstanceProperties}}
 {{/hasPublicProperties}}
 
@@ -85,6 +86,7 @@
 
 {{#allPublicInstanceMethods}}
 {{>callable}}
+
 {{/allPublicInstanceMethods}}
 {{/hasPublicMethods}}
 
@@ -93,6 +95,7 @@
 
 {{#allPublicOperators}}
 {{>callable}}
+
 {{/allPublicOperators}}
 {{/hasPublicOperators}}
 
@@ -101,6 +104,7 @@
 
 {{#publicStaticProperties}}
 {{>property}}
+
 {{/publicStaticProperties}}
 {{/hasPublicStaticProperties}}
 
@@ -109,6 +113,7 @@
 
 {{#publicStaticMethods}}
 {{>callable}}
+
 {{/publicStaticMethods}}
 {{/hasPublicStaticMethods}}
 
@@ -117,6 +122,7 @@
 
 {{#publicConstants}}
 {{>constant}}
+
 {{/publicConstants}}
 {{/hasPublicConstants}}
 {{/mixin}}

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -66,8 +66,10 @@
 ## Constructors
 
 {{#publicConstructors}}
-{{{linkedName}}} ({{{ linkedParams }}})
-: {{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{linkedName}}}({{{ linkedParams }}})
+
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}
+
 {{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
 {{/publicConstructors}}
 {{/hasPublicConstructors}}

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -68,9 +68,9 @@
 {{#publicConstructors}}
 {{{linkedName}}}({{{ linkedParams }}})
 
-{{{ oneLineDoc }}} {{{ extendedDocLink }}}
+{{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
+{{#isConst}}_const_{{/isConst}} {{#isFactory}}_factory_{{/isFactory}}
 
-{{#isConst}}const{{/isConst}} {{#isFactory}}factory{{/isFactory}}
 {{/publicConstructors}}
 {{/hasPublicConstructors}}
 

--- a/lib/templates/md/property.md
+++ b/lib/templates/md/property.md
@@ -8,7 +8,7 @@
 
 {{#self}}
 {{#hasNoGetterSetter}}
-{{{ linkedReturnType }}} {{>name_summary}}
+{{{ linkedReturnType }}} {{>name_summary}}  {{!two spaces intentional}}
 {{>features}}
 
 {{>documentation}}

--- a/lib/templates/md/property.md
+++ b/lib/templates/md/property.md
@@ -12,6 +12,7 @@
 {{>features}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/hasNoGetterSetter}}
 

--- a/lib/templates/md/top_level_constant.md
+++ b/lib/templates/md/top_level_constant.md
@@ -6,7 +6,7 @@
 {{>source_link}}
 {{>categorization}}
 
-{{>name_summary}} = {{{ constantValue }}}
+{{>name_summary}} = {{{ constantValue }}}  {{!two spaces intentional}}
 {{>features}}
 
 {{>documentation}}

--- a/lib/templates/md/top_level_constant.md
+++ b/lib/templates/md/top_level_constant.md
@@ -10,6 +10,7 @@
 {{>features}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/self}}
 

--- a/lib/templates/md/top_level_property.md
+++ b/lib/templates/md/top_level_property.md
@@ -7,7 +7,7 @@
 {{>categorization}}
 
 {{#hasNoGetterSetter}}
-{{{ linkedReturnType }}} {{>name_summary}}
+{{{ linkedReturnType }}} {{>name_summary}}  {{!two spaces intentional}}
 {{>features}}
 
 {{>documentation}}

--- a/lib/templates/md/top_level_property.md
+++ b/lib/templates/md/top_level_property.md
@@ -11,6 +11,7 @@
 {{>features}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/hasNoGetterSetter}}
 

--- a/lib/templates/md/typedef.md
+++ b/lib/templates/md/typedef.md
@@ -11,6 +11,7 @@
 {{>callable_multiline}}
 
 {{>documentation}}
+
 {{>source_code}}
 {{/typeDef}}
 


### PR DESCRIPTION
Lots of little tweaks that increase readability of the generated markdown. Some notable issues remain:
- Angle brackets are tricky. We need to escape some so that they aren't interpreted as HTML tags (e.g. `<B>`), however we also end up escaping brackets in source code snippets.
- Special directives like `@tool` seem to not work