### PR TITLE
Do not crash when documenting an export with '//'

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -303,6 +303,16 @@ class Class extends Container
         return __inheritedElements = <ExecutableElement>[];
       }
 
+      if (definingLibrary == null) {
+        // [definingLibrary] may be null if [element] has been imported or
+        // exported with a non-normalized URI, like "src//a.dart".
+        // TODO(srawlins): It would be nice to allow references from such
+        // libraries, but for now, PackageGraph.allLibraries is a Map with
+        // LibraryElement keys, which include [Element.location] in their
+        // `==` calculation; I think we should not key off of Elements.
+        return __inheritedElements = <ExecutableElement>[];
+      }
+
       var inheritance = definingLibrary.inheritanceManager;
       var cmap = inheritance.getInheritedConcreteMap2(element);
       var imap = inheritance.getInheritedMap2(element);

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -568,6 +568,9 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     if (_modelElementsNameMap == null) {
       _modelElementsNameMap = <String, Set<ModelElement>>{};
       allModelElements.forEach((ModelElement modelElement) {
+        // [definingLibrary] may be null if [element] has been imported or
+        // exported with a non-normalized URI, like "src//a.dart".
+        if (modelElement.definingLibrary == null) return;
         _modelElementsNameMap.putIfAbsent(
             modelElement.fullyQualifiedNameWithoutLibrary, () => {});
         _modelElementsNameMap[modelElement.fullyQualifiedNameWithoutLibrary]

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -661,7 +661,8 @@ abstract class ModelElement extends Canonicalization
       // just shortcut them out.
       if (!utils.hasPublicName(element)) {
         _canonicalLibrary = null;
-      } else if (!packageGraph.localPublicLibraries.contains(definingLibrary)) {
+      } else if (definingLibrary != null &&
+          !packageGraph.localPublicLibraries.contains(definingLibrary)) {
         var candidateLibraries = definingLibrary.exportedInLibraries
             ?.where((l) =>
                 l.isPublic &&


### PR DESCRIPTION
Fixes #2242 

When a library exports another with a double slash, like `export "src//a.dart";`, dartdoc may crash.

This avoids that crash. It's not a great fix, but can be addressed again later.