### PR TITLE
Fix paragraph spacing in enum values.

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -341,6 +341,12 @@ dd p {
   margin-bottom: 0;
 }
 
+/* Enum values do not have their own pages; their full docs are presented on the
+ * enum class's page. */
+dt.constant + dd p {
+  margin-bottom: 1em;
+}
+
 /* indents wrapped lines */
 section.summary dt {
   margin-left: 24px;


### PR DESCRIPTION
Since enum values listed on the enum class's page are, I think, the
only case of multiple paragraphs inside a dd, they deserve suome
special styling.

Fixes #2268 