### PR TITLE
Hide non-local embedded SDKs

### DIFF
--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -152,9 +152,23 @@ class Package extends LibraryContainer
   /// was not excluded on the command line.
   bool get isLocal {
     if (_isLocal == null) {
-      _isLocal = (packageMeta == packageGraph.packageMeta ||
-              packageGraph.hasEmbedderSdk && packageMeta.isSdk ||
-              packageGraph.config.autoIncludeDependencies) &&
+      _isLocal = (
+          // Document as local if this is the default package.
+          packageMeta == packageGraph.packageMeta ||
+              // Assume we want to document an embedded SDK as local if
+              // it has libraries defined in the default package.
+              // TODO(jcollins-g): Handle case where embedder SDKs can be
+              // assembled from multiple locations?
+              packageGraph.hasEmbedderSdk &&
+                  packageMeta.isSdk &&
+                  libraries.any(
+                          (l) => path.isWithin(packageGraph.packageMeta.dir.path,
+                          (l.element.source.fullName))) ||
+              // autoIncludeDependencies means everything is local.
+              packageGraph.config.autoIncludeDependencies
+      ) &&
+          // Regardless of the above rules, do not document as local if
+          // we excluded this package by name.
           !packageGraph.config.isPackageExcluded(name);
     }
     return _isLocal;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -153,20 +153,19 @@ class Package extends LibraryContainer
   bool get isLocal {
     if (_isLocal == null) {
       _isLocal = (
-          // Document as local if this is the default package.
-          packageMeta == packageGraph.packageMeta ||
-              // Assume we want to document an embedded SDK as local if
-              // it has libraries defined in the default package.
-              // TODO(jcollins-g): Handle case where embedder SDKs can be
-              // assembled from multiple locations?
-              packageGraph.hasEmbedderSdk &&
-                  packageMeta.isSdk &&
-                  libraries.any(
-                          (l) => path.isWithin(packageGraph.packageMeta.dir.path,
+              // Document as local if this is the default package.
+              packageMeta == packageGraph.packageMeta ||
+                  // Assume we want to document an embedded SDK as local if
+                  // it has libraries defined in the default package.
+                  // TODO(jcollins-g): Handle case where embedder SDKs can be
+                  // assembled from multiple locations?
+                  packageGraph.hasEmbedderSdk &&
+                      packageMeta.isSdk &&
+                      libraries.any((l) => path.isWithin(
+                          packageGraph.packageMeta.dir.path,
                           (l.element.source.fullName))) ||
-              // autoIncludeDependencies means everything is local.
-              packageGraph.config.autoIncludeDependencies
-      ) &&
+                  // autoIncludeDependencies means everything is local.
+                  packageGraph.config.autoIncludeDependencies) &&
           // Regardless of the above rules, do not document as local if
           // we excluded this package by name.
           !packageGraph.config.isPackageExcluded(name);

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -52,9 +52,9 @@ class PackageBuilder {
     return newGraph;
   }
 
-  DartSdk _sdk;
+  FolderBasedDartSdk _sdk;
 
-  DartSdk get sdk {
+  FolderBasedDartSdk get sdk {
     if (_sdk == null) {
       _sdk = FolderBasedDartSdk(PhysicalResourceProvider.INSTANCE,
           PhysicalResourceProvider.INSTANCE.getFolder(config.sdkDir));


### PR DESCRIPTION
Fixes #1949.

Don't treat an embedded SDK as local unless it is defined in the default package.  I decided not to address the issue of complex embedded SDKs defined via the aggregate of multiple embedder.yamls in different packages.  The worst that will happen is for those particular embedded SDKs we will generate duplicate documentation -- a much less severe problem than duplicating SDK documentation for every single Flutter app.