### PR TITLE
Remove FileContents class.

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/render/category_renderer.dart';
 import 'package:dartdoc/src/warnings.dart';
 
@@ -174,14 +173,13 @@ class Category extends Nameable
   @override
   String get kind => 'Topic';
 
-  FileContents _documentationFile;
+  File _documentationFile;
 
   @override
-  FileContents get documentationFile {
+  File get documentationFile {
     if (_documentationFile == null) {
       if (categoryDefinition?.documentationMarkdown != null) {
-        _documentationFile =
-            FileContents(File(categoryDefinition.documentationMarkdown));
+        _documentationFile = File(categoryDefinition.documentationMarkdown);
       }
     }
     return _documentationFile;

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -2,9 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io' show File;
+
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/package_meta.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import 'model.dart';
 
@@ -69,10 +71,10 @@ mixin MarkdownFileDocumentation implements Documentable, Canonicalization {
   @override
   String get oneLineDoc => __documentation.asOneLiner;
 
-  FileContents get documentationFile;
+  File get documentationFile;
 
   @override
-  String get location => path.toUri(documentationFile.file.path).toString();
+  String get location => p.toUri(documentationFile.path).toString();
 
   @override
   Set<String> get locationPieces => <String>{location};

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -125,7 +125,7 @@ class Package extends LibraryContainer
   // plain text or markdown.
   bool get hasDocumentationFile => documentationFile != null;
 
-  FileContents get documentationFile => packageMeta.getReadmeContents();
+  File get documentationFile => packageMeta.getReadmeContents();
 
   @override
   String get oneLineDoc => '';


### PR DESCRIPTION
The public constructor was a factory constructor which can return null, which
is illegal under the null safety language feature. Any refactoring is breaking,
and the class's functionality is better implemented as an extension.

Also change a few `package:path/path.dart` import prefixes from `path` to `p`.