### PR TITLE
Privatize some of the interface of Library

### DIFF
--- a/lib/src/model/library_container.dart
+++ b/lib/src/model/library_container.dart
@@ -7,6 +7,7 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 
 /// A set of libraries, initialized after construction by accessing [libraries].
+///
 /// Do not cache return values of any methods or members excepting [libraries]
 /// and [name] before finishing initialization of a [LibraryContainer].
 abstract class LibraryContainer
@@ -35,11 +36,11 @@ abstract class LibraryContainer
   bool get isSdk => false;
 
   /// Returns:
-  /// -1 if this container is listed in [containerOrder].
-  /// 0 if this container is named the same as the [enclosingName].
-  /// 1 if this container represents the SDK.
-  /// 2 if this group has a name that contains the name [enclosingName].
-  /// 3 otherwise.
+  /// * -1 if this container is listed in [containerOrder].
+  /// * 0 if this container is named the same as the [enclosingName].
+  /// * 1 if this container represents the SDK.
+  /// * 2 if this group has a name that contains the name [enclosingName].
+  /// * 3 otherwise.
   int get _group {
     if (containerOrder.contains(sortKey)) return -1;
     if (equalsIgnoreAsciiCase(sortKey, enclosingName)) return 0;


### PR DESCRIPTION
* Change `Library.fromLibraryResult` to be a factory constructor
* Change `Library. _exportedAndLocalElements` from a `List<Element>` to a `final Set<Element>`
* Deprecate the _public_ methods `Library.getDefinedElements`, `Library.getLibraryName`, and getter `Library.allOriginalModelElementNames`.
* Adjust doc comments to have a short one-liner.
* Extract a RegExp to be static final.
* Mark memoized fields as `/*late final*/`.