### PR TITLE
Contribute functionality that helps debugging

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -98,6 +98,9 @@ Future<void> main(List<String> arguments) async {
     }, onError: (e, Chain chain) {
       if (e is DartdocFailure) {
         stderr.writeln('\ndartdoc failed: ${e}.');
+        if (config.verboseWarnings) {
+          stderr.writeln(chain.terse);
+        }
         exitCode = 1;
         return;
       } else {

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -651,15 +651,15 @@ class PackageGraph {
 
   @override
   String toString() {
-    final divider = "=========================================================";
+    final divider = '=========================================================';
     final buffer =
         StringBuffer('PackageGraph built from ${defaultPackage.name}');
     buffer.writeln(divider);
     buffer.writeln();
     for (final name in packageMap.keys) {
       final package = packageMap[name];
-      buffer.writeln("Package $name documented at ${package.documentedWhere} "
-          "with libraries: ${package.allLibraries}");
+      buffer.writeln('Package $name documented at ${package.documentedWhere} '
+          'with libraries: ${package.allLibraries}');
     }
     buffer.writeln(divider);
     return buffer.toString();

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -650,7 +650,20 @@ class PackageGraph {
   }
 
   @override
-  String toString() => 'PackageGraph built from ${defaultPackage.name}';
+  String toString() {
+    final divider = "=========================================================";
+    final buffer =
+        StringBuffer('PackageGraph built from ${defaultPackage.name}');
+    buffer.writeln(divider);
+    buffer.writeln();
+    for (final name in packageMap.keys) {
+      final package = packageMap[name];
+      buffer.writeln("Package $name documented at ${package.documentedWhere} "
+          "with libraries: ${package.allLibraries}");
+    }
+    buffer.writeln(divider);
+    return buffer.toString();
+  }
 
   final Map<Element, Library> _canonicalLibraryFor = {};
 


### PR DESCRIPTION
- Get the stack trace of a `DartdocFailure` if verbose warnings is on.
- Print detailed information about `PackageGraph` in its string representation.