### PR TITLE
Split apart ModelElement.from into a few pieces for cleaner code

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -428,14 +428,14 @@ class Class extends Container
     if ((getter == null || getter.isInherited) &&
         (setter == null || setter.isInherited)) {
       // Field is 100% inherited.
-      field = ModelElement.from(f, library, packageGraph,
+      field = ModelElement.fromPropertyInducingElement(f, library, packageGraph,
           enclosingContainer: this, getter: getter, setter: setter);
     } else {
       // Field is <100% inherited (could be half-inherited).
       // TODO(jcollins-g): Navigation is probably still confusing for
       // half-inherited fields when traversing the inheritance tree.  Make
       // this better, somehow.
-      field = ModelElement.from(f, library, packageGraph,
+      field = ModelElement.fromPropertyInducingElement(f, library, packageGraph,
           getter: getter, setter: setter);
     }
     _allFields.add(field);

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -76,7 +76,7 @@ class Extension extends Container
       if (f.setter != null) {
         setter = ContainerAccessor(f.setter, library, packageGraph);
       }
-      return ModelElement.from(f, library, packageGraph,
+      return ModelElement.fromPropertyInducingElement(f, library, packageGraph,
           getter: getter, setter: setter) as Field;
     }).toList(growable: false)
       ..sort(byName);

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -140,22 +140,27 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   /// to inheritance and reexporting.  Most useful for error reporting.
   Iterable<String> get allOriginalModelElementNames {
     _allOriginalModelElementNames ??= allModelElements.map((e) {
-      Accessor getter;
-      Accessor setter;
       if (e is GetterSetterCombo) {
+        Accessor getter;
+        Accessor setter;
         if (e.hasGetter) {
           getter = ModelElement.fromElement(e.getter.element, packageGraph);
         }
         if (e.hasSetter) {
           setter = ModelElement.fromElement(e.setter.element, packageGraph);
         }
+        return ModelElement.fromPropertyInducingElement(
+                e.element,
+                packageGraph.findButDoNotCreateLibraryFor(e.element),
+                packageGraph,
+                getter: getter,
+                setter: setter)
+            .fullyQualifiedName;
       }
       return ModelElement.from(
               e.element,
               packageGraph.findButDoNotCreateLibraryFor(e.element),
-              packageGraph,
-              getter: getter,
-              setter: setter)
+              packageGraph)
           .fullyQualifiedName;
     }).toList();
     return _allOriginalModelElementNames;
@@ -504,7 +509,8 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
         if (element.setter != null) {
           setter = ModelElement.from(element.setter, this, packageGraph);
         }
-        var me = ModelElement.from(element, this, packageGraph,
+        var me = ModelElement.fromPropertyInducingElement(
+            element, this, packageGraph,
             getter: getter, setter: setter);
         _variables.add(me);
       }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -798,18 +798,19 @@ class PackageGraph {
       }
     } else {
       if (lib != null) {
-        Accessor getter;
-        Accessor setter;
         if (e is PropertyInducingElement) {
-          if (e.getter != null) {
-            getter = ModelElement.from(e.getter, lib, packageGraph);
-          }
-          if (e.setter != null) {
-            setter = ModelElement.from(e.setter, lib, packageGraph);
-          }
+          var getter = e.getter != null
+              ? ModelElement.from(e.getter, lib, packageGraph)
+              : null;
+          var setter = e.setter != null
+              ? ModelElement.from(e.setter, lib, packageGraph)
+              : null;
+          modelElement = ModelElement.fromPropertyInducingElement(
+              e, lib, packageGraph,
+              getter: getter, setter: setter);
+        } else {
+          modelElement = ModelElement.from(e, lib, packageGraph);
         }
-        modelElement = ModelElement.from(e, lib, packageGraph,
-            getter: getter, setter: setter);
       }
       assert(modelElement is! Inheritable);
       if (modelElement != null && !modelElement.isCanonical) {


### PR DESCRIPTION
ModelElement.from was huge; it handles all types of elements, including
property-inducing ones. It handled verification, and element caching.  This
changes splits it into 4 functions:

* ModelElement.fromPropertyInducingElement, a factory constructor.
* ModelElement.from, the sibling constructor for non-property-inducing
  elements.
* ModelElement._from, a helper which performs the actual constructions.
* ModelElement._cacheNewModelElement, a helper which caches the newly
  constructed ModelElement.

Callers frequently had conditional logic for property-inducing elements, so the
splitting of the constructor does not complicate callers, but allows them to be
explicit about which constructor they are calling.