### PR TITLE
Add 'href' and 'kind' to Documentable.

### DIFF
--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -27,6 +27,10 @@ abstract class Documentable extends Nameable {
   bool get isDocumented;
 
   DartdocOptionContext get config;
+
+  String get href;
+
+  String get kind;
 }
 
 /// For a given package, indicate with this enum whether it should be documented

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -90,6 +90,7 @@ class Package extends LibraryContainer
 
   String get homepage => packageMeta.homepage;
 
+  @override
   String get kind => (isSdk) ? 'SDK' : 'package';
 
   @override


### PR DESCRIPTION
These are each referenced from mustache templates where Documentable is the
context type:

* 'kind' is used in category.html, at the top-level.
* 'href' is used in _head.html while iterating over navLinks, which are
  Documentable.