### PR TITLE
Introduce a Mustachio Builder.

### DIFF
--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'parser.dart';
+
+/// The base class for a generated Mustache renderer.
+abstract class RendererBase<T> {
+  /// The context object which this renderer can render.
+  final T context;
+
+  /// The output buffer into which [context] is rendered, using a template.
+  final buffer = StringBuffer();
+
+  RendererBase(this.context);
+
+  void write(String text) => buffer.write(text);
+
+  /// Renders a block of Mustache template, the [ast], into [buffer].
+  void renderBlock(List<MustachioNode> ast) {
+    for (var node in ast) {
+      if (node is Text) {
+        write(node.content);
+      } else if (node is Variable) {
+        var content = getFields(node.key);
+        write(content);
+      } else if (node is Section) {
+        section(node);
+      } else if (node is Partial) {
+        partial(node);
+      }
+    }
+  }
+
+  void section(Section node) {
+    // TODO(srawlins): Implement.
+  }
+
+  void partial(Partial node) {
+    // TODO(srawlins): Implement.
+  }
+
+  /// Resolves [key] into one or more field accesses, returning the result as a
+  /// String.
+  ///
+  /// [key] may have multiple dot-separate names, and [key] may not be a valid
+  /// property of _this_ context type, in which the [parent] renderer is
+  /// referenced.
+  String getFields(List<String> names);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dev_dependencies:
   async: '>=2.0.8'
   build: ^1.5.0
   build_runner: ^1.10.0
+  build_test: ^1.3.0
   build_version: ^2.0.1
   coverage: ^0.14.0
   dhttpd: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   build_test: ^1.3.0
   build_version: ^2.0.1
   coverage: ^0.14.0
+  dart_style: ^1.3.9
   dhttpd: ^3.0.0
   grinder: ^0.8.2
   http: ^0.12.0

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -1,0 +1,248 @@
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import '../../tool/mustachio/builder.dart';
+
+const _annotationsAsset = {
+  'mustachio|lib/annotations.dart': '''
+class Renderer {
+  final Symbol name;
+
+  final Context context;
+
+  final String templateUri;
+
+  const Renderer(this.name, this.context, this.templateUri);
+}
+
+class Context<T> {
+  const Context();
+}
+'''
+};
+
+TypeMatcher<List<int>> _containsAllOf(Object a,
+    [Object b, Object c, Object d]) {
+  if (d != null) {
+    return decodedMatches(
+        allOf(contains(a), contains(b), contains(c), contains(d)));
+  } else if (c != null) {
+    return decodedMatches(allOf(contains(a), contains(b), contains(c)));
+  } else {
+    return decodedMatches(
+        b != null ? allOf(contains(a), contains(b)) : allOf(contains(a)));
+  }
+}
+
+TypeMatcher<List<int>> _containsNoneOf(Object a, [Object b]) {
+  return decodedMatches(b != null
+      ? allOf(isNot(contains(a)), isNot(contains(b)))
+      : allOf(isNot(contains(a))));
+}
+
+void main() {
+  test('builds a renderer for a class which extends Object', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'foo.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+class Foo {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsAllOf(
+          // The requested 'renderFoo' function
+          '''
+String renderFoo(Foo context, List<MustachioNode> ast) {
+  var renderer = _Renderer_Foo(context);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+''',
+          // The renderer class for Foo
+          '''
+class _Renderer_Foo extends RendererBase<Foo> {
+  _Renderer_Foo(Foo context) : super(context);
+}
+''',
+          // The render function for Object
+          '''
+String _render_Object(Object context, List<MustachioNode> ast) {
+  var renderer = _Renderer_Object(context);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+''',
+          // The renderer class for Object
+          '''
+class _Renderer_Object extends RendererBase<Object> {
+  _Renderer_Object(Object context) : super(context);
+}
+''')
+    });
+  });
+
+  test('builds renderers from multiple annotations', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'foo.html.mustache')
+@Renderer(#renderBar, Context<Bar>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+class Foo {}
+class Bar {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsAllOf(
+          // The requested 'renderFoo' function
+          'String renderFoo(Foo context, List<MustachioNode> ast)',
+          // The renderer class for Foo
+          'class _Renderer_Foo extends RendererBase<Foo>',
+          // The requested 'renderBar' function
+          'String renderBar(Bar context, List<MustachioNode> ast)',
+          // The renderer class for Bar
+          'class _Renderer_Bar extends RendererBase<Bar>')
+    });
+  });
+
+  test('builds a renderer for a class which extends another class', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+class FooBase {}
+
+class Foo extends FooBase {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsAllOf(
+          'String _render_FooBase(FooBase context, List<MustachioNode> ast)',
+          'class _Renderer_FooBase extends RendererBase<FooBase>')
+    });
+  });
+
+  test('builds a renderer for a generic type', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+class Foo<T> {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsAllOf(
+          // The requested 'renderFoo' function
+          'String renderFoo<T>(Foo<T> context, List<MustachioNode> ast)',
+          // The renderer class for Foo
+          'class _Renderer_Foo<T> extends RendererBase<Foo<T>>')
+    });
+  });
+
+  test('builds a renderer for a type found in a getter', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+abstract class Foo {
+  Bar get bar;
+}
+
+class Bar {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsAllOf(
+          // The render function for Bar
+          'String _render_Bar(Bar context, List<MustachioNode> ast)',
+          // The renderer class for Bar
+          'class _Renderer_Bar extends RendererBase<Bar>')
+    });
+  });
+
+  test('skips a type found in a static or private getter', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+class Foo {
+  static Bar get bar1 => Bar();
+  Bar get _bar2 => Bar();
+}
+
+class Bar {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsNoneOf(
+          // No render function for Bar
+          'String _render_Bar',
+          // No renderer class for Bar
+          'class _Renderer_Bar extends RendererBase<Bar>')
+    });
+  });
+
+  test('skips a type found in a setter or method', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+abstract class Foo {
+  void set bar1(Bar b);
+  Bar bar2(Bar b);
+}
+
+class Bar {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsNoneOf(
+          // No render function for Bar
+          'String _render_Bar',
+          // No renderer class for Bar
+          'class _Renderer_Bar extends RendererBase<Bar>')
+    });
+  });
+
+  test('builds a renderer for a generic, bounded type', () async {
+    await testBuilder(mustachioBuilder(BuilderOptions({})), {
+      ..._annotationsAsset,
+      'foo|lib/foo.dart': '''
+@Renderer(#renderFoo, Context<Foo>(), 'bar.html.mustache')
+library foo;
+import 'package:mustachio/annotations.dart';
+
+class Foo<T extends num> {}
+''',
+    }, outputs: {
+      'foo|lib/foo.renderers.dart': _containsAllOf(
+          // The requested 'renderFoo' function
+          'String renderFoo<T extends num>(Foo<T> context, List<MustachioNode> ast)',
+          // The renderer class for Foo
+          '''
+class _Renderer_Foo<T extends num> extends RendererBase<Foo<T>> {
+  _Renderer_Foo(Foo<T> context) : super(context);
+}
+''',
+          // The render function for num, found in Foo's type parameter bound
+          'String _render_num(num context, List<MustachioNode> ast)',
+          // The renderer class for num
+          'class _Renderer_num extends RendererBase<num>')
+    });
+  });
+}

--- a/tool/mustachio/builder.dart
+++ b/tool/mustachio/builder.dart
@@ -1,0 +1,92 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/member.dart';
+import 'package:build/build.dart';
+
+import 'codegen_runtime_renderer.dart';
+
+/// A [Builder] which builds runtime Mustachio renderers.
+class MustachioBuilder implements Builder {
+  @override
+  final buildExtensions = const {
+    '.dart': ['.renderers.dart']
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    // Each `buildStep` has a single input.
+    var inputId = buildStep.inputId;
+
+    final entryLib = await buildStep.inputLibrary;
+    if (entryLib == null) return;
+
+    final rendererGatherer = _RendererGatherer(entryLib);
+
+    // Create a new target `AssetId` based on the old one.
+    var renderersLibrary = inputId.changeExtension('.renderers.dart');
+    var contents = '';
+
+    if (rendererGatherer._rendererSpecs.isNotEmpty) {
+      contents += buildTemplateRenderers(rendererGatherer._rendererSpecs);
+
+      await buildStep.writeAsString(renderersLibrary, contents);
+    }
+  }
+}
+
+class _RendererGatherer {
+  final Set<RendererSpec> _rendererSpecs;
+
+  _RendererGatherer._(this._rendererSpecs);
+
+  factory _RendererGatherer(LibraryElement entryLib) {
+    final rendererSpecs = <RendererSpec>{};
+
+    void addRendererSpecs(List<ElementAnnotation> annotations) {
+      for (var annotation in annotations) {
+        if (annotation == null) continue;
+        if (annotation.element is ConstructorElement) {
+          if (annotation.element.enclosingElement.name == 'Renderer') {
+            rendererSpecs.add(_buildRendererSpec(annotation));
+          }
+        } else if (annotation.element is ConstructorMember) {
+          if (annotation.element.enclosingElement.name == 'Renderer') {
+            rendererSpecs.add(_buildRendererSpec(annotation));
+          }
+        }
+      }
+    }
+
+    if (entryLib.metadata != null) {
+      addRendererSpecs(entryLib.metadata);
+    }
+    for (final element in entryLib.topLevelElements) {
+      if (element.metadata != null) {
+        addRendererSpecs(element.metadata);
+      }
+    }
+    return _RendererGatherer._(rendererSpecs);
+  }
+
+  static RendererSpec _buildRendererSpec(ElementAnnotation annotation) {
+    var constantValue = annotation.computeConstantValue();
+    var nameField = constantValue.getField('name');
+    if (nameField.isNull) {
+      throw StateError('@Renderer name must not be null');
+    }
+    var contextField = constantValue.getField('context');
+    if (contextField.isNull) {
+      throw StateError('@Renderer context must not be null');
+    }
+    var contextFieldType = contextField.type;
+    assert(contextFieldType.typeArguments.length == 1);
+    var contextType = contextFieldType.typeArguments.single;
+    var templateUriField = constantValue.getField('templateUri');
+    if (templateUriField.isNull) {
+      throw StateError('@Renderer templateUri must not be null');
+    }
+
+    return RendererSpec(nameField.toSymbolValue(), contextType);
+  }
+}
+
+Builder mustachioBuilder(BuilderOptions options) => MustachioBuilder();

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -1,0 +1,166 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:dart_style/dart_style.dart';
+
+/// The specification of a renderer, as derived from a @Renderer annotation.
+class RendererSpec {
+  /// The name of the render function.
+  final String _name;
+
+  final InterfaceType _contextType;
+
+  RendererSpec(this._name, this._contextType);
+}
+
+/// Builds [specs] into a Dart library containing runtime renderers.
+String buildTemplateRenderers(Set<RendererSpec> specs) {
+  var raw = RuntimeRenderersBuilder()._buildTemplateRenderers(specs);
+  return DartFormatter().format(raw.toString());
+}
+
+/// This class builds runtime Mustache renderers from a set of [RendererSpec]s.
+class RuntimeRenderersBuilder {
+  final _buffer = StringBuffer();
+
+  /// A queue of types to process, in order to find all types for which we need
+  /// to build renderers.
+  final _typesToProcess = Queue<_RendererInfo>();
+
+  /// Maps a type to the name of the render function which can render that type
+  /// as a context type.
+  final _typeToRenderFunctionName = <InterfaceType, String>{};
+
+  /// Maps a type to the name of the renderer class which can render that type
+  /// as a context type.
+  final _typeToRendererClassName = <InterfaceType, String>{};
+
+  RuntimeRenderersBuilder();
+
+  String _buildTemplateRenderers(Set<RendererSpec> specs) {
+    _buffer.writeln('''
+// ignore_for_file: camel_case_types
+import 'package:dartdoc/src/mustachio/renderer_base.dart';
+import 'package:dartdoc/src/mustachio/parser.dart';
+''');
+
+    specs.forEach(_addTypesForRendererSpec);
+
+    while (_typesToProcess.isNotEmpty) {
+      var info = _typesToProcess.removeFirst();
+
+      _typeToRenderFunctionName[info._contextType] = info._functionName;
+      _typeToRendererClassName[info._contextType] = info._rendererClassName;
+      _buildRenderer(info);
+    }
+
+    return _buffer.toString();
+  }
+
+  void _addTypesForRendererSpec(RendererSpec spec) {
+    var element = spec._contextType.element;
+    _typesToProcess.add(_RendererInfo(element.thisType, spec._name));
+    _typeToRenderFunctionName[element.thisType] = spec._name;
+    _typeToRendererClassName[element.thisType] = element.name;
+
+    spec._contextType.accessors.forEach(_addPropertyToProcess);
+    var superclass = spec._contextType.superclass;
+    while (superclass != null) {
+      _addTypeToProcess(superclass.element.thisType);
+      superclass.accessors.forEach(_addPropertyToProcess);
+      superclass = superclass.superclass;
+    }
+  }
+
+  /// Adds the return type of [property] to the [_typesToProcess] queue, if it
+  /// is a "valid" property.
+  ///
+  /// A "valid" property is a public, instance getter with an interface type
+  /// return type.
+  void _addPropertyToProcess(PropertyAccessorElement property) {
+    if (property.isPrivate || property.isStatic || property.isSetter) return;
+    var type = property.type.returnType;
+    while (type != null && type is InterfaceType) {
+      _addTypeToProcess((type as InterfaceType).element.thisType);
+      type = (type as InterfaceType).superclass;
+    }
+  }
+
+  /// Adds [type] to the [_typesToProcess] queue, if it is not already there.
+  void _addTypeToProcess(InterfaceType type) {
+    var typeName = type.element.name;
+    var rendererName = '_render_$typeName';
+    var typeToProcess = _typesToProcess
+        .singleWhere((rs) => rs._contextType == type, orElse: () => null);
+    if (typeToProcess == null) {
+      return _typesToProcess.add(_RendererInfo(type, rendererName));
+    }
+  }
+
+  /// Builds both the render function and the renderer class for [renderer].
+  ///
+  /// The function and the class are each written as Dart code to [_buffer].
+  void _buildRenderer(_RendererInfo renderer) {
+    var typeName = renderer._typeName;
+    _buffer.writeln('''
+String ${renderer._functionName}${renderer._typeParametersString}(
+    $typeName context, List<MustachioNode> ast) {
+  var renderer = ${renderer._rendererClassName}(context);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+''');
+
+    _buffer.write('''
+class ${renderer._rendererClassName}${renderer._typeParametersString}
+    extends RendererBase<$typeName> {
+  ${renderer._rendererClassName}($typeName context) : super(context);
+}
+''');
+  }
+}
+
+/// A container with the information needed to distinguish one
+/// renderer-to-be-built from another.
+///
+/// This can be used when building a set of renderers to build (both the render
+/// functions and the renderer class), and also to refer from one renderer to
+/// another.
+class _RendererInfo {
+  final InterfaceType _contextType;
+
+  /// The name of the top level render function.
+  ///
+  /// This function is public when specified in a @Renderer annotation, and
+  /// private otherwise.
+  final String _functionName;
+
+  _RendererInfo(this._contextType, this._functionName);
+
+  String get _typeName => _contextType.getDisplayString(withNullability: false);
+
+  /// The name of the context type, without any type parameters, type arguments,
+  /// or nullability tokens.
+  String get _typeBaseName => _contextType.element.name;
+
+  String get _rendererClassName => '_Renderer_$_typeBaseName';
+
+  /// The type parameters of the context type, if any, as a String, including
+  /// the angled brackets.
+  String get _typeParametersString {
+    var typeParamters = _contextType.element.typeParameters;
+    if (typeParamters.isEmpty) {
+      return '';
+    } else {
+      var parameterStrings = typeParamters.map((tp) {
+        return tp.getDisplayString(withNullability: false);
+      });
+      return '<${parameterStrings.join(', ')}>';
+    }
+  }
+}


### PR DESCRIPTION
This change is mostly concerned with gathering 'Renderer' annotations (which
isn't included yet; only a mock is included in specs), and walking the graph of
properties and types to gather all of the types which need renderers, for
resolving keys into property values.

There isn't much generated code in this change, but the base renderer is
included, which is referenced in generated renderer classes (stubs, for now).