### PR TITLE
remove a use of resource loading

### DIFF
--- a/lib/resources/sdk_footer_text.html
+++ b/lib/resources/sdk_footer_text.html
@@ -1,4 +1,0 @@
-&bull;
-<span class="copyright no-break">
-  <a href="http://creativecommons.org/licenses/by-sa/4.0/">cc license</a>
-</span>

--- a/lib/resources/sdk_footer_text.md
+++ b/lib/resources/sdk_footer_text.md
@@ -1,1 +1,0 @@
-&bull; [cc license](http://creativecommons.org/licenses/by-sa/4.0/)

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -7,7 +7,6 @@ library dartdoc.generator;
 
 import 'dart:async' show Future;
 
-import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart' show PackageGraph;
 import 'package:dartdoc/src/package_meta.dart';
@@ -37,9 +36,6 @@ mixin GeneratorContext on DartdocOptionContextBase {
   List<String> get footer => optionSet['footer'].valueAt(context);
 
   List<String> get footerText => optionSet['footerText'].valueAt(context);
-
-  // Synthetic. TODO(jcollins-g): Eliminate special case for SDK and use config file.
-  bool get addSdkFooter => optionSet['addSdkFooter'].valueAt(context);
 
   List<String> get header => optionSet['header'].valueAt(context);
 
@@ -75,14 +71,6 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
             'package name and version).',
         mustExist: true,
         splitCommas: true),
-    DartdocOptionSyntheticOnly<bool>(
-      'addSdkFooter',
-      (DartdocSyntheticOption<bool> option, Folder dir) {
-        return option.root['topLevelPackageMeta'].valueAt(dir).isSdk;
-      },
-      resourceProvider,
-      help: 'Whether the SDK footer text should be added (synthetic)',
-    ),
     DartdocOptionArgFile<List<String>>('header', [], resourceProvider,
         isFile: true,
         help: 'Paths to files with content to add to page headers.',

--- a/lib/src/generator/html_resources.g.dart
+++ b/lib/src/generator/html_resources.g.dart
@@ -10,8 +10,6 @@ const List<String> resource_names = [
   'package:dartdoc/resources/play_button.svg',
   'package:dartdoc/resources/readme.md',
   'package:dartdoc/resources/script.js',
-  'package:dartdoc/resources/sdk_footer_text.html',
-  'package:dartdoc/resources/sdk_footer_text.md',
   'package:dartdoc/resources/styles.css',
   'package:dartdoc/resources/typeahead.bundle.min.js'
 ];

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -6,7 +6,6 @@ library dartdoc.templates;
 
 import 'dart:async' show Future;
 import 'dart:io' show File, Directory;
-import 'dart:isolate';
 
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/resource_loader.dart' as loader;
@@ -101,6 +100,7 @@ Future<Map<String, String>> _loadPartials(
 
 abstract class _TemplatesLoader {
   Future<Map<String, String>> loadPartials();
+
   Future<String> loadTemplate(String name);
 }
 
@@ -196,11 +196,6 @@ class Templates {
     var templatesDir = context.templatesDir;
     var format = context.format;
     var footerTextPaths = context.footerText;
-    if (context.addSdkFooter) {
-      var sdkFooter = await Isolate.resolvePackageUri(
-          Uri.parse('package:dartdoc/resources/sdk_footer_text.$format'));
-      footerTextPaths.add(path.canonicalize(sdkFooter.toFilePath()));
-    }
 
     if (templatesDir != null) {
       return fromDirectory(Directory(templatesDir), format,


### PR DESCRIPTION
- remove a use of resource loading

I believe this is only used when generating the docs for the Dart sdk. I'll prep a CL for the drt-lang/sdk repo; it would need to land in the same commit (or soon after) the one that rolls the next version of dartdoc into the sdk.