### PR TITLE
Support abstract fields

### DIFF
--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -335,14 +335,14 @@ class PropertyTemplateData extends TemplateData<Field> {
 
   @override
   String get title =>
-      '${property.name} $_type - ${container.name} ${containerDesc} - '
+      '${property.name} ${property.kind} - ${container.name} ${containerDesc} - '
       '${library.name} library - Dart API';
   @override
   String get layoutTitle =>
-      _layoutTitle(property.name, _type, property.isDeprecated);
+      _layoutTitle(property.name, property.fullkind, property.isDeprecated);
   @override
   String get metaDescription =>
-      'API docs for the ${property.name} $_type from the '
+      'API docs for the ${property.name} ${property.kind} from the '
       '${container.name} ${containerDesc}, for the Dart programming language.';
   @override
   List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
@@ -350,8 +350,6 @@ class PropertyTemplateData extends TemplateData<Field> {
   List<Documentable> get navLinksWithGenerics => [container];
   @override
   String get htmlBase => '../../';
-
-  String get _type => property.isConst ? 'constant' : 'property';
 }
 
 class TypedefTemplateData extends TemplateData<Typedef> {

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -115,6 +115,11 @@ class Field extends ModelElement
     return allAnnotations;
   }
 
+  String get fullkind {
+    if (field.isAbstract) return 'abstract $kind';
+    return kind;
+  }
+
   @override
   Set<String> get features {
     var allFeatures = super.features..addAll(comboFeatures);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.16
+  analyzer: ^0.39.17
   args: '>=1.5.0 <2.0.0'
   collection: ^1.2.0
   cli_util: '>=0.1.4 <0.3.0'

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1657,7 +1657,7 @@ void main() {
       expect(Cat.fullkind, 'abstract class');
     });
 
-    test('class title has  no abstract keyword', () {
+    test('class title has no abstract keyword', () {
       expect(Dog.fullkind, 'class');
     });
 
@@ -3028,6 +3028,12 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           withGenericSub.inheritedFields.where((p) => p.name == 'prop').length,
           equals(1));
+    });
+
+    test('has abstract kind', () {
+      Field abstractField = UnusualProperties.allModelElements
+          .firstWhere((e) => e.name == 'abstractProperty');
+      expect(abstractField.fullkind, 'abstract property');
     });
   });
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -548,6 +548,9 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   /// This property has some docs, too.
   final Set finalProperty = Set();
 
+  /// This property has docs.
+  abstract Set abstractProperty;
+
   Map implicitReadWrite;
 
   /// Hey there, more things not to warn about: [f], [x], or [q].


### PR DESCRIPTION
Closes #2310 

Abstract fields are indicated as such in the same way as classes and methods.