### PR TITLE
add more types

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,5 +26,6 @@ linter:
     - prefer_final_fields
     - prefer_generic_function_type_aliases
     - slash_for_doc_comments
+    - type_annotate_public_apis
     - unawaited_futures
 #    - unnecessary_brace_in_string_interps

--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -29,5 +29,6 @@ linter:
     - prefer_final_fields
     - prefer_generic_function_type_aliases
     - slash_for_doc_comments
+    - type_annotate_public_apis
     - unawaited_futures
 #    - unnecessary_brace_in_string_interps

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -425,7 +425,7 @@ class Dartdoc {
         }
 
         if (uri == null || !uri.hasAuthority && !uri.hasFragment) {
-          var full;
+          String full;
           if (baseHref != null) {
             full = '${path.dirname(pathToCheck)}/$baseHref/$href';
           } else {

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -20,8 +20,8 @@ abstract class TemplateData<T extends Documentable> {
   String get layoutTitle;
   String get metaDescription;
 
-  List get navLinks;
-  List get navLinksWithGenerics => [];
+  List<Documentable> get navLinks;
+  List<Documentable> get navLinksWithGenerics => [];
   Documentable get parent {
     if (navLinksWithGenerics.isEmpty) {
       return navLinks.isNotEmpty ? navLinks.last : null;
@@ -60,7 +60,7 @@ class PackageTemplateData extends TemplateData<Package> {
   @override
   bool get includeVersion => true;
   @override
-  List get navLinks => [];
+  List<Documentable> get navLinks => [];
   @override
   String get title => '${package.name} - Dart API docs';
   @override
@@ -101,7 +101,7 @@ class CategoryTemplateData extends TemplateData<Category> {
       '${category.name} ${category.kind} docs, for the Dart programming language.';
 
   @override
-  List get navLinks => [category.package];
+  List<Documentable> get navLinks => [category.package];
 
   @override
   Category get self => category;
@@ -122,7 +122,7 @@ class LibraryTemplateData extends TemplateData<Library> {
   String get metaDescription =>
       '${library.name} library API docs, for the Dart programming language.';
   @override
-  List get navLinks => [packageGraph.defaultPackage];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage];
 
   @override
   String get layoutTitle =>
@@ -170,7 +170,7 @@ class ClassTemplateData<T extends Class> extends TemplateData<T> {
   String get layoutTitle => _layoutTitle(
       clazz.nameWithLinkedGenerics, clazz.fullkind, clazz.isDeprecated);
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
   String get htmlBase => '../';
 
@@ -213,7 +213,7 @@ class ExtensionTemplateData<T extends Extension> extends TemplateData<T> {
   @override
   String get layoutTitle => _layoutTitle(extension.name, extension.kind, false);
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
   String get htmlBase => '../';
 }
@@ -233,9 +233,9 @@ class ConstructorTemplateData extends TemplateData<Constructor> {
   String get layoutTitle => _layoutTitle(
       constructor.name, constructor.fullKind, constructor.isDeprecated);
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
-  List get navLinksWithGenerics => [clazz];
+  List<Documentable> get navLinksWithGenerics => [clazz];
   @override
   @override
   String get htmlBase => '../../';
@@ -280,7 +280,7 @@ class FunctionTemplateData extends TemplateData<ModelFunction> {
       'API docs for the ${function.name} function from the '
       '${library.name} library, for the Dart programming language.';
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
   String get htmlBase => '../';
 }
@@ -311,9 +311,9 @@ class MethodTemplateData extends TemplateData<Method> {
       'API docs for the ${method.name} method from the '
       '${container.name} ${containerDesc}, for the Dart programming language.';
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
-  List get navLinksWithGenerics => [container];
+  List<Documentable> get navLinksWithGenerics => [container];
   @override
   String get htmlBase => '../../';
 }
@@ -345,9 +345,9 @@ class PropertyTemplateData extends TemplateData<Field> {
       'API docs for the ${property.name} $_type from the '
       '${container.name} ${containerDesc}, for the Dart programming language.';
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
-  List get navLinksWithGenerics => [container];
+  List<Documentable> get navLinksWithGenerics => [container];
   @override
   String get htmlBase => '../../';
 
@@ -376,7 +376,7 @@ class TypedefTemplateData extends TemplateData<Typedef> {
       'API docs for the ${typeDef.name} property from the '
       '${library.name} library, for the Dart programming language.';
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
   String get htmlBase => '../';
 }
@@ -403,7 +403,7 @@ class TopLevelPropertyTemplateData extends TemplateData<TopLevelVariable> {
       'API docs for the ${property.name} $_type from the '
       '${library.name} library, for the Dart programming language.';
   @override
-  List get navLinks => [packageGraph.defaultPackage, library];
+  List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
   String get htmlBase => '../';
 

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -164,7 +164,8 @@ class MatchingLinkResult {
 }
 
 class IterableBlockParser extends md.BlockParser {
-  IterableBlockParser(lines, document) : super(lines, document);
+  IterableBlockParser(List<String> lines, md.Document document)
+      : super(lines, document);
 
   Iterable<md.Node> parseLinesGenerator() sync* {
     while (!isDone) {
@@ -870,7 +871,7 @@ class MarkdownDocument extends md.Document {
       Iterable<md.InlineSyntax> inlineSyntaxes,
       md.ExtensionSet extensionSet,
       md.Resolver linkResolver,
-      imageLinkResolver})
+      md.Resolver imageLinkResolver})
       : super(
             blockSyntaxes: blockSyntaxes,
             inlineSyntaxes: inlineSyntaxes,

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -71,7 +71,7 @@ class Class extends Container
   @override
   List<ModelElement> get allModelElements {
     _allModelElements ??= List.from(
-        quiver.concat([
+        quiver.concat<ModelElement>([
           super.allModelElements,
           constructors,
           typeParameters,
@@ -471,7 +471,7 @@ class Class extends Container
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
 
   @override
-  bool operator ==(o) =>
+  bool operator ==(Object o) =>
       o is Class &&
       name == o.name &&
       o.library.name == library.name &&

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -102,7 +102,7 @@ class Extension extends Container
   @override
   List<ModelElement> get allModelElements {
     _allModelElements ??= List.from(
-        quiver.concat([
+        quiver.concat<ModelElement>([
           super.allModelElements,
           typeParameters,
         ]),

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -48,7 +48,7 @@ class Field extends ModelElement
     // to prevent displaying more or less than one summary.
     if (isPublic) {
       var assertCheck = <dynamic>{}
-        ..addAll([hasPublicSetter, hasPublicGetterNoSetter]);
+        ..addAll(<bool>[hasPublicSetter, hasPublicGetterNoSetter]);
       assert(assertCheck.containsAll([true, false]));
     }
     documentationFrom;

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -372,7 +372,7 @@ class PubPackageBuilder implements PackageBuilder {
           config.inputDir, config.autoIncludeDependencies);
     }
     files = quiver.concat([files, _includeExternalsFrom(files)]);
-    return Set.from(files.map((s) => File(s).absolute.path));
+    return Set.from(files.map<String>((s) => File(s).absolute.path));
   }
 
   Iterable<String> getEmbedderSdkFiles() sync* {
@@ -412,7 +412,7 @@ class PubPackageBuilder implements PackageBuilder {
         foundLibraries, files, isLibraryIncluded);
     if (config.include.isNotEmpty) {
       var knownLibraryNames = foundLibraries.map((l) => l.name);
-      var notFound = Set.from(config.include)
+      var notFound = Set<String>.from(config.include)
           .difference(Set.from(knownLibraryNames))
           .difference(Set.from(config.exclude));
       if (notFound.isNotEmpty) {

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -27,7 +27,7 @@ class Typedef extends ModelElement
     if (element is GenericTypeAliasElement) {
       return (element as GenericTypeAliasElement).function.typeParameters;
     }
-    return Iterable.empty();
+    return Iterable<TypeParameterElement>.empty();
   }
 
   @override

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -71,9 +71,10 @@ abstract class PackageMeta {
   PackageMeta(this.dir);
 
   @override
-  bool operator ==(other) {
+  bool operator ==(Object other) {
     if (other is! PackageMeta) return false;
-    return path.equals(dir.absolute.path, other.dir.absolute.path);
+    PackageMeta otherMeta = other;
+    return path.equals(dir.absolute.path, otherMeta.dir.absolute.path);
   }
 
   @override
@@ -278,7 +279,7 @@ class _FilePackageMeta extends PubPackageMeta {
     if (f.existsSync()) {
       _pubspec = loadYaml(f.readAsStringSync());
     } else {
-      _pubspec = {};
+      _pubspec = <dynamic, dynamic>{};
     }
   }
 

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -83,7 +83,7 @@ abstract class ParameterRenderer {
   String required(String required);
 
   String renderLinkedParams(List<Parameter> parameters,
-      {showMetadata = true, showNames = true}) {
+      {bool showMetadata = true, bool showNames = true}) {
     var positionalParams =
         parameters.where((Parameter p) => p.isRequiredPositional).toList();
     var optionalPositionalParams =

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -195,7 +195,7 @@ class ToolRunner {
     }
 
     argsWithInput = toolArgs + argsWithInput;
-    var commandPath;
+    String commandPath;
     void Function() callCompleter;
     if (toolDefinition is DartToolDefinition) {
       var modified = await toolDefinition

--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -22,7 +22,8 @@ class Tuple2<T1, T2> {
   String toString() => '[$item1, $item2]';
 
   @override
-  bool operator ==(o) => o is Tuple2 && o.item1 == item1 && o.item2 == item2;
+  bool operator ==(Object o) =>
+      o is Tuple2 && o.item1 == item1 && o.item2 == item2;
 
   @override
   int get hashCode => hash2(item1.hashCode, item2.hashCode);
@@ -46,7 +47,7 @@ class Tuple3<T1, T2, T3> {
   String toString() => '[$item1, $item2, $item3]';
 
   @override
-  bool operator ==(o) =>
+  bool operator ==(Object o) =>
       o is Tuple3 && o.item1 == item1 && o.item2 == item2 && o.item3 == item3;
 
   @override
@@ -74,7 +75,7 @@ class Tuple4<T1, T2, T3, T4> {
   String toString() => '[$item1, $item2, $item3, $item4]';
 
   @override
-  bool operator ==(o) =>
+  bool operator ==(Object o) =>
       o is Tuple4 &&
       o.item1 == item1 &&
       o.item2 == item2 &&

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -4,7 +4,7 @@
 
 library dartdoc.html_generator_test;
 
-import 'dart:io' show File, Directory;
+import 'dart:io' show File, FileSystemEntity, Directory;
 
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/generator_frontend.dart';
@@ -144,12 +144,13 @@ const Matcher doesExist = _DoesExist();
 class _DoesExist extends Matcher {
   const _DoesExist();
   @override
-  bool matches(item, Map matchState) => item.existsSync();
+  bool matches(dynamic item, Map matchState) =>
+      (item as FileSystemEntity).existsSync();
   @override
   Description describe(Description description) => description.add('exists');
   @override
-  Description describeMismatch(
-      item, Description mismatchDescription, Map matchState, bool verbose) {
+  Description describeMismatch(dynamic item, Description mismatchDescription,
+      Map matchState, bool verbose) {
     if (item is! File && item is! Directory) {
       return mismatchDescription
           .addDescriptionOf(item)


### PR DESCRIPTION
- add more types

Add some more explicit typing. This turns on the `type_annotate_public_apis` lint, and addresses a few items found with `implicit-casts: false` and `implicit-dynamic: false` (those last two weren't enabled as there are many more failures).
