### PR TITLE
Prepare for dartdoc 0.30.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.30.4
+* Fix regression in canonicalization from extension methods. (#2099).
+* Do not throw if a const constructor's staticElement can not be resolved
+  (#2176, #2143).
+* Hide non-local embedded SDKs, preventing Flutter's sky_engine from
+  being documented by default with Flutter packages (#1949, #2175).
+* Fix a problem with reentrance on TopLevelVariable doc caching. (#2173, #2143)
+* A batch of tweaks for the new markdown output templates (#2162)
+
 ## 0.30.3
 * Add support for `Never` type from analyzer (#2167, #2170).
 * First markdown renderers landed (#2152) and dartdoc can sometimes

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.30.3/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.30.4/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.30.3';
+const packageVersion = '0.30.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.30.3
+version: 0.30.4
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.4
+  analyzer: ^0.39.6
   args: '>=1.5.0 <2.0.0'
   collection: ^1.2.0
   crypto: ^2.0.6


### PR DESCRIPTION
Updates the changelog and version number for 0.30.4.

Also updates the minimum required version of analyzer and the SDK to 0.39.6 and 2.7.0 respectively -- while dartdoc might work with older versions it hasn't been tested there in a while.