### PR TITLE
Allow dartdoc to customize package builder and package meta creation

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -5,7 +5,6 @@
 library dartdoc.bin;
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/options.dart';
@@ -25,10 +24,8 @@ Future<void> main(List<String> arguments) async {
     PubPackageMeta.fromDir,
   );
   final packageBuilder = PubPackageBuilder(config);
-  var dartdoc = config.generateDocs
+  final dartdoc = config.generateDocs
       ? await Dartdoc.fromContext(config, packageBuilder)
       : await Dartdoc.withEmptyGenerator(config, packageBuilder);
-
-  exitCode = await dartdoc.execute();
-  return;
+  dartdoc.executeGuarded();
 }

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -7,132 +7,28 @@ library dartdoc.bin;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/logging.dart';
-import 'package:dartdoc/src/tool_runner.dart';
-import 'package:stack_trace/stack_trace.dart';
-
-class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
-    with LoggingContext {
-  DartdocProgramOptionContext(DartdocOptionSet optionSet, Directory dir)
-      : super(optionSet, dir);
-
-  bool get asyncStackTraces => optionSet['asyncStackTraces'].valueAt(context);
-  bool get generateDocs => optionSet['generateDocs'].valueAt(context);
-  bool get help => optionSet['help'].valueAt(context);
-  bool get version => optionSet['version'].valueAt(context);
-}
-
-Future<List<DartdocOption>> createDartdocProgramOptions() async {
-  return <DartdocOption>[
-    DartdocOptionArgOnly<bool>('asyncStackTraces', false,
-        help: 'Display coordinated asynchronous stack traces (slow)',
-        negatable: true),
-    DartdocOptionArgOnly<bool>('generateDocs', true,
-        help:
-            'Generate docs into the output directory (or only display warnings if false).',
-        negatable: true),
-    DartdocOptionArgOnly<bool>('help', false,
-        abbr: 'h', help: 'Show command help.', negatable: false),
-    DartdocOptionArgOnly<bool>('version', false,
-        help: 'Display the version for $programName.', negatable: false),
-  ];
-}
+import 'package:dartdoc/options.dart';
 
 /// Analyzes Dart files and generates a representation of included libraries,
 /// classes, and members. Uses the current directory to look for libraries.
 Future<void> main(List<String> arguments) async {
-  var optionSet = await DartdocOptionSet.fromOptionGenerators('dartdoc', [
-    createDartdocOptions,
-    createDartdocProgramOptions,
-    createLoggingOptions,
-    createGeneratorOptions,
-  ]);
-
-  try {
-    optionSet.parseArguments(arguments);
-  } on FormatException catch (e) {
-    stderr.writeln(' fatal error: ${e.message}');
-    stderr.writeln('');
-    _printUsage(optionSet.argParser);
-    // Do not use exit() as this bypasses --pause-isolates-on-exit
-    // TODO(jcollins-g): use exit once dart-lang/sdk#31747 is fixed.
-    exitCode = 64;
+  var config = await parseOptions(arguments);
+  if (config == null) {
+    // There was an error while parsing options.
     return;
   }
-  if (optionSet['help'].valueAt(Directory.current)) {
-    _printHelp(optionSet.argParser);
-    exitCode = 0;
-    return;
-  }
-  if (optionSet['version'].valueAt(Directory.current)) {
-    _printVersion(optionSet.argParser);
-    exitCode = 0;
-    return;
-  }
-
-  DartdocProgramOptionContext config;
-  try {
-    config = DartdocProgramOptionContext(optionSet, null);
-  } on DartdocOptionError catch (e) {
-    stderr.writeln(' fatal error: ${e.message}');
-    stderr.writeln('');
-    await stderr.flush();
-    _printUsage(optionSet.argParser);
-    exitCode = 64;
-    return;
-  }
-  startLogging(config);
-
+  // Set the default way to construct [PackageMeta].
+  PackageMeta.setPackageMetaFactories(
+    PubPackageMeta.fromElement,
+    PubPackageMeta.fromFilename,
+    PubPackageMeta.fromDir,
+  );
+  final packageBuilder = PubPackageBuilder(config);
   var dartdoc = config.generateDocs
-      ? await Dartdoc.fromContext(config)
-      : await Dartdoc.withEmptyGenerator(config);
-  dartdoc.onCheckProgress.listen(logProgress);
-  try {
-    await Chain.capture(() async {
-      await runZoned(dartdoc.generateDocs,
-          zoneSpecification: ZoneSpecification(
-              print: (Zone self, ZoneDelegate parent, Zone zone, String line) =>
-                  logPrint(line)));
-    }, onError: (e, Chain chain) {
-      if (e is DartdocFailure) {
-        stderr.writeln('\ndartdoc failed: ${e}.');
-        if (config.verboseWarnings) {
-          stderr.writeln(chain.terse);
-        }
-        exitCode = 1;
-        return;
-      } else {
-        stderr.writeln('\ndartdoc failed: ${e}\n${chain.terse}');
-        exitCode = 255;
-        return;
-      }
-    }, when: config.asyncStackTraces);
-  } finally {
-    // Clear out any cached tool snapshots and temporary directories.
-    // ignore: unawaited_futures
-    SnapshotCache.instance.dispose();
-    // ignore: unawaited_futures
-    ToolTempFileTracker.instance.dispose();
-  }
-  exitCode = 0;
+      ? await Dartdoc.fromContext(config, packageBuilder)
+      : await Dartdoc.withEmptyGenerator(config, packageBuilder);
+
+  exitCode = await dartdoc.execute(config.asyncStackTraces);
   return;
-}
-
-/// Print help if we are passed the help option.
-void _printHelp(ArgParser parser) {
-  print('Generate HTML documentation for Dart libraries.\n');
-  print(parser.usage);
-}
-
-/// Print usage information on invalid command lines.
-void _printUsage(ArgParser parser) {
-  print('Usage: dartdoc [OPTIONS]\n');
-  print(parser.usage);
-}
-
-/// Print version information.
-void _printVersion(ArgParser parser) {
-  print('dartdoc version: ${dartdocVersion}');
 }

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -29,6 +29,6 @@ Future<void> main(List<String> arguments) async {
       ? await Dartdoc.fromContext(config, packageBuilder)
       : await Dartdoc.withEmptyGenerator(config, packageBuilder);
 
-  exitCode = await dartdoc.execute(config.asyncStackTraces);
+  exitCode = await dartdoc.execute();
   return;
 }

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -455,6 +455,12 @@ class Dartdoc {
   /// Runs [generateDocs] function and properly handles the errors.
   Future<int> execute() async {
     onCheckProgress.listen(logProgress);
+    // We catch and report failures coming from the Zone below as it is not an
+    // error zone. Please do *not* convert this into an error zone (by using
+    // package:stack_trace for instance) as it leads to the finally block being
+    // skipped.
+    //
+    // File an issue if this code is problematic when debugging.
     try {
       await runZoned(generateDocs,
           zoneSpecification: ZoneSpecification(

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:dartdoc/dartdoc.dart';
+import 'package:dartdoc/src/logging.dart';
+
+class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
+    with LoggingContext {
+  DartdocProgramOptionContext(DartdocOptionSet optionSet, Directory dir)
+      : super(optionSet, dir);
+
+  bool get asyncStackTraces => optionSet['asyncStackTraces'].valueAt(context);
+  bool get generateDocs => optionSet['generateDocs'].valueAt(context);
+  bool get help => optionSet['help'].valueAt(context);
+  bool get version => optionSet['version'].valueAt(context);
+}
+
+Future<List<DartdocOption>> createDartdocProgramOptions() async {
+  return <DartdocOption>[
+    DartdocOptionArgOnly<bool>('asyncStackTraces', false,
+        help: 'Display coordinated asynchronous stack traces (slow)',
+        negatable: true),
+    DartdocOptionArgOnly<bool>('generateDocs', true,
+        help:
+            'Generate docs into the output directory (or only display warnings if false).',
+        negatable: true),
+    DartdocOptionArgOnly<bool>('help', false,
+        abbr: 'h', help: 'Show command help.', negatable: false),
+    DartdocOptionArgOnly<bool>('version', false,
+        help: 'Display the version for $programName.', negatable: false),
+  ];
+}
+
+Future<DartdocProgramOptionContext> parseOptions(List<String> arguments) async {
+  var optionSet = await DartdocOptionSet.fromOptionGenerators('dartdoc', [
+    createDartdocOptions,
+    createDartdocProgramOptions,
+    createLoggingOptions,
+    createGeneratorOptions,
+  ]);
+
+  try {
+    optionSet.parseArguments(arguments);
+  } on FormatException catch (e) {
+    stderr.writeln(' fatal error: ${e.message}');
+    stderr.writeln('');
+    _printUsage(optionSet.argParser);
+    // Do not use exit() as this bypasses --pause-isolates-on-exit
+    exitCode = 64;
+    return null;
+  }
+  if (optionSet['help'].valueAt(Directory.current)) {
+    _printHelp(optionSet.argParser);
+    exitCode = 0;
+    return null;
+  }
+  if (optionSet['version'].valueAt(Directory.current)) {
+    _printVersion(optionSet.argParser);
+    exitCode = 0;
+    return null;
+  }
+
+  DartdocProgramOptionContext config;
+  try {
+    config = DartdocProgramOptionContext(optionSet, null);
+  } on DartdocOptionError catch (e) {
+    stderr.writeln(' fatal error: ${e.message}');
+    stderr.writeln('');
+    await stderr.flush();
+    _printUsage(optionSet.argParser);
+    exitCode = 64;
+    return null;
+  }
+  startLogging(config);
+  return config;
+}
+
+/// Print help if we are passed the help option.
+void _printHelp(ArgParser parser) {
+  print('Generate HTML documentation for Dart libraries.\n');
+  print(parser.usage);
+}
+
+/// Print usage information on invalid command lines.
+void _printUsage(ArgParser parser) {
+  print('Usage: dartdoc [OPTIONS]\n');
+  print(parser.usage);
+}
+
+/// Print version information.
+void _printVersion(ArgParser parser) {
+  print('dartdoc version: ${dartdocVersion}');
+}

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -10,7 +10,6 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
   DartdocProgramOptionContext(DartdocOptionSet optionSet, Directory dir)
       : super(optionSet, dir);
 
-  bool get asyncStackTraces => optionSet['asyncStackTraces'].valueAt(context);
   bool get generateDocs => optionSet['generateDocs'].valueAt(context);
   bool get help => optionSet['help'].valueAt(context);
   bool get version => optionSet['version'].valueAt(context);
@@ -18,9 +17,6 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
 
 Future<List<DartdocOption>> createDartdocProgramOptions() async {
   return <DartdocOption>[
-    DartdocOptionArgOnly<bool>('asyncStackTraces', false,
-        help: 'Display coordinated asynchronous stack traces (slow)',
-        negatable: true),
     DartdocOptionArgOnly<bool>('generateDocs', true,
         help:
             'Generate docs into the output directory (or only display warnings if false).',

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -39,6 +39,7 @@ abstract class PackageBuilder {
   Future<PackageGraph> buildPackageGraph();
 }
 
+/// A package builder that understands pub package format.
 class PubPackageBuilder implements PackageBuilder {
   final DartdocOptionContext config;
 

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -34,11 +34,17 @@ import 'package:path/path.dart' as path;
 import 'package:quiver/iterables.dart' as quiver;
 
 /// Everything you need to instantiate a PackageGraph object for documenting.
-class PackageBuilder {
+abstract class PackageBuilder {
+  // Builds package graph to be used by documentation generator.
+  Future<PackageGraph> buildPackageGraph();
+}
+
+class PubPackageBuilder implements PackageBuilder {
   final DartdocOptionContext config;
 
-  PackageBuilder(this.config);
+  PubPackageBuilder(this.config);
 
+  @override
   Future<PackageGraph> buildPackageGraph() async {
     if (!config.sdkDocs) {
       if (config.topLevelPackageMeta.needsPubGet &&

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -35,6 +35,14 @@ final List<List<String>> __sdkDirFilePathsPosix = [
   ['lib/core/core.dart'],
 ];
 
+/// Describes a single package in the context of `dartdoc`.
+///
+/// The primary function of this class is to allow canonicalization of packages
+/// by returning the same [PackageMeta] for a given filename, library or path
+/// if they belong to the same package.
+///
+/// Overriding this is typically done by overriding factories as rest of
+/// `dartdoc` creates this object by calling these static factories.
 abstract class PackageMeta {
   final Directory dir;
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -118,23 +118,32 @@ abstract class PackageMeta {
     PackageMeta Function(String) fromFilenameFactory,
     PackageMeta Function(Directory) fromDirFactory,
   ) {
-    if (_elem != null || _file != null || _dir != null) {
-      throw StateError('PackageMeta factories have been defined already.');
+    assert(fromElementFactory != null);
+    assert(fromFilenameFactory != null);
+    assert(fromDirFactory != null);
+    if (_fromElement == fromElementFactory &&
+        _fromFilename == fromFilenameFactory &&
+        _fromDir == fromDirFactory) {
+      // Nothing to do.
+      return;
     }
-    _elem = fromElementFactory;
-    _file = fromFilenameFactory;
-    _dir = fromDirFactory;
-    if (_elem == null || _file == null || _dir == null) {
-      throw StateError('Null factories are not allowed for PackageMeta.');
+    if (_fromElement != null || _fromFilename != null || _fromDir != null) {
+      throw StateError('PackageMeta factories cannot be changed once defined.');
     }
+    _fromElement = fromElementFactory;
+    _fromFilename = fromFilenameFactory;
+    _fromDir = fromDirFactory;
   }
 
-  static PackageMeta Function(LibraryElement, String) _elem;
-  static PackageMeta Function(String) _file;
-  static PackageMeta Function(Directory) _dir;
-  static PackageMeta Function(LibraryElement, String) get fromElement => _elem;
-  static PackageMeta Function(String) get fromFilename => _file;
-  static PackageMeta Function(Directory) get fromDir => _dir;
+  static PackageMeta Function(LibraryElement, String) _fromElement;
+  static PackageMeta Function(String) _fromFilename;
+  static PackageMeta Function(Directory) _fromDir;
+  static PackageMeta Function(LibraryElement, String) get fromElement =>
+      _fromElement ?? PubPackageMeta.fromElement;
+  static PackageMeta Function(String) get fromFilename =>
+      _fromFilename ?? PubPackageMeta.fromFilename;
+  static PackageMeta Function(Directory) get fromDir =>
+      _fromDir ?? PubPackageMeta.fromDir;
 }
 
 /// Default implementation of [PackageMeta] depends on pub packages.

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -45,8 +45,12 @@ void main() {
 
     Future<Dartdoc> buildDartdoc(
         List<String> argv, Directory packageRoot, Directory tempDir) async {
-      return await Dartdoc.fromContext(await generatorContextFromArgv(argv
-        ..addAll(['--input', packageRoot.path, '--output', tempDir.path])));
+      var context = await generatorContextFromArgv(argv
+        ..addAll(['--input', packageRoot.path, '--output', tempDir.path]));
+      return await Dartdoc.fromContext(
+        context,
+        PubPackageBuilder(context),
+      );
     }
 
     group('Option handling', () {

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -114,7 +114,7 @@ Future<DartdocOptionContext> contextFromArgv(List<String> argv) async {
 }
 
 Future<PackageGraph> bootSdkPackage() async {
-  return PackageBuilder(await contextFromArgv(['--input', sdkDir.path]))
+  return PubPackageBuilder(await contextFromArgv(['--input', sdkDir.path]))
       .buildPackageGraph();
 }
 
@@ -123,7 +123,7 @@ Future<PackageGraph> bootBasicPackage(
     {List<String> additionalArguments}) async {
   var dir = Directory(dirPath);
   additionalArguments ??= <String>[];
-  return PackageBuilder(await contextFromArgv([
+  return PubPackageBuilder(await contextFromArgv([
             '--input',
             dir.path,
             '--sdk-dir',


### PR DESCRIPTION
This is necessary for customizing `dartdoc` to generate documentation in g3. The integration boils down to two main points:

- **package_builder**: This normally invokes an `AnalysisDriver` and scrapes the packages directory to find all the dependencies. dartdoc calls a single API (`buildPackageGraph`).
- **package_meta**: Canonicalization of packages in g3 cannot be done merely based on path so we need a way to customize package_meta creation. This is done by providing a way for `main` to override `PackageMeta` factories **once**. 

_PS: I am not quite happy with the PackageMeta change. I would have liked to configure all objects that need a specific implementation to accept a builder class so they can properly be injected. That is a much larger change since even option processing uses PackageMeta. That's why I opted for this incremental change._

Additional Changes in the PR:
- I refactored option processing and other functionality out of `main` because we intend to provide a different dartdoc entrypoint. `main` should primarily be about configuring dartdoc.
- I also considered the option of configuring dartdoc entirely based off of flags but that would imply the g3 specific code would need to live in this repo (unless we use dart:mirrors). 
- I had to remove the asyncStackTraces option which was covering a bug. `Chain.capture` runs the code in an error zone which meant the main zone never got a chance to execute when there was an error. The `finally` block that was responsible for doing cleanup was skipped. Instead I reverted back to a simple `runZoned` call which is cleaner, easier to understand and bug free. 
