### PR TITLE
Add Never to type text

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -114,7 +114,9 @@ class UndefinedElementType extends ElementType {
       }
     }
     if (type.isVoid) return 'void';
-    assert(false, 'Unrecognized type for UndefinedElementType');
+    if (type.isBottom) return 'Never';
+    assert(false,
+        'Unrecognized type for UndefinedElementType: ${type.toString()}');
     return '';
   }
 


### PR DESCRIPTION
This prevents an assert when attempting to generate docs for something including the 'Never' type.

Real tests for this will depend on dart-lang/sdk#41222, but this will unblock dartdoc for the snapshot shipped with the SDK.