### PR TITLE
Support FunctionTypeAliasElement separately in modelType.

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -965,6 +965,9 @@ abstract class ModelElement extends Canonicalization
         }
       } else if (element is ClassElement) {
         _modelType = ElementType.from(element.thisType, library, packageGraph);
+      } else if (element is FunctionTypeAliasElement) {
+        _modelType =
+            ElementType.from(element.function.type, library, packageGraph);
       } else if (element is FunctionTypedElement) {
         _modelType = ElementType.from(element.type, library, packageGraph);
       } else if (element is ParameterElement) {


### PR DESCRIPTION
It will stop being a `FunctionTypedElement` in the analyzer `0.40.0`.