### PR TITLE
Add testing/analysis_options.yaml

### DIFF
--- a/testing/analysis_options.yaml
+++ b/testing/analysis_options.yaml
@@ -1,0 +1,2 @@
+# This file exists only to prevent the analyzer from climbing up and using
+# the analysis_options.yaml file from the dartdoc package.


### PR DESCRIPTION
Packages in `testing/` should not be analyzed with the `analysis_options.yaml` from the root of the `dartdoc` package, for example because this file completely excludes `testing/**` from analysis.