### PR TITLE
Correct invalid member linkage

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -744,10 +744,14 @@ class _MarkdownCommentReference {
       // [thing], a member of this class
       _addCanonicalResult(modelElement, tryClass);
     }
-    membersToCheck = (c.allModelElementsByNamePart[codeRefChompedParts.last] ??
-            <ModelElement>[])
-        .map(_convertConstructors);
-    membersToCheck.forEach((m) => _addCanonicalResult(m, tryClass));
+    if (codeRefChompedParts.length < 2 ||
+        codeRefChompedParts[codeRefChompedParts.length - 2] == c.name) {
+      membersToCheck =
+          (c.allModelElementsByNamePart[codeRefChompedParts.last] ??
+                  <ModelElement>[])
+              .map(_convertConstructors);
+      membersToCheck.forEach((m) => _addCanonicalResult(m, tryClass));
+    }
     results.remove(null);
     if (results.isNotEmpty) return;
     if (c.fullyQualifiedNameWithoutLibrary == codeRefChomped) {

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -1389,6 +1389,23 @@ void main() {
   });
 
   group('Class edge cases', () {
+    test('Factories from unrelated classes are linked correctly', () {
+      Class A = packageGraph.localPublicLibraries
+          .firstWhere((l) => l.name == 'unrelated_factories')
+          .allClasses
+          .firstWhere((c) => c.name == 'A');
+      Constructor fromMap =
+          A.constructors.firstWhere((c) => c.name == 'A.fromMap');
+      expect(fromMap.documentationAsHtml,
+          contains(r'unrelated_factories/AB/AB.fromMap.html">AB.fromMap</a>'));
+      expect(fromMap.documentationAsHtml,
+          contains(r'A/A.fromMap.html">fromMap</a>'));
+      expect(fromMap.documentationAsHtml,
+          contains(r'unrelated_factories/AB-class.html">AB</a>'));
+      expect(fromMap.documentationAsHtml,
+          contains(r'unrelated_factories/A-class.html">A</a>'));
+    });
+
     test('Inherit from private class across private library to public library',
         () {
       Class GadgetExtender = packageGraph.localPublicLibraries

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -17,7 +17,7 @@ import 'package:path/path.dart' as path;
 /// The number of public libraries in testing/test_package, minus 2 for
 /// the excluded libraries listed in the initializers for _testPackageGraphMemo
 /// and minus 1 for the <nodoc> tag in the 'excluded' library.
-const int kTestPackagePublicLibraries = 16;
+const int kTestPackagePublicLibraries = 17;
 
 final RegExp quotables = RegExp(r'[ "\r\n\$]');
 final RegExp observatoryPortRegexp =

--- a/testing/test_package/lib/unrelated_factories.dart
+++ b/testing/test_package/lib/unrelated_factories.dart
@@ -1,12 +1,12 @@
 class A {
-  /// A link to [B.fromMap].
-  factory A.fromMap(Map<String, dynamic> map) => A();
+  /// A link to [AB.fromMap], [fromMap], and [AB] and [A].
+  factory A.fromMap(Map<String, dynamic> map) => A._A();
 
-  A();
+  A._A();
 }
 
-class B {
-  factory B.fromMap(Map<String, dynamic> map) => B();
+class AB {
+  factory AB.fromMap(Map<String, dynamic> map) => AB._AB();
 
-  B();
+  AB._AB();
 }

--- a/testing/test_package/lib/unrelated_factories.dart
+++ b/testing/test_package/lib/unrelated_factories.dart
@@ -1,0 +1,12 @@
+class A {
+  /// A link to [B.fromMap].
+  factory A.fromMap(Map<String, dynamic> map) => A();
+
+  A();
+}
+
+class B {
+  factory B.fromMap(Map<String, dynamic> map) => B();
+
+  B();
+}


### PR DESCRIPTION
Fixes #2008.

Dartdoc forgot to consider the explicitly specified class name, if available, when matching members in comment references.  This fixes that, and adds a test.