### PR TITLE
Fix issues with source code HTML of fields and accessors

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/render/source_code_renderer.dart';
 import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/warnings.dart';
 
@@ -22,6 +23,9 @@ class Accessor extends ModelElement implements EnclosedElement {
   }
 
   bool get isSynthetic => element.isSynthetic;
+
+  SourceCodeRenderer get _sourceCodeRenderer =>
+      packageGraph.rendererFactory.sourceCodeRenderer;
 
   GetterSetterCombo _definingCombo;
   // The [enclosingCombo] where this element was defined.
@@ -44,8 +48,8 @@ class Accessor extends ModelElement implements EnclosedElement {
   String get sourceCode {
     if (_sourceCode == null) {
       if (isSynthetic) {
-        _sourceCode =
-            packageGraph.getModelNodeFor(definingCombo.element).sourceCode;
+        _sourceCode = _sourceCodeRenderer.renderSourceCode(
+            packageGraph.getModelNodeFor(definingCombo.element).sourceCode);
       } else {
         _sourceCode = super.sourceCode;
       }

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/render/source_code_renderer.dart';
 
 class Field extends ModelElement
     with GetterSetterCombo, ContainerMember, Inheritable
@@ -160,6 +161,9 @@ class Field extends ModelElement
   @override
   String get fileName => '${isConst ? '$name-constant' : name}.$fileType';
 
+  SourceCodeRenderer get _sourceCodeRenderer =>
+      packageGraph.rendererFactory.sourceCodeRenderer;
+
   String _sourceCode;
 
   @override
@@ -171,6 +175,7 @@ class Field extends ModelElement
       var setterSourceCode = setter?.sourceCode ?? '';
       var buffer = StringBuffer();
       if (fieldSourceCode.isNotEmpty) {
+        fieldSourceCode = _sourceCodeRenderer.renderSourceCode(fieldSourceCode);
         buffer.write(fieldSourceCode);
       }
       if (buffer.isNotEmpty) buffer.write('\n\n');

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -48,9 +48,9 @@ class ModelNode {
       if (_sourceNode?.offset != null) {
         var sourceNode = _sourceNode;
 
-        // Get a node higher up the syntax tree that includes the semicolon.
-        // In this case, it is either a [FieldDeclaration] or
-        // [TopLevelVariableDeclaration]. (#2401)
+        /// Get a node higher up the syntax tree that includes the semicolon.
+        /// In this case, it is either a [FieldDeclaration] or
+        /// [TopLevelVariableDeclaration]. (#2401)
         if (sourceNode is VariableDeclaration) {
           sourceNode = sourceNode.parent.parent;
           assert(sourceNode is FieldDeclaration ||

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -46,19 +46,19 @@ class ModelNode {
   String get sourceCode {
     if (_sourceCode == null) {
       if (_sourceNode?.offset != null) {
-        var sourceNode = _sourceNode;
+        var enclosingSourceNode = _sourceNode;
 
         /// Get a node higher up the syntax tree that includes the semicolon.
         /// In this case, it is either a [FieldDeclaration] or
         /// [TopLevelVariableDeclaration]. (#2401)
-        if (sourceNode is VariableDeclaration) {
-          sourceNode = sourceNode.parent.parent;
-          assert(sourceNode is FieldDeclaration ||
-              sourceNode is TopLevelVariableDeclaration);
+        if (_sourceNode is VariableDeclaration) {
+          enclosingSourceNode = _sourceNode.parent.parent;
+          assert(enclosingSourceNode is FieldDeclaration ||
+              enclosingSourceNode is TopLevelVariableDeclaration);
         }
 
-        var sourceEnd = sourceNode.end;
-        var sourceOffset = sourceNode.offset;
+        var sourceEnd = enclosingSourceNode.end;
+        var sourceOffset = enclosingSourceNode.offset;
 
         var contents =
             model_utils.getFileContentsFor(element, resourceProvider);

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -67,6 +67,12 @@ class ModelNode {
         source = model_utils.stripIndentFromSource(source);
         source = model_utils.stripDartdocCommentsFromSource(source);
 
+        // The calculated source code end for field elements doesn't include
+        // the semicolon for field elements, so it has to be added manually
+        if (element is FieldElement) {
+          source += ';';
+        }
+
         _sourceCode = source.trim();
       } else {
         _sourceCode = '';

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3806,6 +3806,25 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(explicitGetterSetterForInheriting.setter.sourceCode,
           contains('&lt;int&gt;'));
     });
+
+    test('Property fields are terminated with semicolon', () {
+      expect(finalProperty.sourceCode.trim(), endsWith('List&lt;int&gt;();'));
+      expect(simpleProperty.sourceCode.trim(), endsWith('List&lt;int&gt;();'));
+      expect(forInheriting.sourceCode.trim(), endsWith('forInheriting;'));
+    });
+
+    test('Arrow accessors are terminated with semicolon', () {
+      expect(explicitGetterImplicitSetter.getter.sourceCode.trim(),
+          endsWith('List&lt;int&gt;();'));
+      expect(explicitGetterSetter.getter.sourceCode.trim(),
+          endsWith('List&lt;int&gt;();'));
+    });
+
+    test('Traditional accessors are not terminated with semicolon', () {
+      expect(implicitGetterExplicitSetter.setter.sourceCode.trim(),
+          endsWith('\{\}'));
+      expect(explicitGetterSetter.setter.sourceCode.trim(), endsWith('\{\}'));
+    });
   });
 
   group('Sorting by name', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3761,6 +3761,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     Field implicitGetterExplicitSetter, explicitGetterImplicitSetter;
     Field explicitGetterSetter, explicitGetterSetterForInheriting;
     Field finalProperty, simpleProperty, forInheriting;
+    Field ensureWholeDeclarationIsVisible;
 
     setUpAll(() {
       EscapableProperties = fakeLibrary.classes
@@ -3779,6 +3780,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .firstWhere((e) => e.name == 'forInheriting');
       explicitGetterSetterForInheriting = EscapableProperties.allModelElements
           .firstWhere((e) => e.name == 'explicitGetterSetterForInheriting');
+      ensureWholeDeclarationIsVisible = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'ensureWholeDeclarationIsVisible');
     });
 
     test('Normal property fields are escaped', () {
@@ -3824,6 +3827,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(implicitGetterExplicitSetter.setter.sourceCode.trim(),
           endsWith('\{\}'));
       expect(explicitGetterSetter.setter.sourceCode.trim(), endsWith('\{\}'));
+    });
+
+    test('Whole declaration is visible when declaration spans many lines', () {
+      expect(ensureWholeDeclarationIsVisible.sourceCode,
+          contains('List&lt;int&gt; '));
     });
   });
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3756,6 +3756,58 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
   });
 
+  group('Source Code HTML', () {
+    Class EscapableProperties;
+    Field implicitGetterExplicitSetter, explicitGetterImplicitSetter;
+    Field explicitGetterSetter, explicitGetterSetterForInheriting;
+    Field finalProperty, simpleProperty, forInheriting;
+
+    setUpAll(() {
+      EscapableProperties = fakeLibrary.classes
+          .firstWhere((c) => c.name == 'HtmlEscapableProperties');
+      implicitGetterExplicitSetter = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'implicitGetterExplicitSetter');
+      explicitGetterImplicitSetter = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'explicitGetterImplicitSetter');
+      explicitGetterSetter = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'explicitGetterSetter');
+      finalProperty = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'finalProperty');
+      simpleProperty = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'simpleProperty');
+      forInheriting = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'forInheriting');
+      explicitGetterSetterForInheriting = EscapableProperties.allModelElements
+          .firstWhere((e) => e.name == 'explicitGetterSetterForInheriting');
+    });
+
+    test('Normal property fields are escaped', () {
+      expect(finalProperty.sourceCode, contains('&lt;int&gt;'));
+      expect(simpleProperty.sourceCode, contains('&lt;int&gt;'));
+      expect(forInheriting.sourceCode, contains('&lt;int&gt;'));
+    });
+
+    test('Explicit accessors are escaped', () {
+      expect(explicitGetterSetter.getter.sourceCode, contains('&lt;int&gt;'));
+      expect(explicitGetterSetter.setter.sourceCode, contains('&lt;int&gt;'));
+    });
+
+    test('Implicit accessors are escaped', () {
+      expect(implicitGetterExplicitSetter.getter.sourceCode,
+          contains('&lt;int&gt;'));
+      expect(implicitGetterExplicitSetter.setter.sourceCode,
+          contains('&lt;int&gt;'));
+      expect(explicitGetterImplicitSetter.getter.sourceCode,
+          contains('&lt;int&gt;'));
+      expect(explicitGetterImplicitSetter.setter.sourceCode,
+          contains('&lt;int&gt;'));
+      expect(explicitGetterSetterForInheriting.getter.sourceCode,
+          contains('&lt;int&gt;'));
+      expect(explicitGetterSetterForInheriting.setter.sourceCode,
+          contains('&lt;int&gt;'));
+    });
+  });
+
   group('Sorting by name', () {
     // Order by uppercased lexical ordering for non-digits,
     // lexicographical ordering of embedded digit sequences.

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -564,6 +564,47 @@ class ClassWithUnusualProperties extends ImplicitProperties {
   }
 }
 
+class HtmlEscapableImplicitProperties {
+  /// Docs for implicitGetterExplicitSetter from HtmlEscapableImplicitProperties.
+  List<int> implicitGetterExplicitSetter;
+
+  /// Docs for explicitGetterImplicitSetter from HtmlEscapableImplicitProperties.
+  List<int> explicitGetterImplicitSetter;
+
+  /// A simple property to inherit.
+  List<int> forInheriting;
+
+  /// Explicit getter for inheriting.
+  List<int> get explicitGetterSetterForInheriting => [1, 2];
+
+  /// Explicit setter for inheriting.
+  set explicitGetterSetterForInheriting(List<int> foo) {}
+}
+
+class HtmlEscapableProperties extends HtmlEscapableImplicitProperties {
+  @override
+
+  /// Docs for setter of implicitGetterExplicitSetter.
+  set implicitGetterExplicitSetter(List<int> x) {}
+
+  @override
+
+  /// Getter doc for explicitGetterImplicitSetter
+  List<int> get explicitGetterImplicitSetter => List<int>();
+
+  /// Getter doc for explicitGetterSetter.
+  List<int> get explicitGetterSetter => List<int>();
+
+  /// Setter doc for explicitGetterSetter.
+  set explicitGetterSetter(List<int> aList) {}
+
+  /// A final property.
+  final List<int> finalProperty = List<int>();
+
+  /// A simple property.
+  List<int> simpleProperty = List<int>();
+}
+
 /// This is a very long line spread
 /// across... wait for it... two physical lines.
 ///

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -603,6 +603,10 @@ class HtmlEscapableProperties extends HtmlEscapableImplicitProperties {
 
   /// A simple property.
   List<int> simpleProperty = List<int>();
+
+  /// A long multiple variable declaration.
+  List<int> iAmALongLongLongLongLongLongLongLongLongName,
+      ensureWholeDeclarationIsVisible;
 }
 
 /// This is a very long line spread


### PR DESCRIPTION
Fixes flutter/flutter#67802 
* The issue occurs as models for Field and Accessor override the `sourceCode` getter but don't escape special characters in their implementation. This is now fixed.

Fixes #2202 
* The issue occurs as the `ASTNode` which is obtained for `FieldElement` is not high enough up the syntax tree to include the semicolon. So the calculated `_sourceEnd` doesn't include the semicolon. ~So it is now added manually.~ So, in that case, the parent node that contains the entire statement is obtained to calculate the offset and end. 