### PR TITLE
Performance improvements and refactoring

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -290,10 +290,10 @@ class Dartdoc {
     var indexJson = path.joinAll([normalOrigin, 'index.json']);
     var foundIndexJson = false;
     for (var f in Directory(normalOrigin).listSync(recursive: true)) {
-      var fullPath = path.normalize(f.path);
       if (f is Directory) {
         continue;
       }
+      var fullPath = path.normalize(f.path);
       if (fullPath.startsWith(staticAssets)) {
         continue;
       }
@@ -331,6 +331,9 @@ class Dartdoc {
     if (!file.existsSync()) {
       return null;
     }
+    // TODO(srawlins): It is possible that instantiating an HtmlParser using
+    // `lowercaseElementName: false` and `lowercaseAttrName: false` may save
+    // time or memory.
     var doc = parse(file.readAsBytesSync());
     var base = doc.querySelector('base');
     String baseHref;

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -15,8 +15,8 @@ abstract class Canonicalization implements Locatable, Documentable {
   /// Pieces of the location, split to remove 'package:' and slashes.
   Set<String> get locationPieces;
 
-  List<ScoredCandidate> scoreCanonicalCandidates(List<Library> libraries) {
-    return libraries.map((l) => scoreElementWithLibrary(l)).toList()..sort();
+  List<ScoredCandidate> scoreCanonicalCandidates(Iterable<Library> libraries) {
+    return libraries.map(scoreElementWithLibrary).toList()..sort();
   }
 
   ScoredCandidate scoreElementWithLibrary(Library lib) {

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -628,13 +628,9 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   List<ModelElement> _allModelElements;
 
   Iterable<ModelElement> get allModelElements {
-    if (_allModelElements == null) {
-      _allModelElements = [];
-      for (var modelElements in modelElementsMap.values) {
-        _allModelElements.addAll(modelElements);
-      }
-    }
-    return _allModelElements;
+    return _allModelElements ??= [
+      for (var modelElements in modelElementsMap.values) ...modelElements,
+    ];
   }
 
   List<ModelElement> _allCanonicalModelElements;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -171,22 +171,27 @@ class Package extends LibraryContainer
     return _isLocal;
   }
 
+  /* late */ DocumentLocation _documentedWhere;
+
   DocumentLocation get documentedWhere {
-    if (isLocal) {
-      if (isPublic) {
-        return DocumentLocation.local;
+    if (_documentedWhere == null) {
+      if (isLocal) {
+        if (isPublic) {
+          _documentedWhere = DocumentLocation.local;
+        } else {
+          // Possible if excludes result in a "documented" package not having
+          // any actual documentation.
+          _documentedWhere = DocumentLocation.missing;
+        }
       } else {
-        // Possible if excludes result in a "documented" package not having
-        // any actual documentation.
-        return DocumentLocation.missing;
-      }
-    } else {
-      if (config.linkToRemote && config.linkToUrl.isNotEmpty && isPublic) {
-        return DocumentLocation.remote;
-      } else {
-        return DocumentLocation.missing;
+        if (config.linkToRemote && config.linkToUrl.isNotEmpty && isPublic) {
+          _documentedWhere = DocumentLocation.remote;
+        } else {
+          _documentedWhere = DocumentLocation.missing;
+        }
       }
     }
+    return _documentedWhere;
   }
 
   @override

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -68,24 +68,23 @@ class PackageGraph {
     specialClasses = SpecialClasses();
     // Go through docs of every ModelElement in package to pre-build the macros
     // index.  Uses toList() in order to get all the precaching on the stack.
-    var precacheFutures = precacheLocalDocs().toList();
-    for (var f in precacheFutures) {
-      await f;
-    }
+    await Future.wait(precacheLocalDocs());
     _localDocumentationBuilt = true;
 
     // Scan all model elements to insure that interceptor and other special
     // objects are found.
     // After the allModelElements traversal to be sure that all packages
     // are picked up.
-    documentedPackages.toList().forEach((package) {
+    for (var package in documentedPackages) {
       package.libraries.sort((a, b) => compareNatural(a.name, b.name));
-      package.libraries.forEach((library) {
+      for (var library in package.libraries) {
         library.allClasses.forEach(_addToImplementors);
         _extensions.addAll(library.extensions);
-      });
-    });
-    _implementors.values.forEach((l) => l.sort());
+      }
+    }
+    for (var l in _implementors.values) {
+      l.sort();
+    }
     allImplementorsAdded = true;
     allExtensionsAdded = true;
 
@@ -574,18 +573,14 @@ class PackageGraph {
       }
     }
 
-    if (c.mixins.isNotEmpty) {
-      c.mixins.forEach((t) {
-        _checkAndAddClass(t.element, c);
-      });
+    for (var type in c.mixins) {
+      _checkAndAddClass(type.element, c);
     }
     if (c.supertype != null) {
       _checkAndAddClass(c.supertype.element, c);
     }
-    if (c.interfaces.isNotEmpty) {
-      c.interfaces.forEach((t) {
-        _checkAndAddClass(t.element, c);
-      });
+    for (var type in c.interfaces) {
+      _checkAndAddClass(type.element, c);
     }
   }
 
@@ -908,8 +903,8 @@ class PackageGraph {
   List<ModelElement> _allCanonicalModelElements;
 
   Iterable<ModelElement> get allCanonicalModelElements {
-    return (_allCanonicalModelElements ??=
-        allLocalModelElements.where((e) => e.isCanonical).toList());
+    return _allCanonicalModelElements ??=
+        allLocalModelElements.where((e) => e.isCanonical).toList();
   }
 
   String getMacro(String name) {


### PR DESCRIPTION
When documenting the camera Flutter plugin, these changes reduce the time to document from 52 seconds to 51 seconds.

Much of this speedup likely came from memoizing Package.documentedWhere, which has a few expensive calls like `linkToRemote` and `linkToUrl`. Additionally ModelElement.locationPieces is now memoized.

The rest is a few categorical refactorings:

* ModelElement.canonicalLibrary:
    * Refactor most of the complexity of ModelElement.canonicalLibrary into a new private method.
    * Don't compute topLevelElement until you need it.
    * Short circuit if `definingLibrary.exportedInLibraries` is null.
    * Reduce nesting
    * Create warning message only if it will be used.
* Prefer for loops over Iterable.forEach.