### PR TITLE
Adjust interfaces for mustache.

### DIFF
--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -111,6 +111,7 @@ abstract class Categorization implements ModelElement {
     return _categories;
   }
 
+  @override
   Iterable<Category> get displayedCategories {
     if (config.showUndocumentedCategories) return categories;
     return categories.where((c) => c.isDocumented);

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -149,8 +149,6 @@ class Category extends Nameable
 
   String get categoryLabel => _categoryRenderer.renderCategoryLabel(this);
 
-  @Deprecated(
-      'Public field is unused; will be removed as early as Dartdoc 1.0.0')
   String get linkedName => _categoryRenderer.renderLinkedName(this);
 
   int _categoryIndex;

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -77,7 +77,7 @@ class Class extends Container
   Iterable<Method> get instanceMethods =>
       quiver.concat([super.instanceMethods, inheritedMethods]);
 
-  // Whether all instance methods are inherited, used in mustache templates.
+  @override
   bool get publicInheritedInstanceMethods =>
       instanceMethods.every((f) => f.isInherited);
 
@@ -131,11 +131,12 @@ class Class extends Container
     return kind;
   }
 
-  // Whether any constructors are public, used in mustache templates.
+  @override
   bool get hasPublicConstructors => publicConstructorsSorted.isNotEmpty;
 
   List<Constructor> _publicConstructorsSorted;
 
+  @override
   List<Constructor> get publicConstructorsSorted =>
       _publicConstructorsSorted ??= publicConstructors.toList()..sort(byName);
 
@@ -247,6 +248,7 @@ class Class extends Container
     return _inheritedOperators;
   }
 
+  @override
   Iterable<Operator> get publicInheritedInstanceOperators =>
       model_utils.filterNonPublic(inheritedOperators);
 
@@ -524,6 +526,7 @@ class Class extends Container
   Iterable<Field> get instanceFields =>
       _instanceFields ??= allFields.where((f) => !f.isStatic);
 
+  @override
   bool get publicInheritedInstanceFields =>
       publicInstanceFields.every((f) => f.isInherited);
 

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -54,6 +54,25 @@ abstract class Container extends ModelElement with TypeParameters {
       .where((m) => !m.isStatic && !m.isOperator)
       .toList(growable: false);
 
+  /// Whether any constructors are public.
+  ///
+  /// This is only used in mustache templates.
+  bool get hasPublicConstructors => false;
+
+  Iterable<Constructor> get publicConstructorsSorted => [];
+
+  /// Whether all instance fields are inherited.
+  ///
+  /// This is only used in mustache templates.
+  bool get publicInheritedInstanceFields => false;
+
+  /// Whether all instance methods are inherited.
+  ///
+  /// This is only used in mustache templates.
+  bool get publicInheritedInstanceMethods => false;
+
+  Iterable<Operator> get publicInheritedInstanceOperators => [];
+
   @nonVirtual
   bool get hasPublicInstanceMethods =>
       model_utils.filterNonPublic(instanceMethods).isNotEmpty;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -382,9 +382,12 @@ abstract class ModelElement extends Canonicalization
     throw 'Unknown type ${e.runtimeType}';
   }
 
-  /// Stub for mustache4dart, or it will search enclosing elements to find
-  /// names for members.
+  // Stub for mustache, which would otherwise search enclosing elements to find
+  // names for members.
   bool get hasCategoryNames => false;
+
+  // Stub for mustache.
+  Iterable<Category> get displayedCategories => [];
 
   Set<Library> get exportedInLibraries {
     return library.packageGraph.libraryElementReexportedBy[element.library];


### PR DESCRIPTION
* Even though ModelElement has `hasCategoryNames`, the _categorization partial
  references `displayedCategories`, so it must exist.
* _sidebar_for_container references `hasPublicConstructors`,
  `publicConstructorsSorted`, `publicInheritedInstanceFields`,
  `publicInheritedInstanceMethods`, `publicInheritedInstanceOperators`.
* Category.linkedName is referenced by templates, so it should no longer be
  deprecated.