### PR TITLE
Avoid raw types, like `Future` or `List`.

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -355,7 +355,7 @@ class Dartdoc {
       return null;
     }
     var decoder = JsonDecoder();
-    List jsonData = decoder.convert(file.readAsStringSync());
+    List<Object> jsonData = decoder.convert(file.readAsStringSync());
 
     var found = <String>{};
     found.add(fullPath);
@@ -390,7 +390,7 @@ class Dartdoc {
       fullPath = path.normalize(fullPath);
     }
 
-    Tuple2 stringLinksAndHref = _getStringLinksAndHref(fullPath);
+    var stringLinksAndHref = _getStringLinksAndHref(fullPath);
     if (stringLinksAndHref == null) {
       _warn(packageGraph, PackageWarning.brokenLink, pathToCheck,
           path.normalize(origin),
@@ -402,8 +402,8 @@ class Dartdoc {
       return null;
     }
     visited.add(fullPath);
-    Iterable<String> stringLinks = stringLinksAndHref.item1;
-    String baseHref = stringLinksAndHref.item2;
+    var stringLinks = stringLinksAndHref.item1;
+    var baseHref = stringLinksAndHref.item2;
 
     // Prevent extremely large stacks by storing the paths we are using
     // here instead -- occasionally, very large jobs have overflowed
@@ -438,7 +438,7 @@ class Dartdoc {
         }
       }
     }
-    for (Tuple2 visitPaths in toVisit) {
+    for (var visitPaths in toVisit) {
       _doCheck(packageGraph, origin, visited, visitPaths.item1, pathToCheck,
           visitPaths.item2);
     }

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -15,8 +15,8 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
   bool get version => optionSet['version'].valueAt(context);
 }
 
-Future<List<DartdocOption>> createDartdocProgramOptions() async {
-  return <DartdocOption>[
+Future<List<DartdocOption<bool>>> createDartdocProgramOptions() async {
+  return [
     DartdocOptionArgOnly<bool>('generateDocs', true,
         help:
             'Generate docs into the output directory (or only display warnings if false).',

--- a/lib/src/experiment_options.dart
+++ b/lib/src/experiment_options.dart
@@ -21,8 +21,8 @@ abstract class DartdocExperimentOptionContext
 
 // TODO(jcollins-g): Implement YAML parsing for these flags and generation
 // of [DartdocExperimentOptionContext], once a YAML file is available.
-Future<List<DartdocOption>> createExperimentOptions() async {
-  return <DartdocOption>[
+Future<List<DartdocOption<Object>>> createExperimentOptions() async {
+  return [
     // TODO(jcollins-g): Consider loading experiment values from dartdoc_options.yaml?
     DartdocOptionArgOnly<List<String>>('enable-experiment', [],
         help: 'Enable or disable listed experiments.\n' +

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -13,7 +13,7 @@ import 'package:dartdoc/src/model_utils.dart';
 /// it were.
 class EmptyGenerator extends Generator {
   @override
-  Future generate(PackageGraph _packageGraph, FileWriter writer) {
+  Future<void> generate(PackageGraph _packageGraph, FileWriter writer) {
     logProgress(_packageGraph.defaultPackage.documentationAsHtml);
     for (var package in {_packageGraph.defaultPackage}
       ..addAll(_packageGraph.localPackages)) {

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -28,7 +28,7 @@ abstract class FileWriter {
 abstract class Generator {
   /// Generate the documentation for the given package using the specified
   /// writer. Completes the returned future when done.
-  Future generate(PackageGraph packageGraph, FileWriter writer);
+  Future<void> generate(PackageGraph packageGraph, FileWriter writer);
 }
 
 /// Dartdoc options related to generators generally.
@@ -55,8 +55,8 @@ mixin GeneratorContext on DartdocOptionContextBase {
   bool get useBaseHref => optionSet['useBaseHref'].valueAt(context);
 }
 
-Future<List<DartdocOption>> createGeneratorOptions() async {
-  return <DartdocOption>[
+Future<List<DartdocOption<Object>>> createGeneratorOptions() async {
+  return [
     DartdocOptionArgFile<List<String>>('footer', [],
         isFile: true,
         help:

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -18,7 +18,7 @@ class GeneratorFrontEnd implements Generator {
   GeneratorFrontEnd(this._generatorBackend);
 
   @override
-  Future generate(PackageGraph packageGraph, FileWriter writer) async {
+  Future<void> generate(PackageGraph packageGraph, FileWriter writer) async {
     var indexElements = <Indexable>[];
     _generateDocs(packageGraph, writer, indexElements);
     await _generatorBackend.generateAdditionalFiles(writer, packageGraph);

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -14,8 +14,9 @@ import 'package:dartdoc/src/model/indexable.dart';
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   var encoder = pretty ? JsonEncoder.withIndent(' ') : JsonEncoder();
   // ignore: omit_local_variable_types
-  final List<Map> indexItems = categories.map((Categorization e) {
-    var data = <String, dynamic>{
+  final List<Map<String, Object>> indexItems =
+      categories.map((Categorization e) {
+    var data = <String, Object>{
       'name': e.name,
       'qualifiedName': e.fullyQualifiedName,
       'href': e.href,
@@ -45,8 +46,8 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
 String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
   var encoder = pretty ? JsonEncoder.withIndent(' ') : JsonEncoder();
-  final List<Map> indexItems = indexedElements.map((Indexable e) {
-    var data = <String, dynamic>{
+  final indexItems = indexedElements.map((Indexable e) {
+    var data = <String, Object>{
       'name': e.name,
       'qualifiedName': e.fullyQualifiedName,
       'href': e.href,

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -50,7 +50,7 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
     }
   }
 
-  Future _copyResources(FileWriter writer) async {
+  Future<void> _copyResources(FileWriter writer) async {
     final prefix = 'package:dartdoc/resources/';
     for (var resourcePath in resources.resource_names) {
       if (!resourcePath.startsWith(prefix)) {

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -106,7 +106,7 @@ class MultiFutureTracker<T> {
     while (_trackedFutures.length > parallel - 1) {
       await Future.any(_trackedFutures);
     }
-    Future future = closure();
+    Future<void> future = closure();
     _trackedFutures.add(future);
     // ignore: unawaited_futures
     future.then((f) => _trackedFutures.remove(future));

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -130,8 +130,8 @@ abstract class LoggingContext implements DartdocOptionContextBase {
   bool get quiet => optionSet['quiet'].valueAt(context);
 }
 
-Future<List<DartdocOption>> createLoggingOptions() async {
-  return <DartdocOption>[
+Future<List<DartdocOption<Object>>> createLoggingOptions() async {
+  return [
     DartdocOptionArgOnly<bool>('json', false,
         help: 'Prints out progress JSON maps. One entry per line.',
         negatable: true),
@@ -139,7 +139,7 @@ Future<List<DartdocOption>> createLoggingOptions() async {
         help: 'Display progress indications to console stdout.',
         negatable: true),
     DartdocOptionArgSynth<bool>('quiet',
-        (DartdocSyntheticOption option, Directory dir) {
+        (DartdocSyntheticOption<Object> option, Directory dir) {
       if (option.root['generateDocs']?.valueAt(dir) == false) {
         return true;
       }

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -172,7 +172,7 @@ class Class extends Container
     return _inheritedMethods;
   }
 
-  Iterable get publicInheritedMethods =>
+  Iterable<Method> get publicInheritedMethods =>
       model_utils.filterNonPublic(inheritedMethods);
 
   bool get hasPublicInheritedMethods => publicInheritedMethods.isNotEmpty;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -158,7 +158,7 @@ abstract class ModelElement extends Canonicalization
         SourceCodeMixin,
         Indexable,
         FeatureSet
-    implements Comparable, Documentable {
+    implements Comparable<ModelElement>, Documentable {
   final Element _element;
 
   // TODO(jcollins-g): This really wants a "member that has a type" class.
@@ -1086,7 +1086,7 @@ abstract class ModelElement extends Canonicalization
   /// Unconditionally precache local documentation.
   ///
   /// Use only in factory for [PackageGraph].
-  Future precacheLocalDocs() async {
+  Future<void> precacheLocalDocs() async {
     _documentationLocal = await _buildDocumentationBase();
   }
 

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -94,11 +94,11 @@ class PackageGraph {
   }
 
   /// Generate a list of futures for any docs that actually require precaching.
-  Iterable<Future> precacheLocalDocs() sync* {
+  Iterable<Future<void>> precacheLocalDocs() sync* {
     // Prevent reentrancy.
     var precachedElements = <ModelElement>{};
 
-    Iterable<Future> precacheOneElement(ModelElement m) sync* {
+    Iterable<Future<void>> precacheOneElement(ModelElement m) sync* {
       for (var d
           in m.documentationFrom.where((d) => d.documentationComment != null)) {
         if (needsPrecacheRegExp.hasMatch(d.documentationComment) &&
@@ -567,7 +567,7 @@ class PackageGraph {
     _implementors.putIfAbsent(c.href, () => []);
     void _checkAndAddClass(Class key, Class implClass) {
       _implementors.putIfAbsent(key.href, () => []);
-      List list = _implementors[key.href];
+      var list = _implementors[key.href];
 
       if (!list.any((l) => l.element == c.element)) {
         list.add(implClass);

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -280,8 +280,8 @@ class _FilePackageMeta extends PubPackageMeta {
   FileContents _readme;
   FileContents _license;
   FileContents _changelog;
-  Map _pubspec;
-  Map _analysisOptions;
+  Map<dynamic, dynamic> _pubspec;
+  Map<dynamic, dynamic> _analysisOptions;
 
   _FilePackageMeta(Directory dir) : super(dir) {
     var f = File(path.join(dir.path, 'pubspec.yaml'));

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -26,8 +26,8 @@ abstract class SourceLinkerOptionContext implements DartdocOptionContextBase {
       optionSet['linkToSource']['uriTemplate'].valueAt(context);
 }
 
-Future<List<DartdocOption>> createSourceLinkerOptions() async {
-  return <DartdocOption>[
+Future<List<DartdocOption<Object>>> createSourceLinkerOptions() async {
+  return [
     DartdocOptionSet('linkToSource')
       ..addAll([
         DartdocOptionArgFile<List<String>>('excludes', [],

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -17,7 +17,7 @@ typedef FakeResultCallback = String Function(String tool,
 
 /// Set a ceiling on how many tool instances can be in progress at once,
 /// limiting both parallelization and the number of open temporary files.
-final MultiFutureTracker _toolTracker = MultiFutureTracker(4);
+final MultiFutureTracker<void> _toolTracker = MultiFutureTracker(4);
 
 /// Can be called when the ToolRunner is no longer needed.
 ///
@@ -121,7 +121,7 @@ class ToolRunner {
   /// of the tool).
   Future<String> run(List<String> args, ToolErrorCallback toolErrorCallback,
       {String content, Map<String, String> environment}) async {
-    Future runner;
+    Future<String> runner;
     // Prevent too many tools from running simultaneously.
     await _toolTracker.addFutureFromClosure(() {
       runner = _run(args, toolErrorCallback,

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -23,10 +23,10 @@ abstract class PackageWarningOptionContext implements DartdocOptionContextBase {
   bool get verboseWarnings => optionSet['verboseWarnings'].valueAt(context);
 }
 
-Future<List<DartdocOption>> createPackageWarningOptions(
+Future<List<DartdocOption<Object>>> createPackageWarningOptions(
   PackageMetaProvider packageMetaProvider,
 ) async {
-  return <DartdocOption>[
+  return [
     DartdocOptionArgOnly<bool>('allowNonLocalWarnings', false,
         negatable: true,
         help: 'Show warnings from packages we are not documenting locally.'),

--- a/tool/builder.dart
+++ b/tool/builder.dart
@@ -22,7 +22,7 @@ class ResourceBuilder implements Builder {
 
   static final _allResources = Glob('lib/resources/**');
   @override
-  Future build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     var packagePaths = <String>[];
     await for (AssetId asset in buildStep.findAssets(_allResources)) {
       packagePaths.add(asset.uri.toString());

--- a/tool/doc_packages.dart
+++ b/tool/doc_packages.dart
@@ -106,7 +106,7 @@ void generateForPackages(List<String> packages) {
   });
 }
 
-Future _printGenerationResult(
+Future<void> _printGenerationResult(
     PackageInfo package, Future<bool> generationResult) {
   var name = package.name.padRight(20);
 
@@ -190,7 +190,7 @@ Future<bool> _generateFor(PackageInfo package) async {
   }
 }
 
-Future _exec(String command, List<String> args,
+Future<void> _exec(String command, List<String> args,
     {String cwd,
     bool quiet = false,
     Duration timeout = const Duration(seconds: 60)}) {


### PR DESCRIPTION
This reduces dynamicism by reducing implicit dynamics. It also
reduces casts.

This is accomplished by replacing types with `var`, or by adding
type annotations.