### PR TITLE
Use &lt; instead of < in markdown

### DIFF
--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -124,7 +124,7 @@ class FunctionTypeElementTypeRendererMd
     buf.write(elementType.name);
     if (elementType.typeFormals.isNotEmpty) {
       if (!elementType.typeFormals.every((t) => t.name == 'dynamic')) {
-        buf.write('<');
+        buf.write('&lt;');
         buf.writeAll(elementType.typeFormals.map((t) => t.name), ', ');
         buf.write('>');
       }
@@ -141,7 +141,7 @@ class ParameterizedElementTypeRendererMd
     buf.write(elementType.element.linkedName);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('<');
+      buf.write('&lt;');
       buf.writeAll(elementType.typeArguments.map((t) => t.linkedName), ', ');
       buf.write('>');
     }
@@ -154,7 +154,7 @@ class ParameterizedElementTypeRendererMd
     buf.write(elementType.element.name);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('<');
+      buf.write('&lt;');
       buf.writeAll(
           elementType.typeArguments.map((t) => t.nameWithGenerics), ', ');
       buf.write('>');

--- a/lib/src/render/enum_field_renderer.dart
+++ b/lib/src/render/enum_field_renderer.dart
@@ -23,7 +23,7 @@ class EnumFieldRendererMd extends EnumFieldRenderer {
   @override
   String renderValue(EnumField field) {
     if (field.name == 'values') {
-      return 'const List<${field.enclosingElement.name}>';
+      return 'const List&lt;${field.enclosingElement.name}>';
     } else {
       return 'const ${field.enclosingElement.name}(${field.index})';
     }

--- a/lib/src/render/typedef_renderer.dart
+++ b/lib/src/render/typedef_renderer.dart
@@ -28,6 +28,6 @@ class TypedefRendererMd extends TypedefRenderer {
       return '';
     }
     var joined = typedef.genericTypeParameters.map((t) => t.name).join(', ');
-    return '<{$joined}>';
+    return '&lt;{$joined}>';
   }
 }


### PR DESCRIPTION
There are several places in the generated markdown where generics get rendered with <types>. This changes those to instead use &lt;types>. Some markdown renderers don't like <types> because it looks like embedded html.