### PR TITLE
Privatize some of the interface of Class

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -24,6 +24,8 @@ class Category extends Nameable
         Indexable
     implements Documentable {
   /// All libraries in [libraries] must come from [package].
+  // TODO(srawlins): To make final, remove public getter, setter, rename to be
+  // public, and add `final` modifier.
   Package _package;
 
   @override
@@ -35,6 +37,8 @@ class Category extends Nameable
 
   final String _name;
 
+  // TODO(srawlins): To make final, remove public getter, setter, rename to be
+  // public, and add `final` modifier.
   DartdocOptionContext _config;
 
   @override


### PR DESCRIPTION
* Deprecate the setters `Class.mixins` and `Class.supertype` and method `Class.isInheritedFrom`.
* Small clean-ups in Class.