### PR TITLE
Improve performance by 22% via memoization.

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -710,12 +710,12 @@ abstract class ModelElement extends Canonicalization
             var confidence = highestScore - secondHighestScore;
             var message =
                 '${candidateLibraries.map((l) => l.name)} -> ${candidateLibraries.last.name} (confidence ${confidence.toStringAsPrecision(4)})';
-            var debugLines = <String>[];
-            debugLines.addAll(scoredCandidates.map((s) => '${s.toString()}'));
 
             if (confidence < config.ambiguousReexportScorerMinConfidence) {
               warnable.warn(PackageWarning.ambiguousReexport,
-                  message: message, extendedDebug: debugLines);
+                  message: message,
+                  extendedDebug:
+                      scoredCandidates.map((s) => '${s.toString()}'));
             }
           }
           if (candidateLibraries.isNotEmpty) {
@@ -972,8 +972,10 @@ abstract class ModelElement extends Canonicalization
     _modelType = type;
   }
 
+  String _name;
+
   @override
-  String get name => element.name;
+  String get name => _name ??= element.name;
 
   @override
   String get oneLineDoc => _documentation.asOneLiner;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -714,8 +714,7 @@ abstract class ModelElement extends Canonicalization
             if (confidence < config.ambiguousReexportScorerMinConfidence) {
               warnable.warn(PackageWarning.ambiguousReexport,
                   message: message,
-                  extendedDebug:
-                      scoredCandidates.map((s) => '${s.toString()}'));
+                  extendedDebug: scoredCandidates.map((s) => '$s'));
             }
           }
           if (candidateLibraries.isNotEmpty) {

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -194,16 +194,17 @@ class Package extends LibraryContainer
 
   String get filePath => 'index.$fileType';
 
+  String _fileType;
+
   String get fileType {
     // TODO(jdkoren): Provide a way to determine file type of a remote package's
     // docs. Perhaps make this configurable through dartdoc options.
     // In theory, a remote package could be documented in any supported format.
     // In practice, devs depend on Dart, Flutter, and/or packages fetched
     // from pub.dev, and we know that all of those use html docs.
-    if (package.documentedWhere == DocumentLocation.remote) {
-      return 'html';
-    }
-    return config.format;
+    return _fileType ??= (package.documentedWhere == DocumentLocation.remote)
+        ? 'html'
+        : config.format;
   }
 
   @override


### PR DESCRIPTION
I tested with the camera flutter plugin. Before this change it took
67 seconds. Multiple fixes brought down the duration:

* memoize Package.fileType => 53 seconds (79% duration)
* memoize ModelElement.name => 52 seconds (78% duration)