### PR TITLE
Use first element in a MultiplyDefinedElement

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -313,6 +313,7 @@ abstract class ModelElement extends Canonicalization
       return resolveMultiplyInheritedElement(
           e, library, packageGraph, enclosingContainer);
     }
+    assert(e is! MultiplyDefinedElement);
     if (e is LibraryElement) {
       return Library(e, packageGraph);
     }


### PR DESCRIPTION
Fixes #2263 by preventing the crash, and printing a warning.