### PR TITLE
Add type as parameter lint and fix problems

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ linter:
     - always_declare_return_types
     - annotate_overrides
     - avoid_init_to_null
+    - avoid_types_as_parameter_names
     - directives_ordering
     - no_adjacent_strings_in_list
     - package_api_docs

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -388,7 +388,7 @@ class Dartdoc extends PackageBuilder {
         Uri uri;
         try {
           uri = Uri.parse(href);
-        } catch (FormatError) {
+        } on FormatException {
           // ignore
         }
 

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -458,7 +458,7 @@ class PackageWithoutSdkResolver extends UriResolver {
     Uri resolved;
     try {
       resolved = _sdkResolver.restoreAbsolute(source);
-    } catch (ArgumentError) {
+    } on ArgumentError {
       // SDK resolvers really don't like being thrown package paths.
     }
     if (resolved == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dev_dependencies:
   io: ^0.3.0
   http: ^0.12.0
   meta: ^1.0.0
-  pedantic: ^1.8.0
+  pedantic: ^1.9.0
   test: ^1.3.0
 
 executables:

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -308,8 +308,11 @@ class SubprocessLauncher {
       Map result;
       try {
         result = json.decoder.convert(line);
-      } catch (FormatException) {
-        // ignore
+      } on FormatException {
+        // Assume invalid JSON is actually a line of normal text.
+      } on TypeError {
+        // The convert function returns a String if there is no JSON in the
+        // line.  Just ignore it and leave result null.
       }
       if (result != null) {
         if (jsonObjects == null) {


### PR DESCRIPTION
Based on @scheglov 's change, add the lint `avoid_types_as_parameter_names` lint and fix the areas he identified.  For some reason the linter in the current dev release of the SDK doesn't see these but they're definitely problems.