### PR TITLE
Prepare for version 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.31.0
+* `--link-to-remote` is now the default.  (#2147)
+* `--show-progress` is now the default on interactive terminals,
+  and has improved quality of output. (#2147)
+* Excessive notifications for "parsing" have been squelched from
+  stdout. (#2141, #2147)
+* Fixed a bug where explicitly requested private members in a comment
+  reference could result in broken link generation. (#2147)
+* Dartdoc now generates documentation for itself cleanly (#2147)
+
 ## 0.30.4
 * Fix regression in canonicalization from extension methods. (#2099).
 * Do not throw if a const constructor's staticElement can not be resolved

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.30.4/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.31.0/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.30.4';
+const packageVersion = '0.31.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.30.4
+version: 0.31.0
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
Update changelog and pubspec for 0.31.0; assumes that #2147 will land.