### PR TITLE
Fix accidental reentrance on TopLevelVariables in rare case

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -105,7 +105,7 @@ class PackageGraph {
           yield d.precacheLocalDocs();
           // TopLevelVariables get their documentation from getters and setters,
           // so should be precached if either has a template.
-          if (m is TopLevelVariable) {
+          if (m is TopLevelVariable && !precachedElements.contains(m)) {
             precachedElements.add(m);
             yield m.precacheLocalDocs();
           }


### PR DESCRIPTION
Found while looking at #2143.

Simple bug where the precaching forgets to check whether we've already precached a TopLevelVariable (can be a problem if both the getter and the setter require precaching).
