### PR TITLE
Introduce basic glob support to option handling

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -435,7 +435,7 @@ class _YamlFileData {
 
 /// An enum to specify the multiple different kinds of data an option might
 /// represent.
-enum OptionDataIs {
+enum OptionKind {
   other, // Make no assumptions about the option data; it may be of any type
   // or semantic.
   file, // Option data references a filename or filenames with strings.
@@ -514,15 +514,15 @@ abstract class DartdocOption<T> {
   final String name;
 
   /// Set to true if this option represents the name of a directory.
-  bool get isDir => optionIs == OptionDataIs.dir;
+  bool get isDir => optionIs == OptionKind.dir;
 
   /// Set to true if this option represents the name of a file.
-  bool get isFile => optionIs == OptionDataIs.file;
+  bool get isFile => optionIs == OptionKind.file;
 
   /// Set to true if this option represents a glob.
-  bool get isGlob => optionIs == OptionDataIs.glob;
+  bool get isGlob => optionIs == OptionKind.glob;
 
-  final OptionDataIs optionIs;
+  final OptionKind optionIs;
 
   /// Set to true if DartdocOption subclasses should validate that the
   /// directory or file exists.  Does not imply validation of [defaultsTo],
@@ -733,7 +733,7 @@ class DartdocOptionFileSynth<T> extends DartdocOption<T>
       String name, this._compute, ResourceProvider resourceprovider,
       {bool mustExist = false,
       String help = '',
-      OptionDataIs optionIs = OptionDataIs.other,
+      OptionKind optionIs = OptionKind.other,
       bool parentDirOverridesChild,
       ConvertYamlToType<T> convertYamlToType})
       : super(name, null, help, optionIs, mustExist, convertYamlToType,
@@ -782,7 +782,7 @@ class DartdocOptionArgSynth<T> extends DartdocOption<T>
       bool mustExist = false,
       String help = '',
       bool hide = false,
-      OptionDataIs optionIs = OptionDataIs.other,
+      OptionKind optionIs = OptionKind.other,
       bool negatable = false,
       bool splitCommas})
       : super(name, null, help, optionIs, mustExist, null, resourceProvider) {
@@ -833,7 +833,7 @@ class DartdocOptionSyntheticOnly<T> extends DartdocOption<T>
       String name, this._compute, ResourceProvider resourceProvider,
       {bool mustExist = false,
       String help = '',
-      OptionDataIs optionIs = OptionDataIs.other})
+      OptionKind optionIs = OptionKind.other})
       : super(name, null, help, optionIs, mustExist, null, resourceProvider);
 }
 
@@ -869,8 +869,8 @@ typedef OptionGenerator = Future<List<DartdocOption<Object>>> Function(
 /// option itself.
 class DartdocOptionSet extends DartdocOption<void> {
   DartdocOptionSet(String name, ResourceProvider resourceProvider)
-      : super(name, null, null, OptionDataIs.other, false, null,
-            resourceProvider);
+      : super(
+            name, null, null, OptionKind.other, false, null, resourceProvider);
 
   /// Asynchronous factory that is the main entry point to initialize Dartdoc
   /// options for use.
@@ -922,7 +922,7 @@ class DartdocOptionArgOnly<T> extends DartdocOption<T>
       bool mustExist = false,
       String help = '',
       bool hide = false,
-      OptionDataIs optionIs = OptionDataIs.other,
+      OptionKind optionIs = OptionKind.other,
       bool negatable = false,
       bool splitCommas})
       : super(name, defaultsTo, help, optionIs, mustExist, null,
@@ -962,7 +962,7 @@ class DartdocOptionArgFile<T> extends DartdocOption<T>
       bool mustExist = false,
       String help = '',
       bool hide = false,
-      OptionDataIs optionIs = OptionDataIs.other,
+      OptionKind optionIs = OptionKind.other,
       bool negatable = false,
       bool parentDirOverridesChild = false,
       bool splitCommas})
@@ -1019,7 +1019,7 @@ class DartdocOptionFileOnly<T> extends DartdocOption<T>
       String name, T defaultsTo, ResourceProvider resourceProvider,
       {bool mustExist = false,
       String help = '',
-      OptionDataIs optionIs = OptionDataIs.other,
+      OptionKind optionIs = OptionKind.other,
       bool parentDirOverridesChild = false,
       ConvertYamlToType<T> convertYamlToType})
       : super(name, defaultsTo, help, optionIs, mustExist, convertYamlToType,
@@ -1579,7 +1579,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
     }, resourceProvider,
         help: 'Remove text from libraries with the following names.'),
     DartdocOptionArgFile<String>('examplePathPrefix', null, resourceProvider,
-        optionIs: OptionDataIs.dir,
+        optionIs: OptionKind.dir,
         help: 'Prefix for @example paths.\n(defaults to the project root)',
         mustExist: true),
     DartdocOptionArgFile<List<String>>('exclude', [], resourceProvider,
@@ -1593,7 +1593,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
         (DartdocSyntheticOption<String> option, Folder dir) =>
             resolveTildePath(Platform.environment['FLUTTER_ROOT']),
         resourceProvider,
-        optionIs: OptionDataIs.dir,
+        optionIs: OptionKind.dir,
         help: 'Root of the Flutter SDK, specified from environment.',
         mustExist: true),
     DartdocOptionArgOnly<bool>('hideSdkText', false, resourceProvider,
@@ -1605,7 +1605,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
         help: 'Library names to generate docs for.', splitCommas: true),
     DartdocOptionArgFile<List<String>>(
         'includeExternal', null, resourceProvider,
-        optionIs: OptionDataIs.file,
+        optionIs: OptionKind.file,
         help:
             'Additional (external) dart files to include; use "dir/fileName", '
             'as in lib/material.dart.',
@@ -1618,7 +1618,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
             'HTML into dartdoc output.'),
     DartdocOptionArgOnly<String>(
         'input', resourceProvider.pathContext.current, resourceProvider,
-        optionIs: OptionDataIs.dir,
+        optionIs: OptionKind.dir,
         help: 'Path to source directory',
         mustExist: true),
     DartdocOptionSyntheticOnly<String>('inputDir',
@@ -1629,7 +1629,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
       return option.parent['input'].valueAt(dir);
     }, resourceProvider,
         help: 'Path to source directory (with override if --sdk-docs)',
-        optionIs: OptionDataIs.dir,
+        optionIs: OptionKind.dir,
         mustExist: true),
     DartdocOptionSet('linkTo', resourceProvider)
       ..addAll([
@@ -1671,7 +1671,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
       ]),
     DartdocOptionArgOnly<String>('output',
         resourceProvider.pathContext.join('doc', 'api'), resourceProvider,
-        optionIs: OptionDataIs.dir, help: 'Path to output directory.'),
+        optionIs: OptionKind.dir, help: 'Path to output directory.'),
     DartdocOptionSyntheticOnly<PackageMeta>(
       'packageMeta',
       (DartdocSyntheticOption<PackageMeta> option, Folder dir) {
@@ -1707,7 +1707,7 @@ Future<List<DartdocOption<Object>>> createDartdocOptions(
       return packageMetaProvider.defaultSdkDir.path;
     }, packageMetaProvider.resourceProvider,
         help: 'Path to the SDK directory.',
-        optionIs: OptionDataIs.dir,
+        optionIs: OptionKind.dir,
         mustExist: true),
     DartdocOptionArgFile<bool>(
         'showUndocumentedCategories', false, resourceProvider,

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -55,7 +55,7 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgFile<List<String>>('footer', [], resourceProvider,
-        optionIs: OptionDataIs.file,
+        optionIs: OptionKind.file,
         help:
             'Paths to files with content to add to page footers, but possibly '
             'outside of dedicated footer elements for the generator (e.g. '
@@ -64,13 +64,13 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
         mustExist: true,
         splitCommas: true),
     DartdocOptionArgFile<List<String>>('footerText', [], resourceProvider,
-        optionIs: OptionDataIs.file,
+        optionIs: OptionKind.file,
         help: 'Paths to files with content to add to page footers (next to the '
             'package name and version).',
         mustExist: true,
         splitCommas: true),
     DartdocOptionArgFile<List<String>>('header', [], resourceProvider,
-        optionIs: OptionDataIs.file,
+        optionIs: OptionKind.file,
         help: 'Paths to files with content to add to page headers.',
         splitCommas: true),
     DartdocOptionArgOnly<bool>('prettyIndexJson', false, resourceProvider,
@@ -79,7 +79,7 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
             'larger, but it\'s also easier to diff.',
         negatable: false),
     DartdocOptionArgFile<String>('favicon', null, resourceProvider,
-        optionIs: OptionDataIs.file,
+        optionIs: OptionKind.file,
         help: 'A path to a favicon for the generated docs.',
         mustExist: true),
     DartdocOptionArgOnly<String>('relCanonicalPrefix', null, resourceProvider,
@@ -88,7 +88,7 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
             'Consider using if building many versions of the docs for public '
             'SEO; learn more at https://goo.gl/gktN6F.'),
     DartdocOptionArgOnly<String>('templatesDir', null, resourceProvider,
-        optionIs: OptionDataIs.dir,
+        optionIs: OptionKind.dir,
         mustExist: true,
         hide: true,
         help:

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -55,7 +55,7 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgFile<List<String>>('footer', [], resourceProvider,
-        isFile: true,
+        optionIs: OptionDataIs.file,
         help:
             'Paths to files with content to add to page footers, but possibly '
             'outside of dedicated footer elements for the generator (e.g. '
@@ -64,13 +64,13 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
         mustExist: true,
         splitCommas: true),
     DartdocOptionArgFile<List<String>>('footerText', [], resourceProvider,
-        isFile: true,
+        optionIs: OptionDataIs.file,
         help: 'Paths to files with content to add to page footers (next to the '
             'package name and version).',
         mustExist: true,
         splitCommas: true),
     DartdocOptionArgFile<List<String>>('header', [], resourceProvider,
-        isFile: true,
+        optionIs: OptionDataIs.file,
         help: 'Paths to files with content to add to page headers.',
         splitCommas: true),
     DartdocOptionArgOnly<bool>('prettyIndexJson', false, resourceProvider,
@@ -79,7 +79,7 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
             'larger, but it\'s also easier to diff.',
         negatable: false),
     DartdocOptionArgFile<String>('favicon', null, resourceProvider,
-        isFile: true,
+        optionIs: OptionDataIs.file,
         help: 'A path to a favicon for the generated docs.',
         mustExist: true),
     DartdocOptionArgOnly<String>('relCanonicalPrefix', null, resourceProvider,
@@ -88,7 +88,7 @@ Future<List<DartdocOption<Object>>> createGeneratorOptions(
             'Consider using if building many versions of the docs for public '
             'SEO; learn more at https://goo.gl/gktN6F.'),
     DartdocOptionArgOnly<String>('templatesDir', null, resourceProvider,
-        isDir: true,
+        optionIs: OptionDataIs.dir,
         mustExist: true,
         hide: true,
         help:

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -36,14 +36,14 @@ Future<List<DartdocOption<Object>>> createSourceLinkerOptions(
     DartdocOptionSet('linkToSource', resourceProvider)
       ..addAll([
         DartdocOptionArgFile<List<String>>('excludes', [], resourceProvider,
-            isDir: true,
+            optionIs: OptionDataIs.dir,
             help:
                 'A list of directories to exclude from linking to a source code repository.'),
         // TODO(jcollins-g): Use [DartdocOptionArgSynth], possibly in combination with a repository type and the root directory, and get revision number automatically
         DartdocOptionArgOnly<String>('revision', null, resourceProvider,
             help: 'Revision number to insert into the URI.'),
         DartdocOptionArgFile<String>('root', null, resourceProvider,
-            isDir: true,
+            optionIs: OptionDataIs.dir,
             help:
                 'Path to a local directory that is the root of the repository we link to.  All source code files under this directory will be linked.'),
         DartdocOptionArgFile<String>('uriTemplate', null, resourceProvider,

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -36,14 +36,14 @@ Future<List<DartdocOption<Object>>> createSourceLinkerOptions(
     DartdocOptionSet('linkToSource', resourceProvider)
       ..addAll([
         DartdocOptionArgFile<List<String>>('excludes', [], resourceProvider,
-            optionIs: OptionDataIs.dir,
+            optionIs: OptionKind.dir,
             help:
                 'A list of directories to exclude from linking to a source code repository.'),
         // TODO(jcollins-g): Use [DartdocOptionArgSynth], possibly in combination with a repository type and the root directory, and get revision number automatically
         DartdocOptionArgOnly<String>('revision', null, resourceProvider,
             help: 'Revision number to insert into the URI.'),
         DartdocOptionArgFile<String>('root', null, resourceProvider,
-            optionIs: OptionDataIs.dir,
+            optionIs: OptionKind.dir,
             help:
                 'Path to a local directory that is the root of the repository we link to.  All source code files under this directory will be linked.'),
         DartdocOptionArgFile<String>('uriTemplate', null, resourceProvider,

--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -73,7 +73,7 @@ void main() {
         DartdocOptionSyntheticOnly<List<String>>('vegetableLoaderChecked',
             (DartdocSyntheticOption<List<String>> option, Folder dir) {
       return option.root['vegetableLoader'].valueAt(dir);
-    }, resourceProvider, isFile: true, mustExist: true));
+    }, resourceProvider, optionIs: OptionDataIs.file, mustExist: true));
     dartdocOptionSetSynthetic.add(DartdocOptionFileSynth<double>('double',
         (DartdocSyntheticOption<double> option, Folder dir) {
       return 3.7 + 4.1;
@@ -82,7 +82,7 @@ void main() {
         DartdocOptionArgSynth<String>('nonCriticalFileOption',
             (DartdocSyntheticOption<String> option, Folder dir) {
       return option.root['vegetableLoader'].valueAt(dir).first;
-    }, resourceProvider, isFile: true));
+    }, resourceProvider, optionIs: OptionDataIs.file));
 
     dartdocOptionSetFiles = DartdocOptionSet('dartdoc', resourceProvider);
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<List<String>>(
@@ -95,24 +95,24 @@ void main() {
         'mapOption', {'hello': 'world'}, resourceProvider));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<List<String>>(
         'fileOptionList', [], resourceProvider,
-        isFile: true, mustExist: true));
+        optionIs: OptionDataIs.file, mustExist: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'fileOption', null, resourceProvider,
-        isFile: true, mustExist: true));
+        optionIs: OptionDataIs.file, mustExist: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'parentOverride', 'oops', resourceProvider,
         parentDirOverridesChild: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'nonCriticalFileOption', null, resourceProvider,
-        isFile: true));
+        optionIs: OptionDataIs.file));
     dartdocOptionSetFiles.add(DartdocOptionSet('nestedOption', resourceProvider)
       ..addAll([DartdocOptionFileOnly<bool>('flag', false, resourceProvider)]));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'dirOption', null, resourceProvider,
-        isDir: true, mustExist: true));
+        optionIs: OptionDataIs.dir, mustExist: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'nonCriticalDirOption', null, resourceProvider,
-        isDir: true));
+        optionIs: OptionDataIs.dir));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<ConvertedOption>(
       'convertThisMap',
       null,
@@ -142,13 +142,13 @@ void main() {
         splitCommas: true));
     dartdocOptionSetArgs.add(DartdocOptionArgOnly<List<String>>(
         'filesFlag', [], resourceProvider,
-        isFile: true, mustExist: true));
+        optionIs: OptionDataIs.file, mustExist: true));
     dartdocOptionSetArgs.add(DartdocOptionArgOnly<String>(
         'singleFile', 'hello', resourceProvider,
-        isFile: true, mustExist: true));
+        optionIs: OptionDataIs.file, mustExist: true));
     dartdocOptionSetArgs.add(DartdocOptionArgOnly<String>(
         'unimportantFile', 'whatever', resourceProvider,
-        isFile: true));
+        optionIs: OptionDataIs.file));
 
     dartdocOptionSetAll = DartdocOptionSet('dartdoc', resourceProvider);
     dartdocOptionSetAll.add(DartdocOptionArgFile<List<String>>(
@@ -166,7 +166,7 @@ void main() {
         'notInAnyFile', 'so there', resourceProvider));
     dartdocOptionSetAll.add(DartdocOptionArgFile<String>(
         'fileOption', null, resourceProvider,
-        isFile: true, mustExist: true));
+        optionIs: OptionDataIs.file, mustExist: true));
 
     tempDir = resourceProvider.createSystemTemp('options_test');
     firstDir = resourceProvider

--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -73,7 +73,7 @@ void main() {
         DartdocOptionSyntheticOnly<List<String>>('vegetableLoaderChecked',
             (DartdocSyntheticOption<List<String>> option, Folder dir) {
       return option.root['vegetableLoader'].valueAt(dir);
-    }, resourceProvider, optionIs: OptionDataIs.file, mustExist: true));
+    }, resourceProvider, optionIs: OptionKind.file, mustExist: true));
     dartdocOptionSetSynthetic.add(DartdocOptionFileSynth<double>('double',
         (DartdocSyntheticOption<double> option, Folder dir) {
       return 3.7 + 4.1;
@@ -82,7 +82,7 @@ void main() {
         DartdocOptionArgSynth<String>('nonCriticalFileOption',
             (DartdocSyntheticOption<String> option, Folder dir) {
       return option.root['vegetableLoader'].valueAt(dir).first;
-    }, resourceProvider, optionIs: OptionDataIs.file));
+    }, resourceProvider, optionIs: OptionKind.file));
 
     dartdocOptionSetFiles = DartdocOptionSet('dartdoc', resourceProvider);
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<List<String>>(
@@ -95,24 +95,24 @@ void main() {
         'mapOption', {'hello': 'world'}, resourceProvider));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<List<String>>(
         'fileOptionList', [], resourceProvider,
-        optionIs: OptionDataIs.file, mustExist: true));
+        optionIs: OptionKind.file, mustExist: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'fileOption', null, resourceProvider,
-        optionIs: OptionDataIs.file, mustExist: true));
+        optionIs: OptionKind.file, mustExist: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'parentOverride', 'oops', resourceProvider,
         parentDirOverridesChild: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'nonCriticalFileOption', null, resourceProvider,
-        optionIs: OptionDataIs.file));
+        optionIs: OptionKind.file));
     dartdocOptionSetFiles.add(DartdocOptionSet('nestedOption', resourceProvider)
       ..addAll([DartdocOptionFileOnly<bool>('flag', false, resourceProvider)]));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'dirOption', null, resourceProvider,
-        optionIs: OptionDataIs.dir, mustExist: true));
+        optionIs: OptionKind.dir, mustExist: true));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<String>(
         'nonCriticalDirOption', null, resourceProvider,
-        optionIs: OptionDataIs.dir));
+        optionIs: OptionKind.dir));
     dartdocOptionSetFiles.add(DartdocOptionFileOnly<ConvertedOption>(
       'convertThisMap',
       null,
@@ -142,13 +142,13 @@ void main() {
         splitCommas: true));
     dartdocOptionSetArgs.add(DartdocOptionArgOnly<List<String>>(
         'filesFlag', [], resourceProvider,
-        optionIs: OptionDataIs.file, mustExist: true));
+        optionIs: OptionKind.file, mustExist: true));
     dartdocOptionSetArgs.add(DartdocOptionArgOnly<String>(
         'singleFile', 'hello', resourceProvider,
-        optionIs: OptionDataIs.file, mustExist: true));
+        optionIs: OptionKind.file, mustExist: true));
     dartdocOptionSetArgs.add(DartdocOptionArgOnly<String>(
         'unimportantFile', 'whatever', resourceProvider,
-        optionIs: OptionDataIs.file));
+        optionIs: OptionKind.file));
 
     dartdocOptionSetAll = DartdocOptionSet('dartdoc', resourceProvider);
     dartdocOptionSetAll.add(DartdocOptionArgFile<List<String>>(
@@ -166,12 +166,12 @@ void main() {
         'notInAnyFile', 'so there', resourceProvider));
     dartdocOptionSetAll.add(DartdocOptionArgFile<String>(
         'fileOption', null, resourceProvider,
-        optionIs: OptionDataIs.file, mustExist: true));
+        optionIs: OptionKind.file, mustExist: true));
     dartdocOptionSetAll.add(DartdocOptionArgFile<List<String>>(
       'globOption',
       [],
       resourceProvider,
-      optionIs: OptionDataIs.glob,
+      optionIs: OptionKind.glob,
     ));
 
     tempDir = resourceProvider.createSystemTemp('options_test');


### PR DESCRIPTION
It is now possible to create options that understand globs, or port existing options that currently understand only files to understand globs as well.

This PR doesn't actually do matching on globs anywhere (that will be the option user's responsibility), but will properly handle context, config file parsing, and argument/file conflicts to compute a glob that will be matchable.

This is technically a breaking change on the `DartdocOption` class constructor, however you can change code with a very simple text substitution to get identical behavior so I think it is acceptable given the limited number of potential extenders.