### PR TITLE
Refactor comment_processable_test to not use so many mocks.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,6 @@ dev_dependencies:
   glob: ^1.1.5
   grinder: ^0.8.2
   http: ^0.12.0
-  mockito: ^4.1.1
   pedantic: ^1.9.0
   test: ^1.3.0
 

--- a/test/comment_processable_test.dart
+++ b/test/comment_processable_test.dart
@@ -854,5 +854,18 @@ class _HasWarning extends Matcher {
   }
 
   @override
-  Description describe(Description description) => description.add('Hide');
+  Description describe(Description description) =>
+      description.add('Library to be warned with $kind and message:\n$message');
+
+  @override
+  Description describeMismatch(dynamic actual, Description mismatchDescription,
+      Map<Object, Object> matchState, bool verbose) {
+    if (actual is ModelElement) {
+      var warnings = actual
+          .packageGraph.packageWarningCounter.countedWarnings[actual.element];
+      return mismatchDescription.add('has warnings: $warnings');
+    } else {
+      return mismatchDescription.add('is a ${actual.runtimeType}');
+    }
+  }
 }

--- a/test/comment_processable_test.dart
+++ b/test/comment_processable_test.dart
@@ -599,8 +599,9 @@ Code snippet
 
     var abcPath = resourceProvider.pathContext.canonicalize(
         resourceProvider.pathContext.join(projectRoot.path, 'abc.md'));
+    var libPathInWarning = resourceProvider.pathContext.join('lib', 'a.dart');
     expect(libraryModel,
-        hasMissingExampleWarning('$abcPath; path listed at lib/a.dart'));
+        hasMissingExampleWarning('$abcPath; path listed at $libPathInWarning'));
     // When the example path is invalid, the directive should be left in-place.
     expect(doc, equals('{@example abc}'));
   });
@@ -612,8 +613,9 @@ Code snippet
     var abcPath = resourceProvider.pathContext.canonicalize(resourceProvider
         .pathContext
         .join(projectRoot.path, 'abc', 'def', 'ghi.md'));
+    var libPathInWarning = resourceProvider.pathContext.join('lib', 'a.dart');
     expect(libraryModel,
-        hasMissingExampleWarning('$abcPath; path listed at lib/a.dart'));
+        hasMissingExampleWarning('$abcPath; path listed at $libPathInWarning'));
     // When the example path is invalid, the directive should be left in-place.
     expect(doc, equals('{@example abc/def/ghi}'));
   });
@@ -624,8 +626,9 @@ Code snippet
 ''');
     var abcPath = resourceProvider.pathContext.canonicalize(
         resourceProvider.pathContext.join(projectRoot.path, 'abc-r.md'));
+    var libPathInWarning = resourceProvider.pathContext.join('lib', 'a.dart');
     expect(libraryModel,
-        hasMissingExampleWarning('$abcPath; path listed at lib/a.dart'));
+        hasMissingExampleWarning('$abcPath; path listed at $libPathInWarning'));
     // When the example path is invalid, the directive should be left in-place.
     expect(doc, equals('{@example region=r abc}'));
   });

--- a/test/comment_processable_test.dart
+++ b/test/comment_processable_test.dart
@@ -2,84 +2,94 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
-import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
-import 'package:dartdoc/src/render/model_element_renderer.dart';
-import 'package:dartdoc/src/render/renderer_factory.dart';
 import 'package:dartdoc/src/warnings.dart';
-import 'package:path/path.dart' as p;
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'src/utils.dart' as utils;
 
 void main() {
   MemoryResourceProvider resourceProvider;
+  PackageMetaProvider packageMetaProvider;
+  FakePackageConfigProvider packageConfigProvider;
+  MockSdk mockSdk;
+  Folder sdkFolder;
   Folder projectRoot;
-  String libFooPath;
-  _Processor processor;
-  String youtubeRender;
+  String projectPath;
+  var packageName = 'my_package';
+  PackageGraph packageGraph;
+  ModelElement libraryModel;
 
-  void verifyNoWarnings() => verifyNever(processor.packageGraph
-      .warnOnElement(processor, any, message: anyNamed('message')));
+  Matcher hasInvalidParameterWarning(String message) =>
+      _HasWarning(PackageWarning.invalidParameter, message);
+
+  Matcher hasMissingExampleWarning(String message) =>
+      _HasWarning(PackageWarning.missingExampleFile, message);
+
+  void expectNoWarnings() =>
+      expect(packageGraph.packageWarningCounter.countedWarnings, isEmpty);
 
   setUp(() async {
     resourceProvider = MemoryResourceProvider();
-    projectRoot = resourceProvider.getFolder(resourceProvider.pathContext
-        .canonicalize(resourceProvider.convertPath('/project')));
-    projectRoot.create();
-    resourceProvider
-        .getFile(
-            resourceProvider.pathContext.join(projectRoot.path, 'pubspec.yaml'))
-        .writeAsStringSync('''
-name: foo
-''');
-    var packageMetaProvider = PackageMetaProvider(
+    mockSdk = MockSdk(resourceProvider: resourceProvider);
+    sdkFolder = utils.writeMockSdkFiles(mockSdk);
+
+    packageMetaProvider = PackageMetaProvider(
       PubPackageMeta.fromElement,
       PubPackageMeta.fromFilename,
       PubPackageMeta.fromDir,
       resourceProvider,
-      resourceProvider.getFolder(resourceProvider.convertPath(sdkRoot)),
+      sdkFolder,
+      defaultSdk: mockSdk,
     );
     var optionSet = await DartdocOptionSet.fromOptionGenerators(
         'dartdoc', [createDartdocOptions], packageMetaProvider);
     optionSet.parseArguments([]);
-    processor = _Processor(
-        DartdocOptionContext(optionSet, projectRoot, resourceProvider),
-        projectRoot,
-        resourceProvider);
-    when(processor.packageGraph.resourceProvider).thenReturn(resourceProvider);
+    packageConfigProvider = FakePackageConfigProvider();
+    // To build the package graph, we always ask package_config for a
+    // [PackageConfig] for the SDK directory. Put a dummy entry in.
+    packageConfigProvider.addPackageToConfigFor(
+        sdkFolder.path, 'analyzer', Uri.file('/sdk/pkg/analyzer/'));
 
-    libFooPath =
-        resourceProvider.pathContext.join(projectRoot.path, 'foo.dart');
-    processor.href = libFooPath;
-    youtubeRender = processor.modelElementRenderer
-        .renderYoutubeUrl('oHg5SJYRHA0', '200.00');
+    projectRoot = utils.writePackage(
+        packageName, resourceProvider, packageConfigProvider);
+    projectPath = projectRoot.path;
+    projectRoot
+        .getChildAssumingFolder('lib')
+        .getChildAssumingFile('a.dart')
+        .writeAsStringSync('''
+/// Documentation comment.
+int x;
+''');
+    packageGraph = await utils.bootBasicPackage(
+        projectPath, packageMetaProvider, packageConfigProvider,
+        additionalArguments: []);
+    libraryModel = packageGraph.defaultPackage.libraries.first;
   });
 
   test('removes triple slashes', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 /// More text.
 ''');
 
-    verifyNoWarnings();
     expect(doc, equals('''
 Text.
 More text.'''));
   });
 
   test('removes space after triple slashes', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 ///  Text.
 ///    More text.
 ''');
 
-    verifyNoWarnings();
     // TODO(srawlins): Actually, the three spaces before 'More' is perhaps not
     // the best fit. Should it only be two, to match the indent from the first
     // line's "Text"?
@@ -89,13 +99,12 @@ Text.
   });
 
   test('leaves blank lines', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// More text.
 ''');
 
-    verifyNoWarnings();
     expect(doc, equals('''
 Text.
 
@@ -103,34 +112,31 @@ More text.'''));
   });
 
   test('warns when an unknown directive is parsed', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@marco name}
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.unknownDirective,
-            message: "'marco'"))
-        .called(1);
+    expect(
+        packageGraph.packageWarningCounter.hasWarning(
+            libraryModel, PackageWarning.unknownDirective, "'marco'"),
+        isTrue);
   });
 
   test('warns when a directive with wrong case is parsed', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@youTube url}
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.unknownDirective,
-            message: "'youTube' (use lowercase)"))
-        .called(1);
+    expect(
+        packageGraph.packageWarningCounter.hasWarning(libraryModel,
+            PackageWarning.unknownDirective, "'youTube' (use lowercase)"),
+        isTrue);
   });
 
   test('processes @animation', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200 http://host/path/to/video.mp4 id=barHerderAnimation}
@@ -138,8 +144,8 @@ More text.'''));
 /// End text.
 ''');
 
-    verifyNoWarnings();
-    var rendered = processor.modelElementRenderer.renderAnimation(
+    expectNoWarnings();
+    var rendered = libraryModel.modelElementRenderer.renderAnimation(
         'barHerderAnimation',
         100,
         200,
@@ -153,65 +159,142 @@ $rendered
 End text.'''));
   });
 
+  test('renders an unnamed @animation', () async {
+    var doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 http://host/path/to/video.mp4}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="animation_1"'));
+  });
+
+  test('renders a named @animation', () async {
+    var doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 http://host/path/to/video.mp4 id=namedAnimation}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="namedAnimation"'));
+  });
+
+  test('renders a named @animation, out-of-order', () async {
+    var doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 id=namedAnimation http://host/path/to/video.mp4}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="namedAnimation"'));
+  });
+
+  test('renders a named @animation with double quotes', () async {
+    var doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 http://host/path/to/video.mp4 id="namedAnimation"}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="namedAnimation"'));
+  });
+
+  test('renders a named @animation with single quotes', () async {
+    var doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 http://host/path/to/video.mp4 id='namedAnimation'}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="namedAnimation"'));
+  });
+
+  test('renders multiple @animation using unique IDs', () async {
+    var doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 http://host/path/to/video.mp4}
+/// {@animation 100 200 http://host/path/to/video2.mp4}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="animation_1"'));
+    expect(doc, contains('<video id="animation_2"'));
+
+    // A second element with unnamed animations requires unique IDs as well.
+    doc = await libraryModel.processComment('''
+/// First line.
+///
+/// {@animation 100 200 http://host/path/to/video.mp4}
+/// {@animation 100 200 http://host/path/to/video2.mp4}
+''');
+
+    expectNoWarnings();
+    expect(doc, contains('<video id="animation_3"'));
+    expect(doc, contains('<video id="animation_4"'));
+  });
+
   test('warns when @animation has fewer than 3 arguments', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 http://host/path/to/video.mp4 id=barHerderAnimation}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'Invalid @animation directive, "{@animation 100 '
-                'http://host/path/to/video.mp4 id=barHerderAnimation}"\n'
-                'Animation directives must be of the form "{@animation WIDTH '
-                'HEIGHT URL [id=ID]}"'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'Invalid @animation directive, "{@animation 100 '
+            'http://host/path/to/video.mp4 id=barHerderAnimation}"\n'
+            'Animation directives must be of the form "{@animation WIDTH '
+            'HEIGHT URL [id=ID]}"'));
   });
 
   test('warns when @animation has more than 4 arguments', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200 300 400 http://host/path/to/video.mp4 id=barHerderAnimation}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message:
-                'Invalid @animation directive, "{@animation 100 200 300 400 '
-                'http://host/path/to/video.mp4 id=barHerderAnimation}"\n'
-                'Animation directives must be of the form "{@animation WIDTH '
-                'HEIGHT URL [id=ID]}"'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'Invalid @animation directive, "{@animation 100 200 300 400 '
+            'http://host/path/to/video.mp4 id=barHerderAnimation}"\n'
+            'Animation directives must be of the form "{@animation WIDTH '
+            'HEIGHT URL [id=ID]}"'));
   });
 
   test('warns when @animation has more than 4 arguments', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200 300 400 http://host/path/to/video.mp4 id=barHerderAnimation}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message:
-                'Invalid @animation directive, "{@animation 100 200 300 400 '
-                'http://host/path/to/video.mp4 id=barHerderAnimation}"\n'
-                'Animation directives must be of the form "{@animation WIDTH '
-                'HEIGHT URL [id=ID]}"'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'Invalid @animation directive, "{@animation 100 200 300 400 '
+            'http://host/path/to/video.mp4 id=barHerderAnimation}"\n'
+            'Animation directives must be of the form "{@animation WIDTH '
+            'HEIGHT URL [id=ID]}"'));
   });
 
   test('warns when @animation has a non-unique identifier', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200 http://host/path/to/video.mp4 id=barHerderAnimation}
@@ -219,99 +302,101 @@ End text.'''));
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'An animation has a non-unique identifier, '
-                '"barHerderAnimation". Animation identifiers must be unique.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning('An animation has a non-unique identifier, '
+            '"barHerderAnimation". Animation identifiers must be unique.'));
   });
 
   test('warns when @animation has an invalid identifier', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200 http://host/path/to/video.mp4 id=not-valid}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'An animation has an invalid identifier, "not-valid". The '
-                'identifier can only contain letters, numbers and underscores, and '
-                'must not begin with a number.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'An animation has an invalid identifier, "not-valid". The '
+            'identifier can only contain letters, numbers and underscores, and '
+            'must not begin with a number.'));
   });
 
   test('warns when @animation has a malformed width', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100px 200 http://host/path/to/video.mp4 id=barHerderAnimation}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'An animation has an invalid width (barHerderAnimation), '
-                '"100px". The width must be an integer.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'An animation has an invalid width (barHerderAnimation), '
+            '"100px". The width must be an integer.'));
   });
 
   test('warns when @animation has a malformed height', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200px http://host/path/to/video.mp4 id=barHerderAnimation}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'An animation has an invalid height (barHerderAnimation), '
-                '"200px". The height must be an integer.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'An animation has an invalid height (barHerderAnimation), '
+            '"200px". The height must be an integer.'));
   });
 
   test('warns when @animation has an unknown parameter', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation 100 200 http://host/path/to/video.mp4 name=barHerderAnimation}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'The {@animation ...} directive was called with invalid '
-                'parameters. FormatException: Could not find an option named '
-                '"name".'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'The {@animation ...} directive was called with invalid '
+            'parameters. FormatException: Could not find an option named '
+            '"name".'));
   });
 
   test('warns when @animation uses the deprecated syntax', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment('''
+    await libraryModel.processComment('''
 /// Text.
 ///
 /// {@animation barHerderAnimation 100 200 http://host/path/to/video.mp4}
 ///
 /// End text.
 ''');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.deprecated,
-            message: 'Deprecated form of @animation directive, "{@animation '
-                'barHerderAnimation 100 200 http://host/path/to/video.mp4}"\n'
-                'Animation directives are now of the form "{@animation WIDTH '
-                'HEIGHT URL [id=ID]}" (id is an optional parameter)'))
-        .called(1);
+
+    expect(
+        packageGraph.packageWarningCounter.hasWarning(
+            libraryModel,
+            PackageWarning.deprecated,
+            'Deprecated form of @animation directive, "{@animation '
+            'barHerderAnimation 100 200 http://host/path/to/video.mp4}"\n'
+            'Animation directives are now of the form "{@animation WIDTH '
+            'HEIGHT URL [id=ID]}" (id is an optional parameter)'),
+        isTrue);
   });
 
   test('processes @template', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@template abc}
@@ -321,18 +406,17 @@ End text.'''));
 /// End text.
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
 {@macro abc}
 
 End text.'''));
-    verify(processor.packageGraph.addMacro('abc', 'Template text.')).called(1);
   });
 
   test('processes leading @template', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// {@template abc}
 /// Template text.
 /// {@endtemplate}
@@ -340,16 +424,15 @@ End text.'''));
 /// End text.
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 {@macro abc}
 
 End text.'''));
-    verify(processor.packageGraph.addMacro('abc', 'Template text.')).called(1);
   });
 
   test('processes trailing @template', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@template abc}
@@ -357,16 +440,15 @@ End text.'''));
 /// {@endtemplate}
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
 {@macro abc}'''));
-    verify(processor.packageGraph.addMacro('abc', 'Template text.')).called(1);
   });
 
   test('processes @template w/o blank line following', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@template abc}
@@ -375,25 +457,23 @@ Text.
 /// End text.
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
 {@macro abc}
 End text.'''));
-    verify(processor.packageGraph.addMacro('abc', 'Template text.')).called(1);
   });
 
   test('allows whitespace around @template name', () async {
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// {@template    abc    }
 /// Template text.
 /// {@endtemplate}
 ''');
 
-    expect(doc, equals('''
-{@macro abc}'''));
-    verify(processor.packageGraph.addMacro('abc', 'Template text.')).called(1);
+    expectNoWarnings();
+    expect(doc, equals('{@macro abc}'));
   });
 
   test('processes @example with file', () async {
@@ -402,8 +482,7 @@ End text.'''));
 Code snippet
 ```
 ''');
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@example abc}
@@ -411,7 +490,7 @@ Code snippet
 /// End text.
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
@@ -427,14 +506,13 @@ End text.'''));
     projectRoot
         .getChildAssumingFile('abc-r.md')
         .writeAsStringSync('Markdown text.');
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@example region=r abc}
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
@@ -448,8 +526,7 @@ Markdown text.'''));
 Code snippet
 ```
 ''');
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@example abc.html}
@@ -457,7 +534,7 @@ Code snippet
 /// End text.
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
@@ -476,14 +553,13 @@ End text.'''));
 Code snippet
 ```
 ''');
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@example abc.html lang=html}
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
@@ -500,14 +576,13 @@ Code snippet
 Code snippet
 ```
 ''');
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@example abc lang=html}
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
@@ -518,73 +593,93 @@ Code snippet
   });
 
   test('processes @example with file, not found', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// {@example abc}
 ''');
 
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.missingExampleFile,
-            message: '${p.canonicalize(p.join(projectRoot.path, 'abc.md'))}; '
-                'path listed at foo.dart'))
-        .called(1);
+    var abcPath = resourceProvider.pathContext.canonicalize(
+        resourceProvider.pathContext.join(projectRoot.path, 'abc.md'));
+    expect(libraryModel,
+        hasMissingExampleWarning('$abcPath; path listed at lib/a.dart'));
     // When the example path is invalid, the directive should be left in-place.
     expect(doc, equals('{@example abc}'));
   });
 
   test('processes @example with directories, not found', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// {@example abc/def/ghi}
 ''');
-
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.missingExampleFile,
-            message:
-                '${p.canonicalize(p.join(projectRoot.path, 'abc', 'def', 'ghi.md'))}; '
-                'path listed at foo.dart'))
-        .called(1);
+    var abcPath = resourceProvider.pathContext.canonicalize(resourceProvider
+        .pathContext
+        .join(projectRoot.path, 'abc', 'def', 'ghi.md'));
+    expect(libraryModel,
+        hasMissingExampleWarning('$abcPath; path listed at lib/a.dart'));
     // When the example path is invalid, the directive should be left in-place.
     expect(doc, equals('{@example abc/def/ghi}'));
   });
 
   test('processes @example with a region, not found', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// {@example region=r abc}
 ''');
-
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.missingExampleFile,
-            message: '${p.canonicalize(p.join(projectRoot.path, 'abc-r.md'))}; '
-                'path listed at foo.dart'))
-        .called(1);
+    var abcPath = resourceProvider.pathContext.canonicalize(
+        resourceProvider.pathContext.join(projectRoot.path, 'abc-r.md'));
+    expect(libraryModel,
+        hasMissingExampleWarning('$abcPath; path listed at lib/a.dart'));
     // When the example path is invalid, the directive should be left in-place.
     expect(doc, equals('{@example region=r abc}'));
   });
 
   test('leaves @inject-html unprocessed when disabled', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
-/// {@inject-html}
-///
-/// End text.
+/// {@inject-html}<script></script>{@end-inject-html}
 ''');
 
-    verifyNoWarnings();
+    expectNoWarnings();
     expect(doc, equals('''
 Text.
 
-{@inject-html}
+{@inject-html}<script></script>{@end-inject-html}'''));
+  });
 
-End text.'''));
+  test('leaves @tool unprocessed when disabled', () async {
+    var doc = await libraryModel.processComment('''
+/// Text.
+///
+/// {@tool date}{@end-tool}
+''');
+
+    expectNoWarnings();
+    expect(doc, equals('''
+Text.
+
+{@tool date}{@end-tool}'''));
+  });
+
+  test('processes @inject-html when enabled', () async {
+    packageGraph = await utils.bootBasicPackage(
+        projectPath, packageMetaProvider, packageConfigProvider,
+        additionalArguments: ['--inject-html']);
+    libraryModel = packageGraph.defaultPackage.libraries.first;
+    var doc = await libraryModel.processComment('''
+/// Text.
+///
+/// {@inject-html}<script></script>{@end-inject-html}
+''');
+
+    expectNoWarnings();
+    expect(doc, equals('''
+Text.
+
+
+<dartdoc-html>6829def5ec06d211fa90fe69a58213ae901f3ee4</dartdoc-html>
+'''));
   });
 
   test('processes @youtube', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@youtube 100 200 https://www.youtube.com/watch?v=oHg5SJYRHA0}
@@ -592,212 +687,172 @@ End text.'''));
 /// End text.
 ''');
 
-    verifyNoWarnings();
-    expect(doc, equals('''
-Text.
-
-$youtubeRender
-
-End text.'''));
+    expectNoWarnings();
+    expect(
+        doc,
+        matches(RegExp(
+            '^Text.\n\n+'
+            r'<p style="position: relative;\s+padding-top: 200.00%;">\s*'
+            r'<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0\?rel=0".*</iframe>\s*'
+            '</p>\n\n+'
+            r'End text.$',
+            multiLine: true,
+            dotAll: true)));
   });
 
   test('processes leading @youtube', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// {@youtube 100 200 https://www.youtube.com/watch?v=oHg5SJYRHA0}
 ///
 /// End text.
 ''');
 
-    verifyNoWarnings();
-    expect(doc, equals('''
-$youtubeRender
-
-End text.'''));
+    expectNoWarnings();
+    expect(
+        doc,
+        matches(RegExp(
+            r'^<p style="position: relative;\s+padding-top: 200.00%;">\s*'
+            r'<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0\?rel=0".*</iframe>\s*'
+            '</p>\n\n+'
+            r'End text.$',
+            multiLine: true,
+            dotAll: true)));
   });
 
   test('processes trailing @youtube', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    var doc = await processor.processComment('''
+    var doc = await libraryModel.processComment('''
 /// Text.
 ///
 /// {@youtube 100 200 https://www.youtube.com/watch?v=oHg5SJYRHA0}
 ''');
 
-    verifyNoWarnings();
-    expect(doc, equals('''
-Text.
-
-$youtubeRender'''));
+    expectNoWarnings();
+    expect(
+        doc,
+        matches(RegExp(
+            '^Text.\n\n+'
+            r'<p style="position: relative;\s+padding-top: 200.00%;">\s*'
+            r'<iframe src="https://www.youtube.com/embed/oHg5SJYRHA0\?rel=0".*</iframe>\s*'
+            r'</p>$',
+            multiLine: true,
+            dotAll: true)));
   });
 
   test('warns when @youtube has less than 3 arguments', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100 https://www.youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'Invalid @youtube directive, '
-                '"{@youtube 100 https://www.youtube.com/watch?v=oHg5SJYRHA0}"\n'
-                'YouTube directives must be of the form '
-                '"{@youtube WIDTH HEIGHT URL}"'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning('Invalid @youtube directive, '
+            '"{@youtube 100 https://www.youtube.com/watch?v=oHg5SJYRHA0}"\n'
+            'YouTube directives must be of the form '
+            '"{@youtube WIDTH HEIGHT URL}"'));
   });
 
   test('warns when @youtube has more than 3 arguments', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100 200 300 https://www.youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'Invalid @youtube directive, '
-                '"{@youtube 100 200 300 https://www.youtube.com/watch?v=oHg5SJYRHA0}"\n'
-                'YouTube directives must be of the form '
-                '"{@youtube WIDTH HEIGHT URL}"'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning('Invalid @youtube directive, '
+            '"{@youtube 100 200 300 https://www.youtube.com/watch?v=oHg5SJYRHA0}"\n'
+            'YouTube directives must be of the form '
+            '"{@youtube WIDTH HEIGHT URL}"'));
   });
 
   test('warns when @youtube has a malformed width', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100px 200 https://www.youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph
-            .warnOnElement(processor, PackageWarning.invalidParameter,
-                message: 'A @youtube directive has an invalid width, "100px". '
-                    'The width must be a positive integer.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'A @youtube directive has an invalid width, "100px". '
+            'The width must be a positive integer.'));
   });
 
   test('warns when @youtube has a negative width', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube -100 200 https://www.youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'The {@youtube ...} directive was called with invalid '
-                'parameters. FormatException: Could not find an option with '
-                'short name "-1".'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'The {@youtube ...} directive was called with invalid '
+            'parameters. FormatException: Could not find an option with '
+            'short name "-1".'));
   });
 
   test('warns when @youtube has a malformed height', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100 200px https://www.youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph
-            .warnOnElement(processor, PackageWarning.invalidParameter,
-                message: 'A @youtube directive has an invalid height, "200px". '
-                    'The height must be a positive integer.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'A @youtube directive has an invalid height, "200px". The height '
+            'must be a positive integer.'));
   });
 
   test('warns when @youtube has a negative height', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100 -200 https://www.youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'The {@youtube ...} directive was called with invalid '
-                'parameters. FormatException: Could not find an option with '
-                'short name "-2".'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning(
+            'The {@youtube ...} directive was called with invalid '
+            'parameters. FormatException: Could not find an option with '
+            'short name "-2".'));
   });
 
   test('warns when @youtube has an invalid URL', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100 200 https://www.not-youtube.com/watch?v=oHg5SJYRHA0}');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'A @youtube directive has an invalid URL: '
-                '"https://www.not-youtube.com/watch?v=oHg5SJYRHA0". Supported '
-                'YouTube URLs have the following format: '
-                'https://www.youtube.com/watch?v=oHg5SJYRHA0.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning('A @youtube directive has an invalid URL: '
+            '"https://www.not-youtube.com/watch?v=oHg5SJYRHA0". Supported '
+            'YouTube URLs have the following format: '
+            'https://www.youtube.com/watch?v=oHg5SJYRHA0.'));
   });
 
   test('warns when @youtube has a URL with extra query parameters', () async {
-    processor.element = _FakeElement(source: _FakeSource(fullName: libFooPath));
-    await processor.processComment(
+    await libraryModel.processComment(
         '/// {@youtube 100 200 https://www.not-youtube.com/watch?v=oHg5SJYRHA0&a=1}');
-    verify(processor.packageGraph.warnOnElement(
-            processor, PackageWarning.invalidParameter,
-            message: 'A @youtube directive has an invalid URL: '
-                '"https://www.not-youtube.com/watch?v=oHg5SJYRHA0&a=1". Supported '
-                'YouTube URLs have the following format: '
-                'https://www.youtube.com/watch?v=oHg5SJYRHA0.'))
-        .called(1);
+
+    expect(
+        libraryModel,
+        hasInvalidParameterWarning('A @youtube directive has an invalid URL: '
+            '"https://www.not-youtube.com/watch?v=oHg5SJYRHA0&a=1". '
+            'Supported YouTube URLs have the following format: '
+            'https://www.youtube.com/watch?v=oHg5SJYRHA0.'));
   });
 
   // TODO(srawlins): More unit tests: @example with `config.examplePathPrefix`,
-  // @inject-html, @tool.
+  // @tool.
 }
 
-/// In order to mix in [CommentProcessable], we must first implement
-/// the super-class constraints.
-abstract class __Processor extends Fake
-    implements Documentable, Warnable, Locatable, SourceCodeMixin {}
+class _HasWarning extends Matcher {
+  final PackageWarning kind;
 
-/// A simple comment processor for testing [CommentProcessable].
-class _Processor extends __Processor with CommentProcessable {
-  @override
-  final DartdocOptionContext config;
+  final String message;
+
+  _HasWarning(this.kind, this.message);
 
   @override
-  final _FakePackage package;
-
-  @override
-  final _MockPackageGraph packageGraph;
-
-  @override
-  final ModelElementRenderer modelElementRenderer;
-
-  @override
-  String href;
-
-  @override
-  Element element;
-
-  _Processor(this.config, Folder dir, ResourceProvider resourceProvider)
-      : package = _FakePackage(PubPackageMeta.fromDir(dir, resourceProvider)),
-        packageGraph = _MockPackageGraph(),
-        modelElementRenderer =
-            RendererFactory.forFormat('html').modelElementRenderer {
-    throwOnMissingStub(packageGraph);
-    when(packageGraph.addMacro(any, any)).thenReturn(null);
-    when(packageGraph.warnOnElement(this, any, message: anyNamed('message')))
-        .thenReturn(null);
+  bool matches(dynamic actual, Map<Object, Object> matchState) {
+    if (actual is ModelElement) {
+      return actual.packageGraph.packageWarningCounter
+          .hasWarning(actual, kind, message);
+    } else {
+      return false;
+    }
   }
 
   @override
-  void warn(PackageWarning warning,
-          {String message, Iterable<Locatable> referredFrom}) =>
-      packageGraph.warnOnElement(this, warning,
-          message: message, referredFrom: referredFrom);
+  Description describe(Description description) => description.add('Hide');
 }
-
-class _FakePackage extends Fake implements Package {
-  @override
-  final PackageMeta packageMeta;
-
-  @override
-  final Map<String, Set<String>> usedAnimationIdsByHref = {};
-
-  _FakePackage(this.packageMeta);
-}
-
-class _FakeElement extends Fake implements Element {
-  @override
-  final Source source;
-
-  _FakeElement({this.source});
-}
-
-class _FakeSource extends Fake implements Source {
-  @override
-  final String fullName;
-
-  _FakeSource({this.fullName});
-}
-
-class _MockPackageGraph extends Mock implements PackageGraph {}

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -283,14 +283,6 @@ void main() {
     });
 
     test('can inject HTML', () {
-      expect(
-          injectSimpleHtml.documentation,
-          contains(
-              '\n<dartdoc-html>bad2bbdd4a5cf9efb3212afff4449904756851aa</dartdoc-html>\n'));
-      expect(injectSimpleHtml.documentation,
-          isNot(contains('\n{@inject-html}\n')));
-      expect(injectSimpleHtml.documentation,
-          isNot(contains('\n{@end-inject-html}\n')));
       expect(injectSimpleHtml.documentationAsHtml,
           contains('   <div style="opacity: 0.5;">[HtmlInjection]</div>'));
     });

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -301,26 +301,6 @@ void main() {
     });
   });
 
-  group('HTML Injection when not allowed', () {
-    Class htmlInjection;
-    Method injectSimpleHtml;
-
-    setUpAll(() {
-      htmlInjection =
-          exLibrary.classes.firstWhere((c) => c.name == 'HtmlInjection');
-      injectSimpleHtml = htmlInjection.instanceMethods
-          .firstWhere((m) => m.name == 'injectSimpleHtml');
-    });
-    test("doesn't inject HTML if --inject-html option is not present", () {
-      expect(
-          injectSimpleHtml.documentation,
-          isNot(contains(
-              '\n<dartdoc-html>bad2bbdd4a5cf9efb3212afff4449904756851aa</dartdoc-html>\n')));
-      expect(injectSimpleHtml.documentation, isNot(contains('<dartdoc-html>')));
-      expect(injectSimpleHtml.documentationAsHtml, contains('{@inject-html}'));
-    });
-  });
-
   group('Missing and Remote', () {
     test(
         'Verify that SDK libraries are not canonical when documenting a package',
@@ -724,71 +704,17 @@ void main() {
   });
 
   group('Animation', () {
-    Class dog;
-    Method withAnimation;
-    Method withNamedAnimation;
-    Method withQuoteNamedAnimation;
-    Method withDeprecatedAnimation;
     Method withAnimationInOneLineDoc;
     Method withAnimationInline;
-    Method withAnimationOutOfOrder;
-    Enum enumWithAnimation;
-    EnumField enumValue1;
-    EnumField enumValue2;
 
     setUpAll(() {
-      enumWithAnimation =
-          exLibrary.enums.firstWhere((c) => c.name == 'EnumWithAnimation');
-      enumValue1 = enumWithAnimation.constantFields
-          .firstWhere((m) => m.name == 'value1');
-      enumValue2 = enumWithAnimation.constantFields
-          .firstWhere((m) => m.name == 'value2');
-      dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
-      withAnimation =
-          dog.instanceMethods.firstWhere((m) => m.name == 'withAnimation');
-      withNamedAnimation =
-          dog.instanceMethods.firstWhere((m) => m.name == 'withNamedAnimation');
-      withQuoteNamedAnimation = dog.instanceMethods
-          .firstWhere((m) => m.name == 'withQuotedNamedAnimation');
-      withDeprecatedAnimation = dog.instanceMethods
-          .firstWhere((m) => m.name == 'withDeprecatedAnimation');
+      var dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
       withAnimationInOneLineDoc = dog.instanceMethods
           .firstWhere((m) => m.name == 'withAnimationInOneLineDoc');
       withAnimationInline = dog.instanceMethods
           .firstWhere((m) => m.name == 'withAnimationInline');
-      withAnimationOutOfOrder = dog.instanceMethods
-          .firstWhere((m) => m.name == 'withAnimationOutOfOrder');
     });
 
-    test('renders an unnamed animation within the method documentation', () {
-      expect(withAnimation.documentation, contains('<video id="animation_1"'));
-    });
-    test('renders a named animation within the method documentation', () {
-      expect(withNamedAnimation.documentation,
-          contains('<video id="namedAnimation"'));
-    });
-    test('renders a quoted, named animation within the method documentation',
-        () {
-      expect(withQuoteNamedAnimation.documentation,
-          contains('<video id="quotedNamedAnimation"'));
-      expect(withQuoteNamedAnimation.documentation,
-          contains('<video id="quotedNamedAnimation2"'));
-    });
-    test('renders a deprecated-form animation within the method documentation',
-        () {
-      expect(withDeprecatedAnimation.documentation,
-          contains('<video id="deprecatedAnimation"'));
-      expect(
-          packageGraph.packageWarningCounter.hasWarning(
-              withDeprecatedAnimation,
-              PackageWarning.deprecated,
-              'Deprecated form of @animation directive, '
-              '"{@animation deprecatedAnimation 100 100 http://host/path/to/video.mp4}"\n'
-              'Animation directives are now of the form "{@animation '
-              'WIDTH HEIGHT URL [id=ID]}" (id is an optional '
-              'parameter)'),
-          isTrue);
-    });
     test("Doesn't place animations in one line doc", () {
       expect(withAnimationInOneLineDoc.oneLineDoc, isNot(contains('<video')));
       expect(withAnimationInOneLineDoc.documentation, contains('<video'));
@@ -797,24 +723,6 @@ void main() {
       // Make sure it doesn't have a double-space before the continued line,
       // which would indicate to Markdown to indent the line.
       expect(withAnimationInline.documentation, isNot(contains('  works')));
-    });
-    test('Out of order arguments work.', () {
-      expect(withAnimationOutOfOrder.documentation,
-          contains('<video id="outOfOrder"'));
-    });
-    test('Enum field animation identifiers are unique.', () {
-      expect(
-          enumValue1.documentationAsHtml, contains('<video id="animation_1"'));
-      expect(
-          enumValue1.documentationAsHtml, contains('<video id="animation_2"'));
-      expect(enumValue2.documentationAsHtml,
-          isNot(contains('<video id="animation_1"')));
-      expect(enumValue2.documentationAsHtml,
-          isNot(contains('<video id="animation_2"')));
-      expect(
-          enumValue2.documentationAsHtml, contains('<video id="animation_3"'));
-      expect(
-          enumValue2.documentationAsHtml, contains('<video id="animation_4"'));
     });
   });
 
@@ -1644,7 +1552,7 @@ void main() {
 
     test('get methods', () {
       expect(Dog.publicInstanceMethods.where((m) => !m.isInherited),
-          hasLength(21));
+          hasLength(16));
     });
 
     test('get operators', () {
@@ -1712,16 +1620,11 @@ void main() {
             'testGenericMethod',
             'testMethod',
             'toString',
-            'withAnimation',
             'withAnimationInline',
-            'withAnimationOutOfOrder',
             'withAnimationInOneLineDoc',
-            'withDeprecatedAnimation',
             'withMacro',
             'withMacro2',
-            'withNamedAnimation',
             'withPrivateMacro',
-            'withQuotedNamedAnimation',
             'withUndefinedMacro',
             'withYouTubeInline',
             'withYouTubeInOneLineDoc',

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -392,31 +392,6 @@ class Dog implements Cat, E {
   /// Tests to see that an inline {@youtube 100 100 https://www.youtube.com/watch?v=oHg5SJYRHA0} works as expected.
   void withYouTubeInline() {}
 
-  /// Animation method
-  ///
-  /// {@animation 100 100 http://host/path/to/video.mp4}
-  /// More docs
-  void withAnimation() {}
-
-  /// Animation method with name
-  ///
-  /// {@animation 100 100 http://host/path/to/video.mp4 id=namedAnimation}
-  /// More docs
-  void withNamedAnimation() {}
-
-  /// Animation method with quoted name
-  ///
-  /// {@animation 100 100 http://host/path/to/video.mp4 id="quotedNamedAnimation"}
-  /// {@animation 100 100 http://host/path/to/video.mp4 id='quotedNamedAnimation2'}
-  /// More docs
-  void withQuotedNamedAnimation() {}
-
-  /// Deprecated animation method format.
-  ///
-  /// {@animation deprecatedAnimation 100 100 http://host/path/to/video.mp4}
-  /// More docs
-  void withDeprecatedAnimation() {}
-
   /// Animation in one line doc {@animation 100 100 http://host/path/to/video.mp4}
   ///
   /// This tests to see that we do the right thing if the animation is in
@@ -427,13 +402,6 @@ class Dog implements Cat, E {
   ///
   /// Tests to see that an inline {@animation 100 100 http://host/path/to/video.mp4} works as expected.
   void withAnimationInline() {}
-
-  /// Animation with out-of-order id argument.
-  ///
-  /// Tests to see that out of order arguments work.
-  /// {@animation 100 100 id=outOfOrder http://host/path/to/video.mp4}
-  /// works as expected.
-  void withAnimationOutOfOrder() {}
 
   void testGeneric(Map<String, dynamic> args) {}
 
@@ -455,23 +423,6 @@ class Dog implements Cat, E {
 
   @override
   void abstractMethod() {}
-}
-
-/// Animation in an enum
-enum EnumWithAnimation {
-  /// Animation enum value1
-  ///
-  /// {@animation 100 100 http://host/path/to/video1.mp4}
-  /// {@animation 100 100 http://host/path/to/video2.mp4}
-  /// More docs
-  value1,
-
-  /// Animation enum value2
-  ///
-  /// {@animation 100 100 http://host/path/to/video1.mp4}
-  /// {@animation 100 100 http://host/path/to/video2.mp4}
-  /// More docs
-  value2,
 }
 
 abstract class E {}


### PR DESCRIPTION
Now the only mock is the file system, and the MockSdk. This does make the tests
slower (re-analyzing the mock SDK each go), but they're certainly cleaner.

Also move more tests from end2end, mostly @animation and @inject-html tests.

Helps with #2295 