### PR TITLE
Rename some fields which erroneously reference "default" constructors.

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -60,13 +60,18 @@ class Class extends Container
     packageGraph.specialClasses.addSpecial(this);
   }
 
-  Constructor _defaultConstructor;
+  Constructor _unnamedConstructor;
 
-  Constructor get defaultConstructor {
-    _defaultConstructor ??= constructors
-        .firstWhere((c) => c.isDefaultConstructor, orElse: () => null);
-    return _defaultConstructor;
+  Constructor get unnamedConstructor {
+    _unnamedConstructor ??= constructors
+        .firstWhere((c) => c.isUnnamedConstructor, orElse: () => null);
+    return _unnamedConstructor;
   }
+
+  @Deprecated(
+      'Renamed to `unnamedConstructor`; this getter with the old name will be '
+      'removed as early as Dartdoc 1.0.0')
+  Constructor get defaultConstructor => unnamedConstructor;
 
   @override
   Iterable<Method> get instanceMethods =>

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -46,7 +46,7 @@ class Constructor extends ModelElement
 
   @override
   String get fullyQualifiedName {
-    if (isDefaultConstructor) return super.fullyQualifiedName;
+    if (isUnnamedConstructor) return super.fullyQualifiedName;
     return '${library.name}.$name';
   }
 
@@ -63,7 +63,12 @@ class Constructor extends ModelElement
   @override
   bool get isConst => _constructor.isConst;
 
-  bool get isDefaultConstructor => name == enclosingElement.name;
+  bool get isUnnamedConstructor => name == enclosingElement.name;
+
+  @Deprecated(
+      'Renamed to `isUnnamedConstructor`; this getter with the old name will '
+      'be removed as early as Dartdoc 1.0.0')
+  bool get isDefaultConstructor => isUnnamedConstructor;
 
   bool get isFactory => _constructor.isFactory;
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3353,7 +3353,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((c) => c.name == 'ReferToADefaultConstructor');
       withSyntheticConstructor = exLibrary.classes
           .firstWhere((c) => c.name == 'WithSyntheticConstructor');
-      syntheticConstructor = withSyntheticConstructor.defaultConstructor;
+      syntheticConstructor = withSyntheticConstructor.unnamedConstructor;
     });
 
     test('calculates comment references to classes vs. constructors correctly',


### PR DESCRIPTION
A "default constructor" is an unnamed, zero-arg constructor. But the
constructors being referenced in these fields are just "unnamed."

* Deprecated `Class.defaultConstructor`: use `Class.unnamedConstructor`.
* Deprecated `Constructor.isDefaultConstructor`: use
  `Constructor.isUnnamedConstructor`.