### PR TITLE
Switch coverage back to dev branch

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -11,9 +11,7 @@ set -ex
 export PATH="$PATH":"~/.pub-cache/bin"
 DART_VERSION=`dart --version 2>&1 | awk '{print $4}'`
 # Do not run coverage on non-dev builds or non-Linux platforms.
-# Disable coverage on dev builds and switch to stable until
-# dart-lang/sdk#43487 is fixed.
-if ! echo "${DART_VERSION}" | grep -q stable || ! uname | grep -q Linux ; then
+if ! echo "${DART_VERSION}" | grep -q dev || ! uname | grep -q Linux ; then
   unset COVERAGE_TOKEN
 fi
 


### PR DESCRIPTION
Fixes #2356.

Now that the problem in dart-lang/sdk#43487 is fixed we're good to switch coverage to the proper branch again.