### PR TITLE
Switch to pedantic 1.9.0 and enforce lints via presubmit

### DIFF
--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -6,6 +6,9 @@ analyzer:
   errors:
     unused_import: warning
     unused_shown_name: warning
+    ### Extra ignores for presubmit
+    deprecated_member_use: ignore
+    deprecated_member_use_from_same_package: ignore
   exclude:
     - 'doc/**'
     - 'lib/src/third_party/pkg/**'

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -43,8 +43,7 @@ Future<List<DartdocOption>> createDartdocProgramOptions() async {
 /// Analyzes Dart files and generates a representation of included libraries,
 /// classes, and members. Uses the current directory to look for libraries.
 Future<void> main(List<String> arguments) async {
-  DartdocOptionSet optionSet =
-      await DartdocOptionSet.fromOptionGenerators('dartdoc', [
+  var optionSet = await DartdocOptionSet.fromOptionGenerators('dartdoc', [
     createDartdocOptions,
     createDartdocProgramOptions,
     createLoggingOptions,
@@ -86,7 +85,7 @@ Future<void> main(List<String> arguments) async {
   }
   startLogging(config);
 
-  Dartdoc dartdoc = config.generateDocs
+  var dartdoc = config.generateDocs
       ? await Dartdoc.fromContext(config)
       : await Dartdoc.withEmptyGenerator(config);
   dartdoc.onCheckProgress.listen(logProgress);

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -24,7 +24,6 @@ import 'package:dartdoc/src/tuple.dart';
 import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/version.dart';
 import 'package:dartdoc/src/warnings.dart';
-import 'package:html/dom.dart' show Element, Document;
 import 'package:html/parser.dart' show parse;
 import 'package:path/path.dart' as path;
 
@@ -49,7 +48,7 @@ class DartdocFileWriter implements FileWriter {
   final String outputDir;
   final Map<String, Warnable> _fileElementMap = {};
   @override
-  final Set<String> writtenFiles = Set();
+  final Set<String> writtenFiles = {};
 
   DartdocFileWriter(this.outputDir);
 
@@ -57,14 +56,14 @@ class DartdocFileWriter implements FileWriter {
   void write(String filePath, Object content,
       {bool allowOverwrite, Warnable element}) {
     // Replace '/' separators with proper separators for the platform.
-    String outFile = path.joinAll(filePath.split('/'));
+    var outFile = path.joinAll(filePath.split('/'));
 
     allowOverwrite ??= false;
     if (!allowOverwrite) {
       if (_fileElementMap.containsKey(outFile)) {
         assert(element != null,
             'Attempted overwrite of ${outFile} without corresponding element');
-        Warnable originalElement = _fileElementMap[outFile];
+        var originalElement = _fileElementMap[outFile];
         Iterable<Warnable> referredFrom =
             originalElement != null ? [originalElement] : null;
         element?.warn(PackageWarning.duplicateFile,
@@ -97,7 +96,7 @@ class DartdocFileWriter implements FileWriter {
 /// directory.
 class Dartdoc extends PackageBuilder {
   final Generator generator;
-  final Set<String> writtenFiles = Set();
+  final Set<String> writtenFiles = {};
   Directory outputDir;
 
   // Fires when the self checks make progress.
@@ -149,13 +148,13 @@ class Dartdoc extends PackageBuilder {
   /// thrown if dartdoc fails in an expected way, for example if there is an
   /// analysis error in the code.
   Future<DartdocResults> generateDocsBase() async {
-    Stopwatch _stopwatch = Stopwatch()..start();
+    var _stopwatch = Stopwatch()..start();
     double seconds;
     packageGraph = await buildPackageGraph();
     seconds = _stopwatch.elapsedMilliseconds / 1000.0;
-    int libs = packageGraph.libraries.length;
+    var libs = packageGraph.libraries.length;
     logInfo("Initialized dartdoc with ${libs} librar${libs == 1 ? 'y' : 'ies'} "
-        "in ${seconds.toStringAsFixed(1)} seconds");
+        'in ${seconds.toStringAsFixed(1)} seconds');
     _stopwatch.reset();
 
     final generator = this.generator;
@@ -163,7 +162,7 @@ class Dartdoc extends PackageBuilder {
       // Create the out directory.
       if (!outputDir.existsSync()) outputDir.createSync(recursive: true);
 
-      DartdocFileWriter writer = DartdocFileWriter(outputDir.path);
+      var writer = DartdocFileWriter(outputDir.path);
       await generator.generate(packageGraph, writer);
 
       writtenFiles.addAll(writer.writtenFiles);
@@ -172,10 +171,10 @@ class Dartdoc extends PackageBuilder {
       }
     }
 
-    int warnings = packageGraph.packageWarningCounter.warningCount;
-    int errors = packageGraph.packageWarningCounter.errorCount;
+    var warnings = packageGraph.packageWarningCounter.warningCount;
+    var errors = packageGraph.packageWarningCounter.errorCount;
     if (warnings == 0 && errors == 0) {
-      logInfo("no issues found");
+      logInfo('no issues found');
     } else {
       logWarning("found ${warnings} ${pluralize('warning', warnings)} "
           "and ${errors} ${pluralize('error', errors)}");
@@ -184,23 +183,23 @@ class Dartdoc extends PackageBuilder {
     seconds = _stopwatch.elapsedMilliseconds / 1000.0;
     libs = packageGraph.localPublicLibraries.length;
     logInfo("Documented ${libs} public librar${libs == 1 ? 'y' : 'ies'} "
-        "in ${seconds.toStringAsFixed(1)} seconds");
+        'in ${seconds.toStringAsFixed(1)} seconds');
     return DartdocResults(config.topLevelPackageMeta, packageGraph, outputDir);
   }
 
   Future<DartdocResults> generateDocs() async {
-    logInfo("Documenting ${config.topLevelPackageMeta}...");
+    logInfo('Documenting ${config.topLevelPackageMeta}...');
 
-    DartdocResults dartdocResults = await generateDocsBase();
+    var dartdocResults = await generateDocsBase();
     if (dartdocResults.packageGraph.localPublicLibraries.isEmpty) {
-      throw DartdocFailure("dartdoc could not find any libraries to document");
+      throw DartdocFailure('dartdoc could not find any libraries to document');
     }
 
-    final int errorCount =
+    final errorCount =
         dartdocResults.packageGraph.packageWarningCounter.errorCount;
     if (errorCount > 0) {
       throw DartdocFailure(
-          "dartdoc encountered $errorCount errors while processing.");
+          'dartdoc encountered $errorCount errors while processing.');
     }
     logInfo(
         'Success! Docs generated into ${dartdocResults.outDir.absolute.path}');
@@ -214,7 +213,7 @@ class Dartdoc extends PackageBuilder {
     // Ordinarily this would go in [Package.warn], but we don't actually know what
     // ModelElement to warn on yet.
     Warnable warnOnElement;
-    Set<Warnable> referredFromElements = Set();
+    var referredFromElements = <Warnable>{};
     Set<Warnable> warnOnElements;
 
     // Make all paths relative to origin.
@@ -247,7 +246,7 @@ class Dartdoc extends PackageBuilder {
     if (referredFromElements.isEmpty && referredFrom == 'index.html') {
       referredFromElements.add(packageGraph.defaultPackage);
     }
-    String message = warnOn;
+    var message = warnOn;
     if (referredFrom == 'index.json') message = '$warnOn (from index.json)';
     packageGraph.warnOnElement(warnOnElement, kind,
         message: message, referredFrom: referredFromElements);
@@ -255,12 +254,11 @@ class Dartdoc extends PackageBuilder {
 
   void _doOrphanCheck(
       PackageGraph packageGraph, String origin, Set<String> visited) {
-    String normalOrigin = path.normalize(origin);
-    String staticAssets = path.joinAll([normalOrigin, 'static-assets', '']);
-    String indexJson = path.joinAll([normalOrigin, 'index.json']);
-    bool foundIndexJson = false;
-    for (FileSystemEntity f
-        in Directory(normalOrigin).listSync(recursive: true)) {
+    var normalOrigin = path.normalize(origin);
+    var staticAssets = path.joinAll([normalOrigin, 'static-assets', '']);
+    var indexJson = path.joinAll([normalOrigin, 'index.json']);
+    var foundIndexJson = false;
+    for (var f in Directory(normalOrigin).listSync(recursive: true)) {
       var fullPath = path.normalize(f.path);
       if (f is Directory) {
         continue;
@@ -274,7 +272,7 @@ class Dartdoc extends PackageBuilder {
         continue;
       }
       if (visited.contains(fullPath)) continue;
-      String relativeFullPath = path.relative(fullPath, from: normalOrigin);
+      var relativeFullPath = path.relative(fullPath, from: normalOrigin);
       if (!writtenFiles.contains(relativeFullPath)) {
         // This isn't a file we wrote (this time); don't claim we did.
         _warn(packageGraph, PackageWarning.unknownFile, fullPath, normalOrigin);
@@ -298,18 +296,18 @@ class Dartdoc extends PackageBuilder {
   // This is extracted to save memory during the check; be careful not to hang
   // on to anything referencing the full file and doc tree.
   Tuple2<Iterable<String>, String> _getStringLinksAndHref(String fullPath) {
-    File file = File("$fullPath");
+    var file = File('$fullPath');
     if (!file.existsSync()) {
       return null;
     }
-    Document doc = parse(file.readAsBytesSync());
-    Element base = doc.querySelector('base');
+    var doc = parse(file.readAsBytesSync());
+    var base = doc.querySelector('base');
     String baseHref;
     if (base != null) {
       baseHref = base.attributes['href'];
     }
-    List<Element> links = doc.querySelectorAll('a');
-    List<String> stringLinks = links
+    var links = doc.querySelectorAll('a');
+    var stringLinks = links
         .map((link) => link.attributes['href'])
         .where((href) => href != null)
         .toList();
@@ -319,23 +317,23 @@ class Dartdoc extends PackageBuilder {
 
   void _doSearchIndexCheck(
       PackageGraph packageGraph, String origin, Set<String> visited) {
-    String fullPath = path.joinAll([origin, 'index.json']);
-    String indexPath = path.joinAll([origin, 'index.html']);
-    File file = File("$fullPath");
+    var fullPath = path.joinAll([origin, 'index.json']);
+    var indexPath = path.joinAll([origin, 'index.html']);
+    var file = File('$fullPath');
     if (!file.existsSync()) {
       return null;
     }
-    JsonDecoder decoder = JsonDecoder();
+    var decoder = JsonDecoder();
     List jsonData = decoder.convert(file.readAsStringSync());
 
-    Set<String> found = Set();
+    var found = <String>{};
     found.add(fullPath);
     // The package index isn't supposed to be in the search, so suppress the
     // warning.
     found.add(indexPath);
     for (Map<String, dynamic> entry in jsonData) {
       if (entry.containsKey('href')) {
-        String entryPath = path.joinAll([origin, entry['href']]);
+        var entryPath = path.joinAll([origin, entry['href']]);
         if (!visited.contains(entryPath)) {
           _warn(packageGraph, PackageWarning.brokenLink, entryPath,
               path.normalize(origin),
@@ -345,8 +343,8 @@ class Dartdoc extends PackageBuilder {
       }
     }
     // Missing from search index
-    Set<String> missing_from_search = visited.difference(found);
-    for (String s in missing_from_search) {
+    var missing_from_search = visited.difference(found);
+    for (var s in missing_from_search) {
       _warn(packageGraph, PackageWarning.missingFromSearchIndex, s,
           path.normalize(origin),
           referredFrom: fullPath);
@@ -380,10 +378,10 @@ class Dartdoc extends PackageBuilder {
     // here instead -- occasionally, very large jobs have overflowed
     // the stack without this.
     // (newPathToCheck, newFullPath)
-    Set<Tuple2<String, String>> toVisit = Set();
+    var toVisit = <Tuple2<String, String>>{};
 
-    final RegExp ignoreHyperlinks = RegExp(r'^(https:|http:|mailto:|ftp:)');
-    for (String href in stringLinks) {
+    final ignoreHyperlinks = RegExp(r'^(https:|http:|mailto:|ftp:)');
+    for (var href in stringLinks) {
       if (!href.startsWith(ignoreHyperlinks)) {
         Uri uri;
         try {
@@ -400,7 +398,7 @@ class Dartdoc extends PackageBuilder {
             full = '${path.dirname(pathToCheck)}/$href';
           }
           var newPathToCheck = path.normalize(full);
-          String newFullPath = path.joinAll([origin, newPathToCheck]);
+          var newFullPath = path.joinAll([origin, newPathToCheck]);
           newFullPath = path.normalize(newFullPath);
           if (!visited.contains(newFullPath)) {
             toVisit.add(Tuple2(newPathToCheck, newFullPath));
@@ -424,8 +422,8 @@ class Dartdoc extends PackageBuilder {
     assert(_hrefs == null);
     _hrefs = packageGraph.allHrefs;
 
-    final Set<String> visited = Set();
-    final String start = 'index.html';
+    final visited = <String>{};
+    final start = 'index.html';
     logInfo('Validating docs...');
     _doCheck(packageGraph, origin, visited, start);
     _doOrphanCheck(packageGraph, origin, visited);

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -85,9 +85,9 @@ class CategoryConfiguration {
 
   static CategoryConfiguration fromYamlMap(
       YamlMap yamlMap, p.Context pathContext) {
-    Map<String, CategoryDefinition> newCategoryDefinitions = {};
-    for (MapEntry entry in yamlMap.entries) {
-      String name = entry.key.toString();
+    var newCategoryDefinitions = <String, CategoryDefinition>{};
+    for (var entry in yamlMap.entries) {
+      var name = entry.key.toString();
       String displayName;
       String documentationMarkdown;
       var categoryMap = entry.value;
@@ -160,7 +160,7 @@ class ToolDefinition {
 
   @override
   String toString() {
-    final String commandString =
+    final commandString =
         '${this is DartToolDefinition ? '(Dart) ' : ''}"${command.join(' ')}"';
     if (setupCommand == null) {
       return '$runtimeType: $commandString ($description)';
@@ -268,9 +268,9 @@ class DartToolDefinition extends ToolDefinition {
     assert(args[0] == command.first);
     // Set up flags to create a new snapshot, if needed, and use the first run as the training
     // run.
-    Snapshot snapshot = SnapshotCache.instance.getSnapshot(command.first);
-    File snapshotFile = snapshot.snapshotFile;
-    bool needsSnapshot = snapshot.needsSnapshot;
+    var snapshot = SnapshotCache.instance.getSnapshot(command.first);
+    var snapshotFile = snapshot.snapshotFile;
+    var needsSnapshot = snapshot.needsSnapshot;
     if (needsSnapshot) {
       args.insertAll(0, [
         '--snapshot=${snapshotFile.absolute.path}',
@@ -565,11 +565,11 @@ abstract class DartdocOption<T> {
     } else {
       assert(
           false,
-          "Trying to ensure existence of unsupported type "
-          "${valueWithContext.value.runtimeType}");
+          'Trying to ensure existence of unsupported type '
+          '${valueWithContext.value.runtimeType}');
     }
-    for (String path in resolvedPaths) {
-      FileSystemEntity f = isDir ? Directory(path) : File(path);
+    for (var path in resolvedPaths) {
+      var f = isDir ? Directory(path) : File(path);
       if (!f.existsSync()) {
         _onMissing(valueWithContext, path);
       }
@@ -611,7 +611,7 @@ abstract class DartdocOption<T> {
 
   /// All object names starting at the root.
   Iterable<String> get keys {
-    List<String> keyList = [];
+    var keyList = <String>[];
     DartdocOption option = this;
     while (option?.name != null) {
       keyList.add(option.name);
@@ -666,7 +666,7 @@ abstract class DartdocOption<T> {
   }
 
   /// Apply the function [visit] to [this] and all children.
-  void traverse(void visit(DartdocOption option)) {
+  void traverse(void Function(DartdocOption option) visit) {
     visit(this);
     _children.values.forEach((d) => d.traverse(visit));
   }
@@ -693,7 +693,7 @@ class DartdocOptionFileSynth<T> extends DartdocOption<T>
 
   @override
   T valueAt(Directory dir) {
-    _OptionValueWithContext result = _valueAtFromFile(dir);
+    var result = _valueAtFromFile(dir);
     if (result?.definingFile != null) {
       return _handlePathsInContext(result);
     }
@@ -806,8 +806,7 @@ abstract class DartdocSyntheticOption<T> implements DartdocOption<T> {
 
   void _onMissingFromSynthetic(
       _OptionValueWithContext valueWithContext, String missingPath) {
-    String description =
-        'Synthetic configuration option ${name} from <internal>';
+    var description = 'Synthetic configuration option ${name} from <internal>';
     throw DartdocFileMissing(
         '$description, computed as ${valueWithContext.value}, resolves to missing path: "${missingPath}"');
   }
@@ -828,8 +827,8 @@ class DartdocOptionSet extends DartdocOption<Null> {
   /// [DartdocOption]s that will be added to the new option set.
   static Future<DartdocOptionSet> fromOptionGenerators(
       String name, Iterable<OptionGenerator> optionGenerators) async {
-    DartdocOptionSet optionSet = DartdocOptionSet(name);
-    for (OptionGenerator generator in optionGenerators) {
+    var optionSet = DartdocOptionSet(name);
+    for (var generator in optionGenerators) {
       optionSet.addAll(await generator());
     }
     return optionSet;
@@ -846,7 +845,7 @@ class DartdocOptionSet extends DartdocOption<Null> {
 
   /// Traverse skips this node, because it doesn't represent a real configuration object.
   @override
-  void traverse(void visitor(DartdocOption option)) {
+  void traverse(void Function(DartdocOption option) visitor) {
     _children.values.forEach((d) => d.traverse(visitor));
   }
 }
@@ -930,9 +929,9 @@ class DartdocOptionArgFile<T> extends DartdocOption<T>
   /// finally, the default.
   @override
   T valueAt(Directory dir) {
-    T value = _valueAtFromArgs();
-    if (value == null) value = _valueAtFromFiles(dir);
-    if (value == null) value = defaultsTo;
+    var value = _valueAtFromArgs();
+    value ??= _valueAtFromFiles(dir);
+    value ??= defaultsTo;
     return value;
   }
 
@@ -995,7 +994,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
 
   void _onMissingFromFiles(
       _OptionValueWithContext valueWithContext, String missingPath) {
-    String dartdocYaml = p.join(
+    var dartdocYaml = p.join(
         valueWithContext.canonicalDirectoryPath, valueWithContext.definingFile);
     throw DartdocFileMissing(
         'Field ${fieldName} from ${dartdocYaml}, set to ${valueWithContext.value}, resolves to missing path: "${missingPath}"');
@@ -1009,12 +1008,12 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
     return _valueAtFromFiles(dir) ?? defaultsTo;
   }
 
-  final Map<String, T> __valueAtFromFiles = Map();
+  final Map<String, T> __valueAtFromFiles = {};
 
   // The value of this option from files will not change unless files are
   // modified during execution (not allowed in Dartdoc).
   T _valueAtFromFiles(Directory dir) {
-    String key = p.canonicalize(dir.path);
+    var key = p.canonicalize(dir.path);
     if (!__valueAtFromFiles.containsKey(key)) {
       _OptionValueWithContext valueWithContext;
       if (parentDirOverridesChild) {
@@ -1046,7 +1045,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
   _OptionValueWithContext _valueAtFromFilesLastFound(Directory dir) {
     _OptionValueWithContext value;
     while (true) {
-      _OptionValueWithContext tmpValue = _valueAtFromFile(dir);
+      var tmpValue = _valueAtFromFile(dir);
       if (tmpValue != null) value = tmpValue;
       if (p.equals(dir.parent.path, dir.path)) break;
       dir = dir.parent;
@@ -1057,10 +1056,10 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
   /// Returns null if not set in the yaml file in this directory (or its
   /// parents).
   _OptionValueWithContext _valueAtFromFile(Directory dir) {
-    _YamlFileData yamlFileData = _yamlAtDirectory(dir);
-    String contextPath = yamlFileData.canonicalDirectoryPath;
+    var yamlFileData = _yamlAtDirectory(dir);
+    var contextPath = yamlFileData.canonicalDirectoryPath;
     dynamic yamlData = yamlFileData.data;
-    for (String key in keys) {
+    for (var key in keys) {
       if (!yamlData.containsKey(key)) return null;
       yamlData = yamlData[key];
     }
@@ -1084,7 +1083,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
       if (_isMapString && _convertYamlToType == null) {
         _convertYamlToType = (YamlMap yamlMap, p.Context pathContext) {
           var returnData = <String, String>{};
-          for (MapEntry entry in yamlMap.entries) {
+          for (var entry in yamlMap.entries) {
             returnData[entry.key.toString()] = entry.value.toString();
           }
           return returnData as T;
@@ -1094,7 +1093,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
         throw DartdocOptionError(
             'Unable to convert yaml to type for option: $fieldName, method not defined');
       }
-      String canonicalDirectoryPath = p.canonicalize(contextPath);
+      var canonicalDirectoryPath = p.canonicalize(contextPath);
       returnData = _convertYamlToType(
           yamlData, p.Context(current: canonicalDirectoryPath));
     } else if (_isDouble) {
@@ -1113,9 +1112,9 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
   }
 
   _YamlFileData _yamlAtDirectory(Directory dir) {
-    List<String> canonicalPaths = [p.canonicalize(dir.path)];
+    var canonicalPaths = <String>[p.canonicalize(dir.path)];
     if (!_yamlAtCanonicalPathCache.containsKey(canonicalPaths.first)) {
-      _YamlFileData yamlData = _YamlFileData(Map(), directoryCurrentPath);
+      var yamlData = _YamlFileData({}, directoryCurrentPath);
       if (dir.existsSync()) {
         File dartdocOptionsFile;
 
@@ -1173,7 +1172,7 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
 
   /// Returns null if no argument was given on the command line.
   T _valueAtFromArgs() {
-    _OptionValueWithContext valueWithContext = _valueAtFromArgsWithContext();
+    var valueWithContext = _valueAtFromArgsWithContext();
     return _handlePathsInContext(valueWithContext);
   }
 
@@ -1210,7 +1209,7 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
     } else if (_isMapString) {
       retval = <String, String>{} as T;
       for (String pair in _argResults[argName]) {
-        List<String> pairList = pair.split('::');
+        var pairList = pair.split('::');
         if (pairList.length != 2) {
           _throwErrorForTypes(pair);
         }
@@ -1230,14 +1229,14 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
   /// 'something-bar-over-the-hill' (with default skip).
   /// This allows argument names to reflect nested structure.
   static String _keysToArgName(Iterable<String> keys, [int skip = 1]) {
-    String argName = "${keys.skip(skip).join('-')}";
+    var argName = "${keys.skip(skip).join('-')}";
     argName = argName.replaceAll('_', '-');
     // Do not consume the lowercase character after the uppercase one, to handle
     // two character words.
     final camelCaseRegexp = RegExp(r'([a-z])([A-Z])(?=([a-z]))');
     argName = argName.replaceAllMapped(camelCaseRegexp, (Match m) {
-      String before = m.group(1);
-      String after = m.group(2).toLowerCase();
+      var before = m.group(1);
+      var after = m.group(2).toLowerCase();
       return '${before}-${after}';
     });
     return argName;
@@ -1262,7 +1261,7 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
           help: help,
           hide: hide);
     } else if (_isListString || _isMapString) {
-      List<String> defaultsToList = [];
+      var defaultsToList = <String>[];
       if (_isListString) {
         defaultsToList = defaultsTo as List<String>;
       } else {
@@ -1541,13 +1540,13 @@ Future<List<DartdocOption>> createDartdocOptions() async {
           PackageMeta packageMeta =
               option.parent.parent['packageMeta'].valueAt(dir);
           // Prefer SDK check first, then pub cache check.
-          String inSdk = packageMeta
+          var inSdk = packageMeta
               .sdkType(option.parent.parent['flutterRoot'].valueAt(dir));
           if (inSdk != null) {
             Map<String, String> sdks = option.parent['sdks'].valueAt(dir);
             if (sdks.containsKey(inSdk)) return sdks[inSdk];
           }
-          String hostedAt = packageMeta.hostedAt;
+          var hostedAt = packageMeta.hostedAt;
           if (hostedAt != null) {
             Map<String, String> hostMap = option.parent['hosted'].valueAt(dir);
             if (hostMap.containsKey(hostedAt)) return hostMap[hostedAt];
@@ -1563,7 +1562,7 @@ Future<List<DartdocOption>> createDartdocOptions() async {
     DartdocOptionSyntheticOnly<PackageMeta>(
       'packageMeta',
       (DartdocSyntheticOption<PackageMeta> option, Directory dir) {
-        PackageMeta packageMeta = PackageMeta.fromDir(dir);
+        var packageMeta = PackageMeta.fromDir(dir);
         if (packageMeta == null) {
           throw DartdocOptionError(
               'Unable to determine package for directory: ${dir.path}');
@@ -1591,14 +1590,14 @@ Future<List<DartdocOption>> createDartdocOptions() async {
         help: "Label categories that aren't documented", negatable: true),
     DartdocOptionSyntheticOnly<PackageMeta>('topLevelPackageMeta',
         (DartdocSyntheticOption<PackageMeta> option, Directory dir) {
-      PackageMeta packageMeta = PackageMeta.fromDir(
+      var packageMeta = PackageMeta.fromDir(
           Directory(option.parent['inputDir'].valueAt(dir)));
       if (packageMeta == null) {
         throw DartdocOptionError(
             'Unable to generate documentation: no package found');
       }
       if (!packageMeta.isValid) {
-        final String firstError = packageMeta.getInvalidReasons().first;
+        final firstError = packageMeta.getInvalidReasons().first;
         throw DartdocOptionError('Package is invalid: $firstError');
       }
       return packageMeta;
@@ -1632,8 +1631,8 @@ Future<List<DartdocOption>> createDartdocOptions() async {
     DartdocOptionArgOnly<String>('format', 'html', hide: true),
     // TODO(jcollins-g): refactor so there is a single static "create" for
     // each DartdocOptionContext that traverses the inheritance tree itself.
-  ]
-    ..addAll(await createExperimentOptions())
-    ..addAll(await createPackageWarningOptions())
-    ..addAll(await createSourceLinkerOptions());
+    ...await createExperimentOptions(),
+    ...await createPackageWarningOptions(),
+    ...await createSourceLinkerOptions(),
+  ];
 }

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -35,9 +35,9 @@ abstract class ElementType extends Privacy {
       }
       return UndefinedElementType(f, library, packageGraph, returnedFrom);
     } else {
-      ModelElement element = ModelElement.fromElement(f.element, packageGraph);
+      var element = ModelElement.fromElement(f.element, packageGraph);
       assert(f is ParameterizedType || f is TypeParameterType);
-      bool isGenericTypeAlias =
+      var isGenericTypeAlias =
           f.element.enclosingElement is GenericTypeAliasElement;
       if (f is FunctionType) {
         assert(f is ParameterizedType);
@@ -84,7 +84,7 @@ abstract class ElementType extends Privacy {
   bool isSubtypeOf(ElementType t);
 
   @override
-  String toString() => "$type";
+  String toString() => '$type';
 
   DartType get type => _type;
 }
@@ -147,7 +147,7 @@ class FunctionTypeElementType extends UndefinedElementType {
 
   @override
   List<Parameter> get parameters {
-    List<ParameterElement> params = type.parameters;
+    var params = type.parameters;
     return UnmodifiableListView<Parameter>(params
         .map((p) => ModelElement.from(p, library, packageGraph) as Parameter)
         .toList());
@@ -158,9 +158,7 @@ class FunctionTypeElementType extends UndefinedElementType {
 
   @override
   String get linkedName {
-    if (_linkedName == null) {
-      _linkedName = _renderer.renderLinkedName(this);
-    }
+    _linkedName ??= _renderer.renderLinkedName(this);
     return _linkedName;
   }
 
@@ -171,14 +169,12 @@ class FunctionTypeElementType extends UndefinedElementType {
 
   @override
   String get nameWithGenerics {
-    if (_nameWithGenerics == null) {
-      _nameWithGenerics = _renderer.renderNameWithGenerics(this);
-    }
+    _nameWithGenerics ??= _renderer.renderNameWithGenerics(this);
     return _nameWithGenerics;
   }
 
   List<TypeParameter> get typeFormals {
-    List<TypeParameterElement> typeFormals = type.typeFormals;
+    var typeFormals = type.typeFormals;
     return UnmodifiableListView<TypeParameter>(typeFormals
         .map(
             (p) => ModelElement.from(p, library, packageGraph) as TypeParameter)
@@ -200,18 +196,14 @@ class ParameterizedElementType extends DefinedElementType {
   String _linkedName;
   @override
   String get linkedName {
-    if (_linkedName == null) {
-      _linkedName = _renderer.renderLinkedName(this);
-    }
+    _linkedName ??= _renderer.renderLinkedName(this);
     return _linkedName;
   }
 
   String _nameWithGenerics;
   @override
   String get nameWithGenerics {
-    if (_nameWithGenerics == null) {
-      _nameWithGenerics = _renderer.renderNameWithGenerics(this);
-    }
+    _nameWithGenerics ??= _renderer.renderNameWithGenerics(this);
     return _nameWithGenerics;
   }
 
@@ -276,9 +268,7 @@ abstract class DefinedElementType extends ElementType {
   ModelElement get returnElement => element;
   ElementType _returnType;
   ElementType get returnType {
-    if (_returnType == null) {
-      _returnType = ElementType.from(type, library, packageGraph, this);
-    }
+    _returnType ??= ElementType.from(type, library, packageGraph, this);
     return _returnType;
   }
 
@@ -287,12 +277,10 @@ abstract class DefinedElementType extends ElementType {
 
   Iterable<ElementType> _typeArguments;
   Iterable<ElementType> get typeArguments {
-    if (_typeArguments == null) {
-      _typeArguments = (type as ParameterizedType)
-          .typeArguments
-          .map((f) => ElementType.from(f, library, packageGraph))
-          .toList();
-    }
+    _typeArguments ??= (type as ParameterizedType)
+        .typeArguments
+        .map((f) => ElementType.from(f, library, packageGraph))
+        .toList();
     return _typeArguments;
   }
 
@@ -343,9 +331,9 @@ abstract class DefinedElementType extends ElementType {
             library.typeSystem.isSubtypeOf(superType, instantiatedType))) {
       return true;
     }
-    List<InterfaceType> supertypes = [];
+    var supertypes = <InterfaceType>[];
     ClassElementImpl.collectAllSupertypes(supertypes, superType, null);
-    for (InterfaceType toVisit in supertypes) {
+    for (var toVisit in supertypes) {
       if (_isBoundSupertypeTo(toVisit, visited)) return true;
     }
     return false;
@@ -361,10 +349,8 @@ abstract class CallableElementTypeMixin implements ParameterizedElementType {
 
   @override
   ElementType get returnType {
-    if (_returnType == null) {
-      _returnType =
-          ElementType.from(type.returnType, library, packageGraph, this);
-    }
+    _returnType ??=
+        ElementType.from(type.returnType, library, packageGraph, this);
     return _returnType;
   }
 
@@ -427,9 +413,7 @@ class CallableElementType extends ParameterizedElementType
 
   @override
   String get linkedName {
-    if (_linkedName == null) {
-      _linkedName = _renderer.renderLinkedName(this);
-    }
+    _linkedName ??= _renderer.renderLinkedName(this);
     return _linkedName;
   }
 
@@ -461,19 +445,15 @@ class CallableGenericTypeAliasElementType extends ParameterizedElementType
   ModelElement _returnElement;
   @override
   ModelElement get returnElement {
-    if (_returnElement == null) {
-      _returnElement =
-          ModelElement.fromElement(type.element.enclosingElement, packageGraph);
-    }
+    _returnElement ??=
+        ModelElement.fromElement(type.element.enclosingElement, packageGraph);
     return _returnElement;
   }
 
   @override
   ElementType get returnType {
-    if (_returnType == null) {
-      _returnType =
-          ElementType.from(type.returnType, library, packageGraph, this);
-    }
+    _returnType ??=
+        ElementType.from(type.returnType, library, packageGraph, this);
     return _returnType;
   }
 

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -51,12 +51,12 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
 
   DartdocGeneratorBackend(
       DartdocGeneratorBackendOptions options, this.templates)
-      : this.options = (options ?? DartdocGeneratorBackendOptions());
+      : options = (options ?? DartdocGeneratorBackendOptions());
 
   /// Helper method to bind template data and emit the content to the writer.
   void render(FileWriter writer, String filename, Template template,
       TemplateData data) {
-    String content = template.renderString(data);
+    var content = template.renderString(data);
     if (!options.useBaseHref) {
       content = content.replaceAll(HTMLBASE_PLACEHOLDER, data.htmlBase);
     }
@@ -67,7 +67,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   @override
   void generateCategoryJson(
       FileWriter writer, List<Categorization> categories) {
-    String json = generator_util.generateCategoryJson(
+    var json = generator_util.generateCategoryJson(
         categories, options.prettyIndexJson);
     if (!options.useBaseHref) {
       json = json.replaceAll(HTMLBASE_PLACEHOLDER, '');
@@ -77,7 +77,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
 
   @override
   void generateSearchIndex(FileWriter writer, List<Indexable> indexedElements) {
-    String json = generator_util.generateSearchIndexJson(
+    var json = generator_util.generateSearchIndexJson(
         indexedElements, options.prettyIndexJson);
     if (!options.useBaseHref) {
       json = json.replaceAll(HTMLBASE_PLACEHOLDER, '');

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -15,13 +15,13 @@ class EmptyGenerator extends Generator {
   @override
   Future generate(PackageGraph _packageGraph, FileWriter writer) {
     logProgress(_packageGraph.defaultPackage.documentationAsHtml);
-    for (var package in Set.from([_packageGraph.defaultPackage])
+    for (var package in {_packageGraph.defaultPackage}
       ..addAll(_packageGraph.localPackages)) {
       for (var category in filterNonDocumented(package.categories)) {
         logProgress(category.documentationAsHtml);
       }
 
-      for (Library lib in filterNonDocumented(package.libraries)) {
+      for (var lib in filterNonDocumented(package.libraries)) {
         filterNonDocumented(lib.allModelElements)
             .forEach((m) => logProgress(m.documentationAsHtml));
       }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -97,7 +97,7 @@ Future<List<DartdocOption>> createGeneratorOptions() async {
             'If provided, add a rel="canonical" prefixed with provided value. '
             'Consider using if building many versions of the docs for public '
             'SEO; learn more at https://goo.gl/gktN6F.'),
-    DartdocOptionArgOnly<String>("templatesDir", null,
+    DartdocOptionArgOnly<String>('templatesDir', null,
         isDir: true,
         mustExist: true,
         hide: true,

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -19,11 +19,11 @@ class GeneratorFrontEnd implements Generator {
 
   @override
   Future generate(PackageGraph packageGraph, FileWriter writer) async {
-    List<Indexable> indexElements = <Indexable>[];
+    var indexElements = <Indexable>[];
     _generateDocs(packageGraph, writer, indexElements);
     await _generatorBackend.generateAdditionalFiles(writer, packageGraph);
 
-    List<Categorization> categories = indexElements
+    var categories = indexElements
         .whereType<Categorization>()
         .where((e) => e.hasCategorization)
         .toList();

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -13,8 +13,9 @@ import 'package:dartdoc/src/model/indexable.dart';
 /// will likely want the same content for this.
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   var encoder = pretty ? JsonEncoder.withIndent(' ') : JsonEncoder();
+  // ignore: omit_local_variable_types
   final List<Map> indexItems = categories.map((Categorization e) {
-    Map data = {
+    var data = <String, dynamic>{
       'name': e.name,
       'qualifiedName': e.fullyQualifiedName,
       'href': e.href,
@@ -45,7 +46,7 @@ String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
   var encoder = pretty ? JsonEncoder.withIndent(' ') : JsonEncoder();
   final List<Map> indexItems = indexedElements.map((Indexable e) {
-    Map data = {
+    var data = <String, dynamic>{
       'name': e.name,
       'qualifiedName': e.fullyQualifiedName,
       'href': e.href,
@@ -53,7 +54,7 @@ String generateSearchIndexJson(
       'overriddenDepth': e.overriddenDepth,
     };
     if (e is EnclosedElement) {
-      EnclosedElement ee = e as EnclosedElement;
+      var ee = e as EnclosedElement;
       data['enclosedBy'] = {
         'name': ee.enclosingElement.name,
         'type': ee.enclosingElement.kind

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -52,12 +52,12 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
 
   Future _copyResources(FileWriter writer) async {
     final prefix = 'package:dartdoc/resources/';
-    for (String resourcePath in resources.resource_names) {
+    for (var resourcePath in resources.resource_names) {
       if (!resourcePath.startsWith(prefix)) {
         throw StateError('Resource paths must start with $prefix, '
             'encountered $resourcePath');
       }
-      String destFileName = resourcePath.substring(prefix.length);
+      var destFileName = resourcePath.substring(prefix.length);
       writer.write(path.join('static-assets', destFileName),
           await resource_loader.loadAsBytes(resourcePath));
     }

--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -28,6 +28,6 @@ Future<List<int>> loadAsBytes(String path) async {
     throw ArgumentError('path must begin with package:');
   }
 
-  Uri uri = Uri.parse(path);
+  var uri = Uri.parse(path);
   return await ResourceLoader.defaultLoader.readAsBytes(uri);
 }

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -179,14 +179,14 @@ class ClassTemplateData<T extends Class> extends TemplateData<T> {
       return _objectType;
     }
 
-    Library dc = packageGraph.libraries
-        .firstWhere((it) => it.name == "dart:core", orElse: () => null);
+    var dc = packageGraph.libraries
+        .firstWhere((it) => it.name == 'dart:core', orElse: () => null);
 
     if (dc == null) {
       return _objectType = null;
     }
 
-    return _objectType = dc.getClassByName("Object");
+    return _objectType = dc.getClassByName('Object');
   }
 }
 

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -83,8 +83,7 @@ Future<Map<String, String>> _loadPartials(
   void replacePlaceholder(String key, String placeholder, List<String> paths) {
     var template = partials[key];
     if (template != null && paths != null && paths.isNotEmpty) {
-      String replacement =
-          paths.map((p) => File(p).readAsStringSync()).join('\n');
+      var replacement = paths.map((p) => File(p).readAsStringSync()).join('\n');
       template = template.replaceAll(placeholder, replacement);
       partials[key] = template;
     }
@@ -127,7 +126,7 @@ class _DefaultTemplatesLoader extends _TemplatesLoader {
   @override
   Future<Map<String, String>> loadPartials() async {
     var templates = <String, String>{};
-    for (String name in _partials) {
+    for (var name in _partials) {
       var uri = 'package:dartdoc/templates/$_format/_$name.$_format';
       templates[name] = await loader.loadAsString(uri);
     }
@@ -150,7 +149,7 @@ class _DirectoryTemplatesLoader extends _TemplatesLoader {
   Future<Map<String, String>> loadPartials() async {
     var partials = <String, String>{};
 
-    for (File file in _directory.listSync().whereType<File>()) {
+    for (var file in _directory.listSync().whereType<File>()) {
       var basename = path.basename(file.path);
       if (basename.startsWith('_') && basename.endsWith('.$_format')) {
         var content = file.readAsString();
@@ -191,11 +190,11 @@ class Templates {
 
   static Future<Templates> fromContext(
       DartdocGeneratorOptionContext context) async {
-    String templatesDir = context.templatesDir;
-    String format = context.format;
-    List<String> footerTextPaths = context.footerText;
+    var templatesDir = context.templatesDir;
+    var format = context.format;
+    var footerTextPaths = context.footerText;
     if (context.addSdkFooter) {
-      Uri sdkFooter = await Isolate.resolvePackageUri(
+      var sdkFooter = await Isolate.resolvePackageUri(
           Uri.parse('package:dartdoc/resources/sdk_footer_text.$format'));
       footerTextPaths.add(path.canonicalize(sdkFooter.toFilePath()));
     }
@@ -241,7 +240,7 @@ class Templates {
         templatesLoader, headerPaths, footerPaths, footerTextPaths);
 
     Template _partial(String name) {
-      String partial = partials[name];
+      var partial = partials[name];
       if (partial == null || partial.isEmpty) {
         throw StateError('Did not find partial "$name"');
       }
@@ -249,8 +248,7 @@ class Templates {
     }
 
     Future<Template> _loadTemplate(String templatePath) async {
-      String templateContents =
-          await templatesLoader.loadTemplate(templatePath);
+      var templateContents = await templatesLoader.loadTemplate(templatePath);
       return Template(templateContents, partialResolver: _partial);
     }
 

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -37,14 +37,17 @@ String resolveTildePath(String originalPath) {
 /// The returned paths are guaranteed to begin with [dir].
 Iterable<String> listDir(String dir,
     {bool recursive = false,
-    Iterable<FileSystemEntity> listDir(Directory dir)}) {
-  if (listDir == null) listDir = (Directory dir) => dir.listSync();
+    Iterable<FileSystemEntity> Function(Directory dir) listDir}) {
+  listDir ??= (Directory dir) => dir.listSync();
 
-  return _doList(dir, Set<String>(), recursive, listDir);
+  return _doList(dir, <String>{}, recursive, listDir);
 }
 
-Iterable<String> _doList(String dir, Set<String> listedDirectories,
-    bool recurse, Iterable<FileSystemEntity> listDir(Directory dir)) sync* {
+Iterable<String> _doList(
+    String dir,
+    Set<String> listedDirectories,
+    bool recurse,
+    Iterable<FileSystemEntity> Function(Directory dir) listDir) sync* {
   // Avoid recursive symlinks.
   var resolvedPath = Directory(dir).resolveSymbolicLinksSync();
   if (!listedDirectories.contains(resolvedPath)) {
@@ -85,7 +88,7 @@ class MultiFutureTracker<T> {
   /// Approximate maximum number of simultaneous active Futures.
   final int parallel;
 
-  final Set<Future<T>> _trackedFutures = Set();
+  final Set<Future<T>> _trackedFutures = {};
 
   MultiFutureTracker(this.parallel);
 

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -79,9 +79,9 @@ void startLogging(LoggingContext config) {
     // Used to track if we're printing `...` to show progress.
     // Allows unified new-line tracking
     var writingProgress = false;
-    Ansi ansi = Ansi(Ansi.terminalSupportsAnsi);
-    int spinnerIndex = 0;
-    final List<String> spinner = ['-', r'\', '|', '/'];
+    var ansi = Ansi(Ansi.terminalSupportsAnsi);
+    var spinnerIndex = 0;
+    final spinner = ['-', r'\', '|', '/'];
 
     Logger.root.onRecord.listen((record) {
       if (record.level == progressLevel) {

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -16,104 +16,104 @@ import 'package:dartdoc/src/warnings.dart';
 import 'package:markdown/markdown.dart' as md;
 
 const validHtmlTags = [
-  "a",
-  "abbr",
-  "address",
-  "area",
-  "article",
-  "aside",
-  "audio",
-  "b",
-  "bdi",
-  "bdo",
-  "blockquote",
-  "br",
-  "button",
-  "canvas",
-  "caption",
-  "cite",
-  "code",
-  "col",
-  "colgroup",
-  "data",
-  "datalist",
-  "dd",
-  "del",
-  "dfn",
-  "div",
-  "dl",
-  "dt",
-  "em",
-  "fieldset",
-  "figcaption",
-  "figure",
-  "footer",
-  "form",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "header",
-  "hr",
-  "i",
-  "iframe",
-  "img",
-  "input",
-  "ins",
-  "kbd",
-  "keygen",
-  "label",
-  "legend",
-  "li",
-  "link",
-  "main",
-  "map",
-  "mark",
-  "meta",
-  "meter",
-  "nav",
-  "noscript",
-  "object",
-  "ol",
-  "optgroup",
-  "option",
-  "output",
-  "p",
-  "param",
-  "pre",
-  "progress",
-  "q",
-  "s",
-  "samp",
-  "script",
-  "section",
-  "select",
-  "small",
-  "source",
-  "span",
-  "strong",
-  "style",
-  "sub",
-  "sup",
-  "table",
-  "tbody",
-  "td",
-  "template",
-  "textarea",
-  "tfoot",
-  "th",
-  "thead",
-  "time",
-  "title",
-  "tr",
-  "track",
-  "u",
-  "ul",
-  "var",
-  "video",
-  "wbr"
+  'a',
+  'abbr',
+  'address',
+  'area',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'bdi',
+  'bdo',
+  'blockquote',
+  'br',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'dfn',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hr',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'keygen',
+  'label',
+  'legend',
+  'li',
+  'link',
+  'main',
+  'map',
+  'mark',
+  'meta',
+  'meter',
+  'nav',
+  'noscript',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'param',
+  'pre',
+  'progress',
+  'q',
+  's',
+  'samp',
+  'script',
+  'section',
+  'select',
+  'small',
+  'source',
+  'span',
+  'strong',
+  'style',
+  'sub',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'template',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'title',
+  'tr',
+  'track',
+  'u',
+  'ul',
+  'var',
+  'video',
+  'wbr'
 ];
 
 final RegExp nonHTML =
@@ -170,7 +170,7 @@ class IterableBlockParser extends md.BlockParser {
     while (!isDone) {
       for (var syntax in blockSyntaxes) {
         if (syntax.canParse(this)) {
-          md.Node block = syntax.parse(this);
+          var block = syntax.parse(this);
           if (block != null) yield (block);
           break;
         }
@@ -259,12 +259,12 @@ MatchingLinkResult _getMatchingLinkElement(
 Element _getRefElementFromCommentRefs(
     List<ModelCommentReference> commentRefs, String codeRef) {
   if (commentRefs != null) {
-    for (ModelCommentReference ref in commentRefs) {
+    for (var ref in commentRefs) {
       if (ref.name == codeRef) {
-        bool isConstrElement = ref.staticElement is ConstructorElement;
+        var isConstrElement = ref.staticElement is ConstructorElement;
         // Constructors are now handled by library search.
         if (!isConstrElement) {
-          Element refElement = ref.staticElement;
+          var refElement = ref.staticElement;
           if (refElement is PropertyAccessorElement) {
             // yay we found an accessor that wraps a const, but we really
             // want the top-level field itself
@@ -360,9 +360,9 @@ class _MarkdownCommentReference {
   /// [element.warn] for [PackageWarning.ambiguousDocReference] if there
   /// are more than one, but does not warn otherwise.
   ModelElement computeReferredElement() {
-    results = Set();
+    results = {};
     // TODO(jcollins-g): A complex package winds up spending a lot of cycles in here.  Optimize.
-    for (void Function() findMethod in [
+    for (var findMethod in [
       // This might be an operator.  Strip the operator prefix and try again.
       _findWithoutOperatorPrefix,
       // Oh, and someone might have thrown on a 'const' or 'final' in front.
@@ -405,7 +405,7 @@ class _MarkdownCommentReference {
     if (results.length > 1) {
       // This isn't C++.  References to class methods are slightly expensive
       // in Dart so don't build that list unless you need to.
-      for (void Function() reduceMethod in [
+      for (var reduceMethod in [
         // If a result is actually in this library, prefer that.
         _reducePreferResultsInSameLibrary,
         // If a result is accessible in this library, prefer that.
@@ -456,15 +456,15 @@ class _MarkdownCommentReference {
       _codeRefChompedParts ??= codeRefChomped.split('.');
 
   void _reducePreferAnalyzerResolution() {
-    Element refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
+    var refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
     if (results.any((me) => me.element == refElement)) {
       results.removeWhere((me) => me.element != refElement);
     }
   }
 
   void _reducePreferReferencesIncludingFullyQualifiedName() {
-    String startName = "${element.fullyQualifiedName}.";
-    String realName = "${element.fullyQualifiedName}.${codeRefChomped}";
+    var startName = '${element.fullyQualifiedName}.';
+    var realName = '${element.fullyQualifiedName}.${codeRefChomped}';
     if (results.any((r) => r.fullyQualifiedName == realName)) {
       results.removeWhere((r) => r.fullyQualifiedName != realName);
     }
@@ -501,20 +501,20 @@ class _MarkdownCommentReference {
   void _findTypeParameters() {
     if (element is TypeParameters) {
       results.addAll((element as TypeParameters).typeParameters.where((p) =>
-          p.name == codeRefChomped || codeRefChomped.startsWith("${p.name}.")));
+          p.name == codeRefChomped || codeRefChomped.startsWith('${p.name}.')));
     }
   }
 
   void _findParameters() {
     if (element is ModelElement) {
       results.addAll((element as ModelElement).allParameters.where((p) =>
-          p.name == codeRefChomped || codeRefChomped.startsWith("${p.name}.")));
+          p.name == codeRefChomped || codeRefChomped.startsWith('${p.name}.')));
     }
   }
 
   void _findWithoutLeadingIgnoreStuff() {
     if (codeRef.contains(leadingIgnoreStuff)) {
-      String newCodeRef = codeRef.replaceFirst(leadingIgnoreStuff, '');
+      var newCodeRef = codeRef.replaceFirst(leadingIgnoreStuff, '');
       results.add(_MarkdownCommentReference(
               newCodeRef, element, commentRefs, preferredClass)
           .computeReferredElement());
@@ -523,7 +523,7 @@ class _MarkdownCommentReference {
 
   void _findWithoutTrailingIgnoreStuff() {
     if (codeRef.contains(trailingIgnoreStuff)) {
-      String newCodeRef = codeRef.replaceFirst(trailingIgnoreStuff, '');
+      var newCodeRef = codeRef.replaceFirst(trailingIgnoreStuff, '');
       results.add(_MarkdownCommentReference(
               newCodeRef, element, commentRefs, preferredClass)
           .computeReferredElement());
@@ -532,7 +532,7 @@ class _MarkdownCommentReference {
 
   void _findWithoutOperatorPrefix() {
     if (codeRef.startsWith(operatorPrefix)) {
-      String newCodeRef = codeRef.replaceFirst(operatorPrefix, '');
+      var newCodeRef = codeRef.replaceFirst(operatorPrefix, '');
       results.add(_MarkdownCommentReference(
               newCodeRef, element, commentRefs, preferredClass)
           .computeReferredElement());
@@ -543,10 +543,10 @@ class _MarkdownCommentReference {
     // TODO(jcollins-g): Put enum members in allModelElements with useful hrefs without blowing up other assumptions about what that means.
     // TODO(jcollins-g): This doesn't provide good warnings if an enum and class have the same name in different libraries in the same package.  Fix that.
     if (codeRefChompedParts.length >= 2) {
-      String maybeEnumName = codeRefChompedParts
+      var maybeEnumName = codeRefChompedParts
           .sublist(0, codeRefChompedParts.length - 1)
           .join('.');
-      String maybeEnumMember = codeRefChompedParts.last;
+      var maybeEnumMember = codeRefChompedParts.last;
       if (packageGraph.findRefElementCache.containsKey(maybeEnumName)) {
         for (final modelElement
             in packageGraph.findRefElementCache[maybeEnumName]) {
@@ -582,13 +582,13 @@ class _MarkdownCommentReference {
 
   void _findReferenceFromPrefixes() {
     if (element is! ModelElement) return;
-    Map<String, Set<Library>> prefixToLibrary =
+    var prefixToLibrary =
         (element as ModelElement).definingLibrary.prefixToLibrary;
     if (prefixToLibrary.containsKey(codeRefChompedParts.first)) {
       if (codeRefChompedParts.length == 1) {
         results.addAll(prefixToLibrary[codeRefChompedParts.first]);
       } else {
-        String lookup = codeRefChompedParts.sublist(1).join('.');
+        var lookup = codeRefChompedParts.sublist(1).join('.');
         prefixToLibrary[codeRefChompedParts.first]?.forEach((l) => l
             .modelElementsNameMap[lookup]
             ?.map(_convertConstructors)
@@ -626,7 +626,7 @@ class _MarkdownCommentReference {
     // if the codeRef might be qualified, and contains periods.)
     if (codeRefChomped.contains('.') &&
         packageGraph.findRefElementCache.containsKey(codeRefChomped)) {
-      for (final ModelElement modelElement
+      for (var modelElement
           in packageGraph.findRefElementCache[codeRefChomped]) {
         // For fully qualified matches, the original preferredClass passed
         // might make no sense.  Instead, use the enclosing class from the
@@ -644,11 +644,10 @@ class _MarkdownCommentReference {
   void _findWithinTryClasses() {
     // Maybe this is local to a class.
     // TODO(jcollins-g): tryClasses is a strict subset of the superclass chain.  Optimize.
-    List<Class> tryClasses = [preferredClass];
-    Class realClass = tryClasses.first;
+    var tryClasses = <Class>[preferredClass];
+    var realClass = tryClasses.first;
     if (element is Inheritable) {
-      Inheritable overriddenElement =
-          (element as Inheritable).overriddenElement;
+      var overriddenElement = (element as Inheritable).overriddenElement;
       while (overriddenElement != null) {
         tryClasses
             .add((element as Inheritable).overriddenElement.enclosingElement);
@@ -656,7 +655,7 @@ class _MarkdownCommentReference {
       }
     }
 
-    for (Class tryClass in tryClasses) {
+    for (var tryClass in tryClasses) {
       if (tryClass != null) {
         if (codeRefChomped.contains('.') &&
             !codeRefChomped.startsWith(tryClass.name)) {
@@ -669,7 +668,7 @@ class _MarkdownCommentReference {
     }
 
     if (results.isEmpty && realClass != null) {
-      for (Class superClass
+      for (var superClass
           in realClass.publicSuperChain.map((et) => et.element)) {
         if (!tryClasses.contains(superClass)) {
           _getResultsForClass(superClass);
@@ -681,9 +680,9 @@ class _MarkdownCommentReference {
   }
 
   void _findAnalyzerReferences() {
-    Element refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
+    var refElement = _getRefElementFromCommentRefs(commentRefs, codeRef);
     if (refElement != null) {
-      ModelElement refModelElement = ModelElement.fromElement(
+      var refModelElement = ModelElement.fromElement(
           _getRefElementFromCommentRefs(commentRefs, codeRef),
           element.packageGraph);
       if (refModelElement is Accessor) {
@@ -719,7 +718,7 @@ class _MarkdownCommentReference {
       } else {
         // TODO(jcollins-g): get rid of reimplementation of identifier resolution
         //                   or integrate into ModelElement in a simpler way.
-        List<Class> superChain = [tryClass];
+        var superChain = <Class>[tryClass];
         superChain.addAll(tryClass.interfaces.map((t) => t.element));
         // This seems duplicitous with our caller, but the preferredClass
         // hint matters with findCanonicalModelElementFor.
@@ -737,10 +736,9 @@ class _MarkdownCommentReference {
   /// Get any possible results for this class in the superChain.   Returns
   /// true if we found something.
   void _getResultsForSuperChainElement(Class c, Class tryClass) {
-    Iterable<ModelElement> membersToCheck =
-        (c.allModelElementsByNamePart[codeRefChomped] ?? [])
-            .map(_convertConstructors);
-    for (final ModelElement modelElement in membersToCheck) {
+    var membersToCheck = (c.allModelElementsByNamePart[codeRefChomped] ?? [])
+        .map(_convertConstructors);
+    for (var modelElement in membersToCheck) {
       // [thing], a member of this class
       _addCanonicalResult(modelElement, tryClass);
     }
@@ -762,10 +760,9 @@ class _MarkdownCommentReference {
 
 md.Node _makeLinkNode(String codeRef, Warnable warnable,
     List<ModelCommentReference> commentRefs) {
-  MatchingLinkResult result =
-      _getMatchingLinkElement(codeRef, warnable, commentRefs);
-  final textContent = htmlEscape.convert(codeRef);
-  final ModelElement linkedElement = result.element;
+  var result = _getMatchingLinkElement(codeRef, warnable, commentRefs);
+  var textContent = htmlEscape.convert(codeRef);
+  var linkedElement = result.element;
   if (linkedElement != null) {
     if (linkedElement.href != null) {
       var anchor = md.Element.text('a', textContent);
@@ -806,16 +803,16 @@ final RegExp allAfterLastNewline = RegExp(r'\n.*$', multiLine: true);
 // https://github.com/dart-lang/dartdoc/issues/1250#issuecomment-269257942
 void showWarningsForGenericsOutsideSquareBracketsBlocks(
     String text, Warnable element) {
-  List<int> tagPositions = findFreeHangingGenericsPositions(text);
+  var tagPositions = findFreeHangingGenericsPositions(text);
   if (tagPositions.isNotEmpty) {
     tagPositions.forEach((int position) {
-      String priorContext =
-          "${text.substring(max(position - maxPriorContext, 0), position)}";
-      String postContext =
-          "${text.substring(position, min(position + maxPostContext, text.length))}";
+      var priorContext =
+          '${text.substring(max(position - maxPriorContext, 0), position)}';
+      var postContext =
+          '${text.substring(position, min(position + maxPostContext, text.length))}';
       priorContext = priorContext.replaceAll(allBeforeFirstNewline, '');
       postContext = postContext.replaceAll(allAfterLastNewline, '');
-      String errorMessage = "$priorContext$postContext";
+      var errorMessage = '$priorContext$postContext';
       // TODO(jcollins-g):  allow for more specific error location inside comments
       element.warn(PackageWarning.typeAsHtml, message: errorMessage);
     });
@@ -823,18 +820,15 @@ void showWarningsForGenericsOutsideSquareBracketsBlocks(
 }
 
 List<int> findFreeHangingGenericsPositions(String string) {
-  int currentPosition = 0;
-  int squareBracketsDepth = 0;
-  List<int> results = [];
+  var currentPosition = 0;
+  var squareBracketsDepth = 0;
+  var results = <int>[];
   while (true) {
-    final int nextOpenBracket = string.indexOf("[", currentPosition);
-    final int nextCloseBracket = string.indexOf("]", currentPosition);
-    final int nextNonHTMLTag = string.indexOf(nonHTML, currentPosition);
-    final Iterable<int> nextPositions = [
-      nextOpenBracket,
-      nextCloseBracket,
-      nextNonHTMLTag
-    ].where((p) => p != -1);
+    var nextOpenBracket = string.indexOf('[', currentPosition);
+    var nextCloseBracket = string.indexOf(']', currentPosition);
+    var nextNonHTMLTag = string.indexOf(nonHTML, currentPosition);
+    var nextPositions = [nextOpenBracket, nextCloseBracket, nextNonHTMLTag]
+        .where((p) => p != -1);
     if (nextPositions.isNotEmpty) {
       final minPos = nextPositions.reduce(min);
       if (nextOpenBracket == minPos) {
@@ -886,12 +880,11 @@ class MarkdownDocument extends md.Document {
   /// Returns a tuple of List<md.Node> and hasExtendedContent
   Tuple2<List<md.Node>, bool> parseMarkdownText(
       String text, bool processFullText) {
-    bool hasExtendedContent = false;
-    List<String> lines = LineSplitter.split(text).toList();
+    var hasExtendedContent = false;
+    var lines = LineSplitter.split(text).toList();
     md.Node firstNode;
-    List<md.Node> nodes = [];
-    for (md.Node node
-        in IterableBlockParser(lines, this).parseLinesGenerator()) {
+    var nodes = <md.Node>[];
+    for (var node in IterableBlockParser(lines, this).parseLinesGenerator()) {
       if (firstNode != null) {
         hasExtendedContent = true;
         if (!processFullText) break;
@@ -906,11 +899,10 @@ class MarkdownDocument extends md.Document {
   // From package:markdown/src/document.dart
   // TODO(jcollins-g): consider making this a public method in markdown package
   void _parseInlineContent(List<md.Node> nodes) {
-    for (int i = 0; i < nodes.length; i++) {
+    for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i];
       if (node is md.UnparsedContent) {
-        List<md.Node> inlineNodes =
-            md.InlineParser(node.textContent, this).parse();
+        var inlineNodes = md.InlineParser(node.textContent, this).parse();
         nodes.removeAt(i);
         nodes.insertAll(i, inlineNodes);
         i += inlineNodes.length - 1;

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/utils.dart';
@@ -48,7 +47,7 @@ class Accessor extends ModelElement implements EnclosedElement {
   @override
   String computeDocumentationComment() {
     if (isSynthetic) {
-      String docComment =
+      var docComment =
           (element as PropertyAccessorElement).variable.documentationComment;
       // If we're a setter, only display something if we have something different than the getter.
       // TODO(jcollins-g): modify analyzer to do this itself?
@@ -111,9 +110,7 @@ class Accessor extends ModelElement implements EnclosedElement {
 
   @override
   String get namePart {
-    if (_namePart == null) {
-      _namePart = super.namePart.split('=').first;
-    }
+    _namePart ??= super.namePart.split('=').first;
     return _namePart;
   }
 
@@ -161,9 +158,7 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
 
   @override
   Container get enclosingElement {
-    if (_enclosingElement == null) {
-      _enclosingElement = super.enclosingElement;
-    }
+    _enclosingElement ??= super.enclosingElement;
     return _enclosingElement;
   }
 
@@ -175,25 +170,24 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
     assert(packageGraph.allLibrariesAdded);
     if (!_overriddenElementIsSet) {
       _overriddenElementIsSet = true;
-      Element parent = element.enclosingElement;
+      var parent = element.enclosingElement;
       if (parent is ClassElement) {
-        for (InterfaceType t in parent.allSupertypes) {
-          Element accessor = this.isGetter
-              ? t.getGetter(element.name)
-              : t.getSetter(element.name);
+        for (var t in parent.allSupertypes) {
+          Element accessor =
+              isGetter ? t.getGetter(element.name) : t.getSetter(element.name);
           if (accessor != null) {
             accessor = accessor.declaration;
             Class parentClass =
                 ModelElement.fromElement(t.element, packageGraph);
-            List<Field> possibleFields = [];
+            var possibleFields = <Field>[];
             possibleFields.addAll(parentClass.allInstanceFields);
             possibleFields.addAll(parentClass.staticProperties);
-            String fieldName = accessor.name.replaceFirst('=', '');
-            Field foundField = possibleFields.firstWhere(
+            var fieldName = accessor.name.replaceFirst('=', '');
+            var foundField = possibleFields.firstWhere(
                 (f) => f.element.name == fieldName,
                 orElse: () => null);
             if (foundField != null) {
-              if (this.isGetter) {
+              if (isGetter) {
                 _overriddenElement = foundField.getter;
               } else {
                 _overriddenElement = foundField.setter;

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -20,10 +20,10 @@ abstract class Canonicalization implements Locatable, Documentable {
   }
 
   ScoredCandidate scoreElementWithLibrary(Library lib) {
-    ScoredCandidate scoredCandidate = ScoredCandidate(this, lib);
+    var scoredCandidate = ScoredCandidate(this, lib);
     Iterable<String> resplit(Set<String> items) sync* {
-      for (String item in items) {
-        for (String subItem in item.split('_')) {
+      for (var item in items) {
+        for (var subItem in item.split('_')) {
           yield subItem;
         }
       }
@@ -52,9 +52,9 @@ abstract class Canonicalization implements Locatable, Documentable {
             locationPieces.length.toDouble(),
         'element location shares parts with name');
     // If pieces of location at least start with elements of our library name, boost the score a little bit.
-    double scoreBoost = 0.0;
-    for (String piece in resplit(locationPieces)) {
-      for (String namePiece in lib.namePieces) {
+    var scoreBoost = 0.0;
+    for (var piece in resplit(locationPieces)) {
+      for (var namePiece in lib.namePieces) {
         if (piece.startsWith(namePiece)) {
           scoreBoost += 0.001;
         }

--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -18,8 +18,8 @@ abstract class Categorization implements ModelElement {
   /// out that information from the given comments and returning the stripped
   /// version.
   String _stripAndSetDartdocCategories(String rawDocs) {
-    Set<String> _categorySet = Set();
-    Set<String> _subCategorySet = Set();
+    var _categorySet = <String>{};
+    var _subCategorySet = <String>{};
     _hasCategorization = false;
 
     rawDocs = rawDocs.replaceAllMapped(categoryRegexp, (match) {
@@ -99,13 +99,11 @@ abstract class Categorization implements ModelElement {
   Iterable<Category> _categories;
 
   Iterable<Category> get categories {
-    if (_categories == null) {
-      _categories = categoryNames
-          .map((n) => package.nameToCategory[n])
-          .where((c) => c != null)
-          .toList()
-            ..sort();
-    }
+    _categories ??= categoryNames
+        .map((n) => package.nameToCategory[n])
+        .where((c) => c != null)
+        .toList()
+          ..sort();
     return _categories;
   }
 

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -29,7 +29,7 @@ class Category extends Nameable
   final String _name;
   @override
   DartdocOptionContext config;
-  final Set<Categorization> _allItems = Set();
+  final Set<Categorization> _allItems = {};
 
   final List<Class> _classes = [];
   final List<Extension> _extensions = [];
@@ -71,7 +71,7 @@ class Category extends Nameable
     } else if (c is Extension) {
       _extensions.add(c);
     } else {
-      throw UnimplementedError("Unrecognized element");
+      throw UnimplementedError('Unrecognized element');
     }
   }
 
@@ -110,10 +110,8 @@ class Category extends Nameable
 
   @override
   bool get isDocumented {
-    if (_isDocumented == null) {
-      _isDocumented = documentedWhere != DocumentLocation.missing &&
-          documentationFile != null;
-    }
+    _isDocumented ??= documentedWhere != DocumentLocation.missing &&
+        documentationFile != null;
     return _isDocumented;
   }
 
@@ -135,9 +133,7 @@ class Category extends Nameable
 
   /// The position in the container order for this category.
   int get categoryIndex {
-    if (_categoryIndex == null) {
-      _categoryIndex = package.categories.indexOf(this);
-    }
+    _categoryIndex ??= package.categories.indexOf(this);
     return _categoryIndex;
   }
 

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -46,10 +46,8 @@ class Class extends Container
   Constructor _defaultConstructor;
 
   Constructor get defaultConstructor {
-    if (_defaultConstructor == null) {
-      _defaultConstructor = constructors
-          .firstWhere((c) => c.isDefaultConstructor, orElse: () => null);
-    }
+    _defaultConstructor ??= constructors
+        .firstWhere((c) => c.isDefaultConstructor, orElse: () => null);
     return _defaultConstructor;
   }
 
@@ -81,8 +79,8 @@ class Class extends Container
 
   Map<Element, ModelElement> get allElements {
     if (_allElements == null) {
-      _allElements = Map();
-      for (ModelElement me in allModelElements) {
+      _allElements = {};
+      for (var me in allModelElements) {
         assert(!_allElements.containsKey(me.element));
         _allElements[me.element] = me;
       }
@@ -96,7 +94,7 @@ class Class extends Container
   Map<String, List<ModelElement>> get allModelElementsByNamePart {
     if (_allModelElementsByNamePart == null) {
       _allModelElementsByNamePart = {};
-      for (ModelElement me in allModelElements) {
+      for (var me in allModelElements) {
         _allModelElementsByNamePart.update(
             me.namePart, (List<ModelElement> v) => v..add(me),
             ifAbsent: () => <ModelElement>[me]);
@@ -118,16 +116,16 @@ class Class extends Container
   /// for Object.
   ModelElement memberByExample(ModelElement example) {
     if (_membersByName == null) {
-      _membersByName = Map();
-      for (ModelElement me in allModelElements) {
+      _membersByName = {};
+      for (var me in allModelElements) {
         if (!_membersByName.containsKey(me.name)) {
-          _membersByName[me.name] = List();
+          _membersByName[me.name] = [];
         }
         _membersByName[me.name].add(me);
       }
     }
     ModelElement member;
-    Iterable<ModelElement> possibleMembers = _membersByName[example.name]
+    var possibleMembers = _membersByName[example.name]
         .where((e) => e.runtimeType == example.runtimeType);
     if (example.runtimeType == Accessor) {
       possibleMembers = possibleMembers.where(
@@ -141,21 +139,19 @@ class Class extends Container
   List<ModelElement> _allModelElements;
 
   List<ModelElement> get allModelElements {
-    if (_allModelElements == null) {
-      _allModelElements = List.from(
-          quiver.concat([
-            allInstanceMethods,
-            allInstanceFields,
-            allAccessors,
-            allOperators,
-            constants,
-            constructors,
-            staticMethods,
-            staticProperties,
-            typeParameters,
-          ]),
-          growable: false);
-    }
+    _allModelElements ??= List.from(
+        quiver.concat([
+          allInstanceMethods,
+          allInstanceFields,
+          allAccessors,
+          allOperators,
+          constants,
+          constructors,
+          staticMethods,
+          staticProperties,
+          typeParameters,
+        ]),
+        growable: false);
     return _allModelElements;
   }
 
@@ -247,26 +243,23 @@ class Class extends Container
 
   /// Returns all the implementors of this class.
   Iterable<Class> get publicImplementors {
-    return model_utils.filterNonPublic(model_utils.findCanonicalFor(
-        packageGraph.implementors[href] != null
-            ? packageGraph.implementors[href]
-            : []));
+    return model_utils.filterNonPublic(
+        model_utils.findCanonicalFor(packageGraph.implementors[href] ?? []));
   }
 
   List<Method> get inheritedMethods {
     if (_inheritedMethods == null) {
       _inheritedMethods = <Method>[];
-      Set<String> methodNames = methods.map((m) => m.element.name).toSet();
+      var methodNames = methods.map((m) => m.element.name).toSet();
 
-      Set<ExecutableElement> inheritedMethodElements =
-          _inheritedElements.where((e) {
+      var inheritedMethodElements = _inheritedElements.where((e) {
         return (e is MethodElement &&
             !e.isOperator &&
             e is! PropertyAccessorElement &&
             !methodNames.contains(e.name));
       }).toSet();
 
-      for (ExecutableElement e in inheritedMethodElements) {
+      for (var e in inheritedMethodElements) {
         Method m = ModelElement.from(e, library, packageGraph,
             enclosingContainer: this);
         _inheritedMethods.add(m);
@@ -284,15 +277,14 @@ class Class extends Container
   List<Operator> get inheritedOperators {
     if (_inheritedOperators == null) {
       _inheritedOperators = [];
-      Set<String> operatorNames = operators.map((o) => o.element.name).toSet();
+      var operatorNames = operators.map((o) => o.element.name).toSet();
 
-      Set<ExecutableElement> inheritedOperatorElements =
-          _inheritedElements.where((e) {
+      var inheritedOperatorElements = _inheritedElements.where((e) {
         return (e is MethodElement &&
             e.isOperator &&
             !operatorNames.contains(e.name));
       }).toSet();
-      for (ExecutableElement e in inheritedOperatorElements) {
+      for (var e in inheritedOperatorElements) {
         Operator o = ModelElement.from(e, library, packageGraph,
             enclosingContainer: this);
         _inheritedOperators.add(o);
@@ -306,10 +298,8 @@ class Class extends Container
       model_utils.filterNonPublic(inheritedOperators);
 
   List<Field> get inheritedProperties {
-    if (_inheritedProperties == null) {
-      _inheritedProperties = allFields.where((f) => f.isInherited).toList()
-        ..sort(byName);
-    }
+    _inheritedProperties ??= allFields.where((f) => f.isInherited).toList()
+      ..sort(byName);
     return _inheritedProperties;
   }
 
@@ -367,11 +357,11 @@ class Class extends Container
       _inheritanceChain.add(this);
 
       /// Caching should make this recursion a little less painful.
-      for (Class c in mixins.reversed.map((e) => (e.element as Class))) {
+      for (var c in mixins.reversed.map((e) => (e.element as Class))) {
         _inheritanceChain.addAll(c.inheritanceChain);
       }
 
-      for (Class c in superChain.map((e) => (e.element as Class))) {
+      for (var c in superChain.map((e) => (e.element as Class))) {
         _inheritanceChain.addAll(c.inheritanceChain);
       }
 
@@ -384,8 +374,8 @@ class Class extends Container
   }
 
   List<DefinedElementType> get superChain {
-    List<DefinedElementType> typeChain = [];
-    DefinedElementType parent = supertype;
+    var typeChain = <DefinedElementType>[];
+    var parent = supertype;
     while (parent != null) {
       typeChain.add(parent);
       if (parent.type is InterfaceType) {
@@ -442,14 +432,14 @@ class Class extends Container
   List<Field> get allFields {
     if (_fields == null) {
       _fields = [];
-      Set<PropertyAccessorElement> inheritedAccessors = Set()
+      var inheritedAccessors = <PropertyAccessorElement>{}
         ..addAll(_inheritedElements.whereType<PropertyAccessorElement>());
 
       // This structure keeps track of inherited accessors, allowing lookup
       // by field name (stripping the '=' from setters).
-      Map<String, List<PropertyAccessorElement>> accessorMap = Map();
-      for (PropertyAccessorElement accessorElement in inheritedAccessors) {
-        String name = accessorElement.name.replaceFirst('=', '');
+      var accessorMap = <String, List<PropertyAccessorElement>>{};
+      for (var accessorElement in inheritedAccessors) {
+        var name = accessorElement.name.replaceFirst('=', '');
         accessorMap.putIfAbsent(name, () => []);
         accessorMap[name].add(accessorElement);
       }
@@ -457,13 +447,13 @@ class Class extends Container
       // For half-inherited fields, the analyzer only links the non-inherited
       // to the [FieldElement].  Compose our [Field] class by hand by looking up
       // inherited accessors that may be related.
-      for (FieldElement f in element.fields) {
-        PropertyAccessorElement getterElement = f.getter;
+      for (var f in element.fields) {
+        var getterElement = f.getter;
         if (getterElement == null && accessorMap.containsKey(f.name)) {
           getterElement = accessorMap[f.name]
               .firstWhere((e) => e.isGetter, orElse: () => null);
         }
-        PropertyAccessorElement setterElement = f.setter;
+        var setterElement = f.setter;
         if (setterElement == null && accessorMap.containsKey(f.name)) {
           setterElement = accessorMap[f.name]
               .firstWhere((e) => e.isSetter, orElse: () => null);
@@ -474,12 +464,11 @@ class Class extends Container
 
       // Now we only have inherited accessors who aren't associated with
       // anything in cls._fields.
-      for (String fieldName in accessorMap.keys) {
-        List<PropertyAccessorElement> elements =
-            accessorMap[fieldName].toList();
-        PropertyAccessorElement getterElement =
+      for (var fieldName in accessorMap.keys) {
+        var elements = accessorMap[fieldName].toList();
+        var getterElement =
             elements.firstWhere((e) => e.isGetter, orElse: () => null);
-        PropertyAccessorElement setterElement =
+        var setterElement =
             elements.firstWhere((e) => e.isSetter, orElse: () => null);
         _addSingleField(getterElement, setterElement, inheritedAccessors);
       }
@@ -499,9 +488,9 @@ class Class extends Container
       PropertyAccessorElement setterElement,
       Set<PropertyAccessorElement> inheritedAccessors,
       [FieldElement f]) {
-    ContainerAccessor getter =
+    var getter =
         ContainerAccessor.from(getterElement, inheritedAccessors, this);
-    ContainerAccessor setter =
+    var setter =
         ContainerAccessor.from(setterElement, inheritedAccessors, this);
     // Rebind getterElement/setterElement as ModelElement.from can resolve
     // MultiplyInheritedExecutableElements or resolve Members.
@@ -550,12 +539,10 @@ class Class extends Container
 
   @override
   List<Method> get methods {
-    if (_methods == null) {
-      _methods = element.methods.map((e) {
-        return ModelElement.from(e, library, packageGraph) as Method;
-      }).toList(growable: false)
-        ..sort(byName);
-    }
+    _methods ??= element.methods.map((e) {
+      return ModelElement.from(e, library, packageGraph) as Method;
+    }).toList(growable: false)
+      ..sort(byName);
     return _methods;
   }
 
@@ -564,12 +551,10 @@ class Class extends Container
   // a stronger hash?
   @override
   List<TypeParameter> get typeParameters {
-    if (_typeParameters == null) {
-      _typeParameters = element.typeParameters.map((f) {
-        var lib = Library(f.enclosingElement.library, packageGraph);
-        return ModelElement.from(f, lib, packageGraph) as TypeParameter;
-      }).toList();
-    }
+    _typeParameters ??= element.typeParameters.map((f) {
+      var lib = Library(f.enclosingElement.library, packageGraph);
+      return ModelElement.from(f, lib, packageGraph) as TypeParameter;
+    }).toList();
     return _typeParameters;
   }
 

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -78,7 +78,7 @@ class Constructor extends ModelElement
   @override
   String get name {
     if (_name == null) {
-      String constructorName = element.name;
+      var constructorName = element.name;
       if (constructorName.isEmpty) {
         _name = enclosingElement.name;
       } else {
@@ -93,7 +93,7 @@ class Constructor extends ModelElement
   @override
   String get nameWithGenerics {
     if (_nameWithGenerics == null) {
-      String constructorName = element.name;
+      var constructorName = element.name;
       if (constructorName.isEmpty) {
         _nameWithGenerics = '${enclosingElement.name}${genericParameters}';
       } else {

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -43,10 +43,8 @@ abstract class Container extends ModelElement {
       model_utils.filterNonPublic(instanceMethods);
 
   List<Method> get staticMethods {
-    if (_staticMethods == null) {
-      _staticMethods = methods.where((m) => m.isStatic).toList(growable: false)
-        ..sort(byName);
-    }
+    _staticMethods ??= methods.where((m) => m.isStatic).toList(growable: false)
+      ..sort(byName);
     return _staticMethods;
   }
 
@@ -57,13 +55,11 @@ abstract class Container extends ModelElement {
       model_utils.filterNonPublic(staticMethods);
 
   List<Operator> get operators {
-    if (_operators == null) {
-      _operators = methods
-          .where((m) => m.isOperator)
-          .cast<Operator>()
-          .toList(growable: false)
-            ..sort(byName);
-    }
+    _operators ??= methods
+        .where((m) => m.isOperator)
+        .cast<Operator>()
+        .toList(growable: false)
+          ..sort(byName);
     return _operators;
   }
 
@@ -80,12 +76,10 @@ abstract class Container extends ModelElement {
   List<Field> get allFields => [];
 
   List<Field> get staticProperties {
-    if (_staticFields == null) {
-      _staticFields = allFields
-          .where((f) => f.isStatic && !f.isConst)
-          .toList(growable: false)
-            ..sort(byName);
-    }
+    _staticFields ??= allFields
+        .where((f) => f.isStatic && !f.isConst)
+        .toList(growable: false)
+          ..sort(byName);
     return _staticFields;
   }
 
@@ -95,12 +89,10 @@ abstract class Container extends ModelElement {
   bool get hasPublicStaticProperties => publicStaticProperties.isNotEmpty;
 
   List<Field> get instanceProperties {
-    if (_instanceFields == null) {
-      _instanceFields = allFields
-          .where((f) => !f.isStatic && !f.isInherited && !f.isConst)
-          .toList(growable: false)
-            ..sort(byName);
-    }
+    _instanceFields ??= allFields
+        .where((f) => !f.isStatic && !f.isInherited && !f.isConst)
+        .toList(growable: false)
+          ..sort(byName);
     return _instanceFields;
   }
 
@@ -117,10 +109,8 @@ abstract class Container extends ModelElement {
   bool isInheritingFrom(Container other) => false;
 
   List<Field> get constants {
-    if (_constants == null) {
-      _constants = allFields.where((f) => f.isConst).toList(growable: false)
-        ..sort(byName);
-    }
+    _constants ??= allFields.where((f) => f.isConst).toList(growable: false)
+      ..sort(byName);
     return _constants;
   }
 

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -19,16 +19,14 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
   Container _definingEnclosingContainer;
 
   Container get definingEnclosingContainer {
-    if (_definingEnclosingContainer == null) {
-      _definingEnclosingContainer =
-          ModelElement.fromElement(element.enclosingElement, packageGraph);
-    }
+    _definingEnclosingContainer ??=
+        ModelElement.fromElement(element.enclosingElement, packageGraph);
     return _definingEnclosingContainer;
   }
 
   @override
   Set<String> get features {
-    Set<String> _features = super.features;
+    var _features = super.features;
     if (isExtended) _features.add('extended');
     return _features;
   }

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -76,5 +76,5 @@ abstract class MarkdownFileDocumentation
   String get location => path.toUri(documentationFile.file.path).toString();
 
   @override
-  Set<String> get locationPieces => Set.from(<String>[location]);
+  Set<String> get locationPieces => <String>{location};
 }

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -45,22 +45,18 @@ class Documentation {
   List<ModelCommentReference> get commentRefs => _element.commentRefs;
 
   void _renderDocumentation(bool processAllDocs) {
-    Tuple2<List<md.Node>, bool> parseResult =
-        _parseDocumentation(processAllDocs);
+    var parseResult = _parseDocumentation(processAllDocs);
     if (_hasExtendedDocs != null) {
       assert(_hasExtendedDocs == parseResult.item2);
     }
     _hasExtendedDocs = parseResult.item2;
 
-    Tuple2<String, String> renderResult =
-        _renderer.render(parseResult.item1, processAllDocs);
+    var renderResult = _renderer.render(parseResult.item1, processAllDocs);
 
     if (processAllDocs) {
       _asHtml = renderResult.item1;
     }
-    if (_asOneLiner == null) {
-      _asOneLiner = renderResult.item2;
-    }
+    _asOneLiner ??= renderResult.item2;
   }
 
   /// Returns a tuple of List<md.Node> and hasExtendedDocs
@@ -68,9 +64,9 @@ class Documentation {
     if (!_element.hasDocumentation) {
       return Tuple2([], false);
     }
-    String text = _element.documentation;
+    var text = _element.documentation;
     showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
-    MarkdownDocument document =
+    var document =
         MarkdownDocument.withElementLinkResolver(_element, commentRefs);
     return document.parseMarkdownText(text, processFullDocs);
   }

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -15,14 +15,12 @@ class Enum extends Class {
 
   @override
   List<EnumField> get instanceProperties {
-    if (_instanceProperties == null) {
-      _instanceProperties = super
-          .instanceProperties
-          .map((Field p) => ModelElement.from(
-              p.element, p.library, p.packageGraph,
-              getter: p.getter, setter: p.setter) as EnumField)
-          .toList(growable: false);
-    }
+    _instanceProperties ??= super
+        .instanceProperties
+        .map((Field p) => ModelElement.from(
+            p.element, p.library, p.packageGraph,
+            getter: p.getter, setter: p.setter) as EnumField)
+        .toList(growable: false);
     return _instanceProperties;
   }
 

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -54,12 +54,10 @@ class Extension extends Container
 
   @override
   List<Method> get methods {
-    if (_methods == null) {
-      _methods = _extension.methods.map((e) {
-        return ModelElement.from(e, library, packageGraph) as Method;
-      }).toList(growable: false)
-        ..sort(byName);
-    }
+    _methods ??= _extension.methods.map((e) {
+      return ModelElement.from(e, library, packageGraph) as Method;
+    }).toList(growable: false)
+      ..sort(byName);
     return _methods;
   }
 
@@ -67,20 +65,18 @@ class Extension extends Container
 
   @override
   List<Field> get allFields {
-    if (_fields == null) {
-      _fields = _extension.fields.map((f) {
-        Accessor getter, setter;
-        if (f.getter != null) {
-          getter = ContainerAccessor(f.getter, library, packageGraph);
-        }
-        if (f.setter != null) {
-          setter = ContainerAccessor(f.setter, library, packageGraph);
-        }
-        return ModelElement.from(f, library, packageGraph,
-            getter: getter, setter: setter) as Field;
-      }).toList(growable: false)
-        ..sort(byName);
-    }
+    _fields ??= _extension.fields.map((f) {
+      Accessor getter, setter;
+      if (f.getter != null) {
+        getter = ContainerAccessor(f.getter, library, packageGraph);
+      }
+      if (f.setter != null) {
+        setter = ContainerAccessor(f.setter, library, packageGraph);
+      }
+      return ModelElement.from(f, library, packageGraph,
+          getter: getter, setter: setter) as Field;
+    }).toList(growable: false)
+      ..sort(byName);
     return _fields;
   }
 
@@ -89,12 +85,10 @@ class Extension extends Container
   // a stronger hash?
   @override
   List<TypeParameter> get typeParameters {
-    if (_typeParameters == null) {
-      _typeParameters = _extension.typeParameters.map((f) {
-        var lib = Library(f.enclosingElement.library, packageGraph);
-        return ModelElement.from(f, lib, packageGraph) as TypeParameter;
-      }).toList();
-    }
+    _typeParameters ??= _extension.typeParameters.map((f) {
+      var lib = Library(f.enclosingElement.library, packageGraph);
+      return ModelElement.from(f, lib, packageGraph) as TypeParameter;
+    }).toList();
     return _typeParameters;
   }
 
@@ -104,20 +98,18 @@ class Extension extends Container
   List<ModelElement> _allModelElements;
 
   List<ModelElement> get allModelElements {
-    if (_allModelElements == null) {
-      _allModelElements = List.from(
-          quiver.concat([
-            instanceMethods,
-            allInstanceFields,
-            allAccessors,
-            allOperators,
-            constants,
-            staticMethods,
-            staticProperties,
-            typeParameters,
-          ]),
-          growable: false);
-    }
+    _allModelElements ??= List.from(
+        quiver.concat([
+          instanceMethods,
+          allInstanceFields,
+          allAccessors,
+          allOperators,
+          constants,
+          staticMethods,
+          staticProperties,
+          typeParameters,
+        ]),
+        growable: false);
     return _allModelElements;
   }
 

--- a/lib/src/model/extension_target.dart
+++ b/lib/src/model/extension_target.dart
@@ -20,13 +20,11 @@ mixin ExtensionTarget on ModelElement {
   /// defined by [element] can exist where this extension applies, not including
   /// any extension that applies to every type.
   Iterable<Extension> get potentiallyApplicableExtensions {
-    if (_potentiallyApplicableExtensions == null) {
-      _potentiallyApplicableExtensions = packageGraph.documentedExtensions
-          .where((e) => !e.alwaysApplies)
-          .where((e) => e.couldApplyTo(this))
-          .toList(growable: false)
-            ..sort(byName);
-    }
+    _potentiallyApplicableExtensions ??= packageGraph.documentedExtensions
+        .where((e) => !e.alwaysApplies)
+        .where((e) => e.couldApplyTo(this))
+        .toList(growable: false)
+          ..sort(byName);
     return _potentiallyApplicableExtensions;
   }
 }

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -33,7 +33,7 @@ class Field extends ModelElement
       PackageGraph packageGraph,
       Accessor getter,
       Accessor setter) {
-    Field newField = Field(element, library, packageGraph, getter, setter);
+    var newField = Field(element, library, packageGraph, getter, setter);
     newField._isInherited = true;
     newField._enclosingClass = enclosingClass;
     // Can't set _isInherited to true if this is the defining element, because
@@ -47,7 +47,7 @@ class Field extends ModelElement
     // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
     // to prevent displaying more or less than one summary.
     if (isPublic) {
-      Set<bool> assertCheck = Set()
+      var assertCheck = <dynamic>{}
         ..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
       assert(assertCheck.containsAll([true, false]));
     }
@@ -57,10 +57,8 @@ class Field extends ModelElement
 
   @override
   ModelElement get enclosingElement {
-    if (_enclosingClass == null) {
-      _enclosingClass =
-          ModelElement.from(field.enclosingElement, library, packageGraph);
-    }
+    _enclosingClass ??=
+        ModelElement.from(field.enclosingElement, library, packageGraph);
     return _enclosingClass;
   }
 
@@ -107,7 +105,7 @@ class Field extends ModelElement
 
   @override
   List<String> get annotations {
-    List<String> all_annotations = List<String>();
+    var all_annotations = <String>[];
     all_annotations.addAll(super.annotations);
 
     if (element is PropertyInducingElement) {
@@ -120,7 +118,7 @@ class Field extends ModelElement
 
   @override
   Set<String> get features {
-    Set<String> allFeatures = super.features..addAll(comboFeatures);
+    var allFeatures = super.features..addAll(comboFeatures);
     // Combo features can indicate 'inherited' and 'override' if
     // either the getter or setter has one of those properties, but that's not
     // really specific enough for [Field]s that have public getter/setters.
@@ -148,7 +146,7 @@ class Field extends ModelElement
 
   @override
   String computeDocumentationComment() {
-    String docs = getterSetterDocumentationComment;
+    var docs = getterSetterDocumentationComment;
     if (docs.isEmpty) return field.documentationComment;
     return docs;
   }
@@ -164,10 +162,10 @@ class Field extends ModelElement
   String get sourceCode {
     if (_sourceCode == null) {
       // We could use a set to figure the dupes out, but that would lose ordering.
-      String fieldSourceCode = modelNode.sourceCode ?? '';
-      String getterSourceCode = getter?.sourceCode ?? '';
-      String setterSourceCode = setter?.sourceCode ?? '';
-      StringBuffer buffer = StringBuffer();
+      var fieldSourceCode = modelNode.sourceCode ?? '';
+      var getterSourceCode = getter?.sourceCode ?? '';
+      var setterSourceCode = setter?.sourceCode ?? '';
+      var buffer = StringBuffer();
       if (fieldSourceCode.isNotEmpty) {
         buffer.write(fieldSourceCode);
       }

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -19,13 +19,13 @@ mixin GetterSetterCombo on ModelElement {
   Accessor get setter;
 
   Iterable<Accessor> get allAccessors sync* {
-    for (Accessor a in [getter, setter]) {
+    for (var a in [getter, setter]) {
       if (a != null) yield a;
     }
   }
 
   Set<String> get comboFeatures {
-    Set<String> allFeatures = Set();
+    var allFeatures = <String>{};
     if (hasExplicitGetter && hasPublicGetter) {
       allFeatures.addAll(getter.features);
     }
@@ -49,7 +49,7 @@ mixin GetterSetterCombo on ModelElement {
   String linkifyConstantValue(String original) {
     if (constantInitializer is! InstanceCreationExpression) return original;
     var creationExpression = constantInitializer as InstanceCreationExpression;
-    String constructorName = creationExpression.constructorName.toString();
+    var constructorName = creationExpression.constructorName.toString();
     Element staticElement = creationExpression.staticElement;
     if (staticElement == null) {
       warn(PackageWarning.missingConstantConstructor, message: constructorName);
@@ -60,14 +60,14 @@ mixin GetterSetterCombo on ModelElement {
     // TODO(jcollins-g): this logic really should be integrated into Constructor,
     // but that's not trivial because of linkedName's usage.
     if (targetClass.name == target.name) {
-      return original.replaceAll(constructorName, "${target.linkedName}");
+      return original.replaceAll(constructorName, '${target.linkedName}');
     }
-    return original.replaceAll("${targetClass.name}.${target.name}",
-        "${targetClass.linkedName}.${target.linkedName}");
+    return original.replaceAll('${targetClass.name}.${target.name}',
+        '${targetClass.linkedName}.${target.linkedName}');
   }
 
   String _buildConstantValueBase() {
-    String result = constantInitializer?.toString() ?? '';
+    var result = constantInitializer?.toString() ?? '';
     return const HtmlEscape(HtmlEscapeMode.unknown).convert(result);
   }
 
@@ -140,7 +140,7 @@ mixin GetterSetterCombo on ModelElement {
       if (!hasAccessorsWithDocs) {
         _oneLineDoc = super.oneLineDoc;
       } else {
-        StringBuffer buffer = StringBuffer();
+        var buffer = StringBuffer();
         if (hasPublicGetter && getter.oneLineDoc.isNotEmpty) {
           buffer.write('${getter.oneLineDoc}');
         }
@@ -162,7 +162,7 @@ mixin GetterSetterCombo on ModelElement {
       // doesn't yield the real elements for GetterSetterCombos.
       if (!config.dropTextFrom
           .contains(getter.documentationFrom.first.element.library.name)) {
-        String docs = getter.documentationFrom.first.documentationComment;
+        var docs = getter.documentationFrom.first.documentationComment;
         if (docs != null) buffer.write(docs);
       }
     }
@@ -171,7 +171,7 @@ mixin GetterSetterCombo on ModelElement {
       assert(setter.documentationFrom.length == 1);
       if (!config.dropTextFrom
           .contains(setter.documentationFrom.first.element.library.name)) {
-        String docs = setter.documentationFrom.first.documentationComment;
+        var docs = setter.documentationFrom.first.documentationComment;
         if (docs != null) {
           if (buffer.isNotEmpty) buffer.write('\n\n');
           buffer.write(docs);

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/special_elements.dart';
 
@@ -30,7 +29,7 @@ mixin Inheritable on ContainerMember {
 
   @override
   Set<String> get features {
-    Set<String> _features = super.features;
+    var _features = super.features;
     if (isOverride) _features.add('override');
     if (isInherited) _features.add('inherited');
     if (isCovariant) _features.add('covariant');
@@ -63,13 +62,13 @@ mixin Inheritable on ContainerMember {
   @override
   Container computeCanonicalEnclosingContainer() {
     if (isInherited) {
-      Element searchElement = element.declaration;
+      var searchElement = element.declaration;
       // TODO(jcollins-g): generate warning if an inherited element's definition
       // is in an intermediate non-canonical class in the inheritance chain?
       Class previous;
       Class previousNonSkippable;
       Class found;
-      for (Class c in inheritance.reversed) {
+      for (var c in inheritance.reversed) {
         // Filter out mixins.
         if (c.contains(searchElement)) {
           if ((packageGraph.inheritThrough.contains(previous) &&
@@ -113,9 +112,9 @@ mixin Inheritable on ContainerMember {
   }
 
   List<Class> get inheritance {
-    List<Class> inheritance = [];
+    var inheritance = <Class>[];
     inheritance.addAll((enclosingElement as Class).inheritanceChain);
-    Class object = packageGraph.specialClasses[SpecialClass.object];
+    var object = packageGraph.specialClasses[SpecialClass.object];
     if (!inheritance.contains(definingEnclosingContainer) &&
         definingEnclosingContainer != null) {
       assert(definingEnclosingContainer == object);
@@ -152,7 +151,7 @@ mixin Inheritable on ContainerMember {
           definingEnclosingContainer.canonicalModelElement ??
               definingEnclosingContainer;
       // The canonical version of the element we're overriding, if available.
-      ModelElement overriddenCanonical =
+      var overriddenCanonical =
           overriddenElement?.canonicalModelElement ?? overriddenElement;
 
       // We have to have an overridden element for it to be possible for this
@@ -175,7 +174,7 @@ mixin Inheritable on ContainerMember {
   int get overriddenDepth {
     if (_overriddenDepth == null) {
       _overriddenDepth = 0;
-      Inheritable e = this;
+      var e = this;
       while (e.overriddenElement != null) {
         _overriddenDepth += 1;
         e = e.overriddenElement;

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/element_type.dart';
@@ -51,10 +50,8 @@ class Method extends ModelElement
 
   @override
   ModelElement get enclosingElement {
-    if (_enclosingContainer == null) {
-      _enclosingContainer =
-          ModelElement.from(_method.enclosingElement, library, packageGraph);
-    }
+    _enclosingContainer ??=
+        ModelElement.from(_method.enclosingElement, library, packageGraph);
     return _enclosingContainer;
   }
 
@@ -85,7 +82,7 @@ class Method extends ModelElement
 
   @override
   Set<String> get features {
-    Set<String> allFeatures = super.features;
+    var allFeatures = super.features;
     if (isInherited) allFeatures.add('inherited');
     return allFeatures;
   }
@@ -107,7 +104,7 @@ class Method extends ModelElement
       return null;
     }
     ClassElement parent = element.enclosingElement;
-    for (InterfaceType t in parent.allSupertypes) {
+    for (var t in parent.allSupertypes) {
       Element e = t.getMethod(element.name);
       if (e != null) {
         assert(e.enclosingElement is ClassElement);

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -44,12 +44,10 @@ class Mixin extends Class {
 
   /// Returns a list of superclass constraints for this mixin.
   Iterable<ParameterizedElementType> get superclassConstraints {
-    if (_superclassConstraints == null) {
-      _superclassConstraints = element.superclassConstraints
-          .map<ParameterizedElementType>(
-              (InterfaceType i) => ElementType.from(i, library, packageGraph))
-          .toList();
-    }
+    _superclassConstraints ??= element.superclassConstraints
+        .map<ParameterizedElementType>(
+            (InterfaceType i) => ElementType.from(i, library, packageGraph))
+        .toList();
     return _superclassConstraints;
   }
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -15,8 +15,6 @@ import 'package:analyzer/source/line_info.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member, ParameterMember;
-import 'package:analyzer/src/generated/source.dart';
-import 'package:analyzer/src/generated/source_io.dart';
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
@@ -55,8 +53,8 @@ const Map<String, int> featureOrder = {
 };
 
 int byFeatureOrdering(String a, String b) {
-  int scoreA = 0;
-  int scoreB = 0;
+  var scoreA = 0;
+  var scoreB = 0;
 
   if (featureOrder.containsKey(a)) scoreA = featureOrder[a];
   if (featureOrder.containsKey(b)) scoreB = featureOrder[b];
@@ -107,12 +105,12 @@ ModelElement resolveMultiplyInheritedElement(
     Library library,
     PackageGraph packageGraph,
     Class enclosingClass) {
-  Iterable<Inheritable> inheritables = e.inheritedElements
+  var inheritables = e.inheritedElements
       .map((ee) => ModelElement.fromElement(ee, packageGraph) as Inheritable);
   Inheritable foundInheritable;
-  int lowIndex = enclosingClass.inheritanceChain.length;
+  var lowIndex = enclosingClass.inheritanceChain.length;
   for (var inheritable in inheritables) {
-    int index =
+    var index =
         enclosingClass.inheritanceChain.indexOf(inheritable.enclosingElement);
     if (index < lowIndex) {
       foundInheritable = inheritable;
@@ -173,7 +171,7 @@ abstract class ModelElement extends Canonicalization
       this._element, this._library, this._packageGraph, this._originalMember);
 
   factory ModelElement.fromElement(Element e, PackageGraph p) {
-    Library lib = p.findButDoNotCreateLibraryFor(e);
+    var lib = p.findButDoNotCreateLibraryFor(e);
     Accessor getter;
     Accessor setter;
     if (e is PropertyInducingElement) {
@@ -212,8 +210,8 @@ abstract class ModelElement extends Canonicalization
       originalMember = e;
       e = e.declaration;
     }
-    Tuple3<Element, Library, Container> key =
-        Tuple3(e, library, enclosingContainer);
+    var key =
+        Tuple3<Element, Library, Container>(e, library, enclosingContainer);
     ModelElement newModelElement;
     if (e.kind != ElementKind.DYNAMIC &&
         e.kind != ElementKind.NEVER &&
@@ -260,7 +258,7 @@ abstract class ModelElement extends Canonicalization
         if (e is FieldElement) {
           if (enclosingContainer == null) {
             if (e.isEnumConstant) {
-              int index =
+              var index =
                   e.computeConstantValue().getField(e.name).toIntValue();
               newModelElement = EnumField.forConstant(
                   index, e, library, packageGraph, getter);
@@ -331,16 +329,15 @@ abstract class ModelElement extends Canonicalization
       }
     }
 
-    if (newModelElement == null) throw "Unknown type ${e.runtimeType}";
+    if (newModelElement == null) throw 'Unknown type ${e.runtimeType}';
     if (enclosingContainer != null) assert(newModelElement is Inheritable);
     // TODO(jcollins-g): Reenable Parameter caching when dart-lang/sdk#30146
     //                   is fixed?
     if (library != null && newModelElement is! Parameter) {
       library.packageGraph.allConstructedModelElements[key] = newModelElement;
       if (newModelElement is Inheritable) {
-        Tuple2<Element, Library> iKey = Tuple2(e, library);
-        library.packageGraph.allInheritableElements
-            .putIfAbsent(iKey, () => Set());
+        var iKey = Tuple2<Element, Library>(e, library);
+        library.packageGraph.allInheritableElements.putIfAbsent(iKey, () => {});
         library.packageGraph.allInheritableElements[iKey].add(newModelElement);
       }
     }
@@ -358,8 +355,7 @@ abstract class ModelElement extends Canonicalization
   bool get hasCategoryNames => false;
 
   Set<Library> get exportedInLibraries {
-    return library
-        .packageGraph.libraryElementReexportedBy[this.element.library];
+    return library.packageGraph.libraryElementReexportedBy[element.library];
   }
 
   ModelNode _modelNode;
@@ -372,11 +368,11 @@ abstract class ModelElement extends Canonicalization
 
   /// Returns linked annotations from a given metadata set, with escaping.
   List<String> annotationsFromMetadata(List<ElementAnnotation> md) {
-    List<String> annotationStrings = [];
+    var annotationStrings = <String>[];
     if (md == null) return annotationStrings;
-    for (ElementAnnotation a in md) {
-      String annotation = (const HtmlEscape()).convert(a.toSource());
-      Element annotationElement = a.element;
+    for (var a in md) {
+      var annotation = (const HtmlEscape()).convert(a.toSource());
+      var annotationElement = a.element;
 
       ClassElement annotationClassElement;
       if (annotationElement is ExecutableElement) {
@@ -386,10 +382,10 @@ abstract class ModelElement extends Canonicalization
       if (annotationElement is ClassElement) {
         annotationClassElement = annotationElement;
       }
-      ModelElement annotationModelElement =
+      var annotationModelElement =
           packageGraph.findCanonicalModelElementFor(annotationElement);
       // annotationElement can be null if the element can't be resolved.
-      Class annotationClass = packageGraph
+      var annotationClass = packageGraph
           .findCanonicalModelElementFor(annotationClassElement) as Class;
       if (annotationClass == null &&
           annotationElement != null &&
@@ -427,7 +423,7 @@ abstract class ModelElement extends Canonicalization
           !(enclosingElement as Extension).isPublic) {
         _isPublic = false;
       } else {
-        String docComment = documentationComment;
+        var docComment = documentationComment;
         if (docComment == null) {
           _isPublic = utils.hasPublicName(element);
         } else {
@@ -446,12 +442,12 @@ abstract class ModelElement extends Canonicalization
   List<ModelCommentReference> get commentRefs {
     if (_commentRefs == null) {
       _commentRefs = [];
-      for (ModelElement from in documentationFrom) {
-        List<ModelElement> checkReferences = [from];
+      for (var from in documentationFrom) {
+        var checkReferences = <ModelElement>[from];
         if (from is Accessor) {
           checkReferences.add(from.enclosingCombo);
         }
-        for (ModelElement e in checkReferences) {
+        for (var e in checkReferences) {
           _commentRefs.addAll(e.modelNode.commentRefs ?? []);
         }
       }
@@ -463,10 +459,8 @@ abstract class ModelElement extends Canonicalization
 
   @override
   DartdocOptionContext get config {
-    if (_config == null) {
-      _config =
-          DartdocOptionContext.fromContextElement(packageGraph.config, element);
-    }
+    _config ??=
+        DartdocOptionContext.fromContextElement(packageGraph.config, element);
     return _config;
   }
 
@@ -479,7 +473,7 @@ abstract class ModelElement extends Canonicalization
   }
 
   Set<String> get features {
-    Set<String> allFeatures = Set<String>();
+    var allFeatures = <String>{};
     allFeatures.addAll(annotations);
 
     // Replace the @override annotation with a feature that explicitly
@@ -497,7 +491,7 @@ abstract class ModelElement extends Canonicalization
   }
 
   String get featuresAsString {
-    List<String> allFeatures = features.toList()..sort(byFeatureOrdering);
+    var allFeatures = features.toList()..sort(byFeatureOrdering);
     return allFeatures.join(', ');
   }
 
@@ -527,9 +521,7 @@ abstract class ModelElement extends Canonicalization
   // TODO(jcollins-g): untangle when mixins can call super
   @override
   List<ModelElement> get documentationFrom {
-    if (_documentationFrom == null) {
-      _documentationFrom = computeDocumentationFrom;
-    }
+    _documentationFrom ??= computeDocumentationFrom;
     return _documentationFrom;
   }
 
@@ -557,8 +549,8 @@ abstract class ModelElement extends Canonicalization
         (this as Inheritable).overriddenElement != null) {
       docFrom = (this as Inheritable).overriddenElement.documentationFrom;
     } else if (this is Inheritable && (this as Inheritable).isInherited) {
-      Inheritable thisInheritable = (this as Inheritable);
-      ModelElement fromThis = ModelElement.fromElement(
+      var thisInheritable = (this as Inheritable);
+      var fromThis = ModelElement.fromElement(
           element, thisInheritable.definingEnclosingContainer.packageGraph);
       docFrom = fromThis.documentationFrom;
     } else {
@@ -649,7 +641,7 @@ abstract class ModelElement extends Canonicalization
       assert(packageGraph.allLibrariesAdded);
       // Since we're looking for a library, find the [Element] immediately
       // contained by a [CompilationUnitElement] in the tree.
-      Element topLevelElement = element;
+      var topLevelElement = element;
       while (topLevelElement != null &&
           topLevelElement.enclosingElement is! LibraryElement &&
           topLevelElement.enclosingElement is! CompilationUnitElement &&
@@ -662,7 +654,7 @@ abstract class ModelElement extends Canonicalization
       if (!utils.hasPublicName(element)) {
         _canonicalLibrary = null;
       } else if (!packageGraph.localPublicLibraries.contains(definingLibrary)) {
-        List<Library> candidateLibraries = definingLibrary.exportedInLibraries
+        var candidateLibraries = definingLibrary.exportedInLibraries
             ?.where((l) =>
                 l.isPublic &&
                 l.package.documentedWhere != DocumentLocation.missing)
@@ -670,7 +662,7 @@ abstract class ModelElement extends Canonicalization
 
         if (candidateLibraries != null) {
           candidateLibraries = candidateLibraries.where((l) {
-            Element lookup =
+            var lookup =
                 l.element.exportNamespace.definedNames[topLevelElement?.name];
             if (lookup is PropertyAccessorElement) {
               lookup = (lookup as PropertyAccessorElement).variable;
@@ -694,23 +686,23 @@ abstract class ModelElement extends Canonicalization
           }
 
           // Start with our top-level element.
-          ModelElement warnable =
+          var warnable =
               ModelElement.fromElement(topLevelElement, packageGraph);
           if (candidateLibraries.length > 1) {
             // Heuristic scoring to determine which library a human likely
             // considers this element to be primarily 'from', and therefore,
             // canonical.  Still warn if the heuristic isn't that confident.
-            List<ScoredCandidate> scoredCandidates =
+            var scoredCandidates =
                 warnable.scoreCanonicalCandidates(candidateLibraries);
             candidateLibraries =
                 scoredCandidates.map((s) => s.library).toList();
-            double secondHighestScore =
+            var secondHighestScore =
                 scoredCandidates[scoredCandidates.length - 2].score;
-            double highestScore = scoredCandidates.last.score;
-            double confidence = highestScore - secondHighestScore;
-            String message =
-                "${candidateLibraries.map((l) => l.name)} -> ${candidateLibraries.last.name} (confidence ${confidence.toStringAsPrecision(4)})";
-            List<String> debugLines = [];
+            var highestScore = scoredCandidates.last.score;
+            var confidence = highestScore - secondHighestScore;
+            var message =
+                '${candidateLibraries.map((l) => l.name)} -> ${candidateLibraries.last.name} (confidence ${confidence.toStringAsPrecision(4)})';
+            var debugLines = <String>[];
             debugLines.addAll(scoredCandidates.map((s) => '${s.toString()}'));
 
             if (confidence < config.ambiguousReexportScorerMinConfidence) {
@@ -747,7 +739,7 @@ abstract class ModelElement extends Canonicalization
     if (!isPublic) return false;
     if (library == canonicalLibrary) {
       if (this is Inheritable) {
-        Inheritable i = (this as Inheritable);
+        var i = (this as Inheritable);
         // If we're the defining element, or if the defining element is not
         // in the set of libraries being documented, then this element
         // should be treated as canonical (given library == canonicalLibrary).
@@ -779,9 +771,9 @@ abstract class ModelElement extends Canonicalization
   String get location {
     // Call nothing from here that can emit warnings or you'll cause stack overflows.
     if (characterLocation != null) {
-      return "(${path.toUri(sourceFileName)}:${characterLocation.toString()})";
+      return '(${path.toUri(sourceFileName)}:${characterLocation.toString()})';
     }
-    return "(${path.toUri(sourceFileName)})";
+    return '(${path.toUri(sourceFileName)})';
   }
 
   /// Returns a link to extended documentation, or the empty string if that
@@ -809,10 +801,8 @@ abstract class ModelElement extends Canonicalization
 
   String get fullyQualifiedNameWithoutLibrary {
     // Remember, periods are legal in library names.
-    if (_fullyQualifiedNameWithoutLibrary == null) {
-      _fullyQualifiedNameWithoutLibrary =
-          fullyQualifiedName.replaceFirst("${library.fullyQualifiedName}.", '');
-    }
+    _fullyQualifiedNameWithoutLibrary ??=
+        fullyQualifiedName.replaceFirst('${library.fullyQualifiedName}.', '');
     return _fullyQualifiedNameWithoutLibrary;
   }
 
@@ -824,7 +814,7 @@ abstract class ModelElement extends Canonicalization
   @override
   CharacterLocation get characterLocation {
     if (!_characterLocationIsSet) {
-      LineInfo lineInfo = compilationUnitElement.lineInfo;
+      var lineInfo = compilationUnitElement.lineInfo;
       _characterLocationIsSet = true;
       assert(element.nameOffset >= 0,
           'Invalid location data for element: $fullyQualifiedName');
@@ -918,9 +908,7 @@ abstract class ModelElement extends Canonicalization
   Library get library => _library;
 
   String get linkedName {
-    if (_linkedName == null) {
-      _linkedName = _calculateLinkedName();
-    }
+    _linkedName ??= _calculateLinkedName();
     return _linkedName;
   }
 
@@ -1001,8 +989,8 @@ abstract class ModelElement extends Canonicalization
   // elsewhere as appropriate?
   List<Parameter> get allParameters {
     if (_allParameters == null) {
-      final Set<Parameter> recursedParameters = Set();
-      final Set<Parameter> newParameters = Set();
+      var recursedParameters = <Parameter>{};
+      var newParameters = <Parameter>{};
       if (this is GetterSetterCombo &&
           (this as GetterSetterCombo).setter != null) {
         newParameters.addAll((this as GetterSetterCombo).setter.parameters);
@@ -1012,7 +1000,7 @@ abstract class ModelElement extends Canonicalization
       while (newParameters.isNotEmpty) {
         recursedParameters.addAll(newParameters);
         newParameters.clear();
-        for (Parameter p in recursedParameters) {
+        for (var p in recursedParameters) {
           var l = p.modelType.parameters
               .where((pm) => !recursedParameters.contains(pm));
           newParameters.addAll(l);
@@ -1025,7 +1013,7 @@ abstract class ModelElement extends Canonicalization
 
   List<Parameter> get parameters {
     if (!canHaveParameters) {
-      throw StateError("$element cannot have parameters");
+      throw StateError('$element cannot have parameters');
     }
 
     if (_parameters == null) {
@@ -1125,8 +1113,8 @@ abstract class ModelElement extends Canonicalization
     // If we're calling this with an empty name, we probably have the wrong
     // element associated with a ModelElement or there's an analysis bug.
     assert(name.isNotEmpty ||
-        this.element?.kind == ElementKind.DYNAMIC ||
-        this.element?.kind == ElementKind.NEVER ||
+        element?.kind == ElementKind.DYNAMIC ||
+        element?.kind == ElementKind.NEVER ||
         this is ModelFunction);
 
     if (href == null) {
@@ -1157,7 +1145,7 @@ abstract class ModelElement extends Canonicalization
   ///
   String _injectExamples(String rawdocs) {
     final dirPath = package.packageMeta.dir.path;
-    RegExp exampleRE = RegExp(r'{@example\s+([^}]+)}');
+    var exampleRE = RegExp(r'{@example\s+([^}]+)}');
     return rawdocs.replaceAllMapped(exampleRE, (match) {
       var args = _getExampleArgs(match[1]);
       if (args == null) {
@@ -1177,8 +1165,7 @@ abstract class ModelElement extends Canonicalization
         }
       } else {
         // TODO(jcollins-g): move this to Package.warn system
-        var filePath =
-            this.element.source.fullName.substring(dirPath.length + 1);
+        var filePath = element.source.fullName.substring(dirPath.length + 1);
 
         logWarning(
             'warning: ${filePath}: @example file not found, ${fragmentFile.path}');
@@ -1187,12 +1174,12 @@ abstract class ModelElement extends Canonicalization
     });
   }
 
-  static Future<String> _replaceAllMappedAsync(
-      String string, Pattern exp, Future<String> replace(Match match)) async {
-    StringBuffer replaced = StringBuffer();
-    int currentIndex = 0;
-    for (Match match in exp.allMatches(string)) {
-      String prefix = match.input.substring(currentIndex, match.start);
+  static Future<String> _replaceAllMappedAsync(String string, Pattern exp,
+      Future<String> Function(Match match) replace) async {
+    var replaced = StringBuffer();
+    var currentIndex = 0;
+    for (var match in exp.allMatches(string)) {
+      var prefix = match.input.substring(currentIndex, match.start);
       currentIndex = match.end;
       replaced..write(prefix)..write(await replace(match));
     }
@@ -1253,10 +1240,10 @@ abstract class ModelElement extends Canonicalization
   /// 2018-09-18T21:15+00:00
   Future<String> _evaluateTools(String rawDocs) async {
     if (config.allowTools) {
-      int invocationIndex = 0;
+      var invocationIndex = 0;
       return await _replaceAllMappedAsync(rawDocs, basicToolRegExp,
           (basicMatch) async {
-        List<String> args = _splitUpQuotedArgs(basicMatch[1]).toList();
+        var args = _splitUpQuotedArgs(basicMatch[1]).toList();
         // Tool name must come first.
         if (args.isEmpty) {
           warn(PackageWarning.toolError,
@@ -1320,20 +1307,20 @@ abstract class ModelElement extends Canonicalization
     // Matches all youtube directives (even some invalid ones). This is so
     // we can give good error messages if the directive is malformed, instead of
     // just silently emitting it as-is.
-    final RegExp basicAnimationRegExp = RegExp(r'''{@youtube\s+([^}]+)}''');
+    var basicAnimationRegExp = RegExp(r'''{@youtube\s+([^}]+)}''');
 
     // Matches YouTube IDs from supported YouTube URLs.
-    final RegExp validYouTubeUrlRegExp =
+    var validYouTubeUrlRegExp =
         RegExp('https://www\.youtube\.com/watch\\?v=([^&]+)\$');
 
     return rawDocs.replaceAllMapped(basicAnimationRegExp, (basicMatch) {
-      final ArgParser parser = ArgParser();
-      final ArgResults args = _parseArgs(basicMatch[1], parser, 'youtube');
+      var parser = ArgParser();
+      var args = _parseArgs(basicMatch[1], parser, 'youtube');
       if (args == null) {
         // Already warned about an invalid parameter if this happens.
         return '';
       }
-      final List<String> positionalArgs = args.rest.sublist(0);
+      var positionalArgs = args.rest.sublist(0);
       if (positionalArgs.length != 3) {
         warn(PackageWarning.invalidParameter,
             message: 'Invalid @youtube directive, "${basicMatch[0]}"\n'
@@ -1342,21 +1329,21 @@ abstract class ModelElement extends Canonicalization
         return '';
       }
 
-      final int width = int.tryParse(positionalArgs[0]);
+      var width = int.tryParse(positionalArgs[0]);
       if (width == null || width <= 0) {
         warn(PackageWarning.invalidParameter,
             message: 'A @youtube directive has an invalid width, '
                 '"${positionalArgs[0]}". The width must be a positive integer.');
       }
 
-      final int height = int.tryParse(positionalArgs[1]);
+      var height = int.tryParse(positionalArgs[1]);
       if (height == null || height <= 0) {
         warn(PackageWarning.invalidParameter,
             message: 'A @youtube directive has an invalid height, '
                 '"${positionalArgs[1]}". The height must be a positive integer.');
       }
 
-      final Match url = validYouTubeUrlRegExp.firstMatch(positionalArgs[2]);
+      var url = validYouTubeUrlRegExp.firstMatch(positionalArgs[2]);
       if (url == null) {
         warn(PackageWarning.invalidParameter,
             message: 'A @youtube directive has an invalid URL: '
@@ -1364,8 +1351,8 @@ abstract class ModelElement extends Canonicalization
                 'following format: https://www.youtube.com/watch?v=oHg5SJYRHA0.');
         return '';
       }
-      final String youTubeId = url.group(url.groupCount);
-      final String aspectRatio = (height / width * 100).toStringAsFixed(2);
+      var youTubeId = url.group(url.groupCount);
+      var aspectRatio = (height / width * 100).toStringAsFixed(2);
 
       return _modelElementRenderer.renderYoutubeUrl(youTubeId, aspectRatio);
     });
@@ -1396,17 +1383,17 @@ abstract class ModelElement extends Canonicalization
     // Matches all animation directives (even some invalid ones). This is so
     // we can give good error messages if the directive is malformed, instead of
     // just silently emitting it as-is.
-    final RegExp basicAnimationRegExp = RegExp(r'''{@animation\s+([^}]+)}''');
+    var basicAnimationRegExp = RegExp(r'''{@animation\s+([^}]+)}''');
 
     // Matches valid javascript identifiers.
-    final RegExp validIdRegExp = RegExp(r'^[a-zA-Z_]\w*$');
+    var validIdRegExp = RegExp(r'^[a-zA-Z_]\w*$');
 
     // Make sure we have a set to keep track of used IDs for this href.
     package.usedAnimationIdsByHref[href] ??= {};
 
     String getUniqueId(String base) {
-      int animationIdCount = 1;
-      String id = '$base$animationIdCount';
+      var animationIdCount = 1;
+      var id = '$base$animationIdCount';
       // We check for duplicate IDs so that we make sure not to collide with
       // user-supplied ids on the same page.
       while (package.usedAnimationIdsByHref[href].contains(id)) {
@@ -1417,16 +1404,16 @@ abstract class ModelElement extends Canonicalization
     }
 
     return rawDocs.replaceAllMapped(basicAnimationRegExp, (basicMatch) {
-      final ArgParser parser = ArgParser();
+      var parser = ArgParser();
       parser.addOption('id');
-      final ArgResults args = _parseArgs(basicMatch[1], parser, 'animation');
+      var args = _parseArgs(basicMatch[1], parser, 'animation');
       if (args == null) {
         // Already warned about an invalid parameter if this happens.
         return '';
       }
-      final List<String> positionalArgs = args.rest.sublist(0);
+      final positionalArgs = args.rest.sublist(0);
       String uniqueId;
-      bool wasDeprecated = false;
+      var wasDeprecated = false;
       if (positionalArgs.length == 4) {
         // Supports the original form of the animation tag for backward
         // compatibility.
@@ -1486,7 +1473,7 @@ abstract class ModelElement extends Canonicalization
                 '${positionalArgs[2]}\n$e');
         return '';
       }
-      final String overlayId = '${uniqueId}_play_button_';
+      var overlayId = '${uniqueId}_play_button_';
 
       // Only warn about deprecation if some other warning didn't occur.
       if (wasDeprecated) {
@@ -1541,7 +1528,7 @@ abstract class ModelElement extends Canonicalization
     if (!config.injectHtml) return rawDocs;
 
     return rawDocs.replaceAllMapped(htmlInjectRegExp, (match) {
-      String fragment = packageGraph.getHtmlFragment(match[1]);
+      var fragment = packageGraph.getHtmlFragment(match[1]);
       if (fragment == null) {
         warn(PackageWarning.unknownHtmlFragment, message: match[1]);
       }
@@ -1577,7 +1564,7 @@ abstract class ModelElement extends Canonicalization
   ///
   String _injectMacros(String rawDocs) {
     return rawDocs.replaceAllMapped(macroRegExp, (match) {
-      String macro = packageGraph.getMacro(match[1]);
+      var macro = packageGraph.getMacro(match[1]);
       if (macro == null) {
         warn(PackageWarning.unknownMacro, message: match[1]);
       }
@@ -1597,7 +1584,7 @@ abstract class ModelElement extends Canonicalization
   String _stripMacroTemplatesAndAddToIndex(String rawDocs) {
     return rawDocs.replaceAllMapped(templateRegExp, (match) {
       packageGraph.addMacro(match[1].trim(), match[2].trim());
-      return "{@macro ${match[1].trim()}}";
+      return '{@macro ${match[1].trim()}}';
     });
   }
 
@@ -1615,8 +1602,8 @@ abstract class ModelElement extends Canonicalization
   String _stripHtmlAndAddToIndex(String rawDocs) {
     if (!config.injectHtml) return rawDocs;
     return rawDocs.replaceAllMapped(htmlRegExp, (match) {
-      String fragment = match[1];
-      String digest = sha1.convert(fragment.codeUnits).toString();
+      var fragment = match[1];
+      var digest = sha1.convert(fragment.codeUnits).toString();
       packageGraph.addHtmlFragment(digest, fragment);
       // The newlines are so that Markdown will pass this through without
       // touching it.
@@ -1677,19 +1664,19 @@ abstract class ModelElement extends Canonicalization
   /// The computed file path, constructed from 'src' and 'region' will have key
   /// 'file'.
   Map<String, String> _getExampleArgs(String argsAsString) {
-    ArgParser parser = ArgParser();
+    var parser = ArgParser();
     parser.addOption('lang');
     parser.addOption('region');
-    ArgResults results = _parseArgs(argsAsString, parser, 'example');
+    var results = _parseArgs(argsAsString, parser, 'example');
     if (results == null) {
       return null;
     }
 
     // Extract PATH and fix the path separators.
-    final String src = results.rest.isEmpty
+    var src = results.rest.isEmpty
         ? ''
         : results.rest.first.replaceAll('/', Platform.pathSeparator);
-    final Map<String, String> args = <String, String>{
+    var args = <String, String>{
       'src': src,
       'lang': results['lang'],
       'region': results['region'] ?? '',

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -48,9 +48,9 @@ class ModelNode {
   String get sourceCode {
     if (_sourceCode == null) {
       if (_sourceOffset != null) {
-        String contents = model_utils.getFileContentsFor(element);
+        var contents = model_utils.getFileContentsFor(element);
         // Find the start of the line, so that we can line up all the indents.
-        int i = _sourceOffset;
+        var i = _sourceOffset;
         while (i > 0) {
           i -= 1;
           if (contents[i] == '\n' || contents[i] == '\r') {
@@ -61,7 +61,7 @@ class ModelNode {
 
         // Trim the common indent from the source snippet.
         var start = _sourceOffset - (_sourceOffset - i);
-        String source = contents.substring(start, _sourceEnd);
+        var source = contents.substring(start, _sourceEnd);
 
         source = const HtmlEscape().convert(source);
         source = model_utils.stripIndentFromSource(source);

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -15,10 +15,9 @@ abstract class Nameable {
   Set<String> _namePieces;
 
   Set<String> get namePieces {
-    if (_namePieces == null) {
-      _namePieces = Set()
-        ..addAll(name.split(locationSplitter).where((s) => s.isNotEmpty));
-    }
+    _namePieces ??= {
+      ...name.split(locationSplitter).where((s) => s.isNotEmpty)
+    };
     return _namePieces;
   }
 
@@ -28,9 +27,7 @@ abstract class Nameable {
   String get namePart {
     // TODO(jcollins-g): This should really be the same as 'name', but isn't
     // because of accessors and operators.
-    if (_namePart == null) {
-      _namePart = fullyQualifiedName.split('.').last;
-    }
+    _namePart ??= fullyQualifiedName.split('.').last;
     return _namePart;
   }
 

--- a/lib/src/model/operator.dart
+++ b/lib/src/model/operator.dart
@@ -8,26 +8,26 @@ import 'package:dartdoc/src/model/model.dart';
 
 class Operator extends Method {
   static const Map<String, String> friendlyNames = {
-    "[]": "get",
-    "[]=": "put",
-    "~": "bitwise_negate",
-    "==": "equals",
-    "-": "minus",
-    "+": "plus",
-    "*": "multiply",
-    "/": "divide",
-    "<": "less",
-    ">": "greater",
-    ">=": "greater_equal",
-    "<=": "less_equal",
-    "<<": "shift_left",
-    ">>": "shift_right",
-    "^": "bitwise_exclusive_or",
-    "unary-": "unary_minus",
-    "|": "bitwise_or",
-    "&": "bitwise_and",
-    "~/": "truncate_divide",
-    "%": "modulo"
+    '[]': 'get',
+    '[]=': 'put',
+    '~': 'bitwise_negate',
+    '==': 'equals',
+    '-': 'minus',
+    '+': 'plus',
+    '*': 'multiply',
+    '/': 'divide',
+    '<': 'less',
+    '>': 'greater',
+    '>=': 'greater_equal',
+    '<=': 'less_equal',
+    '<<': 'shift_left',
+    '>>': 'shift_right',
+    '^': 'bitwise_exclusive_or',
+    'unary-': 'unary_minus',
+    '|': 'bitwise_or',
+    '&': 'bitwise_and',
+    '~/': 'truncate_divide',
+    '%': 'modulo'
   };
 
   Operator(MethodElement element, Library library, PackageGraph packageGraph)
@@ -42,7 +42,7 @@ class Operator extends Method {
   String get fileName {
     var actualName = super.name;
     if (friendlyNames.containsKey(actualName)) {
-      actualName = "operator_${friendlyNames[actualName]}";
+      actualName = 'operator_${friendlyNames[actualName]}';
     }
     return '$actualName.$fileType';
   }

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -38,9 +38,9 @@ class Package extends LibraryContainer
   // Creates a package, if necessary, and adds it to the [packageGraph].
   factory Package.fromPackageMeta(
       PackageMeta packageMeta, PackageGraph packageGraph) {
-    String packageName = packageMeta.name;
+    var packageName = packageMeta.name;
 
-    bool expectNonLocal = false;
+    var expectNonLocal = false;
 
     if (!packageGraph.packageMap.containsKey(packageName) &&
         packageGraph.allLibrariesAdded) expectNonLocal = true;
@@ -75,13 +75,13 @@ class Package extends LibraryContainer
 
   /// Pieces of the location, split to remove 'package:' and slashes.
   @override
-  Set<String> get locationPieces => Set();
+  Set<String> get locationPieces => {};
 
   /// Holds all libraries added to this package.  May include non-documented
   /// libraries, but is not guaranteed to include a complete list of
   /// non-documented libraries unless they are all referenced by documented ones.
   /// Not sorted.
-  final Set<Library> allLibraries = Set();
+  final Set<Library> allLibraries = {};
 
   bool get hasHomepage =>
       packageMeta.homepage != null && packageMeta.homepage.isNotEmpty;
@@ -141,7 +141,7 @@ class Package extends LibraryContainer
 
   @override
   bool get isPublic {
-    if (_isPublic == null) _isPublic = libraries.any((l) => l.isPublic);
+    _isPublic ??= libraries.any((l) => l.isPublic);
     return _isPublic;
   }
 
@@ -151,25 +151,23 @@ class Package extends LibraryContainer
   /// SDK, or if [DartdocOptionContext.autoIncludeDependencies] is true -- but
   /// only if the package was not excluded on the command line.
   bool get isLocal {
-    if (_isLocal == null) {
-      _isLocal = (
-              // Document as local if this is the default package.
-              packageMeta == packageGraph.packageMeta ||
-                  // Assume we want to document an embedded SDK as local if
-                  // it has libraries defined in the default package.
-                  // TODO(jcollins-g): Handle case where embedder SDKs can be
-                  // assembled from multiple locations?
-                  packageGraph.hasEmbedderSdk &&
-                      packageMeta.isSdk &&
-                      libraries.any((l) => path.isWithin(
-                          packageGraph.packageMeta.dir.path,
-                          (l.element.source.fullName))) ||
-                  // autoIncludeDependencies means everything is local.
-                  packageGraph.config.autoIncludeDependencies) &&
-          // Regardless of the above rules, do not document as local if
-          // we excluded this package by name.
-          !packageGraph.config.isPackageExcluded(name);
-    }
+    _isLocal ??= (
+            // Document as local if this is the default package.
+            packageMeta == packageGraph.packageMeta ||
+                // Assume we want to document an embedded SDK as local if
+                // it has libraries defined in the default package.
+                // TODO(jcollins-g): Handle case where embedder SDKs can be
+                // assembled from multiple locations?
+                packageGraph.hasEmbedderSdk &&
+                    packageMeta.isSdk &&
+                    libraries.any((l) => path.isWithin(
+                        packageGraph.packageMeta.dir.path,
+                        (l.element.source.fullName))) ||
+                // autoIncludeDependencies means everything is local.
+                packageGraph.config.autoIncludeDependencies) &&
+        // Regardless of the above rules, do not document as local if
+        // we excluded this package by name.
+        !packageGraph.config.isPackageExcluded(name);
     return _isLocal;
   }
 
@@ -225,8 +223,8 @@ class Package extends LibraryContainer
             // elsewhere.
             case 'b':
               {
-                Version version = Version.parse(packageMeta.version);
-                String tag = 'stable';
+                var version = Version.parse(packageMeta.version);
+                var tag = 'stable';
                 if (version.isPreRelease) {
                   // version.preRelease is a List<dynamic> with a mix of
                   // integers and strings.  Given this, handle
@@ -292,10 +290,10 @@ class Package extends LibraryContainer
       }
 
       _nameToCategory[null] = Category(null, this, config);
-      for (Categorization c in libraries.expand(
+      for (var c in libraries.expand(
           (l) => l.allCanonicalModelElements.whereType<Categorization>())) {
         if (c.hasCategoryNames) {
-          for (String category in c.categoryNames) {
+          for (var category in c.categoryNames) {
             categoryFor(category).addItem(c);
           }
         } else {
@@ -310,10 +308,8 @@ class Package extends LibraryContainer
   List<Category> _categories;
 
   List<Category> get categories {
-    if (_categories == null) {
-      _categories = nameToCategory.values.where((c) => c.name != null).toList()
-        ..sort();
-    }
+    _categories ??= nameToCategory.values.where((c) => c.name != null).toList()
+      ..sort();
     return _categories;
   }
 
@@ -329,10 +325,8 @@ class Package extends LibraryContainer
 
   @override
   DartdocOptionContext get config {
-    if (_config == null) {
-      _config = DartdocOptionContext.fromContext(
-          packageGraph.config, Directory(packagePath));
-    }
+    _config ??= DartdocOptionContext.fromContext(
+        packageGraph.config, Directory(packagePath));
     return _config;
   }
 
@@ -348,9 +342,7 @@ class Package extends LibraryContainer
   String _packagePath;
 
   String get packagePath {
-    if (_packagePath == null) {
-      _packagePath = path.canonicalize(packageMeta.dir.path);
-    }
+    _packagePath ??= path.canonicalize(packageMeta.dir.path);
     return _packagePath;
   }
 

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -41,7 +41,7 @@ class PackageGraph {
   /// span packages.
   void addLibraryToGraph(ResolvedLibraryResult result) {
     assert(!allLibrariesAdded);
-    LibraryElement element = result.element;
+    var element = result.element;
     var packageMeta = PackageMeta.fromElement(element, config.sdkDir);
     var lib = Library.fromLibraryResult(
         result, this, Package.fromPackageMeta(packageMeta, this));
@@ -67,8 +67,8 @@ class PackageGraph {
     specialClasses = SpecialClasses();
     // Go through docs of every ModelElement in package to pre-build the macros
     // index.  Uses toList() in order to get all the precaching on the stack.
-    List<Future> precacheFutures = precacheLocalDocs().toList();
-    for (Future f in precacheFutures) {
+    var precacheFutures = precacheLocalDocs().toList();
+    for (var f in precacheFutures) {
       await f;
     }
     _localDocumentationBuilt = true;
@@ -95,10 +95,10 @@ class PackageGraph {
   /// Generate a list of futures for any docs that actually require precaching.
   Iterable<Future> precacheLocalDocs() sync* {
     // Prevent reentrancy.
-    Set<ModelElement> precachedElements = Set();
+    var precachedElements = <ModelElement>{};
 
     Iterable<Future> precacheOneElement(ModelElement m) sync* {
-      for (ModelElement d
+      for (var d
           in m.documentationFrom.where((d) => d.documentationComment != null)) {
         if (needsPrecacheRegExp.hasMatch(d.documentationComment) &&
             !precachedElements.contains(d)) {
@@ -116,7 +116,7 @@ class PackageGraph {
       }
     }
 
-    for (ModelElement m in allModelElements) {
+    for (var m in allModelElements) {
       // Skip if there is a canonicalModelElement somewhere else we can run this
       // for.  Not the same as allCanonicalModelElements since we need to run
       // for any ModelElement that might not have a canonical ModelElement,
@@ -128,7 +128,7 @@ class PackageGraph {
 
   // Many ModelElements have the same ModelNode; don't build/cache this data more
   // than once for them.
-  final Map<Element, ModelNode> _modelNodes = Map();
+  final Map<Element, ModelNode> _modelNodes = {};
 
   void populateModelNodeFor(
       Element element, Map<String, CompilationUnit> compilationUnitMap) {
@@ -157,10 +157,8 @@ class PackageGraph {
 
   List<Extension> _documentedExtensions;
   Iterable<Extension> get documentedExtensions {
-    if (_documentedExtensions == null) {
-      _documentedExtensions =
-          utils.filterNonDocumented(extensions).toList(growable: false);
-    }
+    _documentedExtensions ??=
+        utils.filterNonDocumented(extensions).toList(growable: false);
     return _documentedExtensions;
   }
 
@@ -173,13 +171,13 @@ class PackageGraph {
   Map<String, Set<ModelElement>> get findRefElementCache {
     if (_findRefElementCache == null) {
       assert(packageGraph.allLibrariesAdded);
-      _findRefElementCache = Map();
+      _findRefElementCache = {};
       for (final modelElement
           in utils.filterNonDocumented(packageGraph.allLocalModelElements)) {
         _findRefElementCache.putIfAbsent(
-            modelElement.fullyQualifiedNameWithoutLibrary, () => Set());
+            modelElement.fullyQualifiedNameWithoutLibrary, () => {});
         _findRefElementCache.putIfAbsent(
-            modelElement.fullyQualifiedName, () => Set());
+            modelElement.fullyQualifiedName, () => {});
         _findRefElementCache[modelElement.fullyQualifiedName].add(modelElement);
         _findRefElementCache[modelElement.fullyQualifiedNameWithoutLibrary]
             .add(modelElement);
@@ -189,21 +187,21 @@ class PackageGraph {
   }
 
   // All library objects related to this package; a superset of _libraries.
-  final Map<LibraryElement, Library> allLibraries = Map();
+  final Map<LibraryElement, Library> allLibraries = {};
 
   /// Keep track of warnings
   PackageWarningCounter _packageWarningCounter;
 
   /// All ModelElements constructed for this package; a superset of [allModelElements].
   final Map<Tuple3<Element, Library, Container>, ModelElement>
-      allConstructedModelElements = Map();
+      allConstructedModelElements = {};
 
   /// Anything that might be inheritable, place here for later lookup.
   final Map<Tuple2<Element, Library>, Set<ModelElement>>
-      allInheritableElements = Map();
+      allInheritableElements = {};
 
   /// Map of Class.href to a list of classes implementing that class
-  final Map<String, List<Class>> _implementors = Map();
+  final Map<String, List<Class>> _implementors = {};
 
   /// A list of extensions that exist in the package graph.
   final List<Extension> _extensions = [];
@@ -223,9 +221,7 @@ class PackageGraph {
   Package _defaultPackage;
 
   Package get defaultPackage {
-    if (_defaultPackage == null) {
-      _defaultPackage = Package.fromPackageMeta(packageMeta, this);
-    }
+    _defaultPackage ??= Package.fromPackageMeta(packageMeta, this);
     return _defaultPackage;
   }
 
@@ -247,8 +243,8 @@ class PackageGraph {
 
   Map<Source, SdkLibrary> get sdkLibrarySources {
     if (_sdkLibrarySources == null) {
-      _sdkLibrarySources = Map();
-      for (SdkLibrary lib in sdk?.sdkLibraries) {
+      _sdkLibrarySources = {};
+      for (var lib in sdk?.sdkLibraries) {
         _sdkLibrarySources[sdk.mapDartUri(lib.shortName)] = lib;
       }
     }
@@ -267,16 +263,15 @@ class PackageGraph {
   Set<String> _allRootDirs;
 
   bool packageDocumentedFor(ModelElement element) {
-    if (_allRootDirs == null) {
-      _allRootDirs = Set()
-        ..addAll(publicLibraries.map((l) => l.packageMeta?.resolvedDir));
-    }
+    _allRootDirs ??= {
+      ...(publicLibraries.map((l) => l.packageMeta?.resolvedDir))
+    };
     return (_allRootDirs.contains(element.library.packageMeta?.resolvedDir));
   }
 
   PackageWarningCounter get packageWarningCounter => _packageWarningCounter;
 
-  final Set<Tuple3<Element, PackageWarning, String>> _warnAlreadySeen = Set();
+  final Set<Tuple3<Element, PackageWarning, String>> _warnAlreadySeen = {};
 
   void warnOnElement(Warnable warnable, PackageWarning kind,
       {String message,
@@ -331,8 +326,8 @@ class PackageGraph {
     //                   the user, yet we still want IntelliJ to link properly.
     final warnableName = _safeWarnableName(warnable);
 
-    String warnablePrefix = 'from';
-    String referredFromPrefix = 'referred to by';
+    var warnablePrefix = 'from';
+    var referredFromPrefix = 'referred to by';
     String warningMessage;
     switch (kind) {
       case PackageWarning.noCanonicalFound:
@@ -342,21 +337,21 @@ class PackageGraph {
         //                   messages and warn for non-public canonicalization
         //                   errors.
         warningMessage =
-            "no canonical library found for ${warnableName}, not linking";
+            'no canonical library found for ${warnableName}, not linking';
         break;
       case PackageWarning.ambiguousReexport:
         // Fix these warnings by adding the original library exporting the
         // symbol with --include, by using --auto-include-dependencies,
         // or by using --exclude to hide one of the libraries involved
         warningMessage =
-            "ambiguous reexport of ${warnableName}, canonicalization candidates: ${message}";
+            'ambiguous reexport of ${warnableName}, canonicalization candidates: ${message}';
         break;
       case PackageWarning.noLibraryLevelDocs:
         warningMessage =
-            "${warnable.fullyQualifiedName} has no library level documentation comments";
+            '${warnable.fullyQualifiedName} has no library level documentation comments';
         break;
       case PackageWarning.ambiguousDocReference:
-        warningMessage = "ambiguous doc reference ${message}";
+        warningMessage = 'ambiguous doc reference ${message}';
         break;
       case PackageWarning.ignoredCanonicalFor:
         warningMessage =
@@ -368,20 +363,20 @@ class PackageGraph {
         break;
       case PackageWarning.reexportedPrivateApiAcrossPackages:
         warningMessage =
-            "private API of ${message} is reexported by libraries in other packages: ";
+            'private API of ${message} is reexported by libraries in other packages: ';
         break;
       case PackageWarning.notImplemented:
         warningMessage = message;
         break;
       case PackageWarning.unresolvedDocReference:
-        warningMessage = "unresolved doc reference [${message}]";
+        warningMessage = 'unresolved doc reference [${message}]';
         referredFromPrefix = 'in documentation inherited from';
         break;
       case PackageWarning.unknownMacro:
-        warningMessage = "undefined macro [${message}]";
+        warningMessage = 'undefined macro [${message}]';
         break;
       case PackageWarning.unknownHtmlFragment:
-        warningMessage = "undefined HTML fragment identifier [${message}]";
+        warningMessage = 'undefined HTML fragment identifier [${message}]';
         break;
       case PackageWarning.brokenLink:
         warningMessage = 'dartdoc generated a broken link to: ${message}';
@@ -426,21 +421,21 @@ class PackageGraph {
         break;
     }
 
-    List<String> messageParts = [warningMessage];
+    var messageParts = <String>[warningMessage];
     if (warnable != null) {
-      messageParts.add("$warnablePrefix $warnableName: ${warnable.location}");
+      messageParts.add('$warnablePrefix $warnableName: ${warnable.location}');
     }
     if (referredFrom != null) {
-      for (Locatable referral in referredFrom) {
+      for (var referral in referredFrom) {
         if (referral != warnable) {
           var referredFromStrings = _safeWarnableName(referral);
           messageParts.add(
-              "$referredFromPrefix $referredFromStrings: ${referral.location}");
+              '$referredFromPrefix $referredFromStrings: ${referral.location}');
         }
       }
     }
     if (config.verboseWarnings && extendedDebug != null) {
-      messageParts.addAll(extendedDebug.map((s) => "    $s"));
+      messageParts.addAll(extendedDebug.map((s) => '    $s'));
     }
     String fullMessage;
     if (messageParts.length <= 2) {
@@ -468,7 +463,7 @@ class PackageGraph {
     if (_publicPackages == null) {
       assert(allLibrariesAdded);
       // Help the user if they pass us a package that doesn't exist.
-      for (String packageName in config.packageOrder) {
+      for (var packageName in config.packageOrder) {
         if (!packages.map((p) => p.name).contains(packageName)) {
           warnOnElement(
               null, PackageWarning.packageOrderGivesMissingPackageName,
@@ -489,16 +484,15 @@ class PackageGraph {
   Iterable<Package> get documentedPackages =>
       packages.where((p) => p.documentedWhere != DocumentLocation.missing);
 
-  Map<LibraryElement, Set<Library>> _libraryElementReexportedBy = Map();
+  Map<LibraryElement, Set<Library>> _libraryElementReexportedBy = {};
 
   /// Prevent cycles from breaking our stack.
-  Set<Tuple2<Library, LibraryElement>> _reexportsTagged = Set();
+  Set<Tuple2<Library, LibraryElement>> _reexportsTagged = {};
 
   void _tagReexportsFor(
       final Library topLevelLibrary, final LibraryElement libraryElement,
       [ExportElement lastExportedElement]) {
-    Tuple2<Library, LibraryElement> key =
-        Tuple2(topLevelLibrary, libraryElement);
+    var key = Tuple2<Library, LibraryElement>(topLevelLibrary, libraryElement);
     if (_reexportsTagged.contains(key)) {
       return;
     }
@@ -513,9 +507,9 @@ class PackageGraph {
           referredFrom: <Locatable>[topLevelLibrary]);
       return;
     }
-    _libraryElementReexportedBy.putIfAbsent(libraryElement, () => Set());
+    _libraryElementReexportedBy.putIfAbsent(libraryElement, () => {});
     _libraryElementReexportedBy[libraryElement].add(topLevelLibrary);
-    for (ExportElement exportedElement in libraryElement.exports) {
+    for (var exportedElement in libraryElement.exports) {
       _tagReexportsFor(
           topLevelLibrary, exportedElement.exportedLibrary, exportedElement);
     }
@@ -527,9 +521,9 @@ class PackageGraph {
     // Table must be reset if we're still in the middle of adding libraries.
     if (allLibraries.keys.length != _lastSizeOfAllLibraries) {
       _lastSizeOfAllLibraries = allLibraries.keys.length;
-      _libraryElementReexportedBy = Map<LibraryElement, Set<Library>>();
-      _reexportsTagged = Set();
-      for (Library library in publicLibraries) {
+      _libraryElementReexportedBy = <LibraryElement, Set<Library>>{};
+      _reexportsTagged = {};
+      for (var library in publicLibraries) {
         _tagReexportsFor(library, library.element);
       }
     }
@@ -542,11 +536,10 @@ class PackageGraph {
   /// on more than just [allLocalModelElements] to make the error messages
   /// comprehensive.
   Map<String, Set<ModelElement>> get allHrefs {
-    Map<String, Set<ModelElement>> hrefMap = Map();
+    var hrefMap = <String, Set<ModelElement>>{};
     // TODO(jcollins-g ): handle calculating hrefs causing new elements better
     //                    than toList().
-    for (ModelElement modelElement
-        in allConstructedModelElements.values.toList()) {
+    for (var modelElement in allConstructedModelElements.values.toList()) {
       // Technically speaking we should be able to use canonical model elements
       // only here, but since the warnings that depend on this debug
       // canonicalization problems, don't limit ourselves in case an href is
@@ -555,13 +548,13 @@ class PackageGraph {
       // TODO: see [Accessor.enclosingCombo]
       if (modelElement is Accessor) continue;
       if (modelElement.href == null) continue;
-      hrefMap.putIfAbsent(modelElement.href, () => Set());
+      hrefMap.putIfAbsent(modelElement.href, () => {});
       hrefMap[modelElement.href].add(modelElement);
     }
-    for (Package package in packageMap.values) {
-      for (Library library in package.libraries) {
+    for (var package in packageMap.values) {
+      for (var library in package.libraries) {
         if (library.href == null) continue;
-        hrefMap.putIfAbsent(library.href, () => Set());
+        hrefMap.putIfAbsent(library.href, () => {});
         hrefMap[library.href].add(library);
       }
     }
@@ -638,7 +631,7 @@ class PackageGraph {
   /// and the class these inherit from should instead claim implementation.
   Set<Class> get inheritThrough {
     if (_inheritThrough == null) {
-      _inheritThrough = Set();
+      _inheritThrough = {};
       _inheritThrough.add(specialClasses[SpecialClass.interceptor]);
     }
     return _inheritThrough;
@@ -650,7 +643,7 @@ class PackageGraph {
   /// in that we should never count them as documentable annotations.
   Set<Class> get invisibleAnnotations {
     if (_invisibleAnnotations == null) {
-      _invisibleAnnotations = Set();
+      _invisibleAnnotations = {};
       _invisibleAnnotations.add(specialClasses[SpecialClass.pragma]);
     }
     return _invisibleAnnotations;
@@ -659,12 +652,12 @@ class PackageGraph {
   @override
   String toString() => 'PackageGraph built from ${defaultPackage.name}';
 
-  final Map<Element, Library> _canonicalLibraryFor = Map();
+  final Map<Element, Library> _canonicalLibraryFor = {};
 
   /// Tries to find a top level library that references this element.
   Library findCanonicalLibraryFor(Element e) {
     assert(allLibrariesAdded);
-    Element searchElement = e;
+    var searchElement = e;
     if (e is PropertyAccessorElement) {
       searchElement = e.variable;
     }
@@ -676,10 +669,9 @@ class PackageGraph {
       return _canonicalLibraryFor[e];
     }
     _canonicalLibraryFor[e] = null;
-    for (Library library in publicLibraries) {
+    for (var library in publicLibraries) {
       if (library.modelElementsMap.containsKey(searchElement)) {
-        for (ModelElement modelElement
-            in library.modelElementsMap[searchElement]) {
+        for (var modelElement in library.modelElementsMap[searchElement]) {
           if (modelElement.isCanonical) {
             _canonicalLibraryFor[e] = library;
             break;
@@ -700,7 +692,7 @@ class PackageGraph {
   ModelElement findCanonicalModelElementFor(Element e,
       {Container preferredClass}) {
     assert(allLibrariesAdded);
-    Library lib = findCanonicalLibraryFor(e);
+    var lib = findCanonicalLibraryFor(e);
     if (preferredClass != null && preferredClass is Container) {
       Container canonicalClass =
           findCanonicalModelElementFor(preferredClass.element);
@@ -725,12 +717,12 @@ class PackageGraph {
     // with member elements.
     if (e is ClassMemberElement || e is PropertyAccessorElement) {
       e = e.declaration;
-      Set<ModelElement> candidates = Set();
-      Tuple2<Element, Library> iKey = Tuple2(e, lib);
-      Tuple4<Element, Library, Class, ModelElement> key =
-          Tuple4(e, lib, null, null);
-      Tuple4<Element, Library, Class, ModelElement> keyWithClass =
-          Tuple4(e, lib, preferredClass, null);
+      var candidates = <ModelElement>{};
+      var iKey = Tuple2<Element, Library>(e, lib);
+      var key =
+          Tuple4<Element, Library, Class, ModelElement>(e, lib, null, null);
+      var keyWithClass = Tuple4<Element, Library, Class, ModelElement>(
+          e, lib, preferredClass, null);
       if (allConstructedModelElements.containsKey(key)) {
         candidates.add(allConstructedModelElements[key]);
       }
@@ -748,13 +740,12 @@ class PackageGraph {
           return false;
         }));
       }
-      Set<ModelElement> matches = Set()
-        ..addAll(candidates.where((me) => me.isCanonical));
+      var matches = <ModelElement>{...candidates.where((me) => me.isCanonical)};
 
       // It's possible to find accessors but no combos.  Be sure that if we
       // have Accessors, we find their combos too.
       if (matches.any((me) => me is Accessor)) {
-        List<GetterSetterCombo> combos =
+        var combos =
             matches.whereType<Accessor>().map((a) => a.enclosingCombo).toList();
         matches.addAll(combos);
         assert(combos.every((c) => c.isCanonical));
@@ -766,7 +757,7 @@ class PackageGraph {
           preferredClass != null &&
           preferredClass is Class) {
         // Search for matches inside our superchain.
-        List<Class> superChain = preferredClass.superChain
+        var superChain = preferredClass.superChain
             .map((et) => et.element)
             .cast<Class>()
             .toList();
@@ -775,10 +766,11 @@ class PackageGraph {
             !superChain.contains((me as EnclosedElement).enclosingElement));
         // Assumed all matches are EnclosedElement because we've been told about a
         // preferredClass.
-        Set<Class> enclosingElements = Set()
-          ..addAll(matches
-              .map((me) => (me as EnclosedElement).enclosingElement as Class));
-        for (Class c in superChain.reversed) {
+        var enclosingElements = {
+          ...matches
+              .map((me) => (me as EnclosedElement).enclosingElement as Class)
+        };
+        for (var c in superChain.reversed) {
           if (enclosingElements.contains(c)) {
             matches.removeWhere(
                 (me) => (me as EnclosedElement).enclosingElement != c);
@@ -846,7 +838,7 @@ class PackageGraph {
     if (result.element.library == null) {
       return null;
     }
-    Library foundLibrary = Library.fromLibraryResult(
+    var foundLibrary = Library.fromLibraryResult(
         result,
         this,
         Package.fromPackageMeta(
@@ -862,12 +854,12 @@ class PackageGraph {
     assert(allLibrariesAdded);
     if (_allModelElements == null) {
       _allModelElements = [];
-      Set<Package> packagesToDo = packages.toSet();
-      Set<Package> completedPackages = Set();
+      var packagesToDo = packages.toSet();
+      var completedPackages = <Package>{};
       while (packagesToDo.length > completedPackages.length) {
         packagesToDo.difference(completedPackages).forEach((Package p) {
-          Set<Library> librariesToDo = p.allLibraries.toSet();
-          Set<Library> completedLibraries = Set();
+          var librariesToDo = p.allLibraries.toSet();
+          var completedLibraries = <Library>{};
           while (librariesToDo.length > completedLibraries.length) {
             librariesToDo
                 .difference(completedLibraries)
@@ -891,7 +883,7 @@ class PackageGraph {
     assert(allLibrariesAdded);
     if (_allLocalModelElements == null) {
       _allLocalModelElements = [];
-      this.localLibraries.forEach((library) {
+      localLibraries.forEach((library) {
         _allLocalModelElements.addAll(library.allModelElements);
       });
     }

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -40,12 +40,12 @@ class Parameter extends ModelElement implements EnclosedElement {
   @override
   String get htmlId {
     if (_parameter.enclosingElement != null) {
-      String enclosingName = _parameter.enclosingElement.name;
+      var enclosingName = _parameter.enclosingElement.name;
       if (_parameter.enclosingElement is GenericFunctionTypeElement) {
         // TODO(jcollins-g): Drop when GenericFunctionTypeElement populates name.
         // Also, allowing null here is allowed as a workaround for
         // dart-lang/sdk#32005.
-        for (Element e = _parameter.enclosingElement;
+        for (var e = _parameter.enclosingElement;
             e.enclosingElement != null;
             e = e.enclosingElement) {
           enclosingName = e.name;

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -34,8 +34,7 @@ class TopLevelVariable extends ModelElement
     // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
     // to prevent displaying more or less than one summary.
     if (isPublic) {
-      Set<bool> assertCheck = Set()
-        ..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
+      var assertCheck = {hasPublicSetter, hasPublicGetterNoSetter};
       assert(assertCheck.containsAll([true, false]));
     }
     return super.documentation;
@@ -79,7 +78,7 @@ class TopLevelVariable extends ModelElement
 
   @override
   String computeDocumentationComment() {
-    String docs = getterSetterDocumentationComment;
+    var docs = getterSetterDocumentationComment;
     if (docs.isEmpty) return _variable.documentationComment;
     return docs;
   }

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -50,11 +50,9 @@ class TypeParameter extends ModelElement {
 
   @override
   String get name {
-    if (_name == null) {
-      _name = _typeParameter.bound != null
-          ? '${_typeParameter.name} extends ${boundType.nameWithGenerics}'
-          : _typeParameter.name;
-    }
+    _name ??= _typeParameter.bound != null
+        ? '${_typeParameter.name} extends ${boundType.nameWithGenerics}'
+        : _typeParameter.name;
     return _name;
   }
 
@@ -62,11 +60,9 @@ class TypeParameter extends ModelElement {
 
   @override
   String get linkedName {
-    if (_linkedName == null) {
-      _linkedName = _typeParameter.bound != null
-          ? '${_typeParameter.name} extends ${boundType.linkedName}'
-          : _typeParameter.name;
-    }
+    _linkedName ??= _typeParameter.bound != null
+        ? '${_typeParameter.name} extends ${boundType.linkedName}'
+        : _typeParameter.name;
     return _linkedName;
   }
 

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -23,7 +23,7 @@ AstNode getAstNode(
   if (element?.source?.fullName != null &&
       !element.isSynthetic &&
       element.nameOffset != -1) {
-    CompilationUnit unit = compilationUnitMap[element.source.fullName];
+    var unit = compilationUnitMap[element.source.fullName];
     if (unit != null) {
       var locator = NodeLocator2(element.nameOffset);
       return (locator.searchWithin(unit)?.parent);
@@ -80,7 +80,7 @@ bool hasPrivateName(Element e) {
     return true;
   }
   if (e is LibraryElement) {
-    List<String> locationParts = e.location.components[0].split(slashes);
+    var locationParts = e.location.components[0].split(slashes);
     // TODO(jcollins-g): Implement real cross package detection
     if (locationParts.length >= 2 &&
         locationParts[0].startsWith('package:') &&
@@ -93,11 +93,11 @@ bool hasPublicName(Element e) => !hasPrivateName(e);
 
 /// Strip leading dartdoc comments from the given source code.
 String stripDartdocCommentsFromSource(String source) {
-  String remainer = source.trimLeft();
-  HtmlEscape sanitizer = const HtmlEscape();
-  bool lineComments = remainer.startsWith('///') ||
+  var remainer = source.trimLeft();
+  var sanitizer = const HtmlEscape();
+  var lineComments = remainer.startsWith('///') ||
       remainer.startsWith(sanitizer.convert('///'));
-  bool blockComments = remainer.startsWith('/**') ||
+  var blockComments = remainer.startsWith('/**') ||
       remainer.startsWith(sanitizer.convert('/**'));
 
   return source.split('\n').where((String line) {
@@ -124,8 +124,8 @@ String stripDartdocCommentsFromSource(String source) {
 
 /// Strip the common indent from the given source fragment.
 String stripIndentFromSource(String source) {
-  String remainer = source.trimLeft();
-  String indent = source.substring(0, source.length - remainer.length);
+  var remainer = source.trimLeft();
+  var indent = source.substring(0, source.length - remainer.length);
   return source.split('\n').map((line) {
     line = line.trimRight();
     return line.startsWith(indent) ? line.substring(indent.length) : line;

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -18,7 +18,7 @@ Map<String, PackageMeta> _packageMetaCache = {};
 Encoding utf8AllowMalformed = Utf8Codec(allowMalformed: true);
 
 Directory get defaultSdkDir {
-  Directory sdkDir = File(Platform.resolvedExecutable).parent.parent;
+  var sdkDir = File(Platform.resolvedExecutable).parent.parent;
   assert(path.equals(sdkDir.path, PackageMeta.sdkDirParent(sdkDir).path));
   return sdkDir;
 }
@@ -46,9 +46,9 @@ abstract class PackageMeta {
     if (__sdkDirFilePaths == null) {
       __sdkDirFilePaths = [];
       if (Platform.isWindows) {
-        for (List<String> paths in __sdkDirFilePathsPosix) {
-          List<String> windowsPaths = [];
-          for (String p in paths) {
+        for (var paths in __sdkDirFilePathsPosix) {
+          var windowsPaths = <String>[];
+          for (var p in paths) {
             windowsPaths.add(
                 path.joinAll(path.Context(style: path.Style.posix).split(p)));
           }
@@ -66,7 +66,7 @@ abstract class PackageMeta {
   static final Map<String, Directory> _sdkDirParent = {};
 
   static Directory sdkDirParent(Directory dir) {
-    String dirPathCanonical = path.canonicalize(dir.path);
+    var dirPathCanonical = path.canonicalize(dir.path);
     if (!_sdkDirParent.containsKey(dirPathCanonical)) {
       _sdkDirParent[dirPathCanonical] = null;
       while (dir.existsSync()) {
@@ -111,22 +111,22 @@ abstract class PackageMeta {
   /// same object if they are part of the same package.  Returns null
   /// if the directory is not part of a known package.
   factory PackageMeta.fromDir(Directory dir) {
-    Directory original = dir.absolute;
+    var original = dir.absolute;
     dir = original;
     if (!original.existsSync()) {
       throw PackageMetaFailure(
-          "fatal error: unable to locate the input directory at ${original.path}.");
+          'fatal error: unable to locate the input directory at ${original.path}.');
     }
 
     if (!_packageMetaCache.containsKey(dir.path)) {
       PackageMeta packageMeta;
       // There are pubspec.yaml files inside the SDK.  Ignore them.
-      Directory parentSdkDir = sdkDirParent(dir);
+      var parentSdkDir = sdkDirParent(dir);
       if (parentSdkDir != null) {
         packageMeta = _SdkMeta(parentSdkDir);
       } else {
         while (dir.existsSync()) {
-          File pubspec = File(path.join(dir.path, 'pubspec.yaml'));
+          var pubspec = File(path.join(dir.path, 'pubspec.yaml'));
           if (pubspec.existsSync()) {
             packageMeta = _FilePackageMeta(dir);
             break;
@@ -151,8 +151,8 @@ abstract class PackageMeta {
   /// "both"), or null if this package is not part of a SDK.
   String sdkType(String flutterRootPath) {
     if (flutterRootPath != null) {
-      String flutterPackages = path.join(flutterRootPath, 'packages');
-      String flutterBinCache = path.join(flutterRootPath, 'bin', 'cache');
+      var flutterPackages = path.join(flutterRootPath, 'packages');
+      var flutterBinCache = path.join(flutterRootPath, 'bin', 'cache');
 
       /// Don't include examples or other non-SDK components as being the
       /// "Flutter SDK".
@@ -187,9 +187,7 @@ abstract class PackageMeta {
   String _resolvedDir;
 
   String get resolvedDir {
-    if (_resolvedDir == null) {
-      _resolvedDir = dir.resolveSymbolicLinksSync();
-    }
+    _resolvedDir ??= dir.resolveSymbolicLinksSync();
     return _resolvedDir;
   }
 
@@ -234,7 +232,7 @@ class _FilePackageMeta extends PackageMeta {
   Map _pubspec;
 
   _FilePackageMeta(Directory dir) : super(dir) {
-    File f = File(path.join(dir.path, 'pubspec.yaml'));
+    var f = File(path.join(dir.path, 'pubspec.yaml'));
     if (f.existsSync()) {
       _pubspec = loadYaml(f.readAsStringSync());
     } else {
@@ -259,9 +257,9 @@ class _FilePackageMeta extends PackageMeta {
       // a pub library to do this.
       // People could have a pub cache at root with Windows drive mappings.
       if (path.split(path.canonicalize(dir.path)).length >= 3) {
-        String pubCacheRoot = dir.parent.parent.parent.path;
-        String hosted = path.canonicalize(dir.parent.parent.path);
-        String hostname = path.canonicalize(dir.parent.path);
+        var pubCacheRoot = dir.parent.parent.parent.path;
+        var hosted = path.canonicalize(dir.parent.parent.path);
+        var hostname = path.canonicalize(dir.parent.path);
         if (path.basename(hosted) == 'hosted' &&
             Directory(path.join(pubCacheRoot, '_temp')).existsSync()) {
           _hostedAt = path.basename(hostname);
@@ -292,7 +290,7 @@ class _FilePackageMeta extends PackageMeta {
     }
     if (Platform.isWindows) binPath += '.bat';
 
-    ProcessResult result =
+    var result =
         Process.runSync(binPath, parameters, workingDirectory: dir.path);
 
     var trimmedStdout = (result.stdout as String).trim();
@@ -301,7 +299,7 @@ class _FilePackageMeta extends PackageMeta {
     }
 
     if (result.exitCode != 0) {
-      StringBuffer buf = StringBuffer();
+      var buf = StringBuffer();
       buf.writeln('${result.stdout}');
       buf.writeln('${result.stderr}');
       throw DartdocFailure('pub get failed: ${buf.toString().trim()}');
@@ -352,7 +350,7 @@ class _FilePackageMeta extends PackageMeta {
   /// empty list if no reasons found.
   @override
   List<String> getInvalidReasons() {
-    List<String> reasons = <String>[];
+    var reasons = <String>[];
     if (_pubspec == null || _pubspec.isEmpty) {
       reasons.add('no pubspec.yaml found');
     } else if (!_pubspec.containsKey('name')) {
@@ -363,11 +361,11 @@ class _FilePackageMeta extends PackageMeta {
 }
 
 File _locate(Directory dir, List<String> fileNames) {
-  List<File> files = dir.listSync().whereType<File>().toList();
+  var files = dir.listSync().whereType<File>().toList();
 
-  for (String name in fileNames) {
-    for (File f in files) {
-      String baseName = path.basename(f.path).toLowerCase();
+  for (var name in fileNames) {
+    for (var f in files) {
+      var baseName = path.basename(f.path).toLowerCase();
       if (baseName == name) return f;
       if (baseName.startsWith(name)) return f;
     }
@@ -399,7 +397,7 @@ class _SdkMeta extends PackageMeta {
 
   @override
   String get version {
-    File versionFile = File(path.join(dir.path, 'version'));
+    var versionFile = File(path.join(dir.path, 'version'));
     if (versionFile.existsSync()) return versionFile.readAsStringSync().trim();
     return 'unknown';
   }
@@ -417,7 +415,7 @@ class _SdkMeta extends PackageMeta {
 
   @override
   FileContents getReadmeContents() {
-    File f = File(path.join(dir.path, 'lib', 'api_readme.md'));
+    var f = File(path.join(dir.path, 'lib', 'api_readme.md'));
     if (!f.existsSync()) {
       f = File(path.join(dir.path, 'api_readme.md'));
     }

--- a/lib/src/render/category_renderer.dart
+++ b/lib/src/render/category_renderer.dart
@@ -20,16 +20,16 @@ class CategoryRendererHtml extends CategoryRenderer {
 
   @override
   String renderCategoryLabel(Category category) {
-    List<String> spanClasses = [];
+    var spanClasses = <String>[];
     spanClasses.add('category');
     spanClasses.add(category.name.split(' ').join('-').toLowerCase());
     spanClasses.add('cp-${category.categoryIndex}');
     if (category.isDocumented) {
       spanClasses.add('linked');
     }
-    var spanTitle = "This is part of the ${category.name} ${category.kind}.";
+    var spanTitle = 'This is part of the ${category.name} ${category.kind}.';
 
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write('<span class="${spanClasses.join(' ')}" title="$spanTitle">');
     buf.write(renderLinkedName(category));
     buf.write('</span>');
@@ -38,7 +38,7 @@ class CategoryRendererHtml extends CategoryRenderer {
 
   @override
   String renderLinkedName(Category category) {
-    String unbrokenName = category.name.replaceAll(' ', '&nbsp;');
+    var unbrokenName = category.name.replaceAll(' ', '&nbsp;');
     if (category.isDocumented) {
       return '<a href="${category.href}">$unbrokenName</a>';
     } else {
@@ -53,7 +53,7 @@ class CategoryRendererMd extends CategoryRenderer {
 
   @override
   String renderLinkedName(Category category) {
-    String name = category.name;
+    var name = category.name;
     if (category.isDocumented) {
       return '[$name](${category.href})';
     }

--- a/lib/src/render/documentation_renderer.dart
+++ b/lib/src/render/documentation_renderer.dart
@@ -34,7 +34,7 @@ class DocumentationRendererHtml extends DocumentationRenderer {
             .addAll(code.classes.where((name) => name.startsWith('language-')));
       }
 
-      bool specifiesLanguage = pre.classes.isNotEmpty;
+      var specifiesLanguage = pre.classes.isNotEmpty;
       // Assume the user intended Dart if there are no other classes present.
       if (!specifiesLanguage) pre.classes.add('language-dart');
     }

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -17,7 +17,7 @@ class FunctionTypeElementTypeRendererHtml
     extends ElementTypeRenderer<FunctionTypeElementType> {
   @override
   String renderLinkedName(FunctionTypeElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write('${elementType.returnType.linkedName} ');
     buf.write('${elementType.nameWithGenerics}');
     buf.write('<span class="signature">(');
@@ -29,7 +29,7 @@ class FunctionTypeElementTypeRendererHtml
 
   @override
   String renderNameWithGenerics(FunctionTypeElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.name);
     if (elementType.typeFormals.isNotEmpty) {
       if (!elementType.typeFormals.every((t) => t.name == 'dynamic')) {
@@ -47,7 +47,7 @@ class ParameterizedElementTypeRendererHtml
     extends ElementTypeRenderer<ParameterizedElementType> {
   @override
   String renderLinkedName(ParameterizedElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.element.linkedName);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
@@ -63,7 +63,7 @@ class ParameterizedElementTypeRendererHtml
 
   @override
   String renderNameWithGenerics(ParameterizedElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.element.name);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
@@ -84,7 +84,7 @@ class CallableElementTypeRendererHtml
       return elementType.superLinkedName;
     }
 
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.nameWithGenerics);
     buf.write('(');
     buf.write(ParameterRendererHtml()
@@ -102,7 +102,7 @@ class FunctionTypeElementTypeRendererMd
     extends ElementTypeRenderer<FunctionTypeElementType> {
   @override
   String renderLinkedName(FunctionTypeElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write('${elementType.returnType.linkedName} ');
     buf.write('${elementType.nameWithGenerics}');
     buf.write('(');
@@ -113,7 +113,7 @@ class FunctionTypeElementTypeRendererMd
 
   @override
   String renderNameWithGenerics(FunctionTypeElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.name);
     if (elementType.typeFormals.isNotEmpty) {
       if (!elementType.typeFormals.every((t) => t.name == 'dynamic')) {
@@ -130,7 +130,7 @@ class ParameterizedElementTypeRendererMd
     extends ElementTypeRenderer<ParameterizedElementType> {
   @override
   String renderLinkedName(ParameterizedElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.element.linkedName);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
@@ -143,7 +143,7 @@ class ParameterizedElementTypeRendererMd
 
   @override
   String renderNameWithGenerics(ParameterizedElementType elementType) {
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.element.name);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
@@ -164,7 +164,7 @@ class CallableElementTypeRendererMd
       return elementType.superLinkedName;
     }
 
-    StringBuffer buf = StringBuffer();
+    var buf = StringBuffer();
     buf.write(elementType.nameWithGenerics);
     buf.write('(');
     buf.write(ParameterRendererMd()

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -84,14 +84,13 @@ abstract class ParameterRenderer {
 
   String renderLinkedParams(List<Parameter> parameters,
       {showMetadata = true, showNames = true}) {
-    List<Parameter> positionalParams =
+    var positionalParams =
         parameters.where((Parameter p) => p.isRequiredPositional).toList();
-    List<Parameter> optionalPositionalParams =
+    var optionalPositionalParams =
         parameters.where((Parameter p) => p.isOptionalPositional).toList();
-    List<Parameter> namedParams =
-        parameters.where((Parameter p) => p.isNamed).toList();
+    var namedParams = parameters.where((Parameter p) => p.isNamed).toList();
 
-    String positional = '', optional = '', named = '';
+    var positional = '', optional = '', named = '';
     if (positionalParams.isNotEmpty) {
       positional = _linkedParameterSublist(positionalParams,
           optionalPositionalParams.isNotEmpty || namedParams.isNotEmpty,
@@ -120,10 +119,10 @@ abstract class ParameterRenderer {
       String closeBracket = '',
       showMetadata = true,
       showNames = true}) {
-    StringBuffer builder = StringBuffer();
+    var builder = StringBuffer();
     parameters.forEach((p) {
-      String prefix = '';
-      String suffix = '';
+      var prefix = '';
+      var suffix = '';
       if (identical(p, parameters.first)) {
         prefix = openBracket;
       }
@@ -133,7 +132,7 @@ abstract class ParameterRenderer {
       } else {
         suffix += ', ';
       }
-      String renderedParam =
+      var renderedParam =
           _renderParam(p, showMetadata: showMetadata, showNames: showNames);
       builder.write(
           listItem(parameter(prefix + renderedParam + suffix, p.htmlId)));
@@ -143,8 +142,8 @@ abstract class ParameterRenderer {
 
   String _renderParam(Parameter param,
       {showMetadata = true, showNames = true}) {
-    StringBuffer buf = StringBuffer();
-    ElementType paramModelType = param.modelType;
+    var buf = StringBuffer();
+    var paramModelType = param.modelType;
 
     if (showMetadata && param.hasAnnotations) {
       buf.write(param.annotations.map(annotation).join(' ') + ' ');
@@ -185,7 +184,7 @@ abstract class ParameterRenderer {
         buf.write(')');
       }
     } else if (param.modelType != null) {
-      String linkedTypeName = paramModelType.linkedName;
+      var linkedTypeName = paramModelType.linkedName;
       if (linkedTypeName.isNotEmpty) {
         buf.write(typeName(linkedTypeName));
         if (showNames && param.name.isNotEmpty) {

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -7,6 +7,7 @@ library dartdoc.source_linker;
 
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 final uriTemplateRegexp = RegExp(r'(%[frl]%)');
@@ -62,13 +63,12 @@ class SourceLinker {
   /// Most users of this class should use the [SourceLinker.fromElement] factory
   /// instead.  This constructor is public for testing.
   SourceLinker(
-      {this.excludes,
+      {@required this.excludes,
       this.lineNumber,
       this.sourceFileName,
       this.revision,
       this.root,
       this.uriTemplate}) {
-    assert(excludes != null, 'linkToSource excludes can not be null');
     if (revision != null || root != null || uriTemplate != null) {
       if (root == null || uriTemplate == null) {
         throw DartdocOptionError(

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -38,7 +38,7 @@ class ToolTempFileTracker {
 
   Future<File> createTemporaryFile() async {
     _temporaryFileCount++;
-    File tempFile = File(path.join(
+    var tempFile = File(path.join(
         temporaryDirectory.absolute.path, 'input_$_temporaryFileCount'));
     await tempFile.create(recursive: true);
     return tempFile;
@@ -68,7 +68,7 @@ class ToolRunner {
       ToolDefinition tool,
       Map<String, String> environment,
       ToolErrorCallback toolErrorCallback) async {
-    bool isDartSetup = ToolDefinition.isDartExecutable(tool.setupCommand[0]);
+    var isDartSetup = ToolDefinition.isDartExecutable(tool.setupCommand[0]);
     var args = tool.setupCommand.toList();
     String commandPath;
 
@@ -91,7 +91,7 @@ class ToolRunner {
       ToolErrorCallback toolErrorCallback) async {
     String commandString() => ([commandPath] + args).join(' ');
     try {
-      ProcessResult result =
+      var result =
           await Process.run(commandPath, args, environment: environment);
       if (result.exitCode != 0) {
         toolErrorCallback('Tool "$name" returned non-zero exit code '
@@ -144,7 +144,7 @@ class ToolRunner {
           'Did you add it to dartdoc_options.yaml?');
       return '';
     }
-    ToolDefinition toolDefinition = toolConfiguration.tools[tool];
+    var toolDefinition = toolConfiguration.tools[tool];
     var toolArgs = toolDefinition.command;
     // Ideally, we would just be able to send the input text into stdin, but
     // there's no way to do that synchronously, and converting dartdoc to an
@@ -179,7 +179,7 @@ class ToolRunner {
       }
     }
     var substitutions = envWithInput.map<RegExp, String>((key, value) {
-      String escapedKey = RegExp.escape(key);
+      var escapedKey = RegExp.escape(key);
       return MapEntry(RegExp('\\\$(\\($escapedKey\\)|$escapedKey\\b)'), value);
     });
     var argsWithInput = <String>[];

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -6,10 +6,10 @@ library dartdoc.utils;
 final RegExp leadingWhiteSpace = RegExp(r'^([ \t]*)[^ ]');
 
 Iterable<String> stripCommonWhitespace(String str) sync* {
-  List<String> lines = str.split('\n');
+  var lines = str.split('\n');
   int minimumSeen;
 
-  for (String line in lines) {
+  for (var line in lines) {
     if (line.isNotEmpty) {
       Match m = leadingWhiteSpace.firstMatch(line);
       if (m != null) {
@@ -20,7 +20,7 @@ Iterable<String> stripCommonWhitespace(String str) sync* {
     }
   }
   minimumSeen ??= 0;
-  for (String line in lines) {
+  for (var line in lines) {
     if (line.length >= minimumSeen) {
       yield '${line.substring(minimumSeen)}';
     } else {
@@ -30,12 +30,12 @@ Iterable<String> stripCommonWhitespace(String str) sync* {
 }
 
 String stripComments(String str) {
-  bool cStyle = false;
+  var cStyle = false;
   if (str == null) return null;
-  StringBuffer buf = StringBuffer();
+  var buf = StringBuffer();
 
   if (str.startsWith('///')) {
-    for (String line in stripCommonWhitespace(str)) {
+    for (var line in stripCommonWhitespace(str)) {
       if (line.startsWith('/// ')) {
         buf.write('${line.substring(4)}\n');
       } else if (line.startsWith('///')) {
@@ -52,7 +52,7 @@ String stripComments(String str) {
     if (str.endsWith('*/')) {
       str = str.substring(0, str.length - 2);
     }
-    for (String line in stripCommonWhitespace(str)) {
+    for (var line in stripCommonWhitespace(str)) {
       if (cStyle && line.startsWith('* ')) {
         buf.write('${line.substring(2)}\n');
       } else if (cStyle && line.startsWith('*')) {
@@ -68,7 +68,7 @@ String stripComments(String str) {
 String truncateString(String str, int length) {
   if (str != null && str.length > length) {
     // Do not call this on unsanitized HTML.
-    assert(!str.contains("<"));
+    assert(!str.contains('<'));
     return '${str.substring(0, length)}…';
   }
   return str;

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -92,8 +92,8 @@ class PackageWarningDefinition implements Comparable<PackageWarningDefinition> {
 
   const PackageWarningDefinition(this.kind, this.warningName, this.shortHelp,
       {List<String> longHelp, PackageWarningMode defaultWarningMode})
-      : this.longHelp = longHelp ?? const [],
-        this.defaultWarningMode = defaultWarningMode ?? PackageWarningMode.warn;
+      : longHelp = longHelp ?? const [],
+        defaultWarningMode = defaultWarningMode ?? PackageWarningMode.warn;
 
   @override
   int compareTo(PackageWarningDefinition other) {
@@ -112,109 +112,109 @@ final Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
     const {
   PackageWarning.ambiguousDocReference: PackageWarningDefinition(
       PackageWarning.ambiguousDocReference,
-      "ambiguous-doc-reference",
-      "A comment reference could refer to two or more different objects"),
+      'ambiguous-doc-reference',
+      'A comment reference could refer to two or more different objects'),
   PackageWarning.ambiguousReexport: PackageWarningDefinition(
       PackageWarning.ambiguousReexport,
-      "ambiguous-reexport",
-      "A symbol is exported from private to public in more than one library and dartdoc can not determine which one is canonical",
+      'ambiguous-reexport',
+      'A symbol is exported from private to public in more than one library and dartdoc can not determine which one is canonical',
       longHelp: [
         "Use {@canonicalFor @@name@@} in the desired library's documentation to resolve",
         "the ambiguity and/or override dartdoc's decision, or structure your package ",
-        "so the reexport is less ambiguous.  The symbol will still be referenced in ",
-        "all candidates -- this only controls the location where it will be written ",
-        "and which library will be displayed in navigation for the relevant pages.",
-        "The flag --ambiguous-reexport-scorer-min-confidence allows you to set the",
-        "threshold at which this warning will appear."
+        'so the reexport is less ambiguous.  The symbol will still be referenced in ',
+        'all candidates -- this only controls the location where it will be written ',
+        'and which library will be displayed in navigation for the relevant pages.',
+        'The flag --ambiguous-reexport-scorer-min-confidence allows you to set the',
+        'threshold at which this warning will appear.'
       ]),
   PackageWarning.ignoredCanonicalFor: PackageWarningDefinition(
       PackageWarning.ignoredCanonicalFor,
-      "ignored-canonical-for",
-      "A @canonicalFor tag refers to a library which this symbol can not be canonical for"),
+      'ignored-canonical-for',
+      'A @canonicalFor tag refers to a library which this symbol can not be canonical for'),
   PackageWarning.noCanonicalFound: PackageWarningDefinition(
       PackageWarning.noCanonicalFound,
-      "no-canonical-found",
-      "A symbol is part of the public interface for this package, but no library documented with this package documents it so dartdoc can not link to it"),
+      'no-canonical-found',
+      'A symbol is part of the public interface for this package, but no library documented with this package documents it so dartdoc can not link to it'),
   PackageWarning.notImplemented: PackageWarningDefinition(
       PackageWarning.notImplemented,
-      "not-implemented",
-      "The code makes use of a feature that is not yet implemented in dartdoc"),
+      'not-implemented',
+      'The code makes use of a feature that is not yet implemented in dartdoc'),
   PackageWarning.noLibraryLevelDocs: PackageWarningDefinition(
       PackageWarning.noLibraryLevelDocs,
-      "no-library-level-docs",
-      "There are no library level docs for this library"),
+      'no-library-level-docs',
+      'There are no library level docs for this library'),
   PackageWarning.packageOrderGivesMissingPackageName: PackageWarningDefinition(
       PackageWarning.packageOrderGivesMissingPackageName,
-      "category-order-gives-missing-package-name",
-      "The category-order flag on the command line was given the name of a nonexistent package"),
+      'category-order-gives-missing-package-name',
+      'The category-order flag on the command line was given the name of a nonexistent package'),
   PackageWarning.reexportedPrivateApiAcrossPackages: PackageWarningDefinition(
       PackageWarning.reexportedPrivateApiAcrossPackages,
-      "reexported-private-api-across-packages",
-      "One or more libraries reexports private API members from outside its own package"),
+      'reexported-private-api-across-packages',
+      'One or more libraries reexports private API members from outside its own package'),
   PackageWarning.unresolvedDocReference: PackageWarningDefinition(
       PackageWarning.unresolvedDocReference,
-      "unresolved-doc-reference",
-      "A comment reference could not be found in parameters, enclosing class, enclosing library, or at the top level of any documented library with the package"),
+      'unresolved-doc-reference',
+      'A comment reference could not be found in parameters, enclosing class, enclosing library, or at the top level of any documented library with the package'),
   PackageWarning.brokenLink: PackageWarningDefinition(PackageWarning.brokenLink,
-      "broken-link", "Dartdoc generated a link to a non-existent file"),
+      'broken-link', 'Dartdoc generated a link to a non-existent file'),
   PackageWarning.unknownMacro: PackageWarningDefinition(
       PackageWarning.unknownMacro,
-      "unknown-macro",
-      "A comment reference contains an unknown macro"),
+      'unknown-macro',
+      'A comment reference contains an unknown macro'),
   PackageWarning.orphanedFile: PackageWarningDefinition(
       PackageWarning.orphanedFile,
-      "orphaned-file",
-      "Dartdoc generated files that are unreachable from the index"),
+      'orphaned-file',
+      'Dartdoc generated files that are unreachable from the index'),
   PackageWarning.unknownFile: PackageWarningDefinition(
       PackageWarning.unknownFile,
-      "unknown-file",
-      "A leftover file exists in the tree that dartdoc did not write in this pass"),
+      'unknown-file',
+      'A leftover file exists in the tree that dartdoc did not write in this pass'),
   PackageWarning.missingFromSearchIndex: PackageWarningDefinition(
       PackageWarning.missingFromSearchIndex,
-      "missing-from-search-index",
-      "A file generated by dartdoc is not present in the generated index.json"),
+      'missing-from-search-index',
+      'A file generated by dartdoc is not present in the generated index.json'),
   PackageWarning.typeAsHtml: PackageWarningDefinition(
       PackageWarning.typeAsHtml,
-      "type-as-html",
-      "Use of <> in a comment for type parameters is being treated as HTML by markdown",
+      'type-as-html',
+      'Use of <> in a comment for type parameters is being treated as HTML by markdown',
       defaultWarningMode: PackageWarningMode.ignore),
   PackageWarning.invalidParameter: PackageWarningDefinition(
       PackageWarning.invalidParameter,
-      "invalid-parameter",
-      "A parameter given to a dartdoc directive was invalid.",
+      'invalid-parameter',
+      'A parameter given to a dartdoc directive was invalid.',
       defaultWarningMode: PackageWarningMode.error),
   PackageWarning.toolError: PackageWarningDefinition(PackageWarning.toolError,
-      "tool-error", "Unable to execute external tool.",
+      'tool-error', 'Unable to execute external tool.',
       defaultWarningMode: PackageWarningMode.error),
   PackageWarning.deprecated: PackageWarningDefinition(PackageWarning.deprecated,
-      "deprecated", "A dartdoc directive has a deprecated format."),
+      'deprecated', 'A dartdoc directive has a deprecated format.'),
   PackageWarning.unresolvedExport: PackageWarningDefinition(
       PackageWarning.unresolvedExport,
-      "unresolved-export",
-      "An export refers to a URI that cannot be resolved.",
+      'unresolved-export',
+      'An export refers to a URI that cannot be resolved.',
       defaultWarningMode: PackageWarningMode.error),
   PackageWarning.duplicateFile: PackageWarningDefinition(
       PackageWarning.duplicateFile,
-      "duplicate-file",
-      "Dartdoc is trying to write to a duplicate filename based on the names of Dart symbols.",
+      'duplicate-file',
+      'Dartdoc is trying to write to a duplicate filename based on the names of Dart symbols.',
       longHelp: [
-        "Dartdoc generates a path and filename to write to for each symbol.",
-        "@@name@@ conflicts with another symbol in the generated path, and",
-        "therefore can not be written out.  Changing the name, library name, or",
-        "class name (if appropriate) of one of the conflicting items can resolve",
+        'Dartdoc generates a path and filename to write to for each symbol.',
+        '@@name@@ conflicts with another symbol in the generated path, and',
+        'therefore can not be written out.  Changing the name, library name, or',
+        'class name (if appropriate) of one of the conflicting items can resolve',
         "the conflict.   Alternatively, use the @nodoc tag in one symbol's",
-        "documentation comments to hide it."
+        'documentation comments to hide it.'
       ],
       defaultWarningMode: PackageWarningMode.error),
   PackageWarning.missingConstantConstructor: PackageWarningDefinition(
       PackageWarning.missingConstantConstructor,
-      "missing-constant-constructor",
-      "Dartdoc can not show the value of a constant because its constructor could not be resolved.",
+      'missing-constant-constructor',
+      'Dartdoc can not show the value of a constant because its constructor could not be resolved.',
       longHelp: [
-        "To resolve a constant into its literal value, Dartdoc relies on the",
+        'To resolve a constant into its literal value, Dartdoc relies on the',
         "analyzer to resolve the constructor.  The analyzer didn't provide",
-        "the constructor for @@name@@, which is usually due to an error in the",
-        "code.  Use the analyzer to find missing imports.",
+        'the constructor for @@name@@, which is usually due to an error in the',
+        'code.  Use the analyzer to find missing imports.',
       ],
       // Defaults to ignore as this doesn't impact the docs severely but is
       // useful for debugging package structure.
@@ -271,15 +271,16 @@ enum PackageWarningMode {
 /// In particular, this set should not include warnings around public/private
 /// or canonicalization problems, because those can break the isDocumented()
 /// check.
-final Set<PackageWarning> skipWarningIfNotDocumentedFor = Set()
-  ..addAll([PackageWarning.unresolvedDocReference, PackageWarning.typeAsHtml]);
+final Set<PackageWarning> skipWarningIfNotDocumentedFor = {
+  PackageWarning.unresolvedDocReference,
+  PackageWarning.typeAsHtml
+};
 
 class PackageWarningOptions {
   final Map<PackageWarning, PackageWarningMode> warningModes = {};
 
   PackageWarningOptions() {
-    for (PackageWarningDefinition definition
-        in packageWarningDefinitions.values) {
+    for (var definition in packageWarningDefinitions.values) {
       switch (definition.defaultWarningMode) {
         case PackageWarningMode.warn:
           {
@@ -304,8 +305,8 @@ class PackageWarningOptions {
   static PackageWarningOptions fromOptions(
       DartdocSyntheticOption<PackageWarningOptions> option, Directory dir) {
     // First, initialize defaults.
-    PackageWarningOptions newOptions = PackageWarningOptions();
-    PackageMeta packageMeta = PackageMeta.fromDir(dir);
+    var newOptions = PackageWarningOptions();
+    var packageMeta = PackageMeta.fromDir(dir);
 
     // Interpret errors/warnings/ignore options.  In the event of conflict, warning overrides error and
     // ignore overrides warning.
@@ -370,7 +371,7 @@ class PackageWarningOptions {
 }
 
 class PackageWarningCounter {
-  final countedWarnings = Map<Element, Set<Tuple2<PackageWarning, String>>>();
+  final countedWarnings = <Element, Set<Tuple2<PackageWarning, String>>>{};
   final _items = <Jsonable>[];
   final _displayedWarningCounts = <PackageWarning, int>{};
   final PackageGraph packageGraph;
@@ -385,21 +386,21 @@ class PackageWarningCounter {
     }
     String type;
     if (mode == PackageWarningMode.error) {
-      type = "error";
+      type = 'error';
     } else if (mode == PackageWarningMode.warn) {
-      type = "warning";
+      type = 'warning';
     }
     if (type != null) {
-      var entry = "  $type: $fullMessage";
+      var entry = '  $type: $fullMessage';
       _displayedWarningCounts.putIfAbsent(kind, () => 0);
       _displayedWarningCounts[kind] += 1;
       if (_displayedWarningCounts[kind] == 1 &&
           verboseWarnings &&
           packageWarningDefinitions[kind].longHelp.isNotEmpty) {
         // First time we've seen this warning.  Give a little extra info.
-        final String separator = '\n            ';
-        final String nameSub = r'@@name@@';
-        String verboseOut =
+        final separator = '\n            ';
+        final nameSub = r'@@name@@';
+        var verboseOut =
             '$separator${packageWarningDefinitions[kind].longHelp.join(separator)}'
                 .replaceAll(nameSub, name);
         entry = '$entry$verboseOut';
@@ -415,7 +416,7 @@ class PackageWarningCounter {
 
   /// Returns true if we've already warned for this.
   bool hasWarning(Warnable element, PackageWarning kind, String message) {
-    Tuple2<PackageWarning, String> warningData = Tuple2(kind, message);
+    var warningData = Tuple2<PackageWarning, String>(kind, message);
     if (countedWarnings.containsKey(element?.element)) {
       return countedWarnings[element?.element].contains(warningData);
     }
@@ -430,7 +431,7 @@ class PackageWarningCounter {
     // TODO(jcollins-g): Make addWarning not accept nulls for element.
     PackageWarningOptionContext config =
         element?.config ?? packageGraph.defaultPackage.config;
-    PackageWarningMode warningMode = config.packageWarningOptions.getMode(kind);
+    var warningMode = config.packageWarningOptions.getMode(kind);
     if (!config.allowNonLocalWarnings &&
         element != null &&
         !element.package.isLocal) {
@@ -441,8 +442,8 @@ class PackageWarningCounter {
     } else if (warningMode == PackageWarningMode.error) {
       errorCount += 1;
     }
-    Tuple2<PackageWarning, String> warningData = Tuple2(kind, message);
-    countedWarnings.putIfAbsent(element?.element, () => Set());
+    var warningData = Tuple2<PackageWarning, String>(kind, message);
+    countedWarnings.putIfAbsent(element?.element, () => {});
     countedWarnings[element?.element].add(warningData);
     _writeWarning(kind, warningMode, config.verboseWarnings,
         element?.fullyQualifiedName, fullMessage);
@@ -453,8 +454,8 @@ class PackageWarningCounter {
 
   @override
   String toString() {
-    String errors = '$errorCount ${errorCount == 1 ? "error" : "errors"}';
-    String warnings =
+    var errors = '$errorCount ${errorCount == 1 ? "error" : "errors"}';
+    var warnings =
         '$warningCount ${warningCount == 1 ? "warning" : "warnings"}';
     return [errors, warnings].join(', ');
   }

--- a/test/dartdoc_integration_test.dart
+++ b/test/dartdoc_integration_test.dart
@@ -23,7 +23,7 @@ String get _testPackageFlutterPluginPath => path
 
 void main() {
   group('Invoking command-line dartdoc', () {
-    String dartdocPath = path.canonicalize(path.join('bin', 'dartdoc.dart'));
+    var dartdocPath = path.canonicalize(path.join('bin', 'dartdoc.dart'));
     CoverageSubprocessLauncher subprocessLauncher;
     Directory tempDir;
 
@@ -46,9 +46,9 @@ void main() {
 
     test('running --no-generate-docs is quiet and does not generate docs',
         () async {
-      Directory outputDir =
+      var outputDir =
           await Directory.systemTemp.createTemp('dartdoc.testEmpty.');
-      List<String> outputLines = [];
+      var outputLines = <String>[];
       await subprocessLauncher.runStreamed(Platform.resolvedExecutable,
           [dartdocPath, '--output', outputDir.path, '--no-generate-docs'],
           perLine: outputLines.add, workingDirectory: _testPackagePath);
@@ -59,9 +59,9 @@ void main() {
     }, timeout: Timeout.factor(2));
 
     test('running --quiet is quiet and does generate docs', () async {
-      Directory outputDir =
+      var outputDir =
           await Directory.systemTemp.createTemp('dartdoc.testEmpty.');
-      List<String> outputLines = [];
+      var outputLines = <String>[];
       await subprocessLauncher.runStreamed(Platform.resolvedExecutable,
           [dartdocPath, '--output', outputDir.path, '--quiet'],
           perLine: outputLines.add, workingDirectory: _testPackagePath);
@@ -73,7 +73,7 @@ void main() {
 
     test('invalid parameters return non-zero and print a fatal-error',
         () async {
-      List outputLines = [];
+      var outputLines = <String>[];
       await expectLater(
           () => subprocessLauncher.runStreamed(
               Platform.resolvedExecutable,
@@ -90,8 +90,8 @@ void main() {
     });
 
     test('missing a required file path prints a fatal-error', () async {
-      List outputLines = [];
-      String impossiblePath = path.join(dartdocPath, 'impossible');
+      var outputLines = [];
+      var impossiblePath = path.join(dartdocPath, 'impossible');
       await expectLater(
           () => subprocessLauncher.runStreamed(
               Platform.resolvedExecutable,
@@ -120,7 +120,7 @@ void main() {
     });
 
     test('help prints command line args', () async {
-      List<String> outputLines = [];
+      var outputLines = <String>[];
       await subprocessLauncher.runStreamed(
           Platform.resolvedExecutable, [dartdocPath, '--help'],
           perLine: outputLines.add);
@@ -133,7 +133,7 @@ void main() {
     });
 
     test('Validate missing FLUTTER_ROOT exception is clean', () async {
-      StringBuffer output = StringBuffer();
+      var output = StringBuffer();
       var args = <String>[dartdocPath];
       var dart_tool =
           Directory(path.join(_testPackageFlutterPluginPath, '.dart_tool'));
@@ -158,19 +158,19 @@ void main() {
       expect(output.toString(), isNot(contains('asynchronous gap')));
     });
 
-    test("Validate --version works", () async {
-      StringBuffer output = StringBuffer();
+    test('Validate --version works', () async {
+      var output = StringBuffer();
       var args = <String>[dartdocPath, '--version'];
       await subprocessLauncher.runStreamed(Platform.resolvedExecutable, args,
           workingDirectory: _testPackagePath,
           perLine: (s) => output.writeln(s));
-      PackageMeta dartdocMeta = PackageMeta.fromFilename(dartdocPath);
+      var dartdocMeta = PackageMeta.fromFilename(dartdocPath);
       expect(output.toString(),
           endsWith('dartdoc version: ${dartdocMeta.version}\n'));
     });
 
     test('Check for sample code in examples', () async {
-      StringBuffer output = StringBuffer();
+      var output = StringBuffer();
       var args = <String>[
         dartdocPath,
         '--include',
@@ -205,7 +205,7 @@ void main() {
         '--json'
       ];
 
-      Iterable<Map> jsonValues = await subprocessLauncher.runStreamed(
+      var jsonValues = await subprocessLauncher.runStreamed(
           Platform.resolvedExecutable, args,
           workingDirectory: _testPackagePath);
 
@@ -214,8 +214,7 @@ void main() {
     }, timeout: Timeout.factor(2));
 
     test('--footer-text includes text', () async {
-      String footerTextPath =
-          path.join(Directory.systemTemp.path, 'footer.txt');
+      var footerTextPath = path.join(Directory.systemTemp.path, 'footer.txt');
       File(footerTextPath).writeAsStringSync(' footer text include ');
 
       var args = <String>[
@@ -230,12 +229,12 @@ void main() {
       await subprocessLauncher.runStreamed(Platform.resolvedExecutable, args,
           workingDirectory: _testPackagePath);
 
-      File outFile = File(path.join(tempDir.path, 'index.html'));
+      var outFile = File(path.join(tempDir.path, 'index.html'));
       expect(outFile.readAsStringSync(), contains('footer text include'));
     }, timeout: Timeout.factor(2));
 
     test('--footer-text excludes version', () async {
-      String _testPackagePath = path
+      var _testPackagePath = path
           .fromUri(_currentFileUri.resolve('../testing/test_package_options'));
 
       var args = <String>[dartdocPath, '--output', tempDir.path];
@@ -243,12 +242,12 @@ void main() {
       await subprocessLauncher.runStreamed(Platform.resolvedExecutable, args,
           workingDirectory: _testPackagePath);
 
-      File outFile = File(path.join(tempDir.path, 'index.html'));
-      RegExp footerRegex =
+      var outFile = File(path.join(tempDir.path, 'index.html'));
+      var footerRegex =
           RegExp('<footer>(.*\s*?\n?)+?</footer>', multiLine: true);
       // get footer, check for version number
-      RegExpMatch m = footerRegex.firstMatch(outFile.readAsStringSync());
-      RegExp version = RegExp(r'(\d+\.)?(\d+\.)?(\*|\d+)');
+      var m = footerRegex.firstMatch(outFile.readAsStringSync());
+      var version = RegExp(r'(\d+\.)?(\d+\.)?(\*|\d+)');
       expect(version.hasMatch(m.group(0)), false);
     });
   }, timeout: Timeout.factor(8));

--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -21,9 +21,9 @@ class ConvertedOption {
   static ConvertedOption fromYamlMap(YamlMap yamlMap, path.Context context) {
     String p1;
     String p2;
-    String contextPath = context.current;
+    var contextPath = context.current;
 
-    for (MapEntry entry in yamlMap.entries) {
+    for (var entry in yamlMap.entries) {
       switch (entry.key.toString()) {
         case 'param1':
           p1 = entry.value.toString();

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -29,7 +29,7 @@ void main() {
 
     setUpAll(() async {
       tempDir = Directory.systemTemp.createTempSync('dartdoc.test.');
-      DartdocOptionSet optionSet = await DartdocOptionSet.fromOptionGenerators(
+      var optionSet = await DartdocOptionSet.fromOptionGenerators(
           'dartdoc', [createLoggingOptions]);
       optionSet.parseArguments([]);
       startLogging(DartdocLoggingOptionContext(optionSet, Directory.current));
@@ -67,19 +67,19 @@ void main() {
       });
 
       test('generator parameters', () async {
-        File favicon =
+        var favicon =
             File(path.joinAll([tempDir.path, 'static-assets', 'favicon.png']));
-        File index = File(path.joinAll([tempDir.path, 'index.html']));
+        var index = File(path.joinAll([tempDir.path, 'index.html']));
         expect(favicon.readAsStringSync(),
             contains('Not really a png, but a test file'));
-        String indexString = index.readAsStringSync();
+        var indexString = index.readAsStringSync();
         expect(indexString, contains('Footer things'));
         expect(indexString, contains('footer.txt data'));
         expect(indexString, contains('HTML header file'));
       });
 
       test('examplePathPrefix', () async {
-        Class UseAnExampleHere = p.allCanonicalModelElements
+        var UseAnExampleHere = p.allCanonicalModelElements
             .whereType<Class>()
             .firstWhere((ModelElement c) => c.name == 'UseAnExampleHere');
         expect(
@@ -89,7 +89,7 @@ void main() {
       });
 
       test('includeExternal and showUndocumentedCategories', () async {
-        Class withUndocumentedCategory = p.allCanonicalModelElements
+        var withUndocumentedCategory = p.allCanonicalModelElements
             .whereType<Class>()
             .firstWhere((ModelElement c) => c.name == 'UseAnExampleHere');
         expect(withUndocumentedCategory.isPublic, isTrue);
@@ -98,12 +98,11 @@ void main() {
     });
 
     test('errors generate errors even when warnings are off', () async {
-      Dartdoc dartdoc =
+      var dartdoc =
           await buildDartdoc(['--allow-tools'], testPackageToolError, tempDir);
-      DartdocResults results = await dartdoc.generateDocsBase();
-      PackageGraph p = results.packageGraph;
-      Iterable<String> unresolvedToolErrors = p
-          .packageWarningCounter.countedWarnings.values
+      var results = await dartdoc.generateDocsBase();
+      var p = results.packageGraph;
+      var unresolvedToolErrors = p.packageWarningCounter.countedWarnings.values
           .expand<String>((Set<Tuple2<PackageWarning, String>> s) => s
               .where((Tuple2<PackageWarning, String> t) =>
                   t.item1 == PackageWarning.toolError)
@@ -134,9 +133,9 @@ void main() {
       });
 
       test('linkToUrl', () async {
-        Library main = testPackageOptions.allLibraries
+        var main = testPackageOptions.allLibraries
             .firstWhere((Library l) => l.name == 'main');
-        Class UseAnExampleHere = main.allClasses
+        var UseAnExampleHere = main.allClasses
             .firstWhere((Class c) => c.name == 'UseAnExampleHere');
         expect(testPackageOptions.documentedWhere,
             equals(DocumentLocation.remote));
@@ -147,7 +146,7 @@ void main() {
       });
 
       test('includeExternal works via remote', () async {
-        Library unusualLibrary = testPackageOptions.allLibraries
+        var unusualLibrary = testPackageOptions.allLibraries
             .firstWhere((Library l) => l.name == 'unusualLibrary');
         expect(
             unusualLibrary.allClasses
@@ -157,11 +156,11 @@ void main() {
     });
 
     test('with broken reexport chain', () async {
-      Dartdoc dartdoc =
+      var dartdoc =
           await buildDartdoc([], testPackageImportExportError, tempDir);
-      DartdocResults results = await dartdoc.generateDocsBase();
-      PackageGraph p = results.packageGraph;
-      Iterable<String> unresolvedExportWarnings = p
+      var results = await dartdoc.generateDocsBase();
+      var p = results.packageGraph;
+      var unresolvedExportWarnings = p
           .packageWarningCounter.countedWarnings.values
           .expand<String>((Set<Tuple2<PackageWarning, String>> s) => s
               .where((Tuple2<PackageWarning, String> t) =>
@@ -175,28 +174,28 @@ void main() {
 
     group('include/exclude parameters', () {
       test('with config file', () async {
-        Dartdoc dartdoc =
+        var dartdoc =
             await buildDartdoc([], testPackageIncludeExclude, tempDir);
-        DartdocResults results = await dartdoc.generateDocs();
-        PackageGraph p = results.packageGraph;
+        var results = await dartdoc.generateDocs();
+        var p = results.packageGraph;
         expect(p.localPublicLibraries.map((l) => l.name),
             orderedEquals(['explicitly_included', 'more_included']));
       });
 
       test('with include command line argument', () async {
-        Dartdoc dartdoc = await buildDartdoc(['--include', 'another_included'],
+        var dartdoc = await buildDartdoc(['--include', 'another_included'],
             testPackageIncludeExclude, tempDir);
-        DartdocResults results = await dartdoc.generateDocs();
-        PackageGraph p = results.packageGraph;
+        var results = await dartdoc.generateDocs();
+        var p = results.packageGraph;
         expect(p.localPublicLibraries.length, equals(1));
         expect(p.localPublicLibraries.first.name, equals('another_included'));
       });
 
       test('with exclude command line argument', () async {
-        Dartdoc dartdoc = await buildDartdoc(
+        var dartdoc = await buildDartdoc(
             ['--exclude', 'more_included'], testPackageIncludeExclude, tempDir);
-        DartdocResults results = await dartdoc.generateDocs();
-        PackageGraph p = results.packageGraph;
+        var results = await dartdoc.generateDocs();
+        var p = results.packageGraph;
         expect(p.localPublicLibraries.length, equals(1));
         expect(
             p.localPublicLibraries.first.name, equals('explicitly_included'));
@@ -204,22 +203,22 @@ void main() {
     });
 
     test('package without version produces valid semver in docs', () async {
-      Dartdoc dartdoc = await buildDartdoc([], testPackageMinimumDir, tempDir);
-      DartdocResults results = await dartdoc.generateDocs();
-      PackageGraph p = results.packageGraph;
+      var dartdoc = await buildDartdoc([], testPackageMinimumDir, tempDir);
+      var results = await dartdoc.generateDocs();
+      var p = results.packageGraph;
       expect(p.defaultPackage.version, equals('0.0.0-unknown'));
     });
 
     test('basic interlinking test', () async {
-      Dartdoc dartdoc = await buildDartdoc([], testPackageDir, tempDir);
-      DartdocResults results = await dartdoc.generateDocs();
-      PackageGraph p = results.packageGraph;
-      Package meta = p.publicPackages.firstWhere((p) => p.name == 'meta');
-      TopLevelVariable useSomethingInAnotherPackage = p.publicLibraries
+      var dartdoc = await buildDartdoc([], testPackageDir, tempDir);
+      var results = await dartdoc.generateDocs();
+      var p = results.packageGraph;
+      var meta = p.publicPackages.firstWhere((p) => p.name == 'meta');
+      var useSomethingInAnotherPackage = p.publicLibraries
           .firstWhere((l) => l.name == 'fake')
           .properties
           .firstWhere((p) => p.name == 'useSomethingInAnotherPackage');
-      TopLevelVariable useSomethingInTheSdk = p.publicLibraries
+      var useSomethingInTheSdk = p.publicLibraries
           .firstWhere((l) => l.name == 'fake')
           .properties
           .firstWhere((p) => p.name == 'useSomethingInTheSdk');
@@ -228,7 +227,7 @@ void main() {
           useSomethingInAnotherPackage.modelType.linkedName,
           matches(
               '<a href=\"https://pub.dev/documentation/meta/[^\"]*/meta/Required-class.html\">Required</a>'));
-      RegExp stringLink = RegExp(
+      var stringLink = RegExp(
           'https://api.dart.dev/(dev|stable|edge|be|beta)/${Platform.version.split(' ').first}/dart-core/String-class.html">String</a>');
       expect(useSomethingInTheSdk.modelType.linkedName, contains(stringLink));
     });
@@ -251,8 +250,8 @@ void main() {
       test('generate docs for ${path.basename(testPackageDir.path)} works',
           () async {
         expect(results.packageGraph, isNotNull);
-        PackageGraph packageGraph = results.packageGraph;
-        Package p = packageGraph.defaultPackage;
+        var packageGraph = results.packageGraph;
+        var p = packageGraph.defaultPackage;
         expect(p.name, 'test_package');
         expect(p.hasDocumentationFile, isTrue);
         // Total number of public libraries in test_package.
@@ -265,7 +264,7 @@ void main() {
       test('source code links are visible', () async {
         // Picked this object as this library explicitly should never contain
         // a library directive, so we can predict what line number it will be.
-        File anonymousOutput = File(path.join(tempDir.path, 'anonymous_library',
+        var anonymousOutput = File(path.join(tempDir.path, 'anonymous_library',
             'anonymous_library-library.html'));
         expect(anonymousOutput.existsSync(), isTrue);
         expect(
@@ -277,7 +276,7 @@ void main() {
 
     test('generate docs for ${path.basename(testPackageBadDir.path)} fails',
         () async {
-      Dartdoc dartdoc = await buildDartdoc([], testPackageBadDir, tempDir);
+      var dartdoc = await buildDartdoc([], testPackageBadDir, tempDir);
 
       try {
         await dartdoc.generateDocs();
@@ -290,13 +289,12 @@ void main() {
             'from analysis_options');
 
     test('generate docs for a package that does not have a readme', () async {
-      Dartdoc dartdoc =
-          await buildDartdoc([], testPackageWithNoReadme, tempDir);
+      var dartdoc = await buildDartdoc([], testPackageWithNoReadme, tempDir);
 
-      DartdocResults results = await dartdoc.generateDocs();
+      var results = await dartdoc.generateDocs();
       expect(results.packageGraph, isNotNull);
 
-      PackageGraph p = results.packageGraph;
+      var p = results.packageGraph;
       expect(p.defaultPackage.name, 'test_package_small');
       expect(p.defaultPackage.hasHomepage, isFalse);
       expect(p.defaultPackage.hasDocumentationFile, isFalse);
@@ -304,13 +302,13 @@ void main() {
     });
 
     test('generate docs including a single library', () async {
-      Dartdoc dartdoc =
+      var dartdoc =
           await buildDartdoc(['--include', 'fake'], testPackageDir, tempDir);
 
-      DartdocResults results = await dartdoc.generateDocs();
+      var results = await dartdoc.generateDocs();
       expect(results.packageGraph, isNotNull);
 
-      PackageGraph p = results.packageGraph;
+      var p = results.packageGraph;
       expect(p.defaultPackage.name, 'test_package');
       expect(p.defaultPackage.hasDocumentationFile, isTrue);
       expect(p.localPublicLibraries, hasLength(1));
@@ -318,13 +316,13 @@ void main() {
     });
 
     test('generate docs excluding a single library', () async {
-      Dartdoc dartdoc =
+      var dartdoc =
           await buildDartdoc(['--exclude', 'fake'], testPackageDir, tempDir);
 
-      DartdocResults results = await dartdoc.generateDocs();
+      var results = await dartdoc.generateDocs();
       expect(results.packageGraph, isNotNull);
 
-      PackageGraph p = results.packageGraph;
+      var p = results.packageGraph;
       expect(p.defaultPackage.name, 'test_package');
       expect(p.defaultPackage.hasDocumentationFile, isTrue);
       // Plus 1 here because we're excluding only two libraries (the specified
@@ -336,13 +334,13 @@ void main() {
     });
 
     test('generate docs for package with embedder yaml', () async {
-      Dartdoc dartdoc =
+      var dartdoc =
           await buildDartdoc([], testPackageWithEmbedderYaml, tempDir);
 
-      DartdocResults results = await dartdoc.generateDocs();
+      var results = await dartdoc.generateDocs();
       expect(results.packageGraph, isNotNull);
 
-      PackageGraph p = results.packageGraph;
+      var p = results.packageGraph;
       expect(p.defaultPackage.name, 'test_package_embedder_yaml');
       expect(p.defaultPackage.hasDocumentationFile, isFalse);
       expect(p.libraries, hasLength(3));
@@ -351,8 +349,8 @@ void main() {
       expect(p.libraries.map((lib) => lib.name).contains('dart:bear'), isTrue);
       expect(p.packageMap.length, equals(2));
       // Things that do not override the core SDK belong in their own package.
-      expect(p.packageMap["Dart"].isSdk, isTrue);
-      expect(p.packageMap["test_package_embedder_yaml"].isSdk, isFalse);
+      expect(p.packageMap['Dart'].isSdk, isTrue);
+      expect(p.packageMap['test_package_embedder_yaml'].isSdk, isFalse);
       // Should be true once dart-lang/sdk#32707 is fixed.
       //expect(
       //    p.publicLibraries,
@@ -360,23 +358,23 @@ void main() {
       //        (l.element as LibraryElement).isInSdk == l.packageMeta.isSdk));
       // Ensure that we actually parsed some source by checking for
       // the 'Bear' class.
-      Library dart_bear = p.packageMap["Dart"].libraries
+      var dart_bear = p.packageMap['Dart'].libraries
           .firstWhere((lib) => lib.name == 'dart:bear');
       expect(
           dart_bear.allClasses.map((cls) => cls.name).contains('Bear'), isTrue);
-      expect(p.packageMap["Dart"].publicLibraries, hasLength(3));
+      expect(p.packageMap['Dart'].publicLibraries, hasLength(3));
     });
 
     test('generate docs with custom templates', () async {
-      String templatesDir =
+      var templatesDir =
           path.join(testPackageCustomTemplates.path, 'templates');
-      Dartdoc dartdoc = await buildDartdoc(['--templates-dir', templatesDir],
+      var dartdoc = await buildDartdoc(['--templates-dir', templatesDir],
           testPackageCustomTemplates, tempDir);
 
-      DartdocResults results = await dartdoc.generateDocs();
+      var results = await dartdoc.generateDocs();
       expect(results.packageGraph, isNotNull);
 
-      PackageGraph p = results.packageGraph;
+      var p = results.packageGraph;
       expect(p.defaultPackage.name, 'test_package_custom_templates');
       expect(p.localPublicLibraries, hasLength(1));
     });
@@ -395,7 +393,7 @@ void main() {
     });
 
     test('generate docs with bad templatesDir path fails', () async {
-      String badPath = path.join(tempDir.path, 'BAD');
+      var badPath = path.join(tempDir.path, 'BAD');
       try {
         await buildDartdoc(
             ['--templates-dir', badPath], testPackageCustomTemplates, tempDir);
@@ -406,19 +404,20 @@ void main() {
     });
 
     test('rel canonical prefix does not include base href', () async {
+      // ignore: omit_local_variable_types
       final String prefix = 'foo.bar/baz';
-      Dartdoc dartdoc = await buildDartdoc(
+      var dartdoc = await buildDartdoc(
           ['--rel-canonical-prefix', prefix], testPackageDir, tempDir);
       await dartdoc.generateDocsBase();
 
       // Verify files at different levels have correct <link> content.
-      File level1 = File(path.join(tempDir.path, 'ex', 'Apple-class.html'));
+      var level1 = File(path.join(tempDir.path, 'ex', 'Apple-class.html'));
       expect(level1.existsSync(), isTrue);
       expect(
           level1.readAsStringSync(),
           contains(
               '<link rel="canonical" href="$prefix/ex/Apple-class.html">'));
-      File level2 = File(path.join(tempDir.path, 'ex', 'Apple', 'm.html'));
+      var level2 = File(path.join(tempDir.path, 'ex', 'Apple', 'm.html'));
       expect(level2.existsSync(), isTrue);
       expect(level2.readAsStringSync(),
           contains('<link rel="canonical" href="$prefix/ex/Apple/m.html">'));

--- a/test/experiment_options_test.dart
+++ b/test/experiment_options_test.dart
@@ -52,8 +52,7 @@ void main() {
   group('Experimental options test', () {
     test('Defaults work for all options', () {
       experimentOptions.parseArguments([]);
-      DartdocOptionContext tester =
-          DartdocOptionContext(experimentOptions, emptyTempDir);
+      var tester = DartdocOptionContext(experimentOptions, emptyTempDir);
       if (defaultOnNotExpired != null) {
         expect(tester.experimentStatus.isEnabled(defaultOnNotExpired), isTrue);
       }
@@ -71,8 +70,7 @@ void main() {
         '--enable-experiment',
         '${defaultOffNotExpired?.disableString},${defaultOnNotExpired?.disableString},${defaultOnExpired.disableString},${defaultOffExpired.enableString}'
       ]);
-      DartdocOptionContext tester =
-          DartdocOptionContext(experimentOptions, emptyTempDir);
+      var tester = DartdocOptionContext(experimentOptions, emptyTempDir);
       if (defaultOnNotExpired != null) {
         expect(tester.experimentStatus.isEnabled(defaultOnNotExpired), isFalse);
       }

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -95,8 +95,7 @@ void main() {
       });
 
       test('resources are put into the right place', () {
-        Directory output =
-            Directory(path.join(tempOutput.path, 'static-assets'));
+        var output = Directory(path.join(tempOutput.path, 'static-assets'));
         expect(output, doesExist);
 
         for (var resource in resource_names.map((r) =>
@@ -130,8 +129,7 @@ void main() {
         await generator.generate(packageGraph, writer);
         expect(generator, isNotNull);
         expect(tempOutput, isNotNull);
-        String expectedPath =
-            path.join('aDuplicate', 'aDuplicate-library.html');
+        var expectedPath = path.join('aDuplicate', 'aDuplicate-library.html');
         expect(
             packageGraph.localPublicLibraries,
             anyElement((l) => packageGraph.packageWarningCounter

--- a/test/markdown_processor_test.dart
+++ b/test/markdown_processor_test.dart
@@ -10,18 +10,18 @@ import 'package:test/test.dart';
 void main() {
   group('findFreeHangingGenericsPositions()', () {
     test('returns empty array if all the generics are in []', () {
-      final string = "One two [three<four>] [[five<six>] seven eight";
+      final string = 'One two [three<four>] [[five<six>] seven eight';
       expect(findFreeHangingGenericsPositions(string), equals([]));
     });
 
     test('returns positions of generics outside of []', () {
-      final string = "One two<int> [[three<four>] five<six>] seven<eight>";
+      final string = 'One two<int> [[three<four>] five<six>] seven<eight>';
       expect(findFreeHangingGenericsPositions(string), equals([7, 44]));
     });
 
     test('ignores HTML tags', () {
       final string =
-          "One two<int> foo<pre> [[three<four>] five<six>] bar</pre> seven<eight>";
+          'One two<int> foo<pre> [[three<four>] five<six>] bar</pre> seven<eight>';
       expect(findFreeHangingGenericsPositions(string), equals([7, 63]));
     });
   });

--- a/test/model_special_cases_test.dart
+++ b/test/model_special_cases_test.dart
@@ -19,10 +19,10 @@ import 'package:test/test.dart';
 import 'src/utils.dart' as utils;
 
 void main() {
-  Directory sdkDir = defaultSdkDir;
+  var sdkDir = defaultSdkDir;
 
   if (sdkDir == null) {
-    print("Warning: unable to locate the Dart SDK.");
+    print('Warning: unable to locate the Dart SDK.');
     exit(1);
   }
 
@@ -43,9 +43,9 @@ void main() {
     });
 
     test('method parameters with required', () {
-      Method m1 = b.allInstanceMethods.firstWhere((m) => m.name == 'm1');
-      Parameter p1 = m1.allParameters.firstWhere((p) => p.name == 'p1');
-      Parameter p2 = m1.allParameters.firstWhere((p) => p.name == 'p2');
+      var m1 = b.allInstanceMethods.firstWhere((m) => m.name == 'm1');
+      var p1 = m1.allParameters.firstWhere((p) => p.name == 'p1');
+      var p2 = m1.allParameters.firstWhere((p) => p.name == 'p2');
       expect(p1.isRequiredNamed, isTrue);
       expect(p2.isRequiredNamed, isFalse);
       expect(p2.isNamed, isTrue);
@@ -64,11 +64,9 @@ void main() {
     });
 
     test('verify no regression on ordinary optionals', () {
-      Method m2 = b.allInstanceMethods.firstWhere((m) => m.name == 'm2');
-      Parameter sometimes =
-          m2.allParameters.firstWhere((p) => p.name == 'sometimes');
-      Parameter optionals =
-          m2.allParameters.firstWhere((p) => p.name == 'optionals');
+      var m2 = b.allInstanceMethods.firstWhere((m) => m.name == 'm2');
+      var sometimes = m2.allParameters.firstWhere((p) => p.name == 'sometimes');
+      var optionals = m2.allParameters.firstWhere((p) => p.name == 'optionals');
       expect(sometimes.isRequiredNamed, isFalse);
       expect(sometimes.isRequiredPositional, isTrue);
       expect(sometimes.isOptionalPositional, isFalse);
@@ -87,12 +85,12 @@ void main() {
     });
 
     test('Late final class member test', () {
-      Class c = lateFinalWithoutInitializer.allClasses
+      var c = lateFinalWithoutInitializer.allClasses
           .firstWhere((c) => c.name == 'C');
-      Field a = c.allFields.firstWhere((f) => f.name == 'a');
-      Field b = c.allFields.firstWhere((f) => f.name == 'b');
-      Field cField = c.allFields.firstWhere((f) => f.name == 'cField');
-      Field dField = c.allFields.firstWhere((f) => f.name == 'dField');
+      var a = c.allFields.firstWhere((f) => f.name == 'a');
+      var b = c.allFields.firstWhere((f) => f.name == 'b');
+      var cField = c.allFields.firstWhere((f) => f.name == 'cField');
+      var dField = c.allFields.firstWhere((f) => f.name == 'dField');
 
       // If nnbd isn't enabled, fields named 'late' come back from the analyzer
       // instead of setting up 'isLate'.
@@ -116,8 +114,7 @@ void main() {
     });
 
     test('Late final top level variables', () {
-      TopLevelVariable initializeMe = lateFinalWithoutInitializer
-          .publicProperties
+      var initializeMe = lateFinalWithoutInitializer.publicProperties
           .firstWhere((v) => v.name == 'initializeMe');
       expect(initializeMe.modelType.returnType.name, equals('String'));
       expect(initializeMe.isLate, isTrue);
@@ -151,7 +148,7 @@ void main() {
           .forEach((m) => m.documentation);
     });
 
-    test("can inject HTML", () {
+    test('can inject HTML', () {
       expect(
           injectSimpleHtml.documentation,
           contains(
@@ -163,11 +160,11 @@ void main() {
       expect(injectSimpleHtml.documentationAsHtml,
           contains('   <div style="opacity: 0.5;">[HtmlInjection]</div>'));
     });
-    test("can inject HTML from tool", () {
-      RegExp envLine = RegExp(r'^Env: \{', multiLine: true);
+    test('can inject HTML from tool', () {
+      var envLine = RegExp(r'^Env: \{', multiLine: true);
       expect(envLine.allMatches(injectHtmlFromTool.documentation).length,
           equals(2));
-      RegExp argLine = RegExp(r'^Args: \[', multiLine: true);
+      var argLine = RegExp(r'^Args: \[', multiLine: true);
       expect(argLine.allMatches(injectHtmlFromTool.documentation).length,
           equals(2));
       expect(
@@ -226,7 +223,7 @@ void main() {
     test(
         'Verify auto-included dependencies do not use default package category definitions',
         () {
-      Class IAmAClassWithCategories = ginormousPackageGraph.localPackages
+      var IAmAClassWithCategories = ginormousPackageGraph.localPackages
           .firstWhere((Package p) => p.name == 'test_package_imported')
           .publicLibraries
           .firstWhere((Library l) => l.name == 'categoriesExported')
@@ -242,8 +239,7 @@ void main() {
     // For flutter, we allow reexports to pick up categories from the package
     // they are exposed in.
     test('Verify that reexported classes pick up categories', () {
-      Class IAmAClassWithCategoriesReexport = ginormousPackageGraph
-          .localPackages
+      var IAmAClassWithCategoriesReexport = ginormousPackageGraph.localPackages
           .firstWhere((Package p) => p.name == 'test_package')
           .publicLibraries
           .firstWhere((Library l) => l.name == 'fake')
@@ -254,20 +250,19 @@ void main() {
       expect(IAmAClassWithCategoriesReexport.categories.first.name,
           equals('Superb'));
       expect(IAmAClassWithCategoriesReexport.displayedCategories, isNotEmpty);
-      Category category =
-          IAmAClassWithCategoriesReexport.displayedCategories.first;
+      var category = IAmAClassWithCategoriesReexport.displayedCategories.first;
       expect(category.categoryIndex, equals(0));
       expect(category.isDocumented, isTrue);
     });
 
     test('Verify that multiple categories work correctly', () {
-      Library fakeLibrary = ginormousPackageGraph.localPackages
+      var fakeLibrary = ginormousPackageGraph.localPackages
           .firstWhere((Package p) => p.name == 'test_package')
           .publicLibraries
           .firstWhere((Library l) => l.name == 'fake');
-      Class BaseForDocComments = fakeLibrary.publicClasses
+      var BaseForDocComments = fakeLibrary.publicClasses
           .firstWhere((Class c) => c.name == 'BaseForDocComments');
-      Class SubForDocComments = fakeLibrary.publicClasses
+      var SubForDocComments = fakeLibrary.publicClasses
           .firstWhere((Class c) => c.name == 'SubForDocComments');
       expect(BaseForDocComments.hasCategoryNames, isTrue);
       // Display both, with the correct order and display name.
@@ -284,11 +279,10 @@ void main() {
     });
 
     test('Verify that packages without categories get handled', () async {
-      PackageGraph packageGraphSmall = await utils.testPackageGraphSmall;
+      var packageGraphSmall = await utils.testPackageGraphSmall;
       expect(packageGraphSmall.localPackages.length, equals(1));
       expect(packageGraphSmall.localPackages.first.hasCategories, isFalse);
-      List<Category> packageCategories =
-          packageGraphSmall.localPackages.first.categories;
+      var packageCategories = packageGraphSmall.localPackages.first.categories;
       expect(packageCategories.length, equals(0));
     }, timeout: Timeout.factor(2));
   });
@@ -331,7 +325,7 @@ void main() {
 
     group('test small package', () {
       test('does not have documentation', () async {
-        PackageGraph packageGraphSmall = await utils.testPackageGraphSmall;
+        var packageGraphSmall = await utils.testPackageGraphSmall;
         expect(packageGraphSmall.defaultPackage.hasDocumentation, isFalse);
         expect(packageGraphSmall.defaultPackage.hasDocumentationFile, isFalse);
         expect(packageGraphSmall.defaultPackage.documentationFile, isNull);
@@ -341,13 +335,13 @@ void main() {
 
     group('SDK-specific cases', () {
       test('Verify Interceptor is hidden from inheritance in docs', () {
-        Library htmlLibrary = sdkAsPackageGraph.libraries
+        var htmlLibrary = sdkAsPackageGraph.libraries
             .singleWhere((l) => l.name == 'dart:html');
-        Class EventTarget =
+        var EventTarget =
             htmlLibrary.allClasses.singleWhere((c) => c.name == 'EventTarget');
-        Field hashCode = EventTarget.allPublicInstanceProperties
+        var hashCode = EventTarget.allPublicInstanceProperties
             .singleWhere((f) => f.name == 'hashCode');
-        Class objectModelElement =
+        var objectModelElement =
             sdkAsPackageGraph.specialClasses[SpecialClass.object];
         // If this fails, EventTarget might have been changed to no longer
         // inherit from Interceptor.  If that's true, adjust test case to
@@ -367,7 +361,7 @@ void main() {
       });
 
       test('Verify pragma is hidden in SDK docs', () {
-        Class pragmaModelElement =
+        var pragmaModelElement =
             sdkAsPackageGraph.specialClasses[SpecialClass.pragma];
         expect(pragmaModelElement.name, equals('pragma'));
       });
@@ -427,7 +421,7 @@ void main() {
             ..documentation;
     });
 
-    test("warns on youtube video with missing parameters", () {
+    test('warns on youtube video with missing parameters', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withYouTubeWrongParams,
@@ -436,7 +430,7 @@ void main() {
               'YouTube directives must be of the form "{@youtube WIDTH HEIGHT URL}"'),
           isTrue);
     });
-    test("warns on youtube video with non-integer width", () {
+    test('warns on youtube video with non-integer width', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withYouTubeBadWidth,
@@ -445,7 +439,7 @@ void main() {
               'must be a positive integer.'),
           isTrue);
     });
-    test("warns on youtube video with non-integer height", () {
+    test('warns on youtube video with non-integer height', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withYouTubeBadHeight,
@@ -454,7 +448,7 @@ void main() {
               'must be a positive integer.'),
           isTrue);
     });
-    test("warns on youtube video with invalid video URL", () {
+    test('warns on youtube video with invalid video URL', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withYouTubeInvalidUrl,
@@ -465,7 +459,7 @@ void main() {
               'https://www.youtube.com/watch?v=oHg5SJYRHA0.'),
           isTrue);
     });
-    test("warns on youtube video with extra parameters in URL", () {
+    test('warns on youtube video with extra parameters in URL', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withYouTubeUrlWithAdditionalParameters,
@@ -519,7 +513,7 @@ void main() {
             ..documentation;
     });
 
-    test("warns with invalidly-named animation within the method documentation",
+    test('warns with invalidly-named animation within the method documentation',
         () async {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
@@ -530,7 +524,7 @@ void main() {
               'underscores, and must not begin with a number.'),
           isTrue);
     });
-    test("warns on a non-unique animation name within a method", () {
+    test('warns on a non-unique animation name within a method', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withAnimationNonUnique,
@@ -539,7 +533,7 @@ void main() {
               'Animation identifiers must be unique.'),
           isTrue);
     });
-    test("warns on a non-unique animation name within a deprecated-form method",
+    test('warns on a non-unique animation name within a deprecated-form method',
         () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
@@ -549,7 +543,7 @@ void main() {
               'Animation identifiers must be unique.'),
           isTrue);
     });
-    test("warns on animation with missing parameters", () {
+    test('warns on animation with missing parameters', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withAnimationWrongParams,
@@ -559,7 +553,7 @@ void main() {
               'HEIGHT URL [id=ID]}"'),
           isTrue);
     });
-    test("warns on animation with non-integer width", () {
+    test('warns on animation with non-integer width', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withAnimationBadWidth,
@@ -568,7 +562,7 @@ void main() {
               'The width must be an integer.'),
           isTrue);
     });
-    test("warns on animation with non-integer height", () {
+    test('warns on animation with non-integer height', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withAnimationBadHeight,
@@ -577,7 +571,7 @@ void main() {
               '"100px". The height must be an integer.'),
           isTrue);
     });
-    test("Unknown arguments generate an error.", () {
+    test('Unknown arguments generate an error.', () {
       expect(
           packageGraphErrors.packageWarningCounter.hasWarning(
               withAnimationUnknownArg,

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -49,10 +49,10 @@ class TestLibraryContainerSdk extends TestLibraryContainer {
 }
 
 void main() {
-  Directory sdkDir = defaultSdkDir;
+  var sdkDir = defaultSdkDir;
 
   if (sdkDir == null) {
-    print("Warning: unable to locate the Dart SDK.");
+    print('Warning: unable to locate the Dart SDK.');
     exit(1);
   }
 
@@ -140,6 +140,7 @@ void main() {
     Method invokeToolNonCanonical, invokeToolNonCanonicalSubclass;
     Method invokeToolPrivateLibrary, invokeToolPrivateLibraryOriginal;
     Method invokeToolParentDoc, invokeToolParentDocOriginal;
+    // ignore: omit_local_variable_types
     final RegExp packageInvocationIndexRegexp =
         RegExp(r'PACKAGE_INVOCATION_INDEX: (\d+)');
 
@@ -272,11 +273,11 @@ void main() {
               '<a href="${HTMLBASE_PLACEHOLDER}ex/Dog-class.html">Dog</a>')));
     });
     test('can invoke a tool multiple times in one comment block', () {
-      RegExp envLine = RegExp(r'^Env: \{', multiLine: true);
+      var envLine = RegExp(r'^Env: \{', multiLine: true);
       expect(
           envLine.allMatches(invokeToolMultipleSections.documentation).length,
           equals(2));
-      RegExp argLine = RegExp(r'^Args: \[', multiLine: true);
+      var argLine = RegExp(r'^Args: \[', multiLine: true);
       expect(
           argLine.allMatches(invokeToolMultipleSections.documentation).length,
           equals(2));
@@ -333,8 +334,7 @@ void main() {
     test('Verify categories for test_package', () {
       expect(packageGraph.localPackages.length, equals(1));
       expect(packageGraph.localPackages.first.hasCategories, isTrue);
-      List<Category> packageCategories =
-          packageGraph.localPackages.first.categories;
+      var packageCategories = packageGraph.localPackages.first.categories;
       expect(packageCategories.length, equals(6));
       expect(
           packageGraph.localPackages.first.categoriesWithPublicLibraries.length,
@@ -355,11 +355,10 @@ void main() {
 
     test('Verify libraries with multiple categories show up in multiple places',
         () {
-      List<Category> packageCategories =
-          packageGraph.publicPackages.first.categories;
-      Category realLibraries =
+      var packageCategories = packageGraph.publicPackages.first.categories;
+      var realLibraries =
           packageCategories.firstWhere((c) => c.name == 'Real Libraries');
-      Category misc = packageCategories.firstWhere((c) => c.name == 'Misc');
+      var misc = packageCategories.firstWhere((c) => c.name == 'Misc');
       expect(
           realLibraries.libraries.map((l) => l.name), contains('two_exports'));
       expect(misc.libraries.map((l) => l.name), contains('two_exports'));
@@ -375,8 +374,8 @@ void main() {
 
     // TODO consider moving these to a separate suite
     test('CategoryRendererHtml renders category label', () {
-      Category category = packageGraph.publicPackages.first.categories.first;
-      CategoryRendererHtml renderer = CategoryRendererHtml();
+      var category = packageGraph.publicPackages.first.categories.first;
+      var renderer = CategoryRendererHtml();
       expect(
           renderer.renderCategoryLabel(category),
           '<span class="category superb cp-0 linked" title="This is part of the Superb Topic.">'
@@ -384,22 +383,22 @@ void main() {
     });
 
     test('CategoryRendererHtml renders linkedName', () {
-      Category category = packageGraph.publicPackages.first.categories.first;
-      CategoryRendererHtml renderer = CategoryRendererHtml();
+      var category = packageGraph.publicPackages.first.categories.first;
+      var renderer = CategoryRendererHtml();
       expect(renderer.renderLinkedName(category),
           '<a href="${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html">Superb</a>');
     });
 
     test('CategoryRendererMd renders category label', () {
-      Category category = packageGraph.publicPackages.first.categories.first;
-      CategoryRendererMd renderer = CategoryRendererMd();
+      var category = packageGraph.publicPackages.first.categories.first;
+      var renderer = CategoryRendererMd();
       expect(renderer.renderCategoryLabel(category),
           '[Superb](${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html)');
     });
 
     test('CategoryRendererMd renders linkedName', () {
-      Category category = packageGraph.publicPackages.first.categories.first;
-      CategoryRendererMd renderer = CategoryRendererMd();
+      var category = packageGraph.publicPackages.first.categories.first;
+      var renderer = CategoryRendererMd();
       expect(renderer.renderLinkedName(category),
           '[Superb](${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html)');
     });
@@ -424,8 +423,9 @@ void main() {
     });
 
     test('multiple containers with specified sort order', () {
-      List<LibraryContainer> containers = [];
-      for (String name in containerNames) {
+      var containers = <LibraryContainer>[];
+      for (var i = 0; i < containerNames.length; i++) {
+        var name = containerNames[i];
         containers.add(TestLibraryContainer(name, sortOrderBasic, topLevel));
       }
       containers.add(TestLibraryContainerSdk('SDK', sortOrderBasic, topLevel));
@@ -444,8 +444,8 @@ void main() {
     });
 
     test('multiple containers, no specified sort order', () {
-      List<LibraryContainer> containers = [];
-      for (String name in containerNames) {
+      var containers = <LibraryContainer>[];
+      for (var name in containerNames) {
         containers.add(TestLibraryContainer(name, [], topLevel));
       }
       containers.add(TestLibraryContainerSdk('SDK', [], topLevel));
@@ -485,7 +485,7 @@ void main() {
       test('packages', () {
         expect(packageGraph.localPackages, hasLength(1));
 
-        Package package = packageGraph.localPackages.first;
+        var package = packageGraph.localPackages.first;
         expect(package.name, 'test_package');
         expect(package.publicLibraries,
             hasLength(utils.kTestPackagePublicLibraries));
@@ -526,7 +526,7 @@ void main() {
 
     group('SDK-specific cases', () {
       test('Verify pragma is hidden in docs', () {
-        Class HasPragma = fakeLibrary.allClasses
+        var HasPragma = fakeLibrary.allClasses
             .firstWhere((Class c) => c.name == 'HasPragma');
         expect(HasPragma.annotations, isEmpty);
       });
@@ -713,26 +713,26 @@ void main() {
           .firstWhere((e) => e.name == 'macroReferencedHere');
     });
 
-    test("renders a macro defined within a enum", () {
+    test('renders a macro defined within a enum', () {
       expect(macroReferencedHere.documentationAsHtml,
           contains('This is a macro defined in an Enum accessor.'));
     });
 
     test("renders a macro within the same comment where it's defined", () {
       expect(withMacro.documentation,
-          equals("Macro method\n\nFoo macro content\nMore docs"));
+          equals('Macro method\n\nFoo macro content\nMore docs'));
     });
 
     test("renders a macro in another method, not the same where it's defined",
         () {
-      expect(withMacro2.documentation, equals("Foo macro content"));
+      expect(withMacro2.documentation, equals('Foo macro content'));
     });
 
-    test("renders a macro defined in a private symbol", () {
-      expect(withPrivateMacro.documentation, contains("Private macro content"));
+    test('renders a macro defined in a private symbol', () {
+      expect(withPrivateMacro.documentation, contains('Private macro content'));
     });
 
-    test("a warning is generated for unknown macros", () {
+    test('a warning is generated for unknown macros', () {
       // Retrieve documentation first to generate the warning.
       withUndefinedMacro.documentation;
       expect(
@@ -759,7 +759,7 @@ void main() {
     });
 
     test(
-        "renders a YouTube video within the method documentation with correct aspect ratio",
+        'renders a YouTube video within the method documentation with correct aspect ratio',
         () {
       expect(
           withYouTubeWatchUrl.documentation,
@@ -779,7 +779,7 @@ void main() {
           contains(
               '<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0?rel=0"'));
     });
-    test("Handles YouTube video inline properly", () {
+    test('Handles YouTube video inline properly', () {
       // Make sure it doesn't have a double-space before the continued line,
       // which would indicate to Markdown to indent the line.
       expect(withYouTubeInline.documentation, isNot(contains('  works')));
@@ -823,21 +823,21 @@ void main() {
           .firstWhere((m) => m.name == 'withAnimationOutOfOrder');
     });
 
-    test("renders an unnamed animation within the method documentation", () {
+    test('renders an unnamed animation within the method documentation', () {
       expect(withAnimation.documentation, contains('<video id="animation_1"'));
     });
-    test("renders a named animation within the method documentation", () {
+    test('renders a named animation within the method documentation', () {
       expect(withNamedAnimation.documentation,
           contains('<video id="namedAnimation"'));
     });
-    test("renders a quoted, named animation within the method documentation",
+    test('renders a quoted, named animation within the method documentation',
         () {
       expect(withQuoteNamedAnimation.documentation,
           contains('<video id="quotedNamedAnimation"'));
       expect(withQuoteNamedAnimation.documentation,
           contains('<video id="quotedNamedAnimation2"'));
     });
-    test("renders a deprecated-form animation within the method documentation",
+    test('renders a deprecated-form animation within the method documentation',
         () {
       expect(withDeprecatedAnimation.documentation,
           contains('<video id="deprecatedAnimation"'));
@@ -856,16 +856,16 @@ void main() {
       expect(withAnimationInOneLineDoc.oneLineDoc, isNot(contains('<video')));
       expect(withAnimationInOneLineDoc.documentation, contains('<video'));
     });
-    test("Handles animations inline properly", () {
+    test('Handles animations inline properly', () {
       // Make sure it doesn't have a double-space before the continued line,
       // which would indicate to Markdown to indent the line.
       expect(withAnimationInline.documentation, isNot(contains('  works')));
     });
-    test("Out of order arguments work.", () {
+    test('Out of order arguments work.', () {
       expect(withAnimationOutOfOrder.documentation,
           contains('<video id="outOfOrder"'));
     });
-    test("Enum field animation identifiers are unique.", () {
+    test('Enum field animation identifiers are unique.', () {
       expect(
           enumValue1.documentationAsHtml, contains('<video id="animation_1"'));
       expect(
@@ -997,7 +997,7 @@ void main() {
       });
 
       test('Verify there is no emoji support', () {
-        TopLevelVariable tpvar = fakeLibrary.constants
+        var tpvar = fakeLibrary.constants
             .firstWhere((t) => t.name == 'hasMarkdownInDoc');
         docsAsHtml = tpvar.documentationAsHtml;
         expect(docsAsHtml.contains('3ffe:2a00:100:7031::1'), isTrue);
@@ -1012,7 +1012,7 @@ void main() {
       });
 
       test('can handle renamed imports', () {
-        ModelFunction aFunctionUsingRenamedLib = fakeLibrary.functions
+        var aFunctionUsingRenamedLib = fakeLibrary.functions
             .firstWhere((f) => f.name == 'aFunctionUsingRenamedLib');
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
@@ -1089,7 +1089,7 @@ void main() {
       test(
           'link to unresolved name in the library in this package still should be linked',
           () {
-        final Class helperClass =
+        var helperClass =
             exLibrary.classes.firstWhere((c) => c.name == 'Helper');
         expect(
             helperClass.documentationAsHtml,
@@ -1102,7 +1102,7 @@ void main() {
       });
 
       test('link to override method in implementer from base class', () {
-        final Class helperClass =
+        var helperClass =
             baseClassLib.classes.firstWhere((c) => c.name == 'Constraints');
         expect(
             helperClass.documentationAsHtml,
@@ -1238,7 +1238,7 @@ void main() {
 
     test('oneLine doc references in inherited methods should not have brackets',
         () {
-      Method add =
+      var add =
           specialList.allInstanceMethods.firstWhere((m) => m.name == 'add');
       expect(
           add.oneLineDoc,
@@ -1249,7 +1249,7 @@ void main() {
     test(
         'full documentation references from inherited methods should not have brackets',
         () {
-      Method add =
+      var add =
           specialList.allInstanceMethods.firstWhere((m) => m.name == 'add');
       expect(
           add.documentationAsHtml,
@@ -1287,7 +1287,7 @@ void main() {
     test('references are correct in exported libraries', () {
       expect(twoExportsLib, isNotNull);
       expect(extendedClass, isNotNull);
-      String resolved = extendedClass.documentationAsHtml;
+      var resolved = extendedClass.documentationAsHtml;
       expect(resolved, isNotNull);
       expect(
           resolved,
@@ -1300,7 +1300,7 @@ void main() {
     });
 
     test('references to class and constructors', () {
-      String comment = B.documentationAsHtml;
+      var comment = B.documentationAsHtml;
       expect(
           comment,
           contains(
@@ -1316,7 +1316,7 @@ void main() {
     });
 
     test('reference to class from another library', () {
-      String comment = superAwesomeClass.documentationAsHtml;
+      var comment = superAwesomeClass.documentationAsHtml;
       expect(
           comment,
           contains(
@@ -1324,7 +1324,7 @@ void main() {
     });
 
     test('reference to method', () {
-      String comment = foo2.documentationAsHtml;
+      var comment = foo2.documentationAsHtml;
       expect(
           comment,
           equals(
@@ -1334,7 +1334,7 @@ void main() {
     test(
         'code references to privately defined elements in public classes work properly',
         () {
-      Method notAMethodFromPrivateClass = fakeLibrary.allClasses
+      var notAMethodFromPrivateClass = fakeLibrary.allClasses
           .firstWhere((Class c) => c.name == 'ReferringClass')
           .allPublicInstanceMethods
           .firstWhere((Method m) => m.name == 'notAMethodFromPrivateClass');
@@ -1356,14 +1356,14 @@ void main() {
     });
 
     test('doc comments to parameters are marked as code', () {
-      Method localMethod = subForDocComments.instanceMethods
+      var localMethod = subForDocComments.instanceMethods
           .firstWhere((m) => m.name == 'localMethod');
       expect(localMethod.documentationAsHtml, contains('<code>foo</code>'));
       expect(localMethod.documentationAsHtml, contains('<code>bar</code>'));
     });
 
     test('doc comment inherited from getter', () {
-      Field getterWithDocs = subForDocComments.instanceProperties
+      var getterWithDocs = subForDocComments.instanceProperties
           .firstWhere((m) => m.name == 'getterWithDocs');
       expect(getterWithDocs.documentationAsHtml,
           contains('Some really great topics.'));
@@ -1372,7 +1372,7 @@ void main() {
     test(
         'a property with no explicit getters and setters does not duplicate docs',
         () {
-      Field powers = superAwesomeClass.instanceProperties
+      var powers = superAwesomeClass.instanceProperties
           .firstWhere((p) => p.name == 'powers');
       Iterable<Match> matches =
           RegExp('In the super class').allMatches(powers.documentationAsHtml);
@@ -1390,12 +1390,11 @@ void main() {
 
   group('Class edge cases', () {
     test('Factories from unrelated classes are linked correctly', () {
-      Class A = packageGraph.localPublicLibraries
+      var A = packageGraph.localPublicLibraries
           .firstWhere((l) => l.name == 'unrelated_factories')
           .allClasses
           .firstWhere((c) => c.name == 'A');
-      Constructor fromMap =
-          A.constructors.firstWhere((c) => c.name == 'A.fromMap');
+      var fromMap = A.constructors.firstWhere((c) => c.name == 'A.fromMap');
       expect(fromMap.documentationAsHtml,
           contains(r'unrelated_factories/AB/AB.fromMap.html">AB.fromMap</a>'));
       expect(fromMap.documentationAsHtml,
@@ -1408,11 +1407,11 @@ void main() {
 
     test('Inherit from private class across private library to public library',
         () {
-      Class GadgetExtender = packageGraph.localPublicLibraries
+      var GadgetExtender = packageGraph.localPublicLibraries
           .firstWhere((l) => l.name == 'gadget_extender')
           .allClasses
           .firstWhere((c) => c.name == 'GadgetExtender');
-      Field gadgetGetter =
+      var gadgetGetter =
           GadgetExtender.allFields.firstWhere((f) => f.name == 'gadgetGetter');
       expect(gadgetGetter.isCanonical, isTrue);
     });
@@ -1420,9 +1419,9 @@ void main() {
     test(
         'ExecutableElements from private classes and from public interfaces (#1561)',
         () {
-      Class MIEEMixinWithOverride = fakeLibrary.publicClasses
+      var MIEEMixinWithOverride = fakeLibrary.publicClasses
           .firstWhere((c) => c.name == 'MIEEMixinWithOverride');
-      Operator problematicOperator = MIEEMixinWithOverride.inheritedOperators
+      var problematicOperator = MIEEMixinWithOverride.inheritedOperators
           .firstWhere((o) => o.name == 'operator []=');
       expect(problematicOperator.element.enclosingElement.name,
           equals('_MIEEPrivateOverride'));
@@ -1440,7 +1439,7 @@ void main() {
         overrideByModifierClass;
 
     setUpAll(() {
-      Iterable<Class> classes = fakeLibrary.publicClasses;
+      var classes = fakeLibrary.publicClasses;
       GenericClass = classes.firstWhere((c) => c.name == 'GenericClass');
       ModifierClass = classes.firstWhere((c) => c.name == 'ModifierClass');
       GenericMixin =
@@ -1490,11 +1489,11 @@ void main() {
     });
 
     test(('Verify non-overridden members have right canonical classes'), () {
-      final Field member = TypeInferenceMixedIn.allInstanceFields
+      var member = TypeInferenceMixedIn.allInstanceFields
           .firstWhere((f) => f.name == 'member');
-      final Field modifierMember = TypeInferenceMixedIn.allInstanceFields
+      var modifierMember = TypeInferenceMixedIn.allInstanceFields
           .firstWhere((f) => f.name == 'modifierMember');
-      final Field mixinMember = TypeInferenceMixedIn.allInstanceFields
+      var mixinMember = TypeInferenceMixedIn.allInstanceFields
           .firstWhere((f) => f.name == 'mixinMember');
       expect(member.canonicalEnclosingContainer, equals(GenericClass));
       expect(modifierMember.canonicalEnclosingContainer, equals(ModifierClass));
@@ -1666,7 +1665,7 @@ void main() {
     });
 
     test('constructors have source', () {
-      Constructor ctor = Dog.constructors.first;
+      var ctor = Dog.constructors.first;
       expect(ctor.sourceCode, isNotEmpty);
     });
 
@@ -1724,7 +1723,7 @@ void main() {
 
     test('exported class should have linkedReturnType for the current library',
         () {
-      Method returnCool = Cool.instanceMethods
+      var returnCool = Cool.instanceMethods
           .firstWhere((m) => m.name == 'returnCool', orElse: () => null);
       expect(returnCool, isNotNull);
       expect(
@@ -1914,7 +1913,7 @@ void main() {
           extensionOnVoid,
           extensionOnNull,
           extensionOnTypeParameter;
-      Class object = packageGraph.specialClasses[SpecialClass.object];
+      var object = packageGraph.specialClasses[SpecialClass.object];
       Extension getExtension(String name) =>
           fakeLibrary.extensions.firstWhere((e) => e.name == name);
 
@@ -2035,7 +2034,7 @@ void main() {
     });
 
     test('has extended type', () {
-      expect(ext.extendedType.name, equals("Apple"));
+      expect(ext.extendedType.name, equals('Apple'));
     });
 
     test('extension name with generics', () {
@@ -2110,7 +2109,7 @@ void main() {
       expect(animal.constants, hasLength(4));
     });
 
-    test("has a (synthetic) values constant", () {
+    test('has a (synthetic) values constant', () {
       var valuesField = animal.constants.firstWhere((f) => f.name == 'values');
       expect(valuesField, isNotNull);
       expect(valuesField.constantValue,
@@ -2278,9 +2277,9 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('typedef params have proper signature', () {
-      ModelFunction function =
+      var function =
           fakeLibrary.functions.firstWhere((f) => f.name == 'addCallback');
-      String params =
+      var params =
           ParameterRendererHtml().renderLinkedParams(function.parameters);
       expect(
           params,
@@ -2304,7 +2303,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('can resolve functions as parameters', () {
-      String params = ParameterRendererHtml()
+      var params = ParameterRendererHtml()
           .renderLinkedParams(doAComplicatedThing.parameters);
       expect(params,
           '<span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, </span><wbr><span class="parameter" id="doAComplicatedThing-param-doSomething">{<span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span><wbr><span class="parameter" id="param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span><wbr>), </span><wbr><span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span><wbr><span class="parameter" id="param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span><wbr>)}</span><wbr>');
@@ -2322,7 +2321,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('setter that takes a function is correctly displayed', () {
-      Field explicitSetter = ClassWithUnusualProperties.instanceProperties
+      var explicitSetter = ClassWithUnusualProperties.instanceProperties
           .singleWhere((f) => f.name == 'explicitSetter');
       // TODO(jcollins-g): really, these shouldn't be called "parameters" in
       // the span class.
@@ -2331,14 +2330,14 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('parameterized type from field is correctly displayed', () {
-      Field aField = TemplatedInterface.instanceProperties
+      var aField = TemplatedInterface.instanceProperties
           .singleWhere((f) => f.name == 'aField');
       expect(aField.linkedReturnType,
           '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
     });
 
     test('parameterized type from inherited field is correctly displayed', () {
-      Field aInheritedField = TemplatedInterface.inheritedProperties
+      var aInheritedField = TemplatedInterface.inheritedProperties
           .singleWhere((f) => f.name == 'aInheritedField');
       expect(aInheritedField.linkedReturnType,
           '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
@@ -2381,7 +2380,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'parameterized type for return value from method is correctly displayed',
         () {
-      Method aMethodInterface = TemplatedInterface.allInstanceMethods
+      var aMethodInterface = TemplatedInterface.allInstanceMethods
           .singleWhere((m) => m.name == 'aMethodInterface');
       expect(aMethodInterface.linkedReturnType,
           '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
@@ -2390,7 +2389,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'parameterized type for return value from inherited method is correctly displayed',
         () {
-      Method aInheritedMethod = TemplatedInterface.allInstanceMethods
+      var aInheritedMethod = TemplatedInterface.allInstanceMethods
           .singleWhere((m) => m.name == 'aInheritedMethod');
       expect(aInheritedMethod.linkedReturnType,
           '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
@@ -2399,7 +2398,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'parameterized type for return value containing a parameterized typedef is correctly displayed',
         () {
-      Method aTypedefReturningMethodInterface = TemplatedInterface
+      var aTypedefReturningMethodInterface = TemplatedInterface
           .allInstanceMethods
           .singleWhere((m) => m.name == 'aTypedefReturningMethodInterface');
       expect(aTypedefReturningMethodInterface.linkedReturnType,
@@ -2409,7 +2408,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'parameterized type for return value containing a parameterized typedef from inherited method is correctly displayed',
         () {
-      Method aInheritedTypedefReturningMethod = TemplatedInterface
+      var aInheritedTypedefReturningMethod = TemplatedInterface
           .allInstanceMethods
           .singleWhere((m) => m.name == 'aInheritedTypedefReturningMethod');
       expect(aInheritedTypedefReturningMethod.linkedReturnType,
@@ -2418,8 +2417,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('parameterized types for inherited operator is correctly displayed',
         () {
-      Operator aInheritedAdditionOperator = TemplatedInterface
-          .inheritedOperators
+      var aInheritedAdditionOperator = TemplatedInterface.inheritedOperators
           .singleWhere((m) => m.name == 'operator +');
       expect(aInheritedAdditionOperator.linkedReturnType,
           '<a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
@@ -2509,9 +2507,9 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(abstractMethod.fullkind, 'abstract method');
     });
 
-    test("returns correct overriddenDepth", () {
+    test('returns correct overriddenDepth', () {
       final bAbstractMethod = classB.allInstanceMethods
-          .firstWhere((m) => m.name == "abstractMethod");
+          .firstWhere((m) => m.name == 'abstractMethod');
       expect(abstractMethod.overriddenDepth, equals(0));
       expect(bAbstractMethod.overriddenDepth, equals(1));
     });
@@ -2902,7 +2900,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('has valid documentation', () {
       expect(mFromApple.hasDocumentation, isTrue);
-      expect(mFromApple.documentation, "The read-write field `m`.");
+      expect(mFromApple.documentation, 'The read-write field `m`.');
     });
 
     test('inherited property has a linked name to superclass in package', () {
@@ -2995,11 +2993,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'has one inherited property for getter/setter when inherited from parameterized class',
         () {
-      Class withGenericSub =
+      var withGenericSub =
           exLibrary.classes.firstWhere((c) => c.name == 'WithGenericSub');
       expect(
           withGenericSub.inheritedProperties
-              .where((p) => p.name == "prop")
+              .where((p) => p.name == 'prop')
               .length,
           equals(1));
     });
@@ -3014,11 +3012,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     Class classB;
 
     setUpAll(() {
-      TopLevelVariable justGetter =
+      var justGetter =
           fakeLibrary.properties.firstWhere((p) => p.name == 'justGetter');
       onlyGetterGetter = justGetter.getter;
       onlyGetterSetter = justGetter.setter;
-      TopLevelVariable justSetter =
+      var justSetter =
           fakeLibrary.properties.firstWhere((p) => p.name == 'justSetter');
       onlySetterSetter = justSetter.setter;
       onlySetterGetter = justSetter.getter;
@@ -3035,18 +3033,18 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('if overridden, gets documentation from superclasses', () {
       final doc = classB.allInstanceFields
-          .firstWhere((p) => p.name == "s")
+          .firstWhere((p) => p.name == 's')
           .getter
           .documentation;
-      expect(doc, equals("The getter for `s`"));
+      expect(doc, equals('The getter for `s`'));
     });
 
     test(
-        "has correct linked return type if the return type is a parameterized typedef",
+        'has correct linked return type if the return type is a parameterized typedef',
         () {
-      Class apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
+      var apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
       final fieldWithTypedef = apple.allInstanceFields
-          .firstWhere((m) => m.name == "fieldWithTypedef");
+          .firstWhere((m) => m.name == 'fieldWithTypedef');
       expect(
           fieldWithTypedef.linkedReturnType,
           equals(
@@ -3101,7 +3099,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'Verify that a map containing anonymous functions as values works correctly',
         () {
-      Iterable<ElementType> typeArguments =
+      var typeArguments =
           (importantComputations.modelType.returnType as DefinedElementType)
               .typeArguments;
       expect(typeArguments, isNotEmpty);
@@ -3127,14 +3125,14 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('@nodoc on simple property works', () {
-      TopLevelVariable nodocSimple = fakeLibrary.publicProperties.firstWhere(
+      var nodocSimple = fakeLibrary.publicProperties.firstWhere(
           (p) => p.name == 'simplePropertyHidden',
           orElse: () => null);
       expect(nodocSimple, isNull);
     });
 
     test('@nodoc on both hides both', () {
-      TopLevelVariable nodocBoth = fakeLibrary.publicProperties.firstWhere(
+      var nodocBoth = fakeLibrary.publicProperties.firstWhere(
           (p) => p.name == 'getterSetterNodocBoth',
           orElse: () => null);
       expect(nodocBoth, isNull);
@@ -3223,7 +3221,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       cat = exLibrary.constants.firstWhere((c) => c.name == 'MY_CAT');
       deprecated =
           exLibrary.constants.firstWhere((c) => c.name == 'deprecated');
-      Class Dog = exLibrary.allClasses.firstWhere((c) => c.name == 'Dog');
+      var Dog = exLibrary.allClasses.firstWhere((c) => c.name == 'Dog');
       customClassPrivate = fakeLibrary.constants
           .firstWhere((c) => c.name == 'CUSTOM_CLASS_PRIVATE');
       aStaticConstField =
@@ -3265,14 +3263,14 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('COLOR_ORANGE has correct value', () {
-      expect(orangeConstant.constantValue, "&#39;orange&#39;");
+      expect(orangeConstant.constantValue, '&#39;orange&#39;');
     });
 
     test('PRETTY_COLORS', () {
       expect(
           prettyColorsConstant.constantValue,
           matches(RegExp(
-              r"const &lt;String&gt;\s?\[COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;\]")));
+              r'const &lt;String&gt;\s?\[COLOR_GREEN, COLOR_ORANGE, &#39;blue&#39;\]')));
     });
 
     test('MY_CAT is linked', () {
@@ -3416,7 +3414,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           ExtendsFutureVoid.linkedName,
           equals(
               '<a href="${HTMLBASE_PLACEHOLDER}fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a>'));
-      DefinedElementType FutureVoid = ExtendsFutureVoid.publicSuperChain
+      var FutureVoid = ExtendsFutureVoid.publicSuperChain
           .firstWhere((c) => c.name == 'Future');
       expect(
           FutureVoid.linkedName,
@@ -3429,7 +3427,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           ImplementsFutureVoid.linkedName,
           equals(
               '<a href="${HTMLBASE_PLACEHOLDER}fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a>'));
-      DefinedElementType FutureVoid = ImplementsFutureVoid.publicInterfaces
+      var FutureVoid = ImplementsFutureVoid.publicInterfaces
           .firstWhere((c) => c.name == 'Future');
       expect(
           FutureVoid.linkedName,
@@ -3442,7 +3440,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           ATypeTakingClassMixedIn.linkedName,
           equals(
               '<a href="${HTMLBASE_PLACEHOLDER}fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a>'));
-      DefinedElementType ATypeTakingClassVoid = ATypeTakingClassMixedIn.mixins
+      var ATypeTakingClassVoid = ATypeTakingClassMixedIn.mixins
           .firstWhere((c) => c.name == 'ATypeTakingClass');
       expect(
           ATypeTakingClassVoid.linkedName,
@@ -3486,7 +3484,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'Typedefs with bound type parameters indirectly referred in parameters are displayed',
         () {
-      Constructor theConstructor = TypedefUsingClass.constructors.first;
+      var theConstructor = TypedefUsingClass.constructors.first;
       expect(
           ParameterRendererHtml().renderLinkedParams(theConstructor.parameters),
           equals(
@@ -3540,7 +3538,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
               'List<span class="signature">&lt;<wbr><span class="type-parameter">S</span>&gt;</span>'));
     });
 
-    test("name with generics", () {
+    test('name with generics', () {
       expect(
           t.nameWithGenerics,
           equals(
@@ -3554,7 +3552,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     // TODO(jdkoren): Not easy to call TypedefRenderer directly because Typedef
     // inspects its element member. Find a better way when we start to isolate
     // renderer tests.
-    test("TypedefRendererHtml renders genericParameters", () {
+    test('TypedefRendererHtml renders genericParameters', () {
       expect(TypedefRendererHtml().renderGenericParameters(t), equals(''));
       expect(TypedefRendererHtml().renderGenericParameters(generic),
           equals('&lt;<wbr><span class="type-parameter">S</span>&gt;'));
@@ -3644,17 +3642,17 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('commas on same param line', () {
-      ModelFunction method =
+      var method =
           fakeLibrary.functions.firstWhere((f) => f.name == 'paintImage1');
-      String params =
+      var params =
           ParameterRendererHtml().renderLinkedParams(method.parameters);
       expect(params, contains(', </span>'));
     });
 
     test('param with annotations', () {
-      ModelFunction method =
+      var method =
           fakeLibrary.functions.firstWhere((f) => f.name == 'paintImage1');
-      String params =
+      var params =
           ParameterRendererHtml().renderLinkedParams(method.parameters);
       expect(params, contains('@required'));
     });
@@ -3703,7 +3701,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('Cat has implementors', () {
       expect(implC, hasLength(3));
-      List<String> implementors = ['B', 'Dog', 'ConstantCat'];
+      var implementors = <String>['B', 'Dog', 'ConstantCat'];
       expect(implementors.contains(implC[0].name), isTrue);
       expect(implementors.contains(implC[1].name), isTrue);
       expect(implementors.contains(implC[2].name), isTrue);
@@ -3717,7 +3715,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
   });
 
   group('Errors and exceptions', () {
-    final List<String> expectedNames = [
+    var expectedNames = <String>[
       'MyError',
       'MyException',
       'MyErrorImplements',
@@ -3771,27 +3769,27 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     // Order by uppercased lexical ordering for non-digits,
     // lexicographical ordering of embedded digit sequences.
     var names = [
-      r"",
-      r"$",
-      r"0",
-      r"0a",
-      r"00",
-      r"1",
-      r"01",
-      r"_",
-      r"a",
-      r"aaab",
-      r"aab",
-      r"Ab",
-      r"B",
-      r"bA",
-      r"x0$",
-      r"x1$",
-      r"x01$",
-      r"x001$",
-      r"x10$",
-      r"x010$",
-      r"x100$",
+      r'',
+      r'$',
+      r'0',
+      r'0a',
+      r'00',
+      r'1',
+      r'01',
+      r'_',
+      r'a',
+      r'aaab',
+      r'aab',
+      r'Ab',
+      r'B',
+      r'bA',
+      r'x0$',
+      r'x1$',
+      r'x01$',
+      r'x001$',
+      r'x10$',
+      r'x010$',
+      r'x100$',
     ];
     for (var i = 1; i < names.length; i++) {
       var a = StringName(names[i - 1]);

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   group('PackageMeta for the test package', () {
-    PackageMeta p = PackageMeta.fromDir(Directory(
+    var p = PackageMeta.fromDir(Directory(
         path.join(Directory.current.path, 'testing', 'test_package')));
 
     test('readme with corrupt UTF-8 loads without throwing', () {
@@ -35,7 +35,7 @@ void main() {
   });
 
   group('PackageMeta.fromDir for this package', () {
-    PackageMeta p = PackageMeta.fromDir(Directory.current);
+    var p = PackageMeta.fromDir(Directory.current);
 
     test('has a name', () {
       expect(p.name, 'dartdoc');
@@ -82,7 +82,7 @@ void main() {
   });
 
   group('PackageMeta.fromSdk', () {
-    PackageMeta p = PackageMeta.fromDir(defaultSdkDir);
+    var p = PackageMeta.fromDir(defaultSdkDir);
 
     test('has a name', () {
       expect(p.name, 'Dart');

--- a/test/render/template_renderer_test.dart
+++ b/test/render/template_renderer_test.dart
@@ -14,12 +14,12 @@ void main() {
     });
 
     test('composeLayoutTitle', () {
-      String test = renderer.composeLayoutTitle('Banana', 'Fruit', false);
+      var test = renderer.composeLayoutTitle('Banana', 'Fruit', false);
       expect(test, equals('Banana Fruit'));
     });
 
     test('composeLayoutTitle deprecated', () {
-      String test = renderer.composeLayoutTitle('Banana', 'Fruit', true);
+      var test = renderer.composeLayoutTitle('Banana', 'Fruit', true);
       expect(test, equals('<span class="deprecated">Banana</span> Fruit'));
     });
   });
@@ -32,12 +32,12 @@ void main() {
     });
 
     test('composeLayoutTitle', () {
-      String test = renderer.composeLayoutTitle('Banana', 'Fruit', false);
+      var test = renderer.composeLayoutTitle('Banana', 'Fruit', false);
       expect(test, equals('Banana Fruit'));
     });
 
     test('composeLayoutTitle deprecated', () {
-      String test = renderer.composeLayoutTitle('Banana', 'Fruit', true);
+      var test = renderer.composeLayoutTitle('Banana', 'Fruit', true);
       expect(test, equals('~~Banana~~ Fruit'));
     });
   });

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -98,7 +98,7 @@ final Directory testPackageCustomTemplates =
 /// the '--input' flag.
 Future<DartdocGeneratorOptionContext> generatorContextFromArgv(
     List<String> argv) async {
-  DartdocOptionSet optionSet = await DartdocOptionSet.fromOptionGenerators(
+  var optionSet = await DartdocOptionSet.fromOptionGenerators(
       'dartdoc', [createDartdocOptions, createGeneratorOptions]);
   optionSet.parseArguments(argv);
   return DartdocGeneratorOptionContext(optionSet, null);
@@ -107,7 +107,7 @@ Future<DartdocGeneratorOptionContext> generatorContextFromArgv(
 /// Convenience factory to build a [DartdocOptionContext] and associate it with a
 /// [DartdocOptionSet] based on the current working directory.
 Future<DartdocOptionContext> contextFromArgv(List<String> argv) async {
-  DartdocOptionSet optionSet = await DartdocOptionSet.fromOptionGenerators(
+  var optionSet = await DartdocOptionSet.fromOptionGenerators(
       'dartdoc', [createDartdocOptions]);
   optionSet.parseArguments(argv);
   return DartdocOptionContext(optionSet, Directory.current);
@@ -121,7 +121,7 @@ Future<PackageGraph> bootSdkPackage() async {
 Future<PackageGraph> bootBasicPackage(
     String dirPath, List<String> excludeLibraries,
     {List<String> additionalArguments}) async {
-  Directory dir = Directory(dirPath);
+  var dir = Directory(dirPath);
   additionalArguments ??= <String>[];
   return PackageBuilder(await contextFromArgv([
             '--input',
@@ -208,10 +208,10 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
             executable == Platform.resolvedExecutable,
         'Must use dart executable for tracking coverage');
 
-    Completer<String> portAsString = Completer();
+    var portAsString = Completer<String>();
     void parsePortAsString(String line) {
       if (!portAsString.isCompleted && coverageEnabled) {
-        Match m = observatoryPortRegexp.matchAsPrefix(line);
+        var m = observatoryPortRegexp.matchAsPrefix(line);
         if (m?.group(1) != null) portAsString.complete(m.group(1));
       } else {
         if (perLine != null) perLine(line);
@@ -227,14 +227,15 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
       arguments = [
         '--disable-service-auth-codes',
         '--enable-vm-service:0',
-        '--pause-isolates-on-exit'
-      ]..addAll(arguments);
+        '--pause-isolates-on-exit',
+        ...arguments
+      ];
       if (!environment.containsKey('DARTDOC_COVERAGE_DATA')) {
         environment['DARTDOC_COVERAGE_DATA'] = tempDir.path;
       }
     }
 
-    Future<Iterable<Map>> results = super.runStreamed(executable, arguments,
+    var results = super.runStreamed(executable, arguments,
         environment: environment,
         includeParentEnvironment: includeParentEnvironment,
         workingDirectory: workingDirectory,
@@ -265,7 +266,7 @@ class SubprocessLauncher {
   static Future<void> _printStream(Stream<List<int>> stream, Stdout output,
       {String prefix = '', Iterable<String> Function(String line) filter}) {
     assert(prefix != null);
-    if (filter == null) filter = (line) => [line];
+    filter ??= (line) => [line];
     return stream
         .transform(utf8.decoder)
         .transform(const LineSplitter())
@@ -279,7 +280,7 @@ class SubprocessLauncher {
   }
 
   SubprocessLauncher(this.context, [Map<String, String> environment])
-      : this.environmentDefaults = environment ?? <String, String>{};
+      : environmentDefaults = environment ?? <String, String>{};
 
   /// A wrapper around start/await process.exitCode that will display the
   /// output of the executable continuously and fail on non-zero exit codes.
@@ -315,9 +316,7 @@ class SubprocessLauncher {
         // line.  Just ignore it and leave result null.
       }
       if (result != null) {
-        if (jsonObjects == null) {
-          jsonObjects = List();
-        }
+        jsonObjects ??= [];
         jsonObjects.add(result);
         if (result.containsKey('message')) {
           line = result['message'];
@@ -335,18 +334,18 @@ class SubprocessLauncher {
         if (environment[key].contains(quotables)) {
           return "$key='${environment[key]}'";
         } else {
-          return "$key=${environment[key]}";
+          return '$key=${environment[key]}';
         }
       }).join(' '));
       stderr.write(' ');
     }
     stderr.write('$executable');
     if (arguments.isNotEmpty) {
-      for (String arg in arguments) {
+      for (var arg in arguments) {
         if (arg.contains(quotables)) {
           stderr.write(" '$arg'");
         } else {
-          stderr.write(" $arg");
+          stderr.write(' $arg');
         }
       }
     }
@@ -355,8 +354,8 @@ class SubprocessLauncher {
 
     if (Platform.environment.containsKey('DRY_RUN')) return null;
 
-    String realExecutable = executable;
-    final List<String> realArguments = [];
+    var realExecutable = executable;
+    var realArguments = <String>[];
     if (Platform.isLinux) {
       // Use GNU coreutils to force line buffering.  This makes sure that
       // subprocesses that die due to fatal signals do not chop off the
@@ -370,20 +369,20 @@ class SubprocessLauncher {
     }
     realArguments.addAll(arguments);
 
-    Process process = await Process.start(realExecutable, realArguments,
+    var process = await Process.start(realExecutable, realArguments,
         workingDirectory: workingDirectory,
         environment: environment,
         includeParentEnvironment: includeParentEnvironment);
-    Future<void> stdoutFuture = _printStream(process.stdout, stdout,
+    var stdoutFuture = _printStream(process.stdout, stdout,
         prefix: prefix, filter: jsonCallback);
-    Future<void> stderrFuture = _printStream(process.stderr, stderr,
+    var stderrFuture = _printStream(process.stderr, stderr,
         prefix: prefix, filter: jsonCallback);
     await Future.wait([stderrFuture, stdoutFuture, process.exitCode]);
 
-    int exitCode = await process.exitCode;
+    var exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw ProcessException(executable, arguments,
-          "SubprocessLauncher got non-zero exitCode: $exitCode", exitCode);
+          'SubprocessLauncher got non-zero exitCode: $exitCode', exitCode);
     }
     return jsonObjects;
   }

--- a/test/template_test.dart
+++ b/test/template_test.dart
@@ -19,7 +19,7 @@ void main() {
         if (sitemap == null) {
           var templatePath =
               path.join(path.current, 'test/templates/sitemap.xml');
-          File tmplFile = File(templatePath);
+          var tmplFile = File(templatePath);
           var siteMapTmpl = tmplFile.readAsStringSync();
           sitemap = Template(siteMapTmpl);
         }

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -79,7 +79,7 @@ echo:
     // yaml map (which would fail on a missing executable), or a file is deleted
     // during execution,it might, so we test it.
     toolMap.tools.addAll({
-      'missing': ToolDefinition(['/a/missing/executable'], null, "missing"),
+      'missing': ToolDefinition(['/a/missing/executable'], null, 'missing'),
     });
 
     runner = ToolRunner(toolMap);
@@ -134,7 +134,7 @@ echo:
       expect(setupFile.existsSync(), isFalse);
     });
     test('can invoke a non-Dart tool', () async {
-      String result = await runner.run(
+      var result = await runner.run(
         ['non_dart', '--version'],
         errorCallback,
         content: 'TEST INPUT',
@@ -164,7 +164,7 @@ echo:
       expect(setupFile.existsSync(), isTrue);
     });
     test('fails if tool not in tool map', () async {
-      String result = await runner.run(
+      var result = await runner.run(
         ['hammer', r'--file=$INPUT'],
         errorCallback,
         content: 'TEST INPUT',
@@ -175,7 +175,7 @@ echo:
       expect(result, isEmpty);
     });
     test('fails if tool returns non-zero status', () async {
-      String result = await runner.run(
+      var result = await runner.run(
         ['drill', r'--file=/a/missing/file'],
         errorCallback,
         content: 'TEST INPUT',
@@ -185,7 +185,7 @@ echo:
       expect(result, isEmpty);
     });
     test("fails if tool in tool map doesn't exist", () async {
-      String result = await runner.run(
+      var result = await runner.run(
         ['missing'],
         errorCallback,
         content: 'TEST INPUT',

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -195,13 +195,13 @@ void main() {
 
   group('leadingWhitespace', () {
     test('strip common leading whitespace, but no more', () {
-      String input = '   3 space indent\n'
+      var input = '   3 space indent\n'
           '    4 space indent (one preserved)\n'
           '       7 space indent (four preserved)\n'
           '\t  2 spaces, one tab (same as 3 space)\n'
           '    \t4 spaces, one tab (preserve the tab)\n'
           '   3 space indent again\n';
-      String output = '3 space indent\n'
+      var output = '3 space indent\n'
           ' 4 space indent (one preserved)\n'
           '    7 space indent (four preserved)\n'
           '2 spaces, one tab (same as 3 space)\n'

--- a/tool/doc_packages.dart
+++ b/tool/doc_packages.dart
@@ -95,7 +95,7 @@ void generateForPackages(List<String> packages) {
   print('Generating docs into ${_rootDir}/');
   print('');
 
-  List<String> urls = packages
+  var urls = packages
       .map((s) => 'https://pub.dartlang.org/packages/${s}.json')
       .toList();
 
@@ -108,7 +108,7 @@ void generateForPackages(List<String> packages) {
 
 Future _printGenerationResult(
     PackageInfo package, Future<bool> generationResult) {
-  String name = package.name.padRight(20);
+  var name = package.name.padRight(20);
 
   return generationResult.then((bool result) {
     if (result) {
@@ -134,7 +134,7 @@ Future<List<PackageInfo>> _getPackageInfos(List<String> packageUrls) {
     return http.get(p).then((response) {
       var decodedJson = json.decode(response.body);
       String name = decodedJson['name'];
-      List<Version> versions = List<Version>.from(
+      var versions = List<Version>.from(
           decodedJson['versions'].map((v) => Version.parse(v)));
       return PackageInfo(name, Version.primary(versions));
     });
@@ -154,7 +154,7 @@ Future<bool> _generateFor(PackageInfo package) async {
   var response = await http.get(package.archiveUrl);
   if (response.statusCode != 200) throw response;
 
-  Directory output = Directory('${_rootDir}/${package.name}');
+  var output = Directory('${_rootDir}/${package.name}');
   output.createSync(recursive: true);
 
   try {
@@ -164,7 +164,7 @@ Future<bool> _generateFor(PackageInfo package) async {
         cwd: output.path, quiet: true);
 
     // Rule out any old packages (old sdk constraints).
-    File pubspecFile = File(output.path + '/pubspec.yaml');
+    var pubspecFile = File(output.path + '/pubspec.yaml');
     var pubspecInfo = loadYaml(pubspecFile.readAsStringSync());
 
     // Check for old versions.
@@ -201,7 +201,7 @@ Future _exec(String command, List<String> args,
       process.stderr.listen((bytes) => _log(utf8.decode(bytes)));
     }
 
-    Future f = process.exitCode.then((code) {
+    var f = process.exitCode.then((code) {
       if (code != 0) throw code;
     });
 
@@ -222,8 +222,8 @@ bool _isOldSdkConstraint(var pubspecInfo) {
   if (environment != null) {
     var sdk = environment['sdk'];
     if (sdk != null) {
-      VersionConstraint constraint = VersionConstraint.parse(sdk);
-      String version = Platform.version;
+      var constraint = VersionConstraint.parse(sdk);
+      var version = Platform.version;
       if (version.contains(' ')) {
         version = version.substring(0, version.indexOf(' '));
       }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -25,11 +25,11 @@ class GrindTestFailure {
 
 /// Kind of an inefficient grepper for now.
 void expectFileContains(String path, List<Pattern> items) {
-  File source = File(path);
+  var source = File(path);
   if (!source.existsSync()) {
     throw GrindTestFailure('file not found: ${path}');
   }
-  for (Pattern item in items) {
+  for (var item in items) {
     if (!File(path).readAsStringSync().contains(item)) {
       throw GrindTestFailure('Can not find ${item} in ${path}');
     }
@@ -69,10 +69,8 @@ Future<FlutterRepo> get cleanFlutterRepo async {
         .openSync(mode: FileMode.write)
         .lock();
     await _lockFuture;
-    File lastSynced =
-        File(path.join(cleanFlutterDir.parent.path, 'lastSynced'));
-    FlutterRepo newRepo =
-        FlutterRepo.fromPath(cleanFlutterDir.path, {}, 'clean');
+    var lastSynced = File(path.join(cleanFlutterDir.parent.path, 'lastSynced'));
+    var newRepo = FlutterRepo.fromPath(cleanFlutterDir.path, {}, 'clean');
 
     // We have a repository, but is it up to date?
     DateTime lastSyncedTime;
@@ -134,7 +132,7 @@ Directory get pluginPackageDocsDir =>
 
 /// Version of dartdoc we should use when making comparisons.
 String get dartdocOriginalBranch {
-  String branch = 'master';
+  var branch = 'master';
   if (Platform.environment.containsKey('DARTDOC_ORIGINAL')) {
     branch = Platform.environment['DARTDOC_ORIGINAL'];
     log('using branch/tag: $branch for comparison from \$DARTDOC_ORIGINAL');
@@ -147,7 +145,7 @@ List<String> _extraDartdocParams;
 /// If DARTDOC_PARAMS is set, add given parameters to the list.
 List<String> get extraDartdocParameters {
   if (_extraDartdocParams == null) {
-    final RegExp whitespace = RegExp(r'\s+');
+    var whitespace = RegExp(r'\s+');
     _extraDartdocParams = [];
     if (Platform.environment.containsKey('DARTDOC_PARAMS')) {
       _extraDartdocParams
@@ -163,8 +161,8 @@ final Directory flutterDirDevTools =
 /// Creates a throwaway pub cache and returns the environment variables
 /// necessary to use it.
 Map<String, String> _createThrowawayPubCache() {
-  final Directory pubCache = Directory.systemTemp.createTempSync('pubcache');
-  final Directory pubCacheBin = Directory(path.join(pubCache.path, 'bin'));
+  var pubCache = Directory.systemTemp.createTempSync('pubcache');
+  var pubCacheBin = Directory(path.join(pubCache.path, 'bin'));
   pubCacheBin.createSync();
   return Map.fromIterables([
     'PUB_CACHE',
@@ -195,7 +193,7 @@ void updateThirdParty() async {
     _mustache4dartDir.path,
   ]);
   run('rm', arguments: ['-rf', path.join(_mustache4dartDir.path, '.git')]);
-  for (String patchFileName in Directory(_pkgDir.path)
+  for (var patchFileName in Directory(_pkgDir.path)
       .listSync()
       .map((e) => path.basename(e.path))
       .where((String filename) => _mustache4dartPatches.hasMatch(filename))
@@ -216,7 +214,9 @@ void analyze() async {
   await SubprocessLauncher('analyze').runStreamed(
     sdkBin('dartanalyzer'),
     [
-      '--fatal-warnings',
+      '--fatal-infos',
+      '--options',
+      'analysis_options_presubmit.yaml',
       'bin',
       'lib',
       'test',
@@ -228,7 +228,7 @@ void analyze() async {
 @Task('Check for dartfmt cleanliness')
 void dartfmt() async {
   if (Platform.version.contains('dev')) {
-    List<String> filesToFix = [];
+    var filesToFix = <String>[];
     // Filter out test packages as they always have strange formatting.
     // Passing parameters to dartfmt for directories to search results in
     // filenames being stripped of the dirname so we have to filter here.
@@ -281,13 +281,13 @@ class WarningsCollection {
   final String pubCachePath;
 
   WarningsCollection(this.tempDir, this.pubCachePath, this.branch)
-      : this.warningKeyCounts = Map();
+      : warningKeyCounts = {};
 
   static const String kPubCachePathReplacement = '_xxxPubDirectoryxxx_';
   static const String kTempDirReplacement = '_xxxTempDirectoryxxx_';
 
   String _toKey(String text) {
-    String key = text.replaceAll(tempDir, kTempDirReplacement);
+    var key = text.replaceAll(tempDir, kTempDirReplacement);
     if (pubCachePath != null) {
       key = key.replaceAll(pubCachePath, kPubCachePathReplacement);
     }
@@ -295,7 +295,7 @@ class WarningsCollection {
   }
 
   String _fromKey(String text) {
-    String key = text.replaceAll(kTempDirReplacement, tempDir);
+    var key = text.replaceAll(kTempDirReplacement, tempDir);
     if (pubCachePath != null) {
       key = key.replaceAll(kPubCachePathReplacement, pubCachePath);
     }
@@ -303,23 +303,24 @@ class WarningsCollection {
   }
 
   void add(String text) {
-    String key = _toKey(text);
+    var key = _toKey(text);
     warningKeyCounts.putIfAbsent(key, () => 0);
     warningKeyCounts[key]++;
   }
 
   /// Output formatter for comparing warnings.  [this] is the original.
   String getPrintableWarningDelta(String title, WarningsCollection current) {
-    StringBuffer printBuffer = StringBuffer();
-    Set<String> quantityChangedOuts = Set();
-    Set<String> onlyOriginal = Set();
-    Set<String> onlyCurrent = Set();
-    Set<String> identical = Set();
-    Set<String> allKeys = Set.from([]
-      ..addAll(warningKeyCounts.keys)
-      ..addAll(current.warningKeyCounts.keys));
+    var printBuffer = StringBuffer();
+    var quantityChangedOuts = <String>{};
+    var onlyOriginal = <String>{};
+    var onlyCurrent = <String>{};
+    var identical = <String>{};
+    var allKeys = <String>{
+      ...warningKeyCounts.keys,
+      ...current.warningKeyCounts.keys
+    };
 
-    for (String key in allKeys) {
+    for (var key in allKeys) {
       if (warningKeyCounts.containsKey(key) &&
           !current.warningKeyCounts.containsKey(key)) {
         onlyOriginal.add(key);
@@ -347,9 +348,9 @@ class WarningsCollection {
     }
     if (quantityChangedOuts.isNotEmpty) {
       printBuffer.writeln('*** $title : Identical warning quantity changed');
-      for (String key in quantityChangedOuts) {
+      for (var key in quantityChangedOuts) {
         printBuffer.writeln(
-            "* Appeared ${warningKeyCounts[key]} times in $branch, ${current.warningKeyCounts[key]} in ${current.branch}:");
+            '* Appeared ${warningKeyCounts[key]} times in $branch, ${current.warningKeyCounts[key]} in ${current.branch}:');
         printBuffer.writeln(current._fromKey(key));
       }
     }
@@ -369,8 +370,7 @@ class WarningsCollection {
 /// Returns a map of warning texts to the number of times each has been seen.
 WarningsCollection jsonMessageIterableToWarnings(Iterable<Map> messageIterable,
     String tempPath, String pubDir, String branch) {
-  WarningsCollection warningTexts =
-      WarningsCollection(tempPath, pubDir, branch);
+  var warningTexts = WarningsCollection(tempPath, pubDir, branch);
   if (messageIterable == null) return warningTexts;
   for (Map<String, dynamic> message in messageIterable) {
     if (message.containsKey('level') &&
@@ -384,16 +384,16 @@ WarningsCollection jsonMessageIterableToWarnings(Iterable<Map> messageIterable,
 
 @Task('Display delta in SDK warnings')
 Future compareSdkWarnings() async {
-  Directory originalDartdocSdkDocs =
+  var originalDartdocSdkDocs =
       Directory.systemTemp.createTempSync('dartdoc-comparison-sdkdocs');
   Future originalDartdoc = createComparisonDartdoc();
   Future currentDartdocSdkBuild = _buildSdkDocs(
       sdkDocsDir.path, Future.value(Directory.current.path), 'current');
   Future originalDartdocSdkBuild =
       _buildSdkDocs(originalDartdocSdkDocs.path, originalDartdoc, 'original');
-  WarningsCollection currentDartdocWarnings = jsonMessageIterableToWarnings(
+  var currentDartdocWarnings = jsonMessageIterableToWarnings(
       await currentDartdocSdkBuild, sdkDocsDir.absolute.path, null, 'HEAD');
-  WarningsCollection originalDartdocWarnings = jsonMessageIterableToWarnings(
+  var originalDartdocWarnings = jsonMessageIterableToWarnings(
       await originalDartdocSdkBuild,
       originalDartdocSdkDocs.absolute.path,
       null,
@@ -408,8 +408,7 @@ Future compareSdkWarnings() async {
 /// to checkout a branch or tag.
 Future<String> createComparisonDartdoc() async {
   var launcher = SubprocessLauncher('create-comparison-dartdoc');
-  Directory dartdocClean =
-      Directory.systemTemp.createTempSync('dartdoc-comparison');
+  var dartdocClean = Directory.systemTemp.createTempSync('dartdoc-comparison');
   await launcher
       .runStreamed('git', ['clone', Directory.current.path, dartdocClean.path]);
   await launcher.runStreamed('git', ['checkout', dartdocOriginalBranch],
@@ -424,13 +423,13 @@ Future<String> createComparisonDartdoc() async {
 /// version of the Dart SDK for analyzer, front-end, and kernel.
 Future<String> createSdkDartdoc() async {
   var launcher = SubprocessLauncher('create-sdk-dartdoc');
-  Directory dartdocSdk = Directory.systemTemp.createTempSync('dartdoc-sdk');
+  var dartdocSdk = Directory.systemTemp.createTempSync('dartdoc-sdk');
   await launcher
       .runStreamed('git', ['clone', Directory.current.path, dartdocSdk.path]);
   await launcher.runStreamed('git', ['checkout'],
       workingDirectory: dartdocSdk.path);
 
-  Directory sdkClone = Directory.systemTemp.createTempSync('sdk-checkout');
+  var sdkClone = Directory.systemTemp.createTempSync('sdk-checkout');
   await launcher.runStreamed('git', [
     'clone',
     '--branch',
@@ -440,10 +439,10 @@ Future<String> createSdkDartdoc() async {
     'https://dart.googlesource.com/sdk.git',
     sdkClone.path
   ]);
-  File dartdocPubspec = File(path.join(dartdocSdk.path, 'pubspec.yaml'));
-  List<String> pubspecLines = await dartdocPubspec.readAsLines();
-  List<String> pubspecLinesFiltered = [];
-  for (String line in pubspecLines) {
+  var dartdocPubspec = File(path.join(dartdocSdk.path, 'pubspec.yaml'));
+  var pubspecLines = await dartdocPubspec.readAsLines();
+  var pubspecLinesFiltered = <String>[];
+  for (var line in pubspecLines) {
     if (line.startsWith('dependency_overrides:')) {
       pubspecLinesFiltered.add('#dependency_overrides:');
     } else {
@@ -469,7 +468,7 @@ dependency_overrides:
 Future<void> testWithAnalyzerSdk() async {
   var launcher = SubprocessLauncher('test-with-analyzer-sdk');
   var sdkDartdoc = await createSdkDartdoc();
-  final String defaultGrindParameter =
+  var defaultGrindParameter =
       Platform.environment['DARTDOC_GRIND_STEP'] ?? 'test';
   await launcher.runStreamed(
       sdkBin('pub'), ['run', 'grinder', defaultGrindParameter],
@@ -478,10 +477,10 @@ Future<void> testWithAnalyzerSdk() async {
 
 Future<List<Map>> _buildSdkDocs(String sdkDocsPath, Future<String> futureCwd,
     [String label]) async {
-  if (label == null) label = '';
+  label ??= '';
   if (label != '') label = '-$label';
   var launcher = SubprocessLauncher('build-sdk-docs$label');
-  String cwd = await futureCwd;
+  var cwd = await futureCwd;
   await launcher.runStreamed(sdkBin('pub'), ['get'], workingDirectory: cwd);
   return await launcher.runStreamed(
       Platform.resolvedExecutable,
@@ -493,19 +492,20 @@ Future<List<Map>> _buildSdkDocs(String sdkDocsPath, Future<String> futureCwd,
         '--sdk-docs',
         '--json',
         '--show-progress',
-      ]..addAll(extraDartdocParameters),
+        ...extraDartdocParameters,
+      ],
       workingDirectory: cwd);
 }
 
 Future<List<Map>> _buildTestPackageDocs(
     String outputDir, Future<String> futureCwd,
     [String label]) async {
-  if (label == null) label = '';
+  label ??= '';
   if (label != '') label = '-$label';
   var launcher = SubprocessLauncher('build-test-package-docs$label');
   Future testPackagePubGet = launcher.runStreamed(sdkBin('pub'), ['get'],
       workingDirectory: testPackage.absolute.path);
-  String cwd = await futureCwd;
+  var cwd = await futureCwd;
   Future dartdocPubGet =
       launcher.runStreamed(sdkBin('pub'), ['get'], workingDirectory: cwd);
   await Future.wait([testPackagePubGet, dartdocPubGet]);
@@ -522,7 +522,8 @@ Future<List<Map>> _buildTestPackageDocs(
         '--json',
         '--link-to-remote',
         '--pretty-index-json',
-      ]..addAll(extraDartdocParameters),
+        ...extraDartdocParameters,
+      ],
       workingDirectory: testPackage.absolute.path);
 }
 
@@ -574,11 +575,11 @@ Future<void> serveSdkDocs() async {
 
 @Task('Compare warnings in Dartdoc for Flutter')
 Future<void> compareFlutterWarnings() async {
-  Directory originalDartdocFlutter =
+  var originalDartdocFlutter =
       Directory.systemTemp.createTempSync('dartdoc-comparison-flutter');
   Future originalDartdoc = createComparisonDartdoc();
-  Map<String, String> envCurrent = _createThrowawayPubCache();
-  Map<String, String> envOriginal = _createThrowawayPubCache();
+  var envCurrent = _createThrowawayPubCache();
+  var envOriginal = _createThrowawayPubCache();
   Future currentDartdocFlutterBuild = _buildFlutterDocs(flutterDir.path,
       Future.value(Directory.current.path), envCurrent, 'docs-current');
   Future originalDartdocFlutterBuild = _buildFlutterDocs(
@@ -586,12 +587,12 @@ Future<void> compareFlutterWarnings() async {
       originalDartdoc,
       envOriginal,
       'docs-original');
-  WarningsCollection currentDartdocWarnings = jsonMessageIterableToWarnings(
+  var currentDartdocWarnings = jsonMessageIterableToWarnings(
       await currentDartdocFlutterBuild,
       flutterDir.absolute.path,
       envCurrent['PUB_CACHE'],
       'HEAD');
-  WarningsCollection originalDartdocWarnings = jsonMessageIterableToWarnings(
+  var originalDartdocWarnings = jsonMessageIterableToWarnings(
       await originalDartdocFlutterBuild,
       originalDartdocFlutter.absolute.path,
       envOriginal['PUB_CACHE'],
@@ -646,10 +647,10 @@ void validateFlutterDocs() {}
 @Task('Build flutter docs')
 Future<void> buildFlutterDocs() async {
   log('building flutter docs into: $flutterDir');
-  Map<String, String> env = _createThrowawayPubCache();
+  var env = _createThrowawayPubCache();
   await _buildFlutterDocs(
       flutterDir.path, Future.value(Directory.current.path), env, 'docs');
-  String index =
+  var index =
       File(path.join(flutterDir.path, 'dev', 'docs', 'doc', 'index.html'))
           .readAsStringSync();
   stdout.write(index);
@@ -696,7 +697,7 @@ class FlutterRepo {
 
   factory FlutterRepo.fromPath(String flutterPath, Map<String, String> env,
       [String label]) {
-    FlutterRepo flutterRepo = FlutterRepo._(flutterPath, env, label);
+    var flutterRepo = FlutterRepo._(flutterPath, env, label);
     return flutterRepo;
   }
 
@@ -705,14 +706,14 @@ class FlutterRepo {
       FlutterRepo origRepo, String flutterPath, Map<String, String> env,
       [String label]) async {
     await copyPath(origRepo.flutterPath, flutterPath);
-    FlutterRepo flutterRepo = FlutterRepo._(flutterPath, env, label);
+    var flutterRepo = FlutterRepo._(flutterPath, env, label);
     return flutterRepo;
   }
 
   /// Doesn't actually copy the existing repo; use for read-only operations only.
   static Future<FlutterRepo> fromExistingFlutterRepo(FlutterRepo origRepo,
       [String label]) async {
-    FlutterRepo flutterRepo = FlutterRepo._(origRepo.flutterPath, {}, label);
+    var flutterRepo = FlutterRepo._(origRepo.flutterPath, {}, label);
     return flutterRepo;
   }
 
@@ -724,7 +725,7 @@ class FlutterRepo {
 Future<List<Map>> _buildFlutterDocs(
     String flutterPath, Future<String> futureCwd, Map<String, String> env,
     [String label]) async {
-  FlutterRepo flutterRepo = await FlutterRepo.copyFromExistingFlutterRepo(
+  var flutterRepo = await FlutterRepo.copyFromExistingFlutterRepo(
       await cleanFlutterRepo, flutterPath, env, label);
   await flutterRepo.launcher.runStreamed(
     flutterRepo.cachePub,
@@ -750,20 +751,20 @@ Future<List<Map>> _buildFlutterDocs(
 Future<String> _buildPubPackageDocs(
     String pubPackageName, List<String> dartdocParameters,
     [String version, String label]) async {
-  Map<String, String> env = _createThrowawayPubCache();
+  var env = _createThrowawayPubCache();
   var launcher = SubprocessLauncher(
       'build-${pubPackageName}${version == null ? "" : "-$version"}${label == null ? "" : "-$label"}',
       env);
-  List<String> args = <String>['cache', 'add'];
+  var args = <String>['cache', 'add'];
   if (version != null) args.addAll(<String>['-v', version]);
   args.add(pubPackageName);
   await launcher.runStreamed('pub', args);
-  Directory cache =
+  var cache =
       Directory(path.join(env['PUB_CACHE'], 'hosted', 'pub.dartlang.org'));
   Directory pubPackageDir =
       cache.listSync().firstWhere((e) => e.path.contains(pubPackageName));
   if (PackageMeta.fromDir(pubPackageDir).requiresFlutter) {
-    FlutterRepo flutterRepo =
+    var flutterRepo =
         await FlutterRepo.fromExistingFlutterRepo(await cleanFlutterRepo);
     await launcher.runStreamed(flutterRepo.cachePub, ['get'],
         environment: flutterRepo.env,
@@ -776,7 +777,8 @@ Future<String> _buildPubPackageDocs(
           '--json',
           '--link-to-remote',
           '--show-progress',
-        ]..addAll(dartdocParameters),
+          ...dartdocParameters,
+        ],
         environment: flutterRepo.env,
         workingDirectory: pubPackageDir.absolute.path);
   } else {
@@ -790,7 +792,8 @@ Future<String> _buildPubPackageDocs(
           '--json',
           '--link-to-remote',
           '--show-progress',
-        ]..addAll(dartdocParameters),
+          ...dartdocParameters,
+        ],
         workingDirectory: pubPackageDir.absolute.path);
   }
   return path.join(pubPackageDir.absolute.path, 'doc', 'api');
@@ -800,8 +803,8 @@ Future<String> _buildPubPackageDocs(
     'Build an arbitrary pub package based on PACKAGE_NAME and PACKAGE_VERSION environment variables')
 Future<String> buildPubPackage() async {
   assert(Platform.environment.containsKey('PACKAGE_NAME'));
-  String packageName = Platform.environment['PACKAGE_NAME'];
-  String version = Platform.environment['PACKAGE_VERSION'];
+  var packageName = Platform.environment['PACKAGE_NAME'];
+  var version = Platform.environment['PACKAGE_VERSION'];
   return _buildPubPackageDocs(packageName, extraDartdocParameters, version);
 }
 
@@ -845,8 +848,8 @@ Future<void> build() async {
       ['run', 'build_runner', 'build', '--delete-conflicting-outputs']);
 
   // TODO(jcollins-g): port to build system?
-  String version = _getPackageVersion();
-  File dartdoc_options = File('dartdoc_options.yaml');
+  var version = _getPackageVersion();
+  var dartdoc_options = File('dartdoc_options.yaml');
   await dartdoc_options.writeAsString('''dartdoc:
   linkToSource:
     root: '.'
@@ -863,22 +866,22 @@ final _generated_files_list = <String>[
 
 @Task('Verify generated files are up to date')
 Future<void> checkBuild() async {
-  var originalFileContents = Map<String, String>();
+  var originalFileContents = <String, String>{};
   var differentFiles = <String>[];
 
   // Load original file contents into memory before running the builder;
   // it modifies them in place.
-  for (String relPath in _generated_files_list) {
-    String origPath = path.joinAll(['lib', relPath]);
-    File oldVersion = File(origPath);
+  for (var relPath in _generated_files_list) {
+    var origPath = path.joinAll(['lib', relPath]);
+    var oldVersion = File(origPath);
     if (oldVersion.existsSync()) {
       originalFileContents[relPath] = oldVersion.readAsStringSync();
     }
   }
 
   await build();
-  for (String relPath in _generated_files_list) {
-    File newVersion = File(path.join('lib', relPath));
+  for (var relPath in _generated_files_list) {
+    var newVersion = File(path.join('lib', relPath));
     if (!await newVersion.exists()) {
       log('${newVersion.path} does not exist\n');
       differentFiles.add(relPath);
@@ -956,16 +959,13 @@ List<File> get testFiles => Directory('test')
     .toList();
 
 Future<void> testDart2(Iterable<File> tests) async {
-  List<String> parameters = ['--enable-asserts'];
+  var parameters = <String>['--enable-asserts'];
 
-  for (File dartFile in tests) {
+  for (var dartFile in tests) {
     await testFutures.addFutureFromClosure(() =>
         CoverageSubprocessLauncher('dart2-${path.basename(dartFile.path)}')
-            .runStreamed(
-                Platform.resolvedExecutable,
-                <String>[]
-                  ..addAll(parameters)
-                  ..add(dartFile.path)));
+            .runStreamed(Platform.resolvedExecutable,
+                <String>[...parameters, dartFile.path]));
   }
 
   return CoverageSubprocessLauncher.generateCoverageToFile(File('lcov.info'));
@@ -983,7 +983,7 @@ Future<void> testDartdoc() async {
   ]);
   expectFileContains(path.join(dartdocDocsDir.path, 'index.html'),
       ['<title>dartdoc - Dart API docs</title>']);
-  final RegExp object = RegExp('<li>Object</li>', multiLine: true);
+  var object = RegExp('<li>Object</li>', multiLine: true);
   expectFileContains(
       path.join(dartdocDocsDir.path, 'dartdoc', 'ModelElement-class.html'),
       [object]);
@@ -992,7 +992,7 @@ Future<void> testDartdoc() async {
 @Task('Generate docs for dartdoc with remote linking')
 Future<void> testDartdocRemote() async {
   var launcher = SubprocessLauncher('test-dartdoc-remote');
-  final RegExp object = RegExp(
+  var object = RegExp(
       '<a href="https://api.dart.dev/(dev|stable|beta|edge)/[^/]*/dart-core/Object-class.html">Object</a>',
       multiLine: true);
   await launcher.runStreamed(Platform.resolvedExecutable, [
@@ -1016,7 +1016,7 @@ Future<void> serveDartdocFlutterPluginDocs() async {
 }
 
 Future<WarningsCollection> _buildDartdocFlutterPluginDocs() async {
-  FlutterRepo flutterRepo = await FlutterRepo.fromExistingFlutterRepo(
+  var flutterRepo = await FlutterRepo.fromExistingFlutterRepo(
       await cleanFlutterRepo, 'docs-flutter-plugin');
 
   return jsonMessageIterableToWarnings(
@@ -1046,7 +1046,7 @@ Future<void> buildDartdocFlutterPluginDocs() async {
 
 @Task('Verify docs for a package that requires flutter with remote linking')
 Future<void> testDartdocFlutterPlugin() async {
-  WarningsCollection warnings = await _buildDartdocFlutterPluginDocs();
+  var warnings = await _buildDartdocFlutterPluginDocs();
   if (warnings.warningKeyCounts.isNotEmpty) {
     fail('No warnings should exist in : ${warnings.warningKeyCounts}');
   }
@@ -1068,20 +1068,20 @@ void validateSdkDocs() {
   const expectedLibCounts = [0, 1];
   const expectedSubLibCount = [19, 20];
   const expectedTotalCount = [19, 20];
-  File indexHtml = joinFile(sdkDocsDir, ['index.html']);
+  var indexHtml = joinFile(sdkDocsDir, ['index.html']);
   if (!indexHtml.existsSync()) {
     fail('no index.html found for SDK docs');
   }
   log('found index.html');
-  String indexContents = indexHtml.readAsStringSync();
-  int foundLibs = _findCount(indexContents, '  <li><a href="dart-');
+  var indexContents = indexHtml.readAsStringSync();
+  var foundLibs = _findCount(indexContents, '  <li><a href="dart-');
   if (!expectedLibCounts.contains(foundLibs)) {
     fail(
         'expected $expectedTotalCount dart: index.html entries, found $foundLibs');
   }
   log('$foundLibs index.html dart: entries found');
 
-  int foundSubLibs =
+  var foundSubLibs =
       _findCount(indexContents, '<li class="section-subitem"><a href="dart-');
   if (!expectedSubLibCount.contains(foundSubLibs)) {
     fail(
@@ -1107,8 +1107,8 @@ void validateSdkDocs() {
 }
 
 int _findCount(String str, String match) {
-  int count = 0;
-  int index = str.indexOf(match);
+  var count = 0;
+  var index = str.indexOf(match);
   while (index != -1) {
     count++;
     index = str.indexOf(match, index + match.length);


### PR DESCRIPTION
The only non-lint related change is the change to tool/grind.dart to use a separate analysis_options.yaml file for presubmits so that deprecation warnings are allowed.   I tried to make the code changes as mechanical as possible -- Alt-Enter except in the places where that didn't work.

This will also prevent lint errors from being introduced in the future.

@kevmoo