### PR TITLE
Typedef implements ModelFunctionTyped.

### DIFF
--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -13,12 +13,13 @@ class ModelFunction extends ModelFunctionTyped with Categorization {
       : super(element, library, packageGraph);
 
   @override
-  bool get isStatic {
-    return (element as FunctionElement).isStatic;
-  }
+  bool get isStatic => element.isStatic;
 
   @override
   String get name => element.name ?? '';
+
+  @override
+  FunctionElement get element => super.element;
 }
 
 /// A [ModelElement] for a [FunctionTypedElement] that is part of an

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -14,14 +14,11 @@ class ModelFunction extends ModelFunctionTyped with Categorization {
 
   @override
   bool get isStatic {
-    return _func.isStatic;
+    return (element as FunctionElement).isStatic;
   }
 
   @override
   String get name => element.name ?? '';
-
-  @override
-  FunctionElement get _func => (element as FunctionElement);
 }
 
 /// A [ModelElement] for a [FunctionTypedElement] that is part of an
@@ -39,19 +36,15 @@ class ModelFunctionTyped extends ModelElement
     with TypeParameters
     implements EnclosedElement {
   @override
-  List<TypeParameter> typeParameters = [];
+  final List<TypeParameter> typeParameters;
 
   ModelFunctionTyped(
       FunctionTypedElement element, Library library, PackageGraph packageGraph)
-      : super(element, library, packageGraph, null) {
-    _calcTypeParameters();
-  }
-
-  void _calcTypeParameters() {
-    typeParameters = _func.typeParameters.map((f) {
-      return ModelElement.from(f, library, packageGraph) as TypeParameter;
-    }).toList();
-  }
+      : typeParameters = <TypeParameter>[
+          for (var p in element.typeParameters)
+            ModelElement.from(p, library, packageGraph),
+        ],
+        super(element, library, packageGraph, null);
 
   @override
   ModelElement get enclosingElement => library;
@@ -79,6 +72,4 @@ class ModelFunctionTyped extends ModelElement
 
   @override
   DefinedElementType get modelType => super.modelType;
-
-  FunctionTypedElement get _func => (element as FunctionTypedElement);
 }

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -60,7 +60,7 @@ abstract class TopLevelContainer implements Nameable {
   Iterable<Class> get publicExceptions =>
       model_utils.filterNonPublic(exceptions);
 
-  Iterable<ModelFunction> get publicFunctions =>
+  Iterable<ModelFunctionTyped> get publicFunctions =>
       model_utils.filterNonPublic(functions);
 
   Iterable<Mixin> get publicMixins => model_utils.filterNonPublic(mixins);
@@ -68,5 +68,6 @@ abstract class TopLevelContainer implements Nameable {
   Iterable<TopLevelVariable> get publicProperties =>
       model_utils.filterNonPublic(properties);
 
-  Iterable<Typedef> get publicTypedefs => model_utils.filterNonPublic(typedefs);
+  Iterable<ModelFunctionTyped> get publicTypedefs =>
+      model_utils.filterNonPublic(typedefs);
 }

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -9,7 +9,7 @@ import 'package:dartdoc/src/render/typedef_renderer.dart';
 
 class Typedef extends ModelElement
     with TypeParameters, Categorization
-    implements EnclosedElement {
+    implements EnclosedElement, ModelFunctionTyped {
   Typedef(FunctionTypeAliasElement element, Library library,
       PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
@@ -44,11 +44,13 @@ class Typedef extends ModelElement
   }
 
   // Food for mustache.
+  @override
   bool get isInherited => false;
 
   @override
   String get kind => 'typedef';
 
+  @override
   String get linkedReturnType => modelType.createLinkedReturnTypeName();
 
   @override


### PR DESCRIPTION
The relationship is different from ModelFunctionTypedef which _extends_
ModelFunctionTyped because the typedef is the alias _which contains_ a
function-typed element. Nevertheless, Typedef was always implementing
(approximately) the interface defined by ModelFunctionTyped because both types
are sent to the _callable template.

Additionally one change is made to the ModelFunctionTyped interface such that
Typedef perfectly implements ModelFunctionTyped.

* **Breaking change**: Remove the `typeParameters` setter. The field is now final.