### PR TITLE
Allow null for unnamed extension methods

### DIFF
--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -63,6 +63,9 @@ class Extension extends Container
     return _methods;
   }
 
+  @override
+  String get name => super.name ?? '';
+
   List<Field> _fields;
 
   @override


### PR DESCRIPTION
The head analyzer returns null for an unnamed extension method.