### PR TITLE
Fix version parsing error for new dev builds

### DIFF
--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -226,21 +226,20 @@ class Package extends LibraryContainer
             case 'b':
               {
                 Version version = Version.parse(packageMeta.version);
+                String tag = 'stable';
                 if (version.isPreRelease) {
                   // version.preRelease is a List<dynamic> with a mix of
                   // integers and strings.  Given this, handle
                   // 2.8.0-dev.1.0, 2.9.0-dev.1.0, and similar
                   // variations.
-                  String tag = version.preRelease.whereType<String>().first;
+                  tag = version.preRelease.whereType<String>().first;
                   // Who knows about non-SDK packages, but assert that SDKs
                   // must conform to the known format.
                   assert(
                       packageMeta.isSdk == false || int.tryParse(tag) == null,
                       'Got an integer as string instead of the expected "dev" tag');
                 }
-                return version.isPreRelease
-                    ? version.preRelease.whereType<String>().first
-                    : 'stable';
+                return tag;
               }
             case 'n':
               return name;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -230,7 +230,7 @@ class Package extends LibraryContainer
                 if (version.isPreRelease) {
                   // version.preRelease is a List<dynamic> with a mix of
                   // integers and strings.  Given this, handle
-                  // 2.8.0-dev.1.0, 2.9.0-dev.1.0, and similar
+                  // 2.8.0-dev.1.0, 2.9.0-1.0.dev, and similar
                   // variations.
                   tag = version.preRelease.whereType<String>().first;
                   // Who knows about non-SDK packages, but assert that SDKs

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -226,8 +226,20 @@ class Package extends LibraryContainer
             case 'b':
               {
                 Version version = Version.parse(packageMeta.version);
+                if (version.isPreRelease) {
+                  // version.preRelease is a List<dynamic> with a mix of
+                  // integers and strings.  Given this, handle
+                  // 2.8.0-dev.1.0, 2.9.0-dev.1.0, and similar
+                  // variations.
+                  String tag = version.preRelease.whereType<String>().first;
+                  // Who knows about non-SDK packages, but assert that SDKs
+                  // must conform to the known format.
+                  assert(
+                      packageMeta.isSdk == false || int.tryParse(tag) == null,
+                      'Got an integer as string instead of the expected "dev" tag');
+                }
                 return version.isPreRelease
-                    ? version.preRelease.first
+                    ? version.preRelease.whereType<String>().first
                     : 'stable';
               }
             case 'n':


### PR DESCRIPTION
Fixes #2185.

Allow more flexibility in how "dev" versions are parsed.  This will allow dartdoc to conform to https://github.com/dart-lang/sdk/issues/40687#issuecomment-614033229 for the SDK.
