### PR TITLE
Adjust hierarchy for correct usage in mustache.

### DIFF
--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -21,7 +21,7 @@ abstract class TemplateData<T extends Documentable> {
   String get metaDescription;
 
   List<Documentable> get navLinks;
-  List<Documentable> get navLinksWithGenerics => [];
+  List<Container> get navLinksWithGenerics => [];
   Documentable get parent {
     if (navLinksWithGenerics.isEmpty) {
       return navLinks.isNotEmpty ? navLinks.last : null;
@@ -32,6 +32,8 @@ abstract class TemplateData<T extends Documentable> {
   bool get includeVersion => false;
 
   bool get hasHomepage => false;
+
+  String get homepage => null;
 
   String get htmlBase;
   T get self;
@@ -73,6 +75,7 @@ class PackageTemplateData extends TemplateData<Package> {
 
   @override
   bool get hasHomepage => package.hasHomepage;
+  @override
   String get homepage => package.homepage;
 
   /// empty for packages because they are at the root – not needed
@@ -235,7 +238,7 @@ class ConstructorTemplateData extends TemplateData<Constructor> {
   @override
   List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
-  List<Documentable> get navLinksWithGenerics => [clazz];
+  List<Container> get navLinksWithGenerics => [clazz];
   @override
   @override
   String get htmlBase => '../../';
@@ -313,7 +316,7 @@ class MethodTemplateData extends TemplateData<Method> {
   @override
   List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
-  List<Documentable> get navLinksWithGenerics => [container];
+  List<Container> get navLinksWithGenerics => [container];
   @override
   String get htmlBase => '../../';
 }
@@ -347,7 +350,7 @@ class PropertyTemplateData extends TemplateData<Field> {
   @override
   List<Documentable> get navLinks => [packageGraph.defaultPackage, library];
   @override
-  List<Documentable> get navLinksWithGenerics => [container];
+  List<Container> get navLinksWithGenerics => [container];
   @override
   String get htmlBase => '../../';
 }

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -88,7 +88,7 @@ class Category extends Nameable
     } else if (c is Extension) {
       _extensions.add(c);
     } else {
-      throw UnimplementedError('Unrecognized element');
+      throw UnimplementedError('Unrecognized element: $c (${c.runtimeType})');
     }
   }
 
@@ -147,8 +147,6 @@ class Category extends Nameable
   @override
   String get href => isCanonical ? '${package.baseHref}$filePath' : null;
 
-  @Deprecated(
-      'Public field is unused; will be removed as early as Dartdoc 1.0.0')
   String get categoryLabel => _categoryRenderer.renderCategoryLabel(this);
 
   @Deprecated(

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -19,7 +19,7 @@ import 'package:meta/meta.dart';
 /// **instance**: As with [Container], but also includes inherited children.
 /// **inherited**: Filtered getters giving only inherited children.
 class Class extends Container
-    with TypeParameters, Categorization, ExtensionTarget
+    with Categorization, ExtensionTarget
     implements EnclosedElement {
   // TODO(srawlins): To make final, remove public getter, setter, rename to be
   // public, and add `final` modifier.

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -27,7 +27,7 @@ import 'package:meta/meta.dart';
 /// **has** : boolean getters indicating whether the underlying getters are
 /// empty.  Mostly for the templating system.
 /// **all** : Referring to all children.
-abstract class Container extends ModelElement {
+abstract class Container extends ModelElement with TypeParameters {
   Container(Element element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
 

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -10,7 +10,7 @@ import 'package:dartdoc/src/quiver.dart' as quiver;
 
 /// Extension methods
 class Extension extends Container
-    with TypeParameters, Categorization
+    with Categorization
     implements EnclosedElement {
   ElementType extendedType;
 


### PR DESCRIPTION
Declare that Container mixes in TypeParameters, as the two classes which extend
Container each already mix it in, and _head.html relies on a Container having a
`hasGenericParameters` getter.

Additional minor changes to Category for debugging, and for use in templates.