### PR TITLE
Privatize some of the interface of Canonicalization, Category

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -24,11 +24,26 @@ class Category extends Nameable
         Indexable
     implements Documentable {
   /// All libraries in [libraries] must come from [package].
+  Package _package;
+
   @override
-  Package package;
+  Package get package => _package;
+
+  @Deprecated('Field intended to be final; setter will be removed as early as '
+      'Dartdoc 1.0.0')
+  set package(Package value) => _package = value;
+
   final String _name;
+
+  DartdocOptionContext _config;
+
   @override
-  DartdocOptionContext config;
+  DartdocOptionContext get config => _config;
+
+  @Deprecated('Field intended to be final; setter will be removed as early as '
+      'Dartdoc 1.0.0')
+  set config(DartdocOptionContext value) => _config = value;
+
   final Set<Categorization> _allItems = {};
 
   final List<Class> _classes = [];
@@ -41,7 +56,7 @@ class Category extends Nameable
   final List<ModelFunction> _functions = [];
   final List<Typedef> _typedefs = [];
 
-  Category(this._name, this.package, this.config);
+  Category(this._name, this._package, this._config);
 
   void addItem(Categorization c) {
     if (_allItems.contains(c)) return;
@@ -118,15 +133,24 @@ class Category extends Nameable
   @override
   String get fullyQualifiedName => name;
 
-  String get fileType => package.fileType;
+  String get _fileType => package.fileType;
 
-  String get filePath => 'topics/$name-topic.$fileType';
+  @Deprecated(
+      'Public field intended to be private; will be removed as early as '
+      'Dartdoc 1.0.0')
+  String get fileType => _fileType;
+
+  String get filePath => 'topics/$name-topic.$_fileType';
 
   @override
   String get href => isCanonical ? '${package.baseHref}$filePath' : null;
 
+  @Deprecated(
+      'Public field is unused; will be removed as early as Dartdoc 1.0.0')
   String get categoryLabel => _categoryRenderer.renderCategoryLabel(this);
 
+  @Deprecated(
+      'Public field is unused; will be removed as early as Dartdoc 1.0.0')
   String get linkedName => _categoryRenderer.renderLinkedName(this);
 
   int _categoryIndex;

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -8,7 +8,7 @@ import 'package:dartdoc/src/model/model.dart';
 
 /// Top-level variables. But also picks up getters and setters?
 class TopLevelVariable extends ModelElement
-    with Canonicalization, GetterSetterCombo, Categorization
+    with GetterSetterCombo, Categorization
     implements EnclosedElement {
   @override
   final Accessor getter;


### PR DESCRIPTION
* Deprecate the _public_ method `Canonicalization.scoreElementWithLibrary`.
* Deprecate the _public_ getters `ScoredCandidate.reasons` and `ScoredCandidate.element`, method `ScoredCandidate.alterScore`.
* Deprecate the setters `Category.package`, and `Category.config`, and the _public_ method `Category.fileType`.
* Deprecate the unused methods `Category.linkedName` and `Category.categoryLabel`.

These should be removed on a major release number, like 1.0.0.