### PR TITLE
Improve error when FLUTTER_ROOT is missing.

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1603,6 +1603,11 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
           (option.root['topLevelPackageMeta'].valueAt(dir) as PackageMeta)
               .requiresFlutter) {
         String flutterRoot = option.root['flutterRoot'].valueAt(dir);
+        if (flutterRoot == null) {
+          // For now, return null. An error is reported in
+          // [PackageBuilder.buildPackageGraph].
+          return null;
+        }
         return p.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
       }
       return defaultSdkDir.absolute.path;


### PR DESCRIPTION
This is a re-do, sort of, of #1714, which was broken in #2190. Fixes #2279 