### PR TITLE
CI: use `dev` instead of `dev/raw/latest`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: false
 dart:
   - stable
-  - "dev/raw/latest"
+  - dev
 env:
   - DARTDOC_BOT=main
   - DARTDOC_BOT=flutter
@@ -18,7 +18,7 @@ matrix:
   include:
   - env: DARTDOC_BOT=main
     os: osx
-    dart: "dev/raw/latest"
+    dart: dev
 
 install:
 - ./tool/install_travis.sh


### PR DESCRIPTION
The only time these are not ~identical is when there is a pending dev release being created.
If the goal is to validate bleeding edge, we should use `be/raw/latest` instead – although I think that's overkill