### PR TITLE
Prepare for dartdoc 0.32.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.32.1
+* Allow documenting code with null safety (#2210, #2221)
+* Refactors moving toward mono-repo support (#2219)
+
 ## 0.32.0
 * Fix type exception in 2.9 dev versions of dart (#2214)
 * **BREAKING** : Refactor `Container` class, changing the names

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.32.0/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.32.1/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.32.0';
+const packageVersion = '0.32.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.32.0
+version: 0.32.1
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
We'll need a publish and roll to the SDK prior to null safety preview 1.

Assumes #2221 will land first.