### PR TITLE
Remove unnecessary dart:async imports

### DIFF
--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -5,7 +5,6 @@
 /// This is a helper library to make working with io easier.
 library dartdoc.io_utils;
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show stderr, stdout;
 

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:collection';
 
 import 'package:analyzer/dart/ast/ast.dart';

--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -4,7 +4,6 @@
 
 library dartdoc.tool_runner;
 
-import 'dart:async';
 import 'dart:io' show Process, ProcessException;
 
 import 'package:analyzer/file_system/file_system.dart';


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.