### PR TITLE
Enable NNBD experiment for dartdoc

### DIFF
--- a/lib/src/experiment_options.dart
+++ b/lib/src/experiment_options.dart
@@ -25,7 +25,7 @@ Future<List<DartdocOption<Object>>> createExperimentOptions(
   return [
     // TODO(jcollins-g): Consider loading experiment values from dartdoc_options.yaml?
     DartdocOptionArgOnly<List<String>>(
-        'enable-experiment', [], resourceProvider,
+        'enable-experiment', ['non-nullable'], resourceProvider,
         help: 'Enable or disable listed experiments.\n' +
             ExperimentStatus.knownFeatures.values
                 .where((e) => e.documentation != null)


### PR DESCRIPTION
This will document any NNBD-enabled packages with "null safety" by default, rather than pretending they aren't null safe.