### PR TITLE
Use new package_config APIs.

### DIFF
--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -545,7 +545,7 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
       hidePackage = package.packageGraph.packageMeta;
     }
     // restoreUri must not result in another file URI.
-    assert(!name.startsWith('file:'));
+    assert(!name.startsWith('file:'), '"$name" must not start with "file:"');
 
     var defaultPackagePrefix = 'package:$hidePackage/';
     if (name.startsWith(defaultPackagePrefix)) {

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -108,6 +108,8 @@ class PubPackageBuilder implements PackageBuilder {
     var oldFirst = info2.packages.first;
     print(
         'OLD: "${oldFirst}": uri: "${info2.asMap()[oldFirst]}"; packagePath: "${path.normalize(path.fromUri(info2.asMap()[oldFirst]))}"');
+    print(
+        'NEW: ${info.packages.first}: packageUriRoot: ${info.packages.first.packageUriRoot}');
 
     for (var package in info.packages) {
       var packagePath = path.normalize(path.fromUri(package.packageUriRoot));
@@ -318,6 +320,8 @@ class PubPackageBuilder implements PackageBuilder {
           .asMap();
       var oldFirst = info2.keys.first;
       print('oldFirst: $oldFirst; toFilePath: ${info2[oldFirst].toFilePath()}');
+      print(
+          'newFirst: ${info.packages.first}, ${info[info.packages.first.name].packageUriRoot.path}');
       for (var package in info.packages) {
         if (!filterExcludes || !config.exclude.contains(package.name)) {
           packageDirs.add(path.dirname(info[package.name].packageUriRoot.path));

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -104,12 +104,6 @@ class PubPackageBuilder implements PackageBuilder {
         PhysicalResourceProvider.INSTANCE.getResource(config.inputDir);
     var info = await findPackageConfig(Directory(cwd.path));
     if (info == null) return;
-    var info2 = package_config.findPackagesFromFile(cwd.toUri());
-    var oldFirst = info2.packages.first;
-    print(
-        'OLD: "${oldFirst}": uri: "${info2.asMap()[oldFirst]}"; packagePath: "${path.normalize(path.fromUri(info2.asMap()[oldFirst]))}"');
-    print(
-        'NEW: ${info.packages.first}: packageUriRoot: ${info.packages.first.packageUriRoot}');
 
     for (var package in info.packages) {
       var packagePath = path.normalize(path.fromUri(package.packageUriRoot));
@@ -313,16 +307,6 @@ class PubPackageBuilder implements PackageBuilder {
 
     if (autoIncludeDependencies) {
       var info = await findPackageConfig(Directory(basePackageDir));
-
-      var info2 = package_config
-          .findPackagesFromFile(
-              Uri.file(path.join(basePackageDir, 'pubspec.yaml')))
-          .asMap();
-      var oldFirst = info2.keys.first;
-      print('oldFirst: $oldFirst; toFilePath: ${info2[oldFirst].toFilePath()}');
-      print(
-          'newFirst: ${info.packages.first}, ${info[info.packages.first.name].packageUriRoot.path}; '
-          'FROMURI: ${path.fromUri(info[info.packages.first.name].packageUriRoot)}');
       for (var package in info.packages) {
         if (!filterExcludes || !config.exclude.contains(package.name)) {
           packageDirs.add(

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -321,10 +321,12 @@ class PubPackageBuilder implements PackageBuilder {
       var oldFirst = info2.keys.first;
       print('oldFirst: $oldFirst; toFilePath: ${info2[oldFirst].toFilePath()}');
       print(
-          'newFirst: ${info.packages.first}, ${info[info.packages.first.name].packageUriRoot.path}');
+          'newFirst: ${info.packages.first}, ${info[info.packages.first.name].packageUriRoot.path}; '
+          'FROMURI: ${path.fromUri(info[info.packages.first.name].packageUriRoot)}');
       for (var package in info.packages) {
         if (!filterExcludes || !config.exclude.contains(package.name)) {
-          packageDirs.add(path.dirname(info[package.name].packageUriRoot.path));
+          packageDirs.add(
+              path.dirname(path.fromUri(info[package.name].packageUriRoot)));
         }
       }
     }

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -32,7 +32,6 @@ import 'package:dartdoc/src/package_meta.dart'
 import 'package:dartdoc/src/render/renderer_factory.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:meta/meta.dart';
-import 'package:package_config/discovery.dart' as package_config;
 import 'package:package_config/package_config.dart' show findPackageConfig;
 import 'package:path/path.dart' as path;
 

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -32,6 +32,7 @@ import 'package:dartdoc/src/package_meta.dart'
 import 'package:dartdoc/src/render/renderer_factory.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/discovery.dart' as package_config;
 import 'package:package_config/package_config.dart' show findPackageConfig;
 import 'package:path/path.dart' as path;
 
@@ -103,6 +104,10 @@ class PubPackageBuilder implements PackageBuilder {
         PhysicalResourceProvider.INSTANCE.getResource(config.inputDir);
     var info = await findPackageConfig(Directory(cwd.path));
     if (info == null) return;
+    var info2 = package_config.findPackagesFromFile(cwd.toUri());
+    var oldFirst = info2.packages.first;
+    print(
+        'OLD: "${oldFirst}": uri: "${info2.asMap()[oldFirst]}"; packagePath: "${path.normalize(path.fromUri(info2.asMap()[oldFirst]))}"');
 
     for (var package in info.packages) {
       var packagePath = path.normalize(path.fromUri(package.packageUriRoot));
@@ -306,6 +311,13 @@ class PubPackageBuilder implements PackageBuilder {
 
     if (autoIncludeDependencies) {
       var info = await findPackageConfig(Directory(basePackageDir));
+
+      var info2 = package_config
+          .findPackagesFromFile(
+              Uri.file(path.join(basePackageDir, 'pubspec.yaml')))
+          .asMap();
+      var oldFirst = info2.keys.first;
+      print('oldFirst: $oldFirst; toFilePath: ${info2[oldFirst].toFilePath()}');
       for (var package in info.packages) {
         if (!filterExcludes || !config.exclude.contains(package.name)) {
           packageDirs.add(path.dirname(info[package.name].packageUriRoot.path));

--- a/testing/test_package/pubspec.yaml
+++ b/testing/test_package/pubspec.yaml
@@ -7,3 +7,5 @@ dependencies:
   args: ^1.5.0
   test_package_imported:
     path: "../test_package_imported"
+environment:
+  sdk: '>=2.7.0 <3.0.0'


### PR DESCRIPTION
The new package_config APIs are async, requiring some breaking restructuring:

* Delete public getter, `PackageBuilder.packageMap`.
* Delete public method, `PackageBuilder.getFiles`.
* `PackageBuilder.findFilesToDocumentInPackage` used to return an
  `Iterable<String>`, and now returns a `Stream<String>`.
* PackageBuilder's package map (now private) is eagerly computed.