### PR TITLE
Fix definingCombo == null for static field members of extension methods

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -149,7 +149,8 @@ class GeneratorFrontEnd implements Generator {
 
           for (var staticField in filterNonDocumented(extension.staticFields)) {
             indexAccumulator.add(staticField);
-            _generatorBackend.generateProperty(writer, packageGraph, lib, extension, staticField);
+            _generatorBackend.generateProperty(
+                writer, packageGraph, lib, extension, staticField);
           }
         }
 

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -146,6 +146,11 @@ class GeneratorFrontEnd implements Generator {
             _generatorBackend.generateProperty(
                 writer, packageGraph, lib, extension, property);
           }
+
+          for (var staticField in filterNonDocumented(extension.staticFields)) {
+            indexAccumulator.add(staticField);
+            _generatorBackend.generateProperty(writer, packageGraph, lib, extension, staticField);
+          }
         }
 
         for (var mixin in filterNonDocumented(lib.mixins)) {

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -28,12 +28,8 @@ class Accessor extends ModelElement implements EnclosedElement {
   GetterSetterCombo get definingCombo {
     if (_definingCombo == null) {
       var variable = (element as PropertyAccessorElement).variable;
-      var accessor = isGetter ? variable.getter : variable.setter;
-      var accessorLibrary = Library(accessor.library, packageGraph);
-      var definingAccessor =
-          ModelElement.from(accessor, accessorLibrary, packageGraph)
-              as Accessor;
-      _definingCombo = definingAccessor.enclosingCombo;
+      _definingCombo = ModelElement.fromElement(variable, packageGraph);
+      assert(_definingCombo != null, 'Unable to find defining combo');
     }
     return _definingCombo;
   }

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -359,12 +359,14 @@ abstract class ModelElement extends Canonicalization
       }
     }
     if (e is PropertyAccessorElement) {
-      // TODO(jcollins-g): why test for ClassElement in enclosingElement?
+      // Accessors can be part of a [Container], or a part of a [Library].
       if (e.enclosingElement is ClassElement ||
+          e.enclosingElement is ExtensionElement ||
           e is MultiplyInheritedExecutableElement) {
         if (enclosingContainer == null) {
           return ContainerAccessor(e, library, packageGraph);
         } else {
+          assert(e.enclosingElement is! ExtensionElement);
           return ContainerAccessor.inherited(
               e, library, packageGraph, enclosingContainer,
               originalMember: originalMember);

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1746,6 +1746,7 @@ void main() {
   group('Extension', () {
     Extension arm, leg, ext, fancyList, uphill;
     Extension documentOnceReexportOne, documentOnceReexportTwo;
+    Extension staticFieldExtension;
     Library reexportOneLib, reexportTwoLib;
     Class apple,
         anotherExtended,
@@ -1784,6 +1785,7 @@ void main() {
           .firstWhere((e) => e.name == 'SimpleStringExtension')
           .instanceMethods
           .firstWhere((m) => m.name == 'doStuff');
+      staticFieldExtension = exLibrary.extensions.firstWhere((e) => e.name == 'StaticFieldExtension');
       extensions = exLibrary.publicExtensions.toList();
       baseTest = fakeLibrary.classes.firstWhere((e) => e.name == 'BaseTest');
       bigAnotherExtended =
@@ -1796,6 +1798,11 @@ void main() {
       megaTron = fakeLibrary.classes.firstWhere((e) => e.name == 'Megatron');
       superMegaTron =
           fakeLibrary.classes.firstWhere((e) => e.name == 'SuperMegaTron');
+    });
+
+    test('static fields inside extensions do not crash', () {
+      expect(staticFieldExtension.staticFields.length, equals(1));
+      expect(staticFieldExtension.staticFields.first.name, equals('aStatic'));
     });
 
     test('basic canonicalization for extensions', () {
@@ -1980,11 +1987,11 @@ void main() {
     });
 
     test('correctly finds all the extensions', () {
-      expect(exLibrary.extensions, hasLength(8));
+      expect(exLibrary.extensions, hasLength(9));
     });
 
     test('correctly finds all the public extensions', () {
-      expect(extensions, hasLength(6));
+      expect(extensions, hasLength(7));
     });
   });
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1785,7 +1785,8 @@ void main() {
           .firstWhere((e) => e.name == 'SimpleStringExtension')
           .instanceMethods
           .firstWhere((m) => m.name == 'doStuff');
-      staticFieldExtension = exLibrary.extensions.firstWhere((e) => e.name == 'StaticFieldExtension');
+      staticFieldExtension = exLibrary.extensions
+          .firstWhere((e) => e.name == 'StaticFieldExtension');
       extensions = exLibrary.publicExtensions.toList();
       baseTest = fakeLibrary.classes.firstWhere((e) => e.name == 'BaseTest');
       bigAnotherExtended =

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -648,6 +648,10 @@ extension on Object {
   void bar() {}
 }
 
+extension StaticFieldExtension on Object {
+  static int aStatic;
+}
+
 /// This class has nothing to do with [_Shhh], [FancyList], or [AnExtension.call],
 /// but should not crash because we referenced them.
 /// We should be able to find [DocumentThisExtensionOnce], too.


### PR DESCRIPTION
Fixes #2402.  Static fields weren't properly initialized or documented in extensions.