### PR TITLE
Fix the analyzer-from-sdk test to work on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
       # it is unlikely to work and produces uninteresting
       # results.
       dart: stable
-  allow_failures:
-    # Some packages at HEAD require 2.10.0-dev.
-    - env: DARTDOC_BOT=sdk-analyzer
-      dart: stable
 
 env:
   jobs:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -490,7 +490,8 @@ dependency_overrides:
 Future<void> testWithAnalyzerSdk() async {
   var launcher = SubprocessLauncher('test-with-analyzer-sdk');
   // Do not override meta on branches outside of stable.
-  var sdkDartdoc = await createSdkDartdoc(RegExp('[.]\w+').hasMatch(Platform.version));
+  var sdkDartdoc =
+      await createSdkDartdoc(RegExp('[.]\w+').hasMatch(Platform.version));
   var defaultGrindParameter =
       Platform.environment['DARTDOC_GRIND_STEP'] ?? 'test';
   await launcher.runStreamed(


### PR DESCRIPTION
This enhances #2323 to override meta outside of stable branch, so the stable check can pass.

