### PR TITLE
Display null safety tag only on migrated packages

### DIFF
--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -491,6 +491,10 @@ void main() {
       expect(exLibrary.name, 'ex');
     });
 
+    test('does not have a null safety label if not null safe', () {
+      expect(exLibrary.isNullSafety, isFalse);
+    });
+
     test('has a line number and column', () {
       expect(exLibrary.characterLocation, isNotNull);
     });


### PR DESCRIPTION
Fixes #2403.  Filing #2410 for the port to AnalysisContextCollection originally anticipated to solve this, and #2409 for removing the null safety tag on individual symbols.

In addition to the end-to-end test, spot checked with  `PACKAGE_NAME=collection PACKAGE_VERSION=1.15.0-nullsafety.4 grind serve-pub-package` and ` PACKAGE_NAME=collection grind serve-pub-package` and verified pages appeared correctly.