### PR TITLE
Change element type expectations for function aliases

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -37,6 +37,8 @@ abstract class ElementType extends Privacy {
     } else {
       var element = ModelElement.fromElement(f.element, packageGraph);
       assert(f is ParameterizedType || f is TypeParameterType);
+      // TODO(jcollins-g): Remove reference to f.element.enclosingElement after
+      // analyzer 0.41.
       var isGenericTypeAlias =
           f.element.enclosingElement is GenericTypeAliasElement || f.element is GenericTypeAliasElement;
       if (f is FunctionType) {

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -38,7 +38,7 @@ abstract class ElementType extends Privacy {
       var element = ModelElement.fromElement(f.element, packageGraph);
       assert(f is ParameterizedType || f is TypeParameterType);
       var isGenericTypeAlias =
-          f.element.enclosingElement is GenericTypeAliasElement;
+          f.element.enclosingElement is GenericTypeAliasElement || f.element is GenericTypeAliasElement;
       if (f is FunctionType) {
         assert(f is ParameterizedType);
         if (isGenericTypeAlias) {

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -40,7 +40,8 @@ abstract class ElementType extends Privacy {
       // TODO(jcollins-g): Remove reference to f.element.enclosingElement after
       // analyzer 0.41.
       var isGenericTypeAlias =
-          f.element.enclosingElement is GenericTypeAliasElement || f.element is GenericTypeAliasElement;
+          f.element.enclosingElement is GenericTypeAliasElement ||
+              f.element is GenericTypeAliasElement;
       if (f is FunctionType) {
         assert(f is ParameterizedType);
         if (isGenericTypeAlias) {

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -68,6 +68,5 @@ abstract class TopLevelContainer implements Nameable {
   Iterable<TopLevelVariable> get publicProperties =>
       model_utils.filterNonPublic(properties);
 
-  Iterable<Typedef> get publicTypedefs =>
-      model_utils.filterNonPublic(typedefs);
+  Iterable<Typedef> get publicTypedefs => model_utils.filterNonPublic(typedefs);
 }

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -68,6 +68,6 @@ abstract class TopLevelContainer implements Nameable {
   Iterable<TopLevelVariable> get publicProperties =>
       model_utils.filterNonPublic(properties);
 
-  Iterable<ModelFunctionTyped> get publicTypedefs =>
+  Iterable<Typedef> get publicTypedefs =>
       model_utils.filterNonPublic(typedefs);
 }

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -54,7 +54,9 @@ class Typedef extends ModelElement
   String get linkedReturnType => modelType.createLinkedReturnTypeName();
 
   @override
-  FunctionTypeElementType get modelType => super.modelType;
+  // TODO(jcollins-g): change to FunctionTypeElementType after analyzer 0.41
+  // ignore: unnecessary_overrides
+  ElementType get modelType => super.modelType;
 
   FunctionTypeAliasElement get _typedef =>
       (element as FunctionTypeAliasElement);

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -44,13 +44,11 @@ class Typedef extends ModelElement
   }
 
   // Food for mustache.
-  @override
   bool get isInherited => false;
 
   @override
   String get kind => 'typedef';
 
-  @override
   String get linkedReturnType => modelType.createLinkedReturnTypeName();
 
   @override

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -9,7 +9,7 @@ import 'package:dartdoc/src/render/typedef_renderer.dart';
 
 class Typedef extends ModelElement
     with TypeParameters, Categorization
-    implements EnclosedElement, ModelFunctionTyped {
+    implements EnclosedElement {
   Typedef(FunctionTypeAliasElement element, Library library,
       PackageGraph packageGraph)
       : super(element, library, packageGraph, null);
@@ -54,7 +54,7 @@ class Typedef extends ModelElement
   String get linkedReturnType => modelType.createLinkedReturnTypeName();
 
   @override
-  DefinedElementType get modelType => super.modelType;
+  FunctionTypeElementType get modelType => super.modelType;
 
   FunctionTypeAliasElement get _typedef =>
       (element as FunctionTypeAliasElement);


### PR DESCRIPTION
This makes dartdoc work with or without https://dart-review.googlesource.com/c/sdk/+/166680.  Some cleanups after we migrate are tagged in the PR; there might be a few more lingering type issues we can correct once this all lands.  But this will get us through the transition.