### PR TITLE
Allow null staticElement for const constructors

### DIFF
--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -52,8 +52,9 @@ mixin GetterSetterCombo on ModelElement {
         .toString();
     Element staticElement =
         (constantInitializer as InstanceCreationExpression).staticElement;
-    if (staticElement == null)
-      return original;
+    assert(staticElement != null,
+        '${original} should be able to be resolved but an analysis error prevents this');
+    if (staticElement == null) return original;
     Constructor target = ModelElement.fromElement(staticElement, packageGraph);
     Class targetClass = target.enclosingElement;
     // TODO(jcollins-g): this logic really should be integrated into Constructor,

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -52,6 +52,8 @@ mixin GetterSetterCombo on ModelElement {
         .toString();
     Element staticElement =
         (constantInitializer as InstanceCreationExpression).staticElement;
+    if (staticElement == null)
+      return original;
     Constructor target = ModelElement.fromElement(staticElement, packageGraph);
     Class targetClass = target.enclosingElement;
     // TODO(jcollins-g): this logic really should be integrated into Constructor,


### PR DESCRIPTION
Part of work on #2143.

Ordinarily we don't support documenting things that do not analyze cleanly, but sky_engine does not have a fully resolved import/export tree.  This works around an issue for missing imports for cases where we intentionally document sky_engine.
