### PR TITLE
Reenable flutter plugin validation

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -639,7 +639,7 @@ Future<void> serveFlutterDocs() async {
 }
 
 @Task('Validate flutter docs')
-@Depends(buildFlutterDocs, buildDartdocFlutterPluginDocs)
+@Depends(buildFlutterDocs, testDartdocFlutterPlugin)
 void validateFlutterDocs() {}
 
 @Task('Build flutter docs')


### PR DESCRIPTION
Fixes #2088.

#2099 was the reason we had to disable this; disabling it is no longer necessary now that it is fixed.