### PR TITLE
Do not throw on "empty" package; emit warning instead

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -222,7 +222,7 @@ class Dartdoc {
 
       var dartdocResults = await generateDocsBase();
       if (dartdocResults.packageGraph.localPublicLibraries.isEmpty) {
-         logWarning('dartdoc could not find any libraries to document');
+        logWarning('dartdoc could not find any libraries to document');
       }
 
       final errorCount =

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -222,8 +222,7 @@ class Dartdoc {
 
       var dartdocResults = await generateDocsBase();
       if (dartdocResults.packageGraph.localPublicLibraries.isEmpty) {
-        throw DartdocFailure(
-            'dartdoc could not find any libraries to document');
+         logWarning('dartdoc could not find any libraries to document');
       }
 
       final errorCount =

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -186,10 +186,6 @@ class Package extends LibraryContainer
       if (isLocal) {
         if (isPublic) {
           _documentedWhere = DocumentLocation.local;
-        } else {
-          // Possible if excludes result in a "documented" package not having
-          // any actual documentation.
-          _documentedWhere = DocumentLocation.missing;
         }
       } else {
         if (config.linkToRemote && config.linkToUrl.isNotEmpty && isPublic) {

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -72,8 +72,9 @@ class PackageGraph {
     await Future.wait(precacheLocalDocs());
     _localDocumentationBuilt = true;
 
-    // Traverse all can all model elements to insure that interceptor and other special
+    // Scan all model elements to insure that interceptor and other special
     // objects are found.
+    // Emit warnings for any local package that has no libraries.
     // After the allModelElements traversal to be sure that all packages
     // are picked up.
     for (var package in documentedPackages) {

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -72,7 +72,7 @@ class PackageGraph {
     await Future.wait(precacheLocalDocs());
     _localDocumentationBuilt = true;
 
-    // Scan all model elements to insure that interceptor and other special
+    // Traverse all can all model elements to insure that interceptor and other special
     // objects are found.
     // After the allModelElements traversal to be sure that all packages
     // are picked up.
@@ -81,6 +81,9 @@ class PackageGraph {
       for (var library in package.libraries) {
         library.allClasses.forEach(_addToImplementors);
         _extensions.addAll(library.extensions);
+      }
+      if (package.isLocal && !package.hasPublicLibraries) {
+        package.warn(PackageWarning.noDocumentableLibrariesInPackage);
       }
     }
     for (var l in _implementors.values) {
@@ -358,6 +361,10 @@ class PackageGraph {
       case PackageWarning.noLibraryLevelDocs:
         warningMessage =
             '${warnable.fullyQualifiedName} has no library level documentation comments';
+        break;
+      case PackageWarning.noDocumentableLibrariesInPackage:
+        warningMessage =
+            '${warnable.fullyQualifiedName} has no documentable libraries';
         break;
       case PackageWarning.ambiguousDocReference:
         warningMessage = 'ambiguous doc reference $message';

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -160,15 +160,15 @@ final Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
       'not-implemented',
       'The code makes use of a feature that is not yet implemented in dartdoc'),
   PackageWarning.noDocumentableLibrariesInPackage: PackageWarningDefinition(
-      PackageWarning.noDocumentableLibrariesInPackage,
-      'no-documentable-libraries',
-      'The package is to be documented but has no Dart libraries to document',
-      longHelp: [
-        'Dartdoc could not find any public libraries to document in @@name@@, ',
-        'but documentation was requested.  This might be expected for an ',
-        'asset only package, in which case, disable this warning in your ',
-        'dartdoc_options.yaml file.',
-      ],
+    PackageWarning.noDocumentableLibrariesInPackage,
+    'no-documentable-libraries',
+    'The package is to be documented but has no Dart libraries to document',
+    longHelp: [
+      'Dartdoc could not find any public libraries to document in @@name@@, ',
+      'but documentation was requested.  This might be expected for an ',
+      'asset only package, in which case, disable this warning in your ',
+      'dartdoc_options.yaml file.',
+    ],
   ),
   PackageWarning.noLibraryLevelDocs: PackageWarningDefinition(
       PackageWarning.noLibraryLevelDocs,

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -159,6 +159,17 @@ final Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
       PackageWarning.notImplemented,
       'not-implemented',
       'The code makes use of a feature that is not yet implemented in dartdoc'),
+  PackageWarning.noDocumentableLibrariesInPackage: PackageWarningDefinition(
+      PackageWarning.noDocumentableLibrariesInPackage,
+      'no-documentable-libraries',
+      'The package is to be documented but has no Dart libraries to document',
+      longHelp: [
+        'Dartdoc could not find any public libraries to document in @@name@@, ',
+        'but documentation was requested.  This might be expected for an ',
+        'asset only package, in which case, disable this warning in your ',
+        'dartdoc_options.yaml file.',
+      ],
+  ),
   PackageWarning.noLibraryLevelDocs: PackageWarningDefinition(
       PackageWarning.noLibraryLevelDocs,
       'no-library-level-docs',
@@ -266,6 +277,7 @@ enum PackageWarning {
   noCanonicalFound,
   noDefiningLibraryFound,
   notImplemented,
+  noDocumentableLibrariesInPackage,
   noLibraryLevelDocs,
   packageOrderGivesMissingPackageName,
   reexportedPrivateApiAcrossPackages,

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -21,8 +21,8 @@ String get _testPackagePath =>
     path.fromUri(_currentFileUri.resolve('../../testing/test_package'));
 String get _testPackageFlutterPluginPath => path.fromUri(_currentFileUri
     .resolve('../../testing/flutter_packages/test_package_flutter_plugin'));
-String get _testPackageMinimumPath => path.fromUri(_currentFileUri
-    .resolve('../../testing/test_package_minimum'));
+String get _testPackageMinimumPath =>
+    path.fromUri(_currentFileUri.resolve('../../testing/test_package_minimum'));
 
 void main() {
   group('Invoking command-line dartdoc', () {
@@ -48,14 +48,17 @@ void main() {
     });
 
     test('running on an empty package does not crash and generates a warning',
-      () async {
+        () async {
       var outputDir =
           await Directory.systemTemp.createTemp('dartdoc.testEmpty.');
       var outputLines = <String>[];
       await subprocessLauncher.runStreamed(Platform.resolvedExecutable,
           [dartdocPath, '--output', outputDir.path],
           perLine: outputLines.add, workingDirectory: _testPackageMinimumPath);
-      expect(outputLines, contains(matches('package:test_package_minimum has no documentable libraries')));
+      expect(
+          outputLines,
+          contains(matches(
+              'package:test_package_minimum has no documentable libraries')));
     }, timeout: Timeout.factor(2));
 
     test('running --no-generate-docs is quiet and does not generate docs',

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -21,6 +21,8 @@ String get _testPackagePath =>
     path.fromUri(_currentFileUri.resolve('../../testing/test_package'));
 String get _testPackageFlutterPluginPath => path.fromUri(_currentFileUri
     .resolve('../../testing/flutter_packages/test_package_flutter_plugin'));
+String get _testPackageMinimumPath => path.fromUri(_currentFileUri
+    .resolve('../../testing/test_package_minimum'));
 
 void main() {
   group('Invoking command-line dartdoc', () {
@@ -44,6 +46,17 @@ void main() {
     tearDownAll(() async {
       await Future.wait(CoverageSubprocessLauncher.coverageResults);
     });
+
+    test('running on an empty package does not crash and generates a warning',
+      () async {
+      var outputDir =
+          await Directory.systemTemp.createTemp('dartdoc.testEmpty.');
+      var outputLines = <String>[];
+      await subprocessLauncher.runStreamed(Platform.resolvedExecutable,
+          [dartdocPath, '--output', outputDir.path],
+          perLine: outputLines.add, workingDirectory: _testPackageMinimumPath);
+      expect(outputLines, contains(matches('package:test_package_minimum has no documentable libraries')));
+    }, timeout: Timeout.factor(2));
 
     test('running --no-generate-docs is quiet and does not generate docs',
         () async {

--- a/testing/test_package_minimum/pubspec.yaml
+++ b/testing/test_package_minimum/pubspec.yaml
@@ -1,0 +1,4 @@
+name: test_package_minimum
+homepage: http://github.com/dart-lang
+description: The only package with no bugs.
+version: 0.0.3

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -36,7 +36,7 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   fi
   PACKAGE_NAME=access PACKAGE_VERSION=">=1.0.1+2" pub run grinder build-pub-package
   # Negative test for flutter_plugin_tools, make sure right error message is displayed.
-  PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" pub run grinder build-pub-package 2>&1 | grep "dartdoc failed: dartdoc could not find any libraries to document.$"
+  PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" pub run grinder build-pub-package 2>&1 | grep "warning: package:flutter_plugin_tools has no documentable libraries"
   PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" pub run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running all tests against the SDK analyzer"


### PR DESCRIPTION
Fixes #2327.

It's valid to have a dart package without libraries, so only emit a (silence-able) warning and generate the index and other bits as normal if this happens.

example output from the new version:
```
jcollins-macbookpro2:dartdoc jcollins$ PACKAGE_NAME=bulma_min grind build-pub-package
grinder running build-pub-package

build-pub-package
build-bulma_min: + PUB_CACHE=/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA PATH=/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA/bin:/Users/jcollins/mdproxy/bin:/Users/jcollins/google-cloud-sdk/bin:/Users/jcollins/bin:/usr/local/bin:/Users/jcollins/.pub-cache/bin:/Users/jcollins/dart/all_sdks/current/bin:/Users/jcollins/dart/flutter/bin:/Users/jcollins/depot_tools:/usr/local/git/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin pub cache add bulma_min
build-bulma_min: Downloading bulma_min 0.7.4...
  copying /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA/hosted/pub.dartlang.org/bulma_min-0.7.4 to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/bulma_minvc8AJM
build-bulma_min: + (cd "/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/bulma_minvc8AJM" && PUB_CACHE=/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA PATH=/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA/bin:/Users/jcollins/mdproxy/bin:/Users/jcollins/google-cloud-sdk/bin:/Users/jcollins/bin:/usr/local/bin:/Users/jcollins/.pub-cache/bin:/Users/jcollins/dart/all_sdks/current/bin:/Users/jcollins/dart/flutter/bin:/Users/jcollins/depot_tools:/usr/local/git/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin pub get)
build-bulma_min: Resolving dependencies...
build-bulma_min: Got dependencies!
build-bulma_min: + (cd "/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/bulma_minvc8AJM" && PUB_CACHE=/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA PATH=/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/pubcachet05MCA/bin:/Users/jcollins/mdproxy/bin:/Users/jcollins/google-cloud-sdk/bin:/Users/jcollins/bin:/usr/local/bin:/Users/jcollins/.pub-cache/bin:/Users/jcollins/dart/all_sdks/current/bin:/Users/jcollins/dart/flutter/bin:/Users/jcollins/depot_tools:/usr/local/git/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin /Users/jcollins/dart/all_sdks/2.10.0-156.0.dev/bin/dart --enable-asserts /Users/jcollins/dart/dartdoc/bin/dartdoc.dart --json --link-to-remote --show-progress)
build-bulma_min: Documenting bulma_min...
build-bulma_min:   warning: package:bulma_min has no documentable libraries, from package-bulma_min: file:///private/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/bulma_minvc8AJM
build-bulma_min:             Dartdoc could not find any public libraries to document in package:bulma_min,
build-bulma_min:             but documentation was requested.  This might be expected for an
build-bulma_min:             asset only package, in which case, disable this warning in your
build-bulma_min:             dartdoc_options.yaml file.
build-bulma_min: Initialized dartdoc with 38 libraries in 15.8 seconds
build-bulma_min: Validating docs...
build-bulma_min: found 1 warning and 0 errors
build-bulma_min: Documented 0 public libraries in 0.7 seconds
build-bulma_min: dartdoc could not find any libraries to document
build-bulma_min: Success! Docs generated into /private/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/bulma_minvc8AJM/doc/api

finished in 23.2 seconds
```