### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/options.dart
+++ b/lib/options.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io' show stderr, exitCode;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -1,7 +1,5 @@
 library dartdoc.empty_generator;
 
-import 'dart:async';
-
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/logging.dart';

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -5,8 +5,6 @@
 /// A library containing an abstract documentation generator.
 library dartdoc.generator;
 
-import 'dart:async' show Future;
-
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart' show PackageGraph;
 import 'package:dartdoc/src/package_meta.dart';

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -4,8 +4,6 @@
 
 library dartdoc.html_generator;
 
-import 'dart:async' show Future;
-
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/dartdoc_generator_backend.dart';
 import 'package:dartdoc/src/generator/generator.dart';

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -4,7 +4,6 @@
 
 library dartdoc.templates;
 
-import 'dart:async' show Future;
 import 'dart:io' show File, Directory;
 
 import 'package:dartdoc/dartdoc.dart';

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -5,7 +5,6 @@
 /// The models used to represent Dart code.
 library dartdoc.models;
 
-import 'dart:async';
 import 'dart:collection' show UnmodifiableListView;
 import 'dart:convert';
 

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -4,8 +4,6 @@
 
 library test_utils;
 
-import 'dart:async';
-
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core