### PR TITLE
Remove dependency on deprecated resource package.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,6 @@ analyzer:
   errors:
     unused_import: warning
     unused_shown_name: warning
-    todo: ignore
   exclude:
     - 'doc/**'
     - 'lib/src/third_party/pkg/**'

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,7 @@ analyzer:
   errors:
     unused_import: warning
     unused_shown_name: warning
+    todo: ignore
   exclude:
     - 'doc/**'
     - 'lib/src/third_party/pkg/**'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
   pub_semver: ^1.3.7
-  resource: ^2.1.2
   stack_trace: ^1.4.2
   yaml: ^2.1.0
 


### PR DESCRIPTION
Copy implementation for loading bytes from a 'package:' URI.