### PR TITLE
PackageConfigProvider, MockSdk, etc for improved unit testing

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -17,7 +17,9 @@ Future<void> main(List<String> arguments) async {
     // There was an error while parsing options.
     return;
   }
-  final packageBuilder = PubPackageBuilder(config, pubPackageMetaProvider);
+  final packageConfigProvider = PhysicalPackageConfigProvider();
+  final packageBuilder =
+      PubPackageBuilder(config, pubPackageMetaProvider, packageConfigProvider);
   final dartdoc = config.generateDocs
       ? await Dartdoc.fromContext(config, packageBuilder)
       : await Dartdoc.withEmptyGenerator(config, packageBuilder);

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -33,6 +33,7 @@ export 'package:dartdoc/src/dartdoc_options.dart';
 export 'package:dartdoc/src/element_type.dart';
 export 'package:dartdoc/src/generator/generator.dart';
 export 'package:dartdoc/src/model/model.dart';
+export 'package:dartdoc/src/package_config_provider.dart';
 export 'package:dartdoc/src/package_meta.dart';
 
 const String programName = 'dartdoc';

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -669,8 +669,8 @@ abstract class DartdocOption<T> {
   String get _directoryCurrentPath => resourceProvider.pathContext.current;
 
   /// Calls [valueAt] on the directory this element is defined in.
-  T valueAtElement(Element element) => valueAt(resourceProvider.getFolder(
-      resourceProvider.pathContext.canonicalize(
+  T valueAtElement(Element element) =>
+      valueAt(resourceProvider.getFolder(resourceProvider.pathContext.normalize(
           resourceProvider.pathContext.basename(element.source.fullName))));
 
   /// Adds a DartdocOption to the children of this DartdocOption.

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1683,7 +1683,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
         return resourceProvider.pathContext
             .join(flutterRoot, 'bin', 'cache', 'dart-sdk');
       }
-      return resourceProvider.defaultSdkDir.path;
+      return packageMetaProvider.defaultSdkDir.path;
     }, packageMetaProvider.resourceProvider,
         help: 'Path to the SDK directory.', isDir: true, mustExist: true),
     DartdocOptionArgFile<bool>(

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -11,9 +11,6 @@ import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
-import 'package:analyzer/src/generated/sdk.dart';
-import 'package:analyzer/src/test_utilities/mock_sdk.dart';
-import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 
 Encoding utf8AllowMalformed = Utf8Codec(allowMalformed: true);
@@ -42,20 +39,6 @@ extension ResourceProviderExtensions on ResourceProvider {
       return getFolder(io.Directory.systemTemp.createTempSync(prefix).path);
     } else {
       return getFolder(pathContext.join('/tmp', prefix))..create();
-    }
-  }
-
-  Folder get defaultSdkDir {
-    if (this is PhysicalResourceProvider) {
-      var sdkDir = getFile(pathContext.absolute(io.Platform.resolvedExecutable))
-          .parent
-          .parent;
-      assert(pathContext.equals(
-          sdkDir.path, PubPackageMeta.sdkDirParent(sdkDir, this).path));
-      return sdkDir;
-    } else {
-      x ??= MockSdk(resourceProvider: this);
-      return getFolder('/sdk');
     }
   }
 
@@ -95,8 +78,6 @@ extension ResourceProviderExtensions on ResourceProvider {
     }
   }
 }
-
-DartSdk x;
 
 /// Converts `.` and `:` into `-`, adding a ".html" extension.
 ///

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -11,6 +11,8 @@ import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
+import 'package:analyzer/src/generated/sdk.dart';
+import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:path/path.dart' as path;
 
 Encoding utf8AllowMalformed = Utf8Codec(allowMalformed: true);
@@ -31,6 +33,14 @@ String resolveTildePath(String originalPath) {
   }
 
   return path.join(homeDir, originalPath.substring(2));
+}
+
+bool isSdkLibraryDocumented(SdkLibrary library) {
+  if (library is MockSdkLibrary) {
+    // Not implemented in [MockSdkLibrary].
+    return true;
+  }
+  return library.isDocumented;
 }
 
 extension ResourceProviderExtensions on ResourceProvider {

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/element/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:analyzer/src/dart/element/inheritance_manager3.dart';
 import 'package:analyzer/src/generated/sdk.dart';
+import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart' show PackageMeta;
 import 'package:dartdoc/src/quiver.dart' as quiver;
@@ -212,7 +213,8 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   @override
   bool get isPublic {
     if (!super.isPublic) return false;
-    if (sdkLib != null && (sdkLib.isInternal || !sdkLib.isDocumented)) {
+    if (sdkLib != null &&
+        (sdkLib.isInternal || !isSdkLibraryDocumented(sdkLib))) {
       return false;
     }
     if (config.isLibraryExcluded(name) ||

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -12,7 +12,9 @@ import 'package:dartdoc/src/warnings.dart';
 import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 
-final RegExp substituteNameVersion = RegExp(r'%([bnv])%');
+@Deprecated('Public variable intended to be private; will be removed as early '
+    'as Dartdoc 1.0.0')
+RegExp get substituteNameVersion => Package._substituteNameVersion;
 
 // All hrefs are emitted as relative paths from the output root. We are unable
 // to compute them from the page we are generating, and many properties computed
@@ -224,50 +226,55 @@ class Package extends LibraryContainer
   String _baseHref;
 
   String get baseHref {
-    if (_baseHref == null) {
-      if (documentedWhere == DocumentLocation.remote) {
-        _baseHref =
-            config.linkToUrl.replaceAllMapped(substituteNameVersion, (m) {
-          switch (m.group(1)) {
-            // Return the prerelease tag of the release if a prerelease,
-            // or 'stable' otherwise. Mostly coded around
-            // the Dart SDK's use of dev/stable, but theoretically applicable
-            // elsewhere.
-            case 'b':
-              {
-                var version = Version.parse(packageMeta.version);
-                var tag = 'stable';
-                if (version.isPreRelease) {
-                  // version.preRelease is a List<dynamic> with a mix of
-                  // integers and strings.  Given this, handle
-                  // 2.8.0-dev.1.0, 2.9.0-1.0.dev, and similar
-                  // variations.
-                  tag = version.preRelease.whereType<String>().first;
-                  // Who knows about non-SDK packages, but assert that SDKs
-                  // must conform to the known format.
-                  assert(
-                      packageMeta.isSdk == false || int.tryParse(tag) == null,
-                      'Got an integer as string instead of the expected "dev" tag');
-                }
-                return tag;
-              }
-            case 'n':
-              return name;
-            // The full version string of the package.
-            case 'v':
-              return packageMeta.version;
-            default:
-              assert(false, 'Unsupported case: ${m.group(1)}');
-              return null;
-          }
-        });
-        if (!_baseHref.endsWith('/')) _baseHref = '${_baseHref}/';
-      } else {
-        _baseHref = config.useBaseHref ? '' : HTMLBASE_PLACEHOLDER;
-      }
+    if (_baseHref != null) {
+      return _baseHref;
     }
+
+    if (documentedWhere == DocumentLocation.remote) {
+      _baseHref = _remoteBaseHref;
+      if (!_baseHref.endsWith('/')) _baseHref = '${_baseHref}/';
+    } else {
+      _baseHref = config.useBaseHref ? '' : HTMLBASE_PLACEHOLDER;
+    }
+
     return _baseHref;
   }
+
+  String get _remoteBaseHref {
+    return config.linkToUrl.replaceAllMapped(_substituteNameVersion, (m) {
+      switch (m.group(1)) {
+        // Return the prerelease tag of the release if a prerelease, or 'stable'
+        // otherwise.  Mostly coded around the Dart SDK's use of dev/stable, but
+        // theoretically applicable elsewhere.
+        case 'b':
+          {
+            var version = Version.parse(packageMeta.version);
+            var tag = 'stable';
+            if (version.isPreRelease) {
+              // `version.preRelease` is a `List<dynamic>` with a mix of
+              // integers and strings.  Given this, handle
+              // "2.8.0-dev.1.0, 2.9.0-1.0.dev", and similar variations.
+              tag = version.preRelease.whereType<String>().first;
+              // Who knows about non-SDK packages, but SDKs must conform to the
+              // known format.
+              assert(packageMeta.isSdk == false || int.tryParse(tag) == null,
+                  'Got an integer as string instead of the expected "dev" tag');
+            }
+            return tag;
+          }
+        case 'n':
+          return name;
+        // The full version string of the package.
+        case 'v':
+          return packageMeta.version;
+        default:
+          assert(false, 'Unsupported case: ${m.group(1)}');
+          return null;
+      }
+    });
+  }
+
+  static final _substituteNameVersion = RegExp(r'%([bnv])%');
 
   @override
   String get href => '$baseHref$filePath';

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -169,17 +169,9 @@ class PubPackageBuilder implements PackageBuilder {
       // TODO(jcollins-g): Make use of currently not existing API for managing
       //                   many AnalysisDrivers
       // TODO(jcollins-g): make use of DartProject isApi()
-      _driver = AnalysisDriver(
-        scheduler,
-        log,
-        resourceProvider,
-        MemoryByteStore(),
-        FileContentOverlay(),
-        null,
-        sourceFactory,
-        options,
-        packages: Packages.empty,
-      );
+      _driver = AnalysisDriver(scheduler, log, resourceProvider,
+          MemoryByteStore(), FileContentOverlay(), null, sourceFactory, options,
+          packages: Packages.empty);
       driver.results.listen((_) => logProgress(''));
       driver.exceptions.listen((_) {});
       scheduler.start();
@@ -439,7 +431,7 @@ class PubPackageBuilder implements PackageBuilder {
   }
 
   Future<void> getLibraries(PackageGraph uninitializedPackageGraph) async {
-    DartSdk findSpecialsSdk = sdk;
+    var findSpecialsSdk = sdk;
     if (embedderSdk != null && embedderSdk.urlMappings.isNotEmpty) {
       findSpecialsSdk = embedderSdk;
     }

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -104,8 +104,8 @@ class PubPackageBuilder implements PackageBuilder {
     assert(_packageMap == null);
     _packageMap = <String, List<Folder>>{};
     Folder cwd = resourceProvider.getResource(config.inputDir);
-    var info =
-        await packageConfigProvider.findPackageConfigUri(Uri.file(cwd.path));
+    var info = await packageConfigProvider
+        .findPackageConfig(resourceProvider.getFolder(cwd.path));
     if (info == null) return;
 
     for (var package in info.packages) {
@@ -313,7 +313,7 @@ class PubPackageBuilder implements PackageBuilder {
 
     if (autoIncludeDependencies) {
       var info = await packageConfigProvider
-          .findPackageConfigUri(Uri.file(basePackageDir));
+          .findPackageConfig(resourceProvider.getFolder(basePackageDir));
       for (var package in info.packages) {
         if (!filterExcludes || !config.exclude.contains(package.name)) {
           packageDirs.add(

--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:package_config/package_config.dart' as package_config;
+
+abstract class PackageConfigProvider {
+  Future<package_config.PackageConfig> findPackageConfigUri(Uri location);
+}
+
+class PhysicalPackageConfigProvider implements PackageConfigProvider {
+  @override
+  Future<package_config.PackageConfig> findPackageConfigUri(Uri location) =>
+      package_config.findPackageConfigUri(location);
+}
+
+class FakePackageConfigProvider implements PackageConfigProvider {
+  /// A mapping of package config search locations to configured packages.
+  final _packageConfigData = <Uri, List<package_config.Package>>{};
+
+  void addPackageToConfigFor(Uri location, String name, Uri root) {
+    _packageConfigData.putIfAbsent(location, () => []);
+    _packageConfigData[location].add(package_config.Package(name, root));
+  }
+
+  @override
+  Future<package_config.PackageConfig> findPackageConfigUri(
+      Uri location) async {
+    return package_config.PackageConfig(_packageConfigData[location]);
+  }
+}

--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -3,31 +3,32 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' as io;
 
+import 'package:analyzer/file_system/file_system.dart';
 import 'package:package_config/package_config.dart' as package_config;
 
 abstract class PackageConfigProvider {
-  Future<package_config.PackageConfig> findPackageConfigUri(Uri location);
+  Future<package_config.PackageConfig> findPackageConfig(Folder dir);
 }
 
 class PhysicalPackageConfigProvider implements PackageConfigProvider {
   @override
-  Future<package_config.PackageConfig> findPackageConfigUri(Uri location) =>
-      package_config.findPackageConfigUri(location);
+  Future<package_config.PackageConfig> findPackageConfig(Folder dir) =>
+      package_config.findPackageConfig(io.Directory(dir.path));
 }
 
 class FakePackageConfigProvider implements PackageConfigProvider {
   /// A mapping of package config search locations to configured packages.
-  final _packageConfigData = <Uri, List<package_config.Package>>{};
+  final _packageConfigData = <String, List<package_config.Package>>{};
 
-  void addPackageToConfigFor(Uri location, String name, Uri root) {
+  void addPackageToConfigFor(String location, String name, Uri root) {
     _packageConfigData.putIfAbsent(location, () => []);
     _packageConfigData[location].add(package_config.Package(name, root));
   }
 
   @override
-  Future<package_config.PackageConfig> findPackageConfigUri(
-      Uri location) async {
-    return package_config.PackageConfig(_packageConfigData[location]);
+  Future<package_config.PackageConfig> findPackageConfig(Folder dir) async {
+    return package_config.PackageConfig(_packageConfigData[dir.path]);
   }
 }

--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -8,6 +8,10 @@ import 'dart:io' as io;
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:package_config/package_config.dart' as package_config;
 
+/// A provider of PackageConfig-finding methods.
+///
+/// This provides an abstraction around package_config, which can only work
+/// with the physical file system.
 abstract class PackageConfigProvider {
   Future<package_config.PackageConfig> findPackageConfig(Folder dir);
 }

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -99,9 +99,10 @@ abstract class PackageMeta {
 
   p.Context get pathContext => resourceProvider.pathContext;
 
-  /// Returns true if this represents a 'Dart' SDK.  A package can be part of
-  /// Dart and Flutter at the same time, but if we are part of a Dart SDK
-  /// sdkType should never return null.
+  /// Returns true if this represents a 'Dart' SDK.
+  ///
+  /// A package can be part of Dart and Flutter at the same time, but if we are
+  /// part of a Dart SDK, [sdkType] should never return null.
   bool get isSdk;
 
   /// Returns 'Dart' or 'Flutter' (preferentially, 'Flutter' when the answer is
@@ -160,11 +161,10 @@ abstract class PubPackageMeta extends PackageMeta {
       __sdkDirFilePaths = [];
       if (Platform.isWindows) {
         for (var paths in __sdkDirFilePathsPosix) {
-          var windowsPaths = <String>[];
-          for (var path in paths) {
-            windowsPaths
-                .add(p.joinAll(p.Context(style: p.Style.posix).split(path)));
-          }
+          var windowsPaths = [
+            for (var path in paths)
+              p.joinAll(p.Context(style: p.Style.posix).split(path)),
+          ];
           __sdkDirFilePaths.add(windowsPaths);
         }
       } else {
@@ -176,8 +176,8 @@ abstract class PubPackageMeta extends PackageMeta {
 
   static final _sdkDirParent = <String, Folder>{};
 
-  /// Returns the directory of the SDK if the given directory is inside a Dart
-  /// SDK.  Returns null if the directory isn't a subdirectory of the SDK.
+  /// If [dir] is inside a Dart SDK, returns the directory of the SDK, and `null`
+  /// otherwise.
   static Folder sdkDirParent(Folder dir, ResourceProvider resourceProvider) {
     var pathContext = resourceProvider.pathContext;
     var dirPathCanonical = pathContext.canonicalize(dir.path);

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -215,8 +215,6 @@ abstract class PubPackageMeta extends PackageMeta {
 
   static PubPackageMeta fromFilename(
       String filename, ResourceProvider resourceProvider) {
-    print(
-        'checking parent of "$filename"; "${resourceProvider.getFile(filename).parent.path}"');
     return PubPackageMeta.fromDir(
         resourceProvider.getFile(filename).parent, resourceProvider);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,3 @@ dev_dependencies:
 
 executables:
   dartdoc: null
-
-dependency_overrides:
-  analyzer:
-    path: '/Users/srawlins/code/dart-sdk/sdk/pkg/analyzer'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   logging: ^0.11.3+1
   process: ^3.0.5
   markdown: ^2.1.5
-  meta: ^1.2.3
+  meta: ^1.1.8
   mustache: ^1.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   logging: ^0.11.3+1
   process: ^3.0.5
   markdown: ^2.1.5
-  meta: ^1.1.8
+  meta: ^1.2.3
   mustache: ^1.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
@@ -44,3 +44,7 @@ dev_dependencies:
 
 executables:
   dartdoc: null
+
+dependency_overrides:
+  analyzer:
+    path: '/Users/srawlins/code/dart-sdk/sdk/pkg/analyzer'

--- a/test/comment_processable_test.dart
+++ b/test/comment_processable_test.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -37,11 +38,13 @@ void main() {
         .writeAsStringSync('''
 name: foo
 ''');
+    //var sdk = MockSdk(resourceProvider: resourceProvider);
     var packageMetaProvider = PackageMetaProvider(
       PubPackageMeta.fromElement,
       PubPackageMeta.fromFilename,
       PubPackageMeta.fromDir,
       resourceProvider,
+      resourceProvider.getFolder(sdkRoot),
     );
     var optionSet = await DartdocOptionSet.fromOptionGenerators(
         'dartdoc', [createDartdocOptions], packageMetaProvider);

--- a/test/comment_processable_test.dart
+++ b/test/comment_processable_test.dart
@@ -38,13 +38,12 @@ void main() {
         .writeAsStringSync('''
 name: foo
 ''');
-    //var sdk = MockSdk(resourceProvider: resourceProvider);
     var packageMetaProvider = PackageMetaProvider(
       PubPackageMeta.fromElement,
       PubPackageMeta.fromFilename,
       PubPackageMeta.fromDir,
       resourceProvider,
-      resourceProvider.getFolder(sdkRoot),
+      resourceProvider.getFolder(resourceProvider.convertPath(sdkRoot)),
     );
     var optionSet = await DartdocOptionSet.fromOptionGenerators(
         'dartdoc', [createDartdocOptions], packageMetaProvider);

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -31,8 +31,6 @@ final Folder _testPackageBadDir = _getFolder('testing/test_package_bad');
 final Folder _testPackageMinimumDir =
     _getFolder('testing/test_package_minimum');
 final Folder _testSkyEnginePackage = _getFolder('testing/sky_engine');
-final Folder _testPackageWithNoReadme =
-    _getFolder('testing/test_package_small');
 final Folder _testPackageIncludeExclude =
     _getFolder('testing/test_package_include_exclude');
 final Folder _testPackageImportExportError =
@@ -331,19 +329,6 @@ void main() {
     },
         skip: 'Blocked on getting analysis errors with correct interpretation'
             'from analysis_options');
-
-    test('generate docs for a package that does not have a readme', () async {
-      var dartdoc = await buildDartdoc([], _testPackageWithNoReadme, tempDir);
-
-      var results = await dartdoc.generateDocs();
-      expect(results.packageGraph, isNotNull);
-
-      var p = results.packageGraph;
-      expect(p.defaultPackage.name, 'test_package_small');
-      expect(p.defaultPackage.hasHomepage, isFalse);
-      expect(p.defaultPackage.hasDocumentationFile, isFalse);
-      expect(p.localPublicLibraries, hasLength(1));
-    });
 
     test('generate docs including a single library', () async {
       var dartdoc =

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -97,7 +97,8 @@ void main() {
 
       return await Dartdoc.fromContext(
         context,
-        PubPackageBuilder(context, pubPackageMetaProvider),
+        PubPackageBuilder(
+            context, pubPackageMetaProvider, PhysicalPackageConfigProvider()),
       );
     }
 

--- a/test/end2end/html_generator_test.dart
+++ b/test/end2end/html_generator_test.dart
@@ -12,6 +12,7 @@ import 'package:dartdoc/src/generator/html_resources.g.dart';
 import 'package:dartdoc/src/generator/templates.dart';
 import 'package:dartdoc/src/model/package_graph.dart';
 import 'package:dartdoc/src/io_utils.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -119,7 +120,10 @@ void main() {
       setUp(() async {
         generator = await _initGeneratorForTest();
         packageGraph = await utils.bootBasicPackage(
-            testPackageDuplicateDir.path, [], pubPackageMetaProvider);
+            testPackageDuplicateDir.path,
+            [],
+            pubPackageMetaProvider,
+            PhysicalPackageConfigProvider());
         tempOutput = await resourceProvider.createSystemTemp('doc_test_temp');
         writer = DartdocFileWriter(tempOutput.path, resourceProvider);
       });

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -12,8 +12,8 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -27,7 +27,10 @@ final Version _platformVersion = Version.parse(_platformVersionString);
 final _testPackageGraphExperimentsMemo = AsyncMemoizer<PackageGraph>();
 Future<PackageGraph> get _testPackageGraphExperiments =>
     _testPackageGraphExperimentsMemo.runOnce(() => utils.bootBasicPackage(
-        'testing/test_package_experiments', [], pubPackageMetaProvider,
+        'testing/test_package_experiments',
+        [],
+        pubPackageMetaProvider,
+        PhysicalPackageConfigProvider(),
         additionalArguments: [
           '--enable-experiment',
           'non-nullable',
@@ -40,6 +43,7 @@ Future<PackageGraph> get _testPackageGraphGinormous =>
         'testing/test_package',
         ['css', 'code_in_commnets', 'excluded'],
         pubPackageMetaProvider,
+        PhysicalPackageConfigProvider(),
         additionalArguments: [
           '--auto-include-dependencies',
           '--no-link-to-remote'
@@ -48,7 +52,10 @@ Future<PackageGraph> get _testPackageGraphGinormous =>
 final _testPackageGraphSmallMemo = AsyncMemoizer<PackageGraph>();
 Future<PackageGraph> get _testPackageGraphSmall =>
     _testPackageGraphSmallMemo.runOnce(() => utils.bootBasicPackage(
-        'testing/test_package_small', [], pubPackageMetaProvider,
+        'testing/test_package_small',
+        [],
+        pubPackageMetaProvider,
+        PhysicalPackageConfigProvider(),
         additionalArguments: ['--no-link-to-remote']));
 
 final _testPackageGraphSdkMemo = AsyncMemoizer<PackageGraph>();
@@ -57,16 +64,16 @@ Future<PackageGraph> get _testPackageGraphSdk =>
 
 Future<PackageGraph> _bootSdkPackage() async {
   return PubPackageBuilder(
-          await utils.contextFromArgv([
-            '--input',
-            pubPackageMetaProvider.resourceProvider.defaultSdkDir.path
-          ], pubPackageMetaProvider),
-          pubPackageMetaProvider)
+          await utils.contextFromArgv(
+              ['--input', pubPackageMetaProvider.defaultSdkDir.path],
+              pubPackageMetaProvider),
+          pubPackageMetaProvider,
+          PhysicalPackageConfigProvider())
       .buildPackageGraph();
 }
 
 void main() {
-  var sdkDir = pubPackageMetaProvider.resourceProvider.defaultSdkDir;
+  var sdkDir = pubPackageMetaProvider.defaultSdkDir;
 
   if (sdkDir == null) {
     print('Warning: unable to locate the Dart SDK.');
@@ -265,6 +272,7 @@ void main() {
           'testing/test_package',
           ['css', 'code_in_comments', 'excluded'],
           pubPackageMetaProvider,
+          PhysicalPackageConfigProvider(),
           additionalArguments: ['--inject-html']);
 
       injectionExLibrary =

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -49,15 +49,6 @@ Future<PackageGraph> get _testPackageGraphGinormous =>
           '--no-link-to-remote'
         ]));
 
-final _testPackageGraphSmallMemo = AsyncMemoizer<PackageGraph>();
-Future<PackageGraph> get _testPackageGraphSmall =>
-    _testPackageGraphSmallMemo.runOnce(() => utils.bootBasicPackage(
-        'testing/test_package_small',
-        [],
-        pubPackageMetaProvider,
-        PhysicalPackageConfigProvider(),
-        additionalArguments: ['--no-link-to-remote']));
-
 final _testPackageGraphSdkMemo = AsyncMemoizer<PackageGraph>();
 Future<PackageGraph> get _testPackageGraphSdk =>
     _testPackageGraphSdkMemo.runOnce(_bootSdkPackage);
@@ -429,31 +420,16 @@ void main() {
       expect(SubForDocComments.categories.first.isDocumented, isFalse);
       expect(SubForDocComments.displayedCategories, isEmpty);
     });
-
-    test('Verify that packages without categories get handled', () async {
-      var packageGraphSmall = await _testPackageGraphSmall;
-      expect(packageGraphSmall.localPackages.length, equals(1));
-      expect(packageGraphSmall.localPackages.first.hasCategories, isFalse);
-      var packageCategories = packageGraphSmall.localPackages.first.categories;
-      expect(packageCategories.length, equals(0));
-    }, timeout: Timeout.factor(2));
   });
 
   group('Package', () {
-    PackageGraph ginormousPackageGraph, sdkAsPackageGraph;
+    PackageGraph sdkAsPackageGraph;
 
     setUpAll(() async {
-      ginormousPackageGraph = await _testPackageGraphGinormous;
       sdkAsPackageGraph = await _testPackageGraphSdk;
     });
 
     group('test package', () {
-      test('multiple packages, sorted default', () {
-        expect(ginormousPackageGraph.localPackages, hasLength(5));
-        expect(ginormousPackageGraph.localPackages.first.name,
-            equals('test_package'));
-      });
-
       test('sdk name', () {
         expect(sdkAsPackageGraph.defaultPackage.name, equals('Dart'));
         expect(sdkAsPackageGraph.defaultPackage.kind, equals('SDK'));
@@ -472,16 +448,6 @@ void main() {
       test('sdk description', () {
         expect(sdkAsPackageGraph.defaultPackage.documentation,
             startsWith('Welcome'));
-      });
-    });
-
-    group('test small package', () {
-      test('does not have documentation', () async {
-        var packageGraphSmall = await _testPackageGraphSmall;
-        expect(packageGraphSmall.defaultPackage.hasDocumentation, isFalse);
-        expect(packageGraphSmall.defaultPackage.hasDocumentationFile, isFalse);
-        expect(packageGraphSmall.defaultPackage.documentationFile, isNull);
-        expect(packageGraphSmall.defaultPackage.documentation, isNull);
       });
     });
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/category_renderer.dart';
 import 'package:dartdoc/src/render/enum_field_renderer.dart';
@@ -27,6 +26,7 @@ Future<PackageGraph> get _testPackageGraph =>
         'testing/test_package',
         ['css', 'code_in_comments'],
         pubPackageMetaProvider,
+        PhysicalPackageConfigProvider(),
         additionalArguments: ['--no-link-to-remote']));
 
 /// For testing sort behavior.
@@ -59,7 +59,7 @@ class TestLibraryContainerSdk extends TestLibraryContainer {
 }
 
 void main() {
-  var sdkDir = pubPackageMetaProvider.resourceProvider.defaultSdkDir;
+  var sdkDir = pubPackageMetaProvider.defaultSdkDir;
 
   if (sdkDir == null) {
     print('Warning: unable to locate the Dart SDK.');

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -98,7 +98,8 @@ void main() {
   });
 
   group('PackageMeta.fromSdk', () {
-    var p = pubPackageMetaProvider.fromDir(resourceProvider.defaultSdkDir);
+    var p =
+        pubPackageMetaProvider.fromDir(pubPackageMetaProvider.defaultSdkDir);
 
     test('has a name', () {
       expect(p.name, 'Dart');

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -53,7 +53,7 @@ name: $packageName
         .writeAsStringSync('');
     resourceProvider.getFolder(pathContext.join(projectRoot, 'lib')).create();
     packageConfigProvider.addPackageToConfigFor(
-        Uri.file(projectRoot), packageName, Uri.file('$projectRoot/'));
+        projectRoot, packageName, Uri.file('$projectRoot/'));
   }
 
   setUp(() async {
@@ -130,6 +130,22 @@ int x;
     expect(packageGraph.defaultPackage.hasDocumentationFile, isFalse);
     expect(packageGraph.defaultPackage.documentationFile, isNull);
     expect(packageGraph.defaultPackage.documentation, isNull);
+  });
+
+  test('package with no README has no homepage', () async {
+    writePackage();
+    resourceProvider
+        .getFile(
+            resourceProvider.pathContext.join(projectRoot, 'lib', 'a.dart'))
+        .writeAsStringSync('''
+/// Documentation comment.
+int x;
+''');
+    packageGraph = await utils.bootBasicPackage(
+        projectRoot, [], packageMetaProvider, packageConfigProvider);
+
+    expect(packageGraph.defaultPackage.hasHomepage, isFalse);
+    expect(packageGraph.localPublicLibraries, hasLength(1));
   });
 
   test('package with no doc comments has no categories', () async {

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/file_system/file_system.dart';
+import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:dartdoc/src/dartdoc_options.dart';
+import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/package_meta.dart';
+import 'package:dartdoc/src/render/model_element_renderer.dart';
+import 'package:dartdoc/src/render/renderer_factory.dart';
+import 'package:dartdoc/src/warnings.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'src/utils.dart' as utils;
+
+void main() {
+  ResourceProvider resourceProvider;
+  Folder projectRoot;
+  String libFooPath;
+  PackageGraph packageGraph;
+  //_Processor processor;
+
+  setUp(() async {
+    resourceProvider = MemoryResourceProvider();
+    projectRoot = resourceProvider
+        .getFolder(resourceProvider.pathContext.join('/', 'project'));
+    projectRoot.create();
+    resourceProvider
+        .getFile(
+            resourceProvider.pathContext.join(projectRoot.path, 'pubspec.yaml'))
+        .writeAsStringSync('''
+name: foo
+''');
+    resourceProvider
+        .getFile(resourceProvider.pathContext
+            .join(projectRoot.path, '.dart_tool', 'package_config.json'))
+        .writeAsStringSync('');
+    var packageMetaProvider = PackageMetaProvider(
+      PubPackageMeta.fromElement,
+      PubPackageMeta.fromFilename,
+      PubPackageMeta.fromDir,
+      resourceProvider,
+    );
+    var optionSet = await DartdocOptionSet.fromOptionGenerators(
+        'dartdoc', [createDartdocOptions], packageMetaProvider);
+    optionSet.parseArguments([]);
+    /*processor = _Processor(
+        DartdocOptionContext(optionSet, projectRoot, resourceProvider),
+        projectRoot,
+        resourceProvider);
+    when(processor.packageGraph.resourceProvider).thenReturn(resourceProvider);
+
+    libFooPath =
+        resourceProvider.pathContext.join(projectRoot.path, 'foo.dart');
+    processor.href = libFooPath;*/
+    packageGraph = await utils.bootBasicPackage(
+        projectRoot.path, [], packageMetaProvider,
+        additionalArguments: [
+          '--auto-include-dependencies',
+          '--no-link-to-remote'
+        ]);
+  });
+
+  test('something has multiple local packages', () {
+    expect(packageGraph.localPackages, hasLength(3));
+  });
+}
+
+/// In order to mix in [CommentProcessable], we must first implement
+/// the super-class constraints.
+abstract class __Processor extends Fake
+    implements Documentable, Warnable, Locatable, SourceCodeMixin {}
+
+/// A simple comment processor for testing [CommentProcessable].
+class _Processor extends __Processor with CommentProcessable {
+  @override
+  final DartdocOptionContext config;
+
+  @override
+  final _FakePackage package;
+
+  @override
+  final _MockPackageGraph packageGraph;
+
+  @override
+  final ModelElementRenderer modelElementRenderer;
+
+  @override
+  String href;
+
+  @override
+  Element element;
+
+  _Processor(this.config, Folder dir, ResourceProvider resourceProvider)
+      : package = _FakePackage(PubPackageMeta.fromDir(dir, resourceProvider)),
+        packageGraph = _MockPackageGraph(),
+        modelElementRenderer =
+            RendererFactory.forFormat('html').modelElementRenderer {
+    throwOnMissingStub(packageGraph);
+    when(packageGraph.addMacro(any, any)).thenReturn(null);
+    when(packageGraph.warnOnElement(this, any, message: anyNamed('message')))
+        .thenReturn(null);
+  }
+
+  @override
+  void warn(PackageWarning warning,
+          {String message, Iterable<Locatable> referredFrom}) =>
+      packageGraph.warnOnElement(this, warning,
+          message: message, referredFrom: referredFrom);
+}
+
+class _FakePackage extends Fake implements Package {
+  @override
+  final PackageMeta packageMeta;
+
+  @override
+  final Map<String, Set<String>> usedAnimationIdsByHref = {};
+
+  _FakePackage(this.packageMeta);
+}
+
+class _FakeElement extends Fake implements Element {
+  @override
+  final Source source;
+
+  _FakeElement({this.source});
+}
+
+class _FakeSource extends Fake implements Source {
+  @override
+  final String fullName;
+
+  _FakeSource({this.fullName});
+}
+
+class _MockPackageGraph extends Mock implements PackageGraph {}

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -2,47 +2,65 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
-import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
-import 'package:dartdoc/src/render/model_element_renderer.dart';
-import 'package:dartdoc/src/render/renderer_factory.dart';
-import 'package:dartdoc/src/warnings.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/utils.dart' as utils;
 
 void main() {
   MemoryResourceProvider resourceProvider;
-  Folder projectRoot;
+  MockSdk mockSdk;
+  Folder sdkFolder;
+  String projectRoot;
+  var packageName = 'my_package';
+  PackageMetaProvider packageMetaProvider;
+  FakePackageConfigProvider packageConfigProvider;
   PackageGraph packageGraph;
-  //_Processor processor;
+
+  void writeSdk() {
+    mockSdk = MockSdk(resourceProvider: resourceProvider);
+    sdkFolder = resourceProvider.getFolder(sdkRoot);
+    var pathContext = resourceProvider.pathContext;
+    resourceProvider.getFolder(sdkRoot).create();
+    resourceProvider
+        .getFile(pathContext.join(sdkRoot, 'bin', 'dart'))
+        .writeAsStringSync('');
+    resourceProvider
+        .getFile(pathContext.join(sdkRoot, 'bin', 'pub'))
+        .writeAsStringSync('');
+  }
+
+  void writePackage() {
+    var pathContext = resourceProvider.pathContext;
+    var projectFolder = resourceProvider
+        .getFolder(resourceProvider.convertPath('/projects/$packageName'));
+    projectRoot = projectFolder.path;
+    projectFolder.create();
+    resourceProvider
+        .getFile(pathContext.join(projectRoot, 'pubspec.yaml'))
+        .writeAsStringSync('''
+name: $packageName
+''');
+    resourceProvider
+        .getFile(
+            pathContext.join(projectRoot, '.dart_tool', 'package_config.json'))
+        .writeAsStringSync('');
+    resourceProvider.getFolder(pathContext.join(projectRoot, 'lib')).create();
+    packageConfigProvider.addPackageToConfigFor(
+        Uri.file(projectRoot), packageName, Uri.file('$projectRoot/'));
+  }
 
   setUp(() async {
     resourceProvider = MemoryResourceProvider();
-    var pathContext = resourceProvider.pathContext;
-    projectRoot =
-        resourceProvider.getFolder(resourceProvider.convertPath('/project'));
-    projectRoot.create();
-    resourceProvider
-        .getFile(pathContext.join(projectRoot.path, 'pubspec.yaml'))
-        .writeAsStringSync('''
-name: foo
-''');
-    resourceProvider
-        .getFile(pathContext.join(
-            projectRoot.path, '.dart_tool', 'package_config.json'))
-        .writeAsStringSync('');
-    var mockSdk = MockSdk(resourceProvider: resourceProvider);
-    var sdkFolder = resourceProvider.getFolder(sdkRoot);
-    var packageMetaProvider = PackageMetaProvider(
+    writeSdk();
+
+    packageMetaProvider = PackageMetaProvider(
       PubPackageMeta.fromElement,
       PubPackageMeta.fromFilename,
       PubPackageMeta.fromDir,
@@ -50,109 +68,83 @@ name: foo
       sdkFolder,
       defaultSdk: mockSdk,
     );
-    resourceProvider.getFolder(sdkFolder.path).create();
-    resourceProvider
-        .getFile(pathContext.join(sdkFolder.path, 'bin/dart'))
-        .writeAsStringSync('');
-    resourceProvider
-        .getFile(pathContext.join(sdkFolder.path, 'bin/pub'))
-        .writeAsStringSync('');
-    resourceProvider
-        .getFile(pathContext.join(sdkFolder.path, 'lib/core/core.dart'))
-        .writeAsStringSync('');
     var optionSet = await DartdocOptionSet.fromOptionGenerators(
         'dartdoc', [createDartdocOptions], packageMetaProvider);
     optionSet.parseArguments([]);
-    /*processor = _Processor(
-        DartdocOptionContext(optionSet, projectRoot, resourceProvider),
-        projectRoot,
-        resourceProvider);
-    when(processor.packageGraph.resourceProvider).thenReturn(resourceProvider);
+    packageConfigProvider = FakePackageConfigProvider();
+  });
 
-    libFooPath =
-        resourceProvider.pathContext.join(projectRoot.path, 'foo.dart');
-    processor.href = libFooPath;*/
-    var packageConfigProvider = FakePackageConfigProvider();
-    packageConfigProvider.addPackageToConfigFor(
-        Uri.file(projectRoot.path), 'foo', Uri.file('${projectRoot.path}/'));
+  test('package with no deps has 2 local packages, including SDK', () async {
+    writePackage();
+    resourceProvider
+        .getFile(
+            resourceProvider.pathContext.join(projectRoot, 'lib', 'a.dart'))
+        .writeAsStringSync('''
+/// Documentation comment.
+int x;
+''');
     packageGraph = await utils.bootBasicPackage(
-        projectRoot.path, [], packageMetaProvider, packageConfigProvider,
+        projectRoot, [], packageMetaProvider, packageConfigProvider,
         additionalArguments: [
           '--auto-include-dependencies',
           '--no-link-to-remote'
         ]);
+
+    var localPackages = packageGraph.localPackages;
+    expect(localPackages, hasLength(2));
+    expect(localPackages[0].name, equals(packageName));
+    expect(localPackages[1].name, equals('Dart'));
   });
 
-  test('something has multiple local packages', () {
-    expect(packageGraph.localPackages, hasLength(3));
+  test('package with no deps has 1 local package, excluding SDK', () async {
+    writePackage();
+    resourceProvider
+        .getFile(
+            resourceProvider.pathContext.join(projectRoot, 'lib', 'a.dart'))
+        .writeAsStringSync('''
+/// Documentation comment.
+int x;
+''');
+    packageGraph = await utils.bootBasicPackage(
+        projectRoot, [], packageMetaProvider, packageConfigProvider,
+        additionalArguments: ['--no-link-to-remote']);
+
+    var localPackages = packageGraph.localPackages;
+    expect(localPackages, hasLength(1));
+    expect(localPackages[0].name, equals(packageName));
+  });
+
+  test('package with no doc comments has no docs', () async {
+    writePackage();
+    resourceProvider
+        .getFile(
+            resourceProvider.pathContext.join(projectRoot, 'lib', 'a.dart'))
+        .writeAsStringSync('''
+// No documentation comment.
+int x;
+''');
+    packageGraph = await utils.bootBasicPackage(
+        projectRoot, [], packageMetaProvider, packageConfigProvider);
+
+    expect(packageGraph.defaultPackage.hasDocumentation, isFalse);
+    expect(packageGraph.defaultPackage.hasDocumentationFile, isFalse);
+    expect(packageGraph.defaultPackage.documentationFile, isNull);
+    expect(packageGraph.defaultPackage.documentation, isNull);
+  });
+
+  test('package with no doc comments has no categories', () async {
+    writePackage();
+    resourceProvider
+        .getFile(
+            resourceProvider.pathContext.join(projectRoot, 'lib', 'a.dart'))
+        .writeAsStringSync('''
+// No documentation comment.
+int x;
+''');
+    packageGraph = await utils.bootBasicPackage(
+        projectRoot, [], packageMetaProvider, packageConfigProvider);
+
+    expect(packageGraph.localPackages.first.hasCategories, isFalse);
+    expect(packageGraph.localPackages.first.categories, isEmpty);
   });
 }
-
-/// In order to mix in [CommentProcessable], we must first implement
-/// the super-class constraints.
-abstract class __Processor extends Fake
-    implements Documentable, Warnable, Locatable, SourceCodeMixin {}
-
-/// A simple comment processor for testing [CommentProcessable].
-class _Processor extends __Processor with CommentProcessable {
-  @override
-  final DartdocOptionContext config;
-
-  @override
-  final _FakePackage package;
-
-  @override
-  final _MockPackageGraph packageGraph;
-
-  @override
-  final ModelElementRenderer modelElementRenderer;
-
-  @override
-  String href;
-
-  @override
-  Element element;
-
-  _Processor(this.config, Folder dir, ResourceProvider resourceProvider)
-      : package = _FakePackage(PubPackageMeta.fromDir(dir, resourceProvider)),
-        packageGraph = _MockPackageGraph(),
-        modelElementRenderer =
-            RendererFactory.forFormat('html').modelElementRenderer {
-    throwOnMissingStub(packageGraph);
-    when(packageGraph.addMacro(any, any)).thenReturn(null);
-    when(packageGraph.warnOnElement(this, any, message: anyNamed('message')))
-        .thenReturn(null);
-  }
-
-  @override
-  void warn(PackageWarning warning,
-          {String message, Iterable<Locatable> referredFrom}) =>
-      packageGraph.warnOnElement(this, warning,
-          message: message, referredFrom: referredFrom);
-}
-
-class _FakePackage extends Fake implements Package {
-  @override
-  final PackageMeta packageMeta;
-
-  @override
-  final Map<String, Set<String>> usedAnimationIdsByHref = {};
-
-  _FakePackage(this.packageMeta);
-}
-
-class _FakeElement extends Fake implements Element {
-  @override
-  final Source source;
-
-  _FakeElement({this.source});
-}
-
-class _FakeSource extends Fake implements Source {
-  @override
-  final String fullName;
-
-  _FakeSource({this.fullName});
-}
-
-class _MockPackageGraph extends Mock implements PackageGraph {}

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -38,11 +38,10 @@ Future<DartdocOptionContext> contextFromArgv(
 
 Future<PackageGraph> bootBasicPackage(String dirPath,
     List<String> excludeLibraries, PackageMetaProvider packageMetaProvider,
-    {List<String> additionalArguments}) async {
+    {List<String> additionalArguments = const []}) async {
   var resourceProvider = packageMetaProvider.resourceProvider;
   var dir = resourceProvider.getFolder(resourceProvider.pathContext
       .absolute(resourceProvider.pathContext.normalize(dirPath)));
-  additionalArguments ??= <String>[];
   return PubPackageBuilder(
           await contextFromArgv([
             '--input',

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -8,7 +8,7 @@ import 'dart:async';
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart';
-import 'package:dartdoc/src/io_utils.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 
 /// The number of public libraries in testing/test_package, minus 2 for
@@ -36,8 +36,11 @@ Future<DartdocOptionContext> contextFromArgv(
       pubPackageMetaProvider.resourceProvider);
 }
 
-Future<PackageGraph> bootBasicPackage(String dirPath,
-    List<String> excludeLibraries, PackageMetaProvider packageMetaProvider,
+Future<PackageGraph> bootBasicPackage(
+    String dirPath,
+    List<String> excludeLibraries,
+    PackageMetaProvider packageMetaProvider,
+    PackageConfigProvider packageConfigProvider,
     {List<String> additionalArguments = const []}) async {
   var resourceProvider = packageMetaProvider.resourceProvider;
   var dir = resourceProvider.getFolder(resourceProvider.pathContext
@@ -47,12 +50,13 @@ Future<PackageGraph> bootBasicPackage(String dirPath,
             '--input',
             dir.path,
             '--sdk-dir',
-            resourceProvider.defaultSdkDir.path,
+            packageMetaProvider.defaultSdkDir.path,
             '--exclude',
             excludeLibraries.join(','),
             '--allow-tools',
             ...additionalArguments,
           ], packageMetaProvider),
-          packageMetaProvider)
+          packageMetaProvider,
+          packageConfigProvider)
       .buildPackageGraph();
 }

--- a/testing/test_package_small/lib/main.dart
+++ b/testing/test_package_small/lib/main.dart
@@ -1,3 +1,0 @@
-main(List<String> args) {
-  print('Hello world!');
-}

--- a/testing/test_package_small/pubspec.yaml
+++ b/testing/test_package_small/pubspec.yaml
@@ -1,5 +1,0 @@
-name: test_package_small
-version: 0.0.1
-description: A simple console application.
-#dependencies:
-#  foo_bar: '>=1.0.0 <2.0.0'


### PR DESCRIPTION
This is a tiny step for #2295 .

* The new PackageConfigProvider class abstracts over PackageConfig from package_config. PhysicalPackageConfigProvider uses the real one; MemoryPackageConfigProvider is used in tests.
* The new `isSdkLibraryDocumented` abstracts over SdkLibrary's `isDocumented`, because it throws unimplemented for `MockSdkLibrary`.
* Remove `ResourceProviderExtensions.defaultSdkDir`. Now this is a property of PackageMetaProvider.
* **Breaking change**: Move `io_utils` `listDir` to be a private method in PackageBuilder.
* **Breaking change**: Add parameter to PubPackageBuilder constructor for a PackageConfigProvider.
* **Breaking change**: Add two parameters to the PackageMetaProvider constructor, one for the default SDK directory, and one for the DartSdk.
* Deprecate package.dart's `substituteNameVersion`.
* Shorten doc comments here and there to 80 columns.
* Move any tests which use `testing/test_package_small` to be unit tests; delete the package in `testing/`.
* Move some tests for properties of package which use the ginormous testing package to unit tests