### PR TITLE
Workaround travis hangs by using default SDK version of pub

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -770,8 +770,8 @@ Future<List<Map>> _buildFlutterDocs(
     ['get'],
     workingDirectory: path.join(flutterPath, 'dev', 'snippets'),
   );
-  await flutterRepo.launcher.runStreamed(
-      flutterRepo.cachePub, ['global', 'activate', '-spath', '.'],
+  await flutterRepo.launcher.runStreamed(flutterRepo.cachePub,
+      ['global', 'activate', '-spath', '.', '-x', 'dartdoc'],
       workingDirectory: await futureCwd);
   return await flutterRepo.launcher.runStreamed(
     flutterRepo.cacheDart,

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -771,7 +771,7 @@ Future<List<Map>> _buildFlutterDocs(
     workingDirectory: path.join(flutterPath, 'dev', 'snippets'),
   );
   await flutterRepo.launcher.runStreamed(flutterRepo.cachePub,
-      ['global', 'activate', '-spath', '.', '-x', 'dartdoc'],
+      ['global', 'activate', '-spath', '.', '-x', 'dartdoc', '-v'],
       workingDirectory: await futureCwd);
   return await flutterRepo.launcher.runStreamed(
     flutterRepo.cacheDart,

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -770,8 +770,10 @@ Future<List<Map>> _buildFlutterDocs(
     ['get'],
     workingDirectory: path.join(flutterPath, 'dev', 'snippets'),
   );
-  await flutterRepo.launcher.runStreamed(flutterRepo.cachePub,
-      ['global', 'activate', '-spath', '.', '-x', 'dartdoc', '-v'],
+  // TODO(jcollins-g): flutter's dart SDK pub tries to precompile the universe
+  // when using -spath.  Why?
+  await flutterRepo.launcher.runStreamed(
+      'pub', ['global', 'activate', '-spath', '.', '-x', 'dartdoc'],
       workingDirectory: await futureCwd);
   return await flutterRepo.launcher.runStreamed(
     flutterRepo.cacheDart,


### PR DESCRIPTION
Filed longer term issue as #2225 -- being able to run dartdoc over Flutter using a slightly off version of dart is better than nothing in the medium term.