### PR TITLE
Fix templates in one liners

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -125,10 +125,20 @@ class PackageGraph {
 
     for (var m in allModelElements) {
       // Skip if there is a canonicalModelElement somewhere else we can run this
-      // for.  Not the same as allCanonicalModelElements since we need to run
+      // for and we won't need a one line document that is precached.
+      // Not the same as allCanonicalModelElements since we need to run
       // for any ModelElement that might not have a canonical ModelElement,
       // too.
-      if (m.canonicalModelElement != null && !m.isCanonical) continue;
+      if (m.canonicalModelElement !=
+                  null // A canonical element exists somewhere
+              &&
+              !m.isCanonical // This element is not canonical
+              &&
+              !m.enclosingElement
+                  .isCanonical // The enclosingElement won't need a oneLineDoc from this
+          ) {
+        continue;
+      }
       yield* precacheOneElement(m);
     }
   }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -610,11 +610,10 @@ void main() {
   });
 
   group('Macros', () {
-    Class dog, ClassTemplateMember, AbstractClassTemplateMember;
+    Class dog, ClassTemplateOneLiner;
     Enum MacrosFromAccessors;
     Method withMacro, withMacro2, withPrivateMacro, withUndefinedMacro;
     EnumField macroReferencedHere;
-    Field templateMember, templateMemberInherited;
 
     setUpAll(() {
       dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
@@ -629,21 +628,22 @@ void main() {
           fakeLibrary.enums.firstWhere((e) => e.name == 'MacrosFromAccessors');
       macroReferencedHere = MacrosFromAccessors.publicConstantFields
           .firstWhere((e) => e.name == 'macroReferencedHere');
-      AbstractClassTemplateMember = exLibrary.classes.firstWhere((c) => c.name == 'AbstractClassTemplateMember');
-      ClassTemplateMember = exLibrary.classes.firstWhere((c) => c.name == 'ClassTemplateMember');
-      templateMember = AbstractClassTemplateMember.allFields.firstWhere((f) => f.name == 'templateMember');
-      templateMemberInherited = ClassTemplateMember.allFields.firstWhere((f) => f.name == 'templateMember');
+      ClassTemplateOneLiner = exLibrary.allClasses
+          .firstWhere((c) => c.name == 'ClassTemplateOneLiner');
     });
 
-    test('does not leave behind template crumbs on inheritance', () {
-      expect(templateMember.oneLineDoc, equals('I had better not have a template directive in my one liner.'));
-      expect(templateMemberInherited.oneLineDoc, equals('I had better not have a template directive in my one liner.'));
+    test('via reexport does not leave behind template crumbs', () {
+      expect(ClassTemplateOneLiner.isCanonical, isFalse);
+      expect(
+          ClassTemplateOneLiner.oneLineDoc,
+          equals(
+              'I had better not have a template directive in my one liner.'));
     });
 
     test('renders a macro defined within a enum', () {
       expect(macroReferencedHere.documentationAsHtml,
           contains('This is a macro defined in an Enum accessor.'));
-      [1,2,3].whereType();
+      [1, 2, 3].whereType();
     });
 
     test("renders a macro within the same comment where it's defined", () {
@@ -1514,7 +1514,7 @@ void main() {
     });
 
     test('correctly finds all the classes', () {
-      expect(classes, hasLength(36));
+      expect(classes, hasLength(37));
     });
 
     test('abstract', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -643,7 +643,6 @@ void main() {
     test('renders a macro defined within a enum', () {
       expect(macroReferencedHere.documentationAsHtml,
           contains('This is a macro defined in an Enum accessor.'));
-      [1, 2, 3].whereType();
     });
 
     test("renders a macro within the same comment where it's defined", () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -610,10 +610,11 @@ void main() {
   });
 
   group('Macros', () {
-    Class dog;
+    Class dog, ClassTemplateMember, AbstractClassTemplateMember;
     Enum MacrosFromAccessors;
     Method withMacro, withMacro2, withPrivateMacro, withUndefinedMacro;
     EnumField macroReferencedHere;
+    Field templateMember, templateMemberInherited;
 
     setUpAll(() {
       dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
@@ -628,11 +629,21 @@ void main() {
           fakeLibrary.enums.firstWhere((e) => e.name == 'MacrosFromAccessors');
       macroReferencedHere = MacrosFromAccessors.publicConstantFields
           .firstWhere((e) => e.name == 'macroReferencedHere');
+      AbstractClassTemplateMember = exLibrary.classes.firstWhere((c) => c.name == 'AbstractClassTemplateMember');
+      ClassTemplateMember = exLibrary.classes.firstWhere((c) => c.name == 'ClassTemplateMember');
+      templateMember = AbstractClassTemplateMember.allFields.firstWhere((f) => f.name == 'templateMember');
+      templateMemberInherited = ClassTemplateMember.allFields.firstWhere((f) => f.name == 'templateMember');
+    });
+
+    test('does not leave behind template crumbs on inheritance', () {
+      expect(templateMember.oneLineDoc, equals('I had better not have a template directive in my one liner.'));
+      expect(templateMemberInherited.oneLineDoc, equals('I had better not have a template directive in my one liner.'));
     });
 
     test('renders a macro defined within a enum', () {
       expect(macroReferencedHere.documentationAsHtml,
           contains('This is a macro defined in an Enum accessor.'));
+      [1,2,3].whereType();
     });
 
     test("renders a macro within the same comment where it's defined", () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -11,7 +11,7 @@ import 'package:test_package_imported/main.dart';
 export 'dart:core' show deprecated, Deprecated;
 import 'package:meta/meta.dart' show protected, factory;
 
-export 'fake.dart' show Cool;
+export 'fake.dart' show Cool, ClassTemplateOneLiner;
 export 'src/mylib.dart' show Helper;
 
 const String COLOR = 'red';
@@ -665,23 +665,4 @@ class ToolPrintingMacroWhichInjectsHtml {
   /// Text for tool.
   /// {@end-tool}
   int b;
-}
-
-/// Verify that documentation in inherited objects also has correct one-liners.
-///
-/// {@tool drill}
-/// Here is some text for a tool, which can change how templates are evaluated.
-/// {@end-tool}
-class ClassTemplateMember extends AbstractClassTemplateMember {
-}
-
-abstract class AbstractClassTemplateMember {
-  /// {@template example:templateMemberTest}
-  /// I had better not have a template directive in my one liner.
-  ///
-  /// Even if it has links to [Dog] or other classes.
-  ///
-  /// And if I do, a test should fail.
-  /// {@endtemplate}
-  final String templateMember;
 }

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -666,3 +666,22 @@ class ToolPrintingMacroWhichInjectsHtml {
   /// {@end-tool}
   int b;
 }
+
+/// Verify that documentation in inherited objects also has correct one-liners.
+///
+/// {@tool drill}
+/// Here is some text for a tool, which can change how templates are evaluated.
+/// {@end-tool}
+class ClassTemplateMember extends AbstractClassTemplateMember {
+}
+
+abstract class AbstractClassTemplateMember {
+  /// {@template example:templateMemberTest}
+  /// I had better not have a template directive in my one liner.
+  ///
+  /// Even if it has links to [Dog] or other classes.
+  ///
+  /// And if I do, a test should fail.
+  /// {@endtemplate}
+  final String templateMember;
+}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -73,6 +73,8 @@ export 'src/tool.dart';
 // ignore: uri_does_not_exist
 export 'package:test_package/fake.dart';
 
+export 'src/reexport_this.dart';
+
 /// Does not render with emoji 3ffe:2a00:100:7031::1
 const int hasMarkdownInDoc = 1;
 

--- a/testing/test_package/lib/src/reexport_this.dart
+++ b/testing/test_package/lib/src/reexport_this.dart
@@ -1,0 +1,12 @@
+
+library reexport_this;
+
+/// {@template example:templateMemberTest}
+/// I had better not have a template directive in my one liner.
+///
+/// Even if it has links to [Dog] or other classes.
+///
+/// And if I do, a test should fail.
+/// {@endtemplate}
+class ClassTemplateOneLiner {
+}


### PR DESCRIPTION
Fixes #2272.

In a reexport chain where the origin is private and the symbol is visible in more than one library, the oneLineDoc won't be properly precached and can leave template detritus behind.