### PR TITLE
use the terminal width for the line length

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -15,7 +15,7 @@
 library dartdoc.dartdoc_options;
 
 import 'dart:async';
-import 'dart:io' show Platform;
+import 'dart:io' show Platform, stdout;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
@@ -38,6 +38,8 @@ const Map<String, String> _kMapStringVal = <String, String>{};
 const int _kIntVal = 0;
 const double _kDoubleVal = 0.0;
 const bool _kBoolVal = true;
+
+int get _usageLineLength => stdout.hasTerminal ? stdout.terminalColumns : null;
 
 typedef ConvertYamlToType<T> = T Function(YamlMap, String, ResourceProvider);
 
@@ -555,7 +557,7 @@ abstract class DartdocOption<T> {
   Map<String, _YamlFileData> get _yamlAtCanonicalPathCache =>
       root.__yamlAtCanonicalPathCache;
 
-  final ArgParser __argParser = ArgParser(usageLineLength: 80);
+  final ArgParser __argParser = ArgParser(usageLineLength: _usageLineLength);
 
   ArgParser get argParser => root.__argParser;
 
@@ -1546,7 +1548,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
           'dart.html',
           'dart.indexed_db',
           'dart.io',
-          'dart.lisolate',
+          'dart.isolate',
           'dart.js',
           'dart.js_util',
           'dart.math',


### PR DESCRIPTION
- use the terminal width for the line length
- fix a typo in the help options

The previous line length had been 80 chars, which made for a vary narrow column of text. Here's the before:

```
Generate HTML documentation for Dart libraries.

    --[no-]allow-tools                            Execute user-defined tools to
                                                  fill in @tool directives.
    --ambiguous-reexport-scorer-min-confidence    Minimum scorer confidence to
                                                  suppress warning on ambiguous
                                                  reexport.
                                                  (defaults to "0.1")
    --[no-]auto-include-dependencies              Include all the used libraries
                                                  into the docs, even the ones
                                                  not in the current package or
                                                  "include-external"
    --category-order                              A list of categories (not
                                                  package names) to place first
                                                  when grouping symbols on
                                                  dartdoc's sidebar. Unmentioned
                                                  categories are sorted after
                                                  these.
    --example-path-prefix                         Prefix for @example paths.
                                                  (defaults to the project root)
    --exclude                                     Library names to ignore.
    --exclude-packages                            Package names to ignore.
    --include                                     Library names to generate docs
                                                  for.
    --include-external                            Additional (external) dart
                                                  files to include; use
                                                  "dir/fileName", as in
                                                  lib/material.dart.
    --[no-]include-source                         Show source code blocks.
                                                  (defaults to on)
    --inject-html                                 Allow the use of the
                                                  {@inject-html} directive to
                                                  inject raw HTML into dartdoc
                                                  output.
    --input                                       Path to source directory
                                                  (defaults to
                                                  "/Users/devoncarew/projects/da
                                                  rt-lang/dartdoc")
    --link-to-hosted                              Specify URLs for hosted pub
                                                  packages
                                                  (defaults to
                                                  "pub.dartlang.org::https://pub
                                                  .dev/documentation/%n%/%v%")
    --link-to-sdks                                Specify URLs for SDKs.
                                                  (defaults to
                                                  "Dart::https://api.dart.dev/%b
                                                  %/%v%",
                                                  "Flutter::https://api.flutter.
                                                  dev/flutter")
    --[no-]link-to-remote                         Allow links to be generated
                                                  for packages outside this one.
                                                  (defaults to on)
    --output                                      Path to output directory.
                                                  (defaults to "doc/api")
    --package-order                               A list of package names to
                                                  place first when grouping
                                                  libraries in packages.
                                                  Unmentioned packages are
                                                  sorted after these.
...
```
