### PR TITLE
Reenable basic NNBD testing and unblock NNBD support development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: false
 dart:
   - stable
-  - "dev/raw/2.9.0-dev.5.0"
+  - "dev/raw/2.9.0-5.0-dev"
 env:
   - DARTDOC_BOT=main
   - DARTDOC_BOT=flutter

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   include:
   - env: DARTDOC_BOT=main
     os: osx
-    dart: "dev/raw/latest"
+    dart: "dev/raw/2.9.0-5.0.dev"
 
 install:
 - ./tool/install_travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: false
 dart:
   - stable
-  - "dev/raw/2.9.0-5.0-dev"
+  - "dev/raw/2.9.0-5.0.dev"
 env:
   - DARTDOC_BOT=main
   - DARTDOC_BOT=flutter

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: false
 dart:
   - stable
-  - "dev/raw/latest"
+  - "dev/raw/2.9.0-dev.5.0"
 env:
   - DARTDOC_BOT=main
   - DARTDOC_BOT=flutter

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - master
 
 install:
-  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/release/2.9.0-dev.5.0/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/release/2.9.0-5.0.dev/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - cmd: del dart-sdk.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - master
 
 install:
-  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/release/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/release/2.9.0-dev.5.0/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
   - cmd: echo "Unzipping dart-sdk..."
   - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - cmd: del dart-sdk.zip

--- a/testing/test_package_experiments/pubspec.yaml
+++ b/testing/test_package_experiments/pubspec.yaml
@@ -1,3 +1,4 @@
 name: test_package_experiments
 version: 0.0.1
+sdk: '>=2.9.0 <2.10.0'
 description: Experimental flags are tested here.


### PR DESCRIPTION
Fixes #2148.

The basic support for some parts of NNBD now works again; specifically, understanding `late` and `required`.

Also pins our dev version temporarily to work around #2199.

![Screen Shot 2020-05-06 at 2 40 15 PM](https://user-images.githubusercontent.com/14116827/81232482-dc826700-8fa9-11ea-9047-61a20755993f.png)
![Screen Shot 2020-05-06 at 2 40 52 PM](https://user-images.githubusercontent.com/14116827/81232487-ddb39400-8fa9-11ea-8ad8-1866d3f1a66e.png)
