### PR TITLE
precreate .dart directory to workaround #2412

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -14,8 +14,9 @@ DART_VERSION=`dart --version 2>&1 | awk '{print $4}'`
 if ! echo "${DART_VERSION}" | grep -q dev || ! uname | grep -q Linux ; then
   unset COVERAGE_TOKEN
 fi
-# workaround for dart-lang/dartdoc#2412
-unset COVERAGE_TOKEN
+if [ -n "${COVERAGE_TOKEN}" ] ; then
+  mkdir -p ~/.dart
+fi
 
 if [ "$DARTDOC_BOT" = "sdk-docs" ]; then
   # Build the SDK docs

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -14,9 +14,8 @@ DART_VERSION=`dart --version 2>&1 | awk '{print $4}'`
 if ! echo "${DART_VERSION}" | grep -q dev || ! uname | grep -q Linux ; then
   unset COVERAGE_TOKEN
 fi
-if [ -n "${COVERAGE_TOKEN}" ] ; then
-  mkdir -p ~/.dart
-fi
+# workaround for dart-lang/sdk#44027
+mkdir -p ~/.dart
 
 if [ "$DARTDOC_BOT" = "sdk-docs" ]; then
   # Build the SDK docs

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -14,6 +14,8 @@ DART_VERSION=`dart --version 2>&1 | awk '{print $4}'`
 if ! echo "${DART_VERSION}" | grep -q dev || ! uname | grep -q Linux ; then
   unset COVERAGE_TOKEN
 fi
+# workaround for dart-lang/dartdoc#2412
+unset COVERAGE_TOKEN
 
 if [ "$DARTDOC_BOT" = "sdk-docs" ]; then
   # Build the SDK docs


### PR DESCRIPTION
Workaround for #2412 precreates the `~/.dart` directory, to avoid dart-lang/sdk#44027.