### PR TITLE
Remove driver and session from PackageGraph

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -55,7 +55,7 @@ class PackageBuilder {
     var rendererFactory = RendererFactory.forFormat(config.format);
 
     var newGraph = PackageGraph.UninitializedPackageGraph(
-        config, driver, sdk, hasEmbedderSdkFiles, rendererFactory);
+        config, sdk, hasEmbedderSdkFiles, rendererFactory);
     await getLibraries(newGraph);
     await newGraph.initializePackageGraph();
     return newGraph;
@@ -187,7 +187,7 @@ class PackageBuilder {
 
   /// Parse a single library at [filePath] using the current analysis driver.
   /// If [filePath] is not a library, returns null.
-  Future<ResolvedLibraryResult> processLibrary(String filePath) async {
+  Future<DartDocResolvedLibrary> processLibrary(String filePath) async {
     var name = filePath;
 
     if (name.startsWith(directoryCurrentPath)) {
@@ -215,7 +215,15 @@ class PackageBuilder {
     if (sourceKind != SourceKind.PART) {
       // Loading libraryElements from part files works, but is painfully slow
       // and creates many duplicates.
-      return await driver.currentSession.getResolvedLibrary(source.fullName);
+      final library =
+          await driver.currentSession.getResolvedLibrary(source.fullName);
+      final libraryElement = library.element;
+      var restoredUri = libraryElement.source.uri.toString();
+      if (!restoredUri.startsWith('dart:')) {
+        restoredUri =
+            driver.sourceFactory.restoreUri(library.element.source).toString();
+      }
+      return DartDocResolvedLibrary(library, restoredUri);
     }
     return null;
   }
@@ -235,7 +243,7 @@ class PackageBuilder {
   /// the callback more than once with the same [LibraryElement].
   /// Adds [LibraryElement]s found to that parameter.
   Future<void> _parseLibraries(
-      void Function(ResolvedLibraryResult) libraryAdder,
+      void Function(DartDocResolvedLibrary) libraryAdder,
       Set<LibraryElement> libraries,
       Set<String> files,
       [bool Function(LibraryElement) isLibraryIncluded]) async {
@@ -246,16 +254,16 @@ class PackageBuilder {
       lastPass = _packageMetasForFiles(files);
 
       // Be careful here not to accidentally stack up multiple
-      // ResolvedLibraryResults, as those eat our heap.
+      // DartDocResolvedLibrarys, as those eat our heap.
       for (var f in files) {
         logProgress(f);
         var r = await processLibrary(f);
         if (r != null &&
-            !libraries.contains(r.element) &&
-            isLibraryIncluded(r.element)) {
+            !libraries.contains(r.result.element) &&
+            isLibraryIncluded(r.result.element)) {
           logDebug('parsing ${f}...');
           libraryAdder(r);
-          libraries.add(r.element);
+          libraries.add(r.result.element);
         }
       }
 
@@ -460,4 +468,18 @@ class PackageWithoutSdkResolver extends UriResolver {
     }
     return null;
   }
+}
+
+/// Contains the [ResolvedLibraryResult] and any additional information about
+/// the library coming from [AnalysisDriver].
+///
+/// Prefer to populate this class with more information rather than passing
+/// [AnalysisDriver] or [AnalysisSession] down to [PackageGraph]. The graph
+/// object is reachable by many DartDoc model objects and there's no guarantee
+/// that there's a valid [AnalysisDriver] in every environment dartdoc runs.
+class DartDocResolvedLibrary {
+  final ResolvedLibraryResult result;
+  final String restoredUri;
+
+  DartDocResolvedLibrary(this.result, this.restoredUri);
 }

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -259,11 +259,11 @@ class PackageBuilder {
         logProgress(f);
         var r = await processLibrary(f);
         if (r != null &&
-            !libraries.contains(r.result.element) &&
-            isLibraryIncluded(r.result.element)) {
+            !libraries.contains(r.element) &&
+            isLibraryIncluded(r.element)) {
           logDebug('parsing ${f}...');
           libraryAdder(r);
-          libraries.add(r.result.element);
+          libraries.add(r.element);
         }
       }
 
@@ -482,4 +482,7 @@ class DartDocResolvedLibrary {
   final String restoredUri;
 
   DartDocResolvedLibrary(this.result, this.restoredUri);
+
+  LibraryElement get element => result.element;
+  LibraryElement get library => result.element.library;
 }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -37,7 +37,7 @@ class PackageGraph {
   /// span packages.
   void addLibraryToGraph(DartDocResolvedLibrary resolvedLibrary) {
     assert(!allLibrariesAdded);
-    var element = resolvedLibrary.result.element;
+    var element = resolvedLibrary.element;
     var packageMeta = PackageMeta.fromElement(element, config.sdkDir);
     var lib = Library.fromLibraryResult(
         resolvedLibrary, this, Package.fromPackageMeta(packageMeta, this));
@@ -823,7 +823,7 @@ class PackageGraph {
   /// a documentation entry point (for elements that have no Library within the
   /// set of canonical Libraries).
   Library findOrCreateLibraryFor(DartDocResolvedLibrary resolvedLibrary) {
-    final elementLibrary = resolvedLibrary.result.element.library;
+    final elementLibrary = resolvedLibrary.library;
     // This is just a cache to avoid creating lots of libraries over and over.
     if (allLibraries.containsKey(elementLibrary)) {
       return allLibraries[elementLibrary];

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -4,11 +4,8 @@
 
 import 'dart:async';
 
-import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
@@ -24,10 +21,9 @@ import 'package:dartdoc/src/tuple.dart';
 import 'package:dartdoc/src/warnings.dart';
 
 class PackageGraph {
-  PackageGraph.UninitializedPackageGraph(this.config, this.driver, this.sdk,
-      this.hasEmbedderSdk, this.rendererFactory)
-      : packageMeta = config.topLevelPackageMeta,
-        session = driver.currentSession {
+  PackageGraph.UninitializedPackageGraph(
+      this.config, this.sdk, this.hasEmbedderSdk, this.rendererFactory)
+      : packageMeta = config.topLevelPackageMeta {
     _packageWarningCounter = PackageWarningCounter(this);
     // Make sure the default package exists, even if it has no libraries.
     // This can happen for packages that only contain embedder SDKs.
@@ -39,12 +35,12 @@ class PackageGraph {
   /// Libraries added in this manner are assumed to be part of documented
   /// packages, even if includes or embedder.yaml files cause these to
   /// span packages.
-  void addLibraryToGraph(ResolvedLibraryResult result) {
+  void addLibraryToGraph(DartDocResolvedLibrary resolvedLibrary) {
     assert(!allLibrariesAdded);
-    var element = result.element;
+    var element = resolvedLibrary.result.element;
     var packageMeta = PackageMeta.fromElement(element, config.sdkDir);
     var lib = Library.fromLibraryResult(
-        result, this, Package.fromPackageMeta(packageMeta, this));
+        resolvedLibrary, this, Package.fromPackageMeta(packageMeta, this));
     packageMap[packageMeta.name].libraries.add(lib);
     allLibraries[element] = lib;
   }
@@ -52,10 +48,10 @@ class PackageGraph {
   /// Call during initialization to add a library possibly containing
   /// special/non-documented elements to this [PackageGraph].  Must be called
   /// after any normal libraries.
-  void addSpecialLibraryToGraph(ResolvedLibraryResult result) {
+  void addSpecialLibraryToGraph(DartDocResolvedLibrary resolvedLibrary) {
     allLibrariesAdded = true;
     assert(!_localDocumentationBuilt);
-    findOrCreateLibraryFor(result);
+    findOrCreateLibraryFor(resolvedLibrary);
   }
 
   /// Call after all libraries are added.
@@ -234,9 +230,6 @@ class PackageGraph {
   /// Map of package name to Package.
   final Map<String, Package> packageMap = {};
 
-  /// TODO(brianwilkerson) Replace the driver with the session.
-  final AnalysisDriver driver;
-  final AnalysisSession session;
   final DartSdk sdk;
 
   Map<Source, SdkLibrary> _sdkLibrarySources;
@@ -829,22 +822,23 @@ class PackageGraph {
   /// This is used when we might need a Library object that isn't actually
   /// a documentation entry point (for elements that have no Library within the
   /// set of canonical Libraries).
-  Library findOrCreateLibraryFor(ResolvedLibraryResult result) {
+  Library findOrCreateLibraryFor(DartDocResolvedLibrary resolvedLibrary) {
+    final elementLibrary = resolvedLibrary.result.element.library;
     // This is just a cache to avoid creating lots of libraries over and over.
-    if (allLibraries.containsKey(result.element.library)) {
-      return allLibraries[result.element.library];
+    if (allLibraries.containsKey(elementLibrary)) {
+      return allLibraries[elementLibrary];
     }
     // can be null if e is for dynamic
-    if (result.element.library == null) {
+    if (elementLibrary == null) {
       return null;
     }
     var foundLibrary = Library.fromLibraryResult(
-        result,
+        resolvedLibrary,
         this,
         Package.fromPackageMeta(
-            PackageMeta.fromElement(result.element.library, config.sdkDir),
+            PackageMeta.fromElement(elementLibrary, config.sdkDir),
             packageGraph));
-    allLibraries[result.element.library] = foundLibrary;
+    allLibraries[elementLibrary] = foundLibrary;
     return foundLibrary;
   }
 


### PR DESCRIPTION
**What**
I would like to remove the presence of `AnalysisDriver` and Session from `PackageGraph`. 

**Why**
`PackageGraph` is available to many model objects and it makes good sense to reduce the available API surface.

It is preferred that `PackageBuilder` populates all necessary information for dartdoc to function during build phase rather than relying on model objects to lazily get them from `AnalysisSession`. This allows us to handle situations where an `AnalysisSession` is not available such as constructing ResolvedLibrary objects from summary data.