### PR TITLE
Change scope for dartdoc configuration to the library being documented

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1405,19 +1405,21 @@ class DartdocOptionContext extends DartdocOptionContextBase
   /// Build a DartdocOptionContext from an analyzer element (using its source
   /// location).
   factory DartdocOptionContext.fromElement(DartdocOptionSet optionSet,
-      Element element, ResourceProvider resourceProvider) {
-    return DartdocOptionContext(optionSet,
-        resourceProvider.getFile(element.source.fullName), resourceProvider);
+      LibraryElement libraryElement, ResourceProvider resourceProvider) {
+    return DartdocOptionContext(
+        optionSet,
+        resourceProvider.getFile(libraryElement.source.fullName),
+        resourceProvider);
   }
 
   /// Build a DartdocOptionContext from an existing [DartdocOptionContext] and a
   /// new analyzer [Element].
   factory DartdocOptionContext.fromContextElement(
       DartdocOptionContext optionContext,
-      Element element,
+      LibraryElement libraryElement,
       ResourceProvider resourceProvider) {
     return DartdocOptionContext.fromElement(
-        optionContext.optionSet, element, resourceProvider);
+        optionContext.optionSet, libraryElement, resourceProvider);
   }
 
   /// Build a DartdocOptionContext from an existing [DartdocOptionContext].

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -182,17 +182,6 @@ class Category extends Nameable
   }
 
   @override
-  void warn(PackageWarning kind,
-      {String message,
-      Iterable<Locatable> referredFrom,
-      Iterable<String> extendedDebug}) {
-    packageGraph.warnOnElement(this, kind,
-        message: message,
-        referredFrom: referredFrom,
-        extendedDebug: extendedDebug);
-  }
-
-  @override
   Iterable<Class> get classes => _classes;
 
   @override

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -508,7 +508,7 @@ abstract class ModelElement extends Canonicalization
   @override
   DartdocOptionContext get config {
     _config ??= DartdocOptionContext.fromContextElement(
-        packageGraph.config, element, packageGraph.resourceProvider);
+        packageGraph.config, library.element, packageGraph.resourceProvider);
     return _config;
   }
 
@@ -1103,17 +1103,6 @@ abstract class ModelElement extends Canonicalization
           .toList());
     }
     return _parameters;
-  }
-
-  @override
-  void warn(PackageWarning kind,
-      {String message,
-      Iterable<Locatable> referredFrom,
-      Iterable<String> extendedDebug}) {
-    packageGraph.warnOnElement(this, kind,
-        message: message,
-        referredFrom: referredFrom,
-        extendedDebug: extendedDebug);
   }
 
   @override

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -369,17 +369,6 @@ class Package extends LibraryContainer
 
   String get version => packageMeta.version ?? '0.0.0-unknown';
 
-  @override
-  void warn(PackageWarning kind,
-      {String message,
-      Iterable<Locatable> referredFrom,
-      Iterable<String> extendedDebug}) {
-    packageGraph.warnOnElement(this, kind,
-        message: message,
-        referredFrom: referredFrom,
-        extendedDebug: extendedDebug);
-  }
-
   final PackageMeta _packageMeta;
 
   PackageMeta get packageMeta => _packageMeta;

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -258,15 +258,22 @@ final Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
 
 /// Something that package warnings can be called on.  Optionally associated
 /// with an analyzer [element].
-abstract class Warnable implements Canonicalization {
-  void warn(PackageWarning warning,
-      {String message, Iterable<Locatable> referredFrom});
-
+mixin Warnable implements Canonicalization {
   Element get element;
 
   Warnable get enclosingElement;
 
   Package get package;
+
+  void warn(PackageWarning kind,
+      {String message,
+      Iterable<Locatable> referredFrom,
+      Iterable<String> extendedDebug}) {
+    packageGraph.warnOnElement(this, kind,
+        message: message,
+        referredFrom: referredFrom,
+        extendedDebug: extendedDebug);
+  }
 }
 
 // The kinds of warnings that can be displayed when documenting a package.


### PR DESCRIPTION
Fixes #2428.

Using the dartdoc configuration for the defining element's location rather than the documented library results in unexpected user behavior (the same library sometimes documents different elements with the same warning as "error" and "warning").  This also makes it impossible to work around situations like #2389.

Fixed.  I'm not sure a useful test can be made for this -- I could write something but it would simply be restating the code a different way.