### PR TITLE
Fix duplicated '@override' and '@deprecated' features.

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -537,10 +537,8 @@ abstract class ModelElement extends Canonicalization
           .where((e) => !_specialFeatures.contains(e.element?.name))),
       // 'const' and 'static' are not needed here because 'const' and 'static'
       // elements get their own sections in the doc.
-      if (isFinal)
-        'final',
-      if (isLate)
-        'late',
+      if (isFinal) 'final',
+      if (isLate) 'late',
     };
   }
 


### PR DESCRIPTION
These features were accidentally duplicated in #2313.