### PR TITLE
Fix issue where excluded packages can sometimes default to remote linking

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -179,12 +179,12 @@ class Class extends Container
     var result = <Class>{};
     var seen = <Class>{};
 
-    // Recursively adds [implementor] if public, or the impelentors of
+    // Recursively adds [implementor] if public, or the implementors of
     // [implementor] if not.
     void addToResult(Class implementor) {
       if (seen.contains(implementor)) return;
       seen.add(implementor);
-      if (implementor.isPublic) {
+      if (implementor.isPublicAndPackageDocumented) {
         result.add(implementor);
       } else {
         model_utils

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -1036,8 +1036,7 @@ abstract class ModelElement extends Canonicalization
   @override
   Package get package => library?.package;
 
-  bool get isPublicAndPackageDocumented =>
-      isPublic && library.packageGraph.packageDocumentedFor(this);
+  bool get isPublicAndPackageDocumented => isPublic && package.isDocumented;
 
   List<Parameter> _allParameters;
 

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -188,7 +188,10 @@ class Package extends LibraryContainer
           _documentedWhere = DocumentLocation.local;
         }
       } else {
-        if (config.linkToRemote && config.linkToUrl.isNotEmpty && isPublic) {
+        if (config.linkToRemote &&
+            config.linkToUrl.isNotEmpty &&
+            isPublic &&
+            !packageGraph.config.isPackageExcluded(name)) {
           _documentedWhere = DocumentLocation.remote;
         } else {
           _documentedWhere = DocumentLocation.missing;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -267,20 +267,6 @@ class PackageGraph {
   bool allLibrariesAdded = false;
   bool _localDocumentationBuilt = false;
 
-  Set<String> _allRootDirs;
-
-  /// Returns true if there's at least one library documented in the package
-  /// that has the same package path as the library for the given element.
-  ///
-  /// Usable as a cross-check for dartdoc's canonicalization to generate
-  /// warnings for ModelElement.isPublicAndPackageDocumented.
-  bool packageDocumentedFor(ModelElement element) {
-    _allRootDirs ??= {
-      ...(publicLibraries.map((l) => l.packageMeta?.resolvedDir))
-    };
-    return _allRootDirs.contains(element.library.packageMeta?.resolvedDir);
-  }
-
   PackageWarningCounter get packageWarningCounter => _packageWarningCounter;
 
   final Set<Tuple3<Element, PackageWarning, String>> _warnAlreadySeen = {};

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -206,10 +206,11 @@ void main() {
     });
 
     test('basic interlinking test', () async {
-      var dartdoc = await buildDartdoc([], _testPackageDir, tempDir);
+      var dartdoc = await buildDartdoc(['--exclude-packages=args'], _testPackageDir, tempDir);
       var results = await dartdoc.generateDocs();
       var p = results.packageGraph;
       var meta = p.publicPackages.firstWhere((p) => p.name == 'meta');
+      var args = p.publicPackages.firstWhere((p) => p.name == 'args');
       var useSomethingInAnotherPackage = p.publicLibraries
           .firstWhere((l) => l.name == 'fake')
           .properties
@@ -219,6 +220,7 @@ void main() {
           .properties
           .firstWhere((p) => p.name == 'useSomethingInTheSdk');
       expect(meta.documentedWhere, equals(DocumentLocation.remote));
+      expect(args.documentedWhere, equals(DocumentLocation.missing));
       expect(
           useSomethingInAnotherPackage.modelType.linkedName,
           matches(

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -206,7 +206,8 @@ void main() {
     });
 
     test('basic interlinking test', () async {
-      var dartdoc = await buildDartdoc(['--exclude-packages=args'], _testPackageDir, tempDir);
+      var dartdoc = await buildDartdoc(
+          ['--exclude-packages=args'], _testPackageDir, tempDir);
       var results = await dartdoc.generateDocs();
       var p = results.packageGraph;
       var meta = p.publicPackages.firstWhere((p) => p.name == 'meta');

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1513,7 +1513,7 @@ void main() {
     });
 
     test('correctly finds all the classes', () {
-      expect(classes, hasLength(37));
+      expect(classes, hasLength(38));
     });
 
     test('abstract', () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'src/mylib.dart' show Helper;
 import 'package:test_package_imported/main.dart';
 
+export 'package:args/args.dart' show ArgParser;
 export 'dart:core' show deprecated, Deprecated;
 import 'package:meta/meta.dart' show protected, factory;
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -1106,8 +1106,6 @@ Future<WarningsCollection> _buildDartdocFlutterPluginDocs() async {
           [
             '--enable-asserts',
             path.join(Directory.current.path, 'bin', 'dartdoc.dart'),
-            '--exclude-packages',
-            'Dart', // TODO(jcollins-g): dart-lang/dartdoc#1431
             '--json',
             '--link-to-remote',
             '--output',


### PR DESCRIPTION
Fixes #2382 and #1431.  In particular, any remaining workarounds for #1431 are now suboptimal and should be removed as, depending on how it is implemented, it may disable remote linking (if using --exclude-packages).

Dartdoc was only half paying attention to the exclude packages flag -- assuming that if you excluded the package you wanted remote linking if it happened to be part of Flutter.  That doesn't work, particularly when you are documenting Flutter itself and leads to #2382.

Also, clean up isPublicAndPackageDocumented now that we don't have to infer documentation status for packages from libraries like we did in the dark ages (**breaking change** for removal of `PackageGraph.packageDocumentedFor`).