### PR TITLE
Improve performance of documenting by 10%.

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -752,22 +752,14 @@ abstract class ModelElement extends Canonicalization
   @override
   bool get isCanonical {
     if (!isPublic) return false;
-    if (library == canonicalLibrary) {
-      if (this is Inheritable) {
-        var i = (this as Inheritable);
-        // If we're the defining element, or if the defining element is not
-        // in the set of libraries being documented, then this element
-        // should be treated as canonical (given library == canonicalLibrary).
-        if (i.enclosingElement == i.canonicalEnclosingContainer) {
-          return true;
-        } else {
-          return false;
-        }
-      }
-      // If there's no inheritance to deal with, we're done.
-      return true;
-    }
-    return false;
+    if (library != canonicalLibrary) return false;
+    // If there's no inheritance to deal with, we're done.
+    if (this is! Inheritable) return true;
+    var i = this as Inheritable;
+    // If we're the defining element, or if the defining element is not in the
+    // set of libraries being documented, then this element should be treated as
+    // canonical (given library == canonicalLibrary).
+    return i.enclosingElement == i.canonicalEnclosingContainer;
   }
 
   String _htmlDocumentation;

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -163,11 +163,10 @@ class PubPackageBuilder implements PackageBuilder {
     if (_driver == null) {
       var log = PerformanceLog(null);
       var scheduler = AnalysisDriverScheduler(log);
-      var options = AnalysisOptionsImpl();
-
-      // TODO(jcollins-g): pass in an ExperimentStatus instead?
-      options.contextFeatures =
-          FeatureSet.fromEnableFlags(config.enableExperiment);
+      var options = AnalysisOptionsImpl()
+        ..hint = false
+        // TODO(jcollins-g): pass in an ExperimentStatus instead?
+        ..contextFeatures = FeatureSet.fromEnableFlags(config.enableExperiment);
 
       // TODO(jcollins-g): Make use of currently not existing API for managing
       //                   many AnalysisDrivers

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -587,12 +587,12 @@ class PackageGraph {
 
   Iterable<Library> get libraries => packages.expand((p) => p.libraries);
 
-  Set<Library> _publicLibraries;
+  List<Library> _publicLibraries;
 
-  Set<Library> get publicLibraries {
+  Iterable<Library> get publicLibraries {
     if (_publicLibraries == null) {
       assert(allLibrariesAdded);
-      _publicLibraries = utils.filterNonPublic(libraries).toSet();
+      _publicLibraries = utils.filterNonPublic(libraries).toList();
     }
     return _publicLibraries;
   }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -585,7 +585,8 @@ class PackageGraph {
     }
   }
 
-  Iterable<Library> get libraries => packages.expand((p) => p.libraries);
+  Iterable<Library> get libraries =>
+      packages.expand((p) => p.libraries).toList()..sort();
 
   List<Library> _publicLibraries;
 

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -256,17 +256,18 @@ class PackageGraph {
   bool allLibrariesAdded = false;
   bool _localDocumentationBuilt = false;
 
-  /// Returns true if there's at least one library documented in the package
-  /// that has the same package path as the library for the given element.
-  /// Usable as a cross-check for dartdoc's canonicalization to generate
-  /// warnings for ModelElement.isPublicAndPackageDocumented.
   Set<String> _allRootDirs;
 
+  /// Returns true if there's at least one library documented in the package
+  /// that has the same package path as the library for the given element.
+  ///
+  /// Usable as a cross-check for dartdoc's canonicalization to generate
+  /// warnings for ModelElement.isPublicAndPackageDocumented.
   bool packageDocumentedFor(ModelElement element) {
     _allRootDirs ??= {
       ...(publicLibraries.map((l) => l.packageMeta?.resolvedDir))
     };
-    return (_allRootDirs.contains(element.library.packageMeta?.resolvedDir));
+    return _allRootDirs.contains(element.library.packageMeta?.resolvedDir);
   }
 
   PackageWarningCounter get packageWarningCounter => _packageWarningCounter;
@@ -584,15 +585,14 @@ class PackageGraph {
     }
   }
 
-  List<Library> get libraries =>
-      packages.expand((p) => p.libraries).toList()..sort();
+  Iterable<Library> get libraries => packages.expand((p) => p.libraries);
 
-  List<Library> _publicLibraries;
+  Set<Library> _publicLibraries;
 
-  Iterable<Library> get publicLibraries {
+  Set<Library> get publicLibraries {
     if (_publicLibraries == null) {
       assert(allLibrariesAdded);
-      _publicLibraries = utils.filterNonPublic(libraries).toList();
+      _publicLibraries = utils.filterNonPublic(libraries).toSet();
     }
     return _publicLibraries;
   }
@@ -682,8 +682,7 @@ class PackageGraph {
       if (library.modelElementsMap.containsKey(searchElement)) {
         for (var modelElement in library.modelElementsMap[searchElement]) {
           if (modelElement.isCanonical) {
-            _canonicalLibraryFor[e] = library;
-            break;
+            return _canonicalLibraryFor[e] = library;
           }
         }
       }
@@ -745,8 +744,7 @@ class PackageGraph {
       Class canonicalClass = findCanonicalModelElementFor(e.enclosingElement);
       if (canonicalClass != null) {
         candidates.addAll(canonicalClass.allCanonicalModelElements.where((m) {
-          if (m.element == e) return true;
-          return false;
+          return m.element == e;
         }));
       }
       var matches = <ModelElement>{...candidates.where((me) => me.isCanonical)};


### PR DESCRIPTION
This change reduces the time to document the camera Flutter plugin from 51 seconds to 46 seconds.

This is mostly accomplished by _not_ analyzing libraries for hints.

In addition, a few other tweaks are made:

* Less nesting.
* Using sets instead of lists where `contains` is the primary use.