### PR TITLE
Redirect users to pub global activate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ For issues/details related to hosted Dart API docs, see
 
 ## Installing dartdoc
 
-- download the [Dart SDK](https://dart.dev/get-dart)
-- add the SDK's `bin` directory to your `PATH`
+Run `pub global activate dartdoc` to install the latest version of dartdoc compatible with your
+SDK.
 
 ## Generating docs
 


### PR DESCRIPTION
Fixes #2385 

I've been advising folks to do this for so long, I didn't realize that the README was still advising people to use the SDK version.