### PR TITLE
Run flutter pub get when appropriate instead of normal pub get

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1583,10 +1583,6 @@ Future<List<DartdocOption>> createDartdocOptions() async {
           (option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
               .requiresFlutter) {
         String flutterRoot = option.root['flutterRoot'].valueAt(dir);
-        if (flutterRoot == null) {
-          throw DartdocOptionError(
-              'Top level package requires Flutter but FLUTTER_ROOT environment variable not set');
-        }
         return p.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
       }
       return defaultSdkDir.absolute.path;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -452,7 +452,7 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
 
   PackageMeta get packageMeta {
     if (_packageMeta == null) {
-      _packageMeta = PackageMeta.fromElement(element, config);
+      _packageMeta = PackageMeta.fromElement(element, config.sdkDir);
     }
     return _packageMeta;
   }

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -40,7 +40,7 @@ class PackageBuilder {
 
   Future<PackageGraph> buildPackageGraph() async {
     if (config.topLevelPackageMeta.needsPubGet) {
-      config.topLevelPackageMeta.runPubGet();
+      config.topLevelPackageMeta.runPubGet(config);
     }
 
     RendererFactory rendererFactory = RendererFactory.forFormat(config.format);

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -47,7 +47,7 @@ class PackageBuilder {
             'Top level package requires Flutter but FLUTTER_ROOT environment variable not set');
       }
       if (config.topLevelPackageMeta.needsPubGet) {
-        config.topLevelPackageMeta.runPubGet(config.sdkDir);
+        config.topLevelPackageMeta.runPubGet(config.flutterRoot);
       }
     }
 

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -41,6 +41,7 @@ class PackageBuilder {
   Future<PackageGraph> buildPackageGraph() async {
     if (!config.sdkDocs) {
       if (config.topLevelPackageMeta.needsPubGet &&
+          config.topLevelPackageMeta.requiresFlutter &&
           config.flutterRoot == null) {
         throw DartdocOptionError(
             'Top level package requires Flutter but FLUTTER_ROOT environment variable not set');

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -39,8 +39,15 @@ class PackageBuilder {
   PackageBuilder(this.config);
 
   Future<PackageGraph> buildPackageGraph() async {
-    if (config.topLevelPackageMeta.needsPubGet) {
-      config.topLevelPackageMeta.runPubGet(config);
+    if (!config.sdkDocs) {
+      if (config.topLevelPackageMeta.needsPubGet &&
+          config.flutterRoot == null) {
+        throw DartdocOptionError(
+            'Top level package requires Flutter but FLUTTER_ROOT environment variable not set');
+      }
+      if (config.topLevelPackageMeta.needsPubGet) {
+        config.topLevelPackageMeta.runPubGet(config.sdkDir);
+      }
     }
 
     RendererFactory rendererFactory = RendererFactory.forFormat(config.format);

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -42,7 +42,7 @@ class PackageGraph {
   void addLibraryToGraph(ResolvedLibraryResult result) {
     assert(!allLibrariesAdded);
     LibraryElement element = result.element;
-    var packageMeta = PackageMeta.fromElement(element, config);
+    var packageMeta = PackageMeta.fromElement(element, config.sdkDir);
     var lib = Library.fromLibraryResult(
         result, this, Package.fromPackageMeta(packageMeta, this));
     packageMap[packageMeta.name].libraries.add(lib);
@@ -850,7 +850,7 @@ class PackageGraph {
         result,
         this,
         Package.fromPackageMeta(
-            PackageMeta.fromElement(result.element.library, config),
+            PackageMeta.fromElement(result.element.library, config.sdkDir),
             packageGraph));
     allLibraries[result.element.library] = foundLibrary;
     return foundLibrary;

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -173,7 +173,7 @@ abstract class PackageMeta {
 
   bool get requiresFlutter;
 
-  void runPubGet();
+  void runPubGet(DartdocOptionContext config);
 
   String get name;
 
@@ -279,16 +279,24 @@ class _FilePackageMeta extends PackageMeta {
 
   @override
   bool get needsPubGet =>
-      !(File(path.join(dir.path, '.packages')).existsSync());
+      !(File(path.join(dir.path, '.dart_tool', 'package_config.json'))
+          .existsSync());
 
   @override
-  void runPubGet() {
-    String pubPath =
-        path.join(path.dirname(Platform.resolvedExecutable), 'pub');
-    if (Platform.isWindows) pubPath += '.bat';
+  void runPubGet(DartdocOptionContext config) {
+    String binPath;
+    List<String> parameters;
+    if (requiresFlutter) {
+      binPath = path.join(config.flutterRoot, 'bin', 'flutter');
+      parameters = ['pub', 'get'];
+    } else {
+      binPath = path.join(path.dirname(Platform.resolvedExecutable), 'pub');
+      parameters = ['get'];
+    }
+    if (Platform.isWindows) binPath += '.bat';
 
     ProcessResult result =
-        Process.runSync(pubPath, ['get'], workingDirectory: dir.path);
+        Process.runSync(binPath, parameters, workingDirectory: dir.path);
 
     var trimmedStdout = (result.stdout as String).trim();
     if (trimmedStdout.isNotEmpty) {
@@ -385,7 +393,7 @@ class _SdkMeta extends PackageMeta {
   bool get isSdk => true;
 
   @override
-  void runPubGet() {
+  void runPubGet(DartdocOptionContext config) {
     throw 'unsupported operation';
   }
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -94,12 +94,9 @@ abstract class PackageMeta {
 
   /// Use this instead of fromDir where possible.
   factory PackageMeta.fromElement(
-      LibraryElement libraryElement, DartdocOptionContext config) {
-    // [config] is only here for sdkDir, and it's OK that it is the wrong
-    // context since sdkDir is argOnly and this is supposed to be a temporary
-    // workaround.
+      LibraryElement libraryElement, String sdkDir) {
     if (libraryElement.isInSdk) {
-      return PackageMeta.fromDir(Directory(config.sdkDir));
+      return PackageMeta.fromDir(Directory(sdkDir));
     }
     return PackageMeta.fromDir(
         File(path.canonicalize(libraryElement.source.fullName)).parent);
@@ -173,7 +170,7 @@ abstract class PackageMeta {
 
   bool get requiresFlutter;
 
-  void runPubGet(DartdocOptionContext config);
+  void runPubGet(String flutterRoot);
 
   String get name;
 
@@ -283,11 +280,11 @@ class _FilePackageMeta extends PackageMeta {
           .existsSync());
 
   @override
-  void runPubGet(DartdocOptionContext config) {
+  void runPubGet(String flutterRoot) {
     String binPath;
     List<String> parameters;
     if (requiresFlutter) {
-      binPath = path.join(config.flutterRoot, 'bin', 'flutter');
+      binPath = path.join(flutterRoot, 'bin', 'flutter');
       parameters = ['pub', 'get'];
     } else {
       binPath = path.join(path.dirname(Platform.resolvedExecutable), 'pub');
@@ -393,7 +390,7 @@ class _SdkMeta extends PackageMeta {
   bool get isSdk => true;
 
   @override
-  void runPubGet(DartdocOptionContext config) {
+  void runPubGet(String flutterRoot) {
     throw 'unsupported operation';
   }
 

--- a/test/dartdoc_integration_test.dart
+++ b/test/dartdoc_integration_test.dart
@@ -135,6 +135,9 @@ void main() {
     test('Validate missing FLUTTER_ROOT exception is clean', () async {
       StringBuffer output = StringBuffer();
       var args = <String>[dartdocPath];
+      var dart_tool =
+          Directory(path.join(_testPackageFlutterPluginPath, '.dart_tool'));
+      if (dart_tool.existsSync()) dart_tool.deleteSync(recursive: true);
       Future run = subprocessLauncher.runStreamed(
           Platform.resolvedExecutable, args,
           environment: Map.from(Platform.environment)..remove('FLUTTER_ROOT'),


### PR DESCRIPTION
Found while looking into #2128, we're running the wrong flutter pub get and not using the right detection for a need to run pub get.  This fixes both.