### PR TITLE
Mustachio: Add property maps for each renderer class

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -16,6 +16,51 @@ String renderIndex(PackageTemplateData context, List<MustachioNode> ast) {
 }
 
 class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
+  static Map<String, Property<PackageTemplateData>> propertyMap() => {
+        'hasHomepage': Property(
+          getValue: (PackageTemplateData c) => c.hasHomepage,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (PackageTemplateData c) => c.hasHomepage == true,
+        ),
+        'homepage': Property(
+          getValue: (PackageTemplateData c) => c.homepage,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'htmlBase': Property(
+          getValue: (PackageTemplateData c) => c.htmlBase,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'includeVersion': Property(
+          getValue: (PackageTemplateData c) => c.includeVersion,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (PackageTemplateData c) => c.includeVersion == true,
+        ),
+        'layoutTitle': Property(
+          getValue: (PackageTemplateData c) => c.layoutTitle,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'metaDescription': Property(
+          getValue: (PackageTemplateData c) => c.metaDescription,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'navLinks': Property(
+          getValue: (PackageTemplateData c) => c.navLinks,
+        ),
+        'package': Property(
+          getValue: (PackageTemplateData c) => c.package,
+          getProperties: _Renderer_Package.propertyMap,
+        ),
+        'self': Property(
+          getValue: (PackageTemplateData c) => c.self,
+          getProperties: _Renderer_Package.propertyMap,
+        ),
+        'title': Property(
+          getValue: (PackageTemplateData c) => c.title,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        ..._Renderer_TemplateData.propertyMap<Package>(),
+      };
+
   _Renderer_PackageTemplateData(PackageTemplateData context) : super(context);
 }
 
@@ -26,6 +71,196 @@ String _render_Package(Package context, List<MustachioNode> ast) {
 }
 
 class _Renderer_Package extends RendererBase<Package> {
+  static Map<String, Property<Package>> propertyMap() => {
+        'allLibraries': Property(
+          getValue: (Package c) => c.allLibraries,
+        ),
+        'baseHref': Property(
+          getValue: (Package c) => c.baseHref,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'canonicalLibrary': Property(
+          getValue: (Package c) => c.canonicalLibrary,
+        ),
+        'categories': Property(
+          getValue: (Package c) => c.categories,
+        ),
+        'categoriesWithPublicLibraries': Property(
+          getValue: (Package c) => c.categoriesWithPublicLibraries,
+        ),
+        'config': Property(
+          getValue: (Package c) => c.config,
+        ),
+        'containerOrder': Property(
+          getValue: (Package c) => c.containerOrder,
+        ),
+        'defaultCategory': Property(
+          getValue: (Package c) => c.defaultCategory,
+          getProperties: _Renderer_LibraryContainer.propertyMap,
+        ),
+        'documentation': Property(
+          getValue: (Package c) => c.documentation,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'documentationAsHtml': Property(
+          getValue: (Package c) => c.documentationAsHtml,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'documentationFile': Property(
+          getValue: (Package c) => c.documentationFile,
+        ),
+        'documentationFrom': Property(
+          getValue: (Package c) => c.documentationFrom,
+        ),
+        'documentedCategories': Property(
+          getValue: (Package c) => c.documentedCategories,
+        ),
+        'documentedWhere': Property(
+          getValue: (Package c) => c.documentedWhere,
+        ),
+        'element': Property(
+          getValue: (Package c) => c.element,
+        ),
+        'enclosingElement': Property(
+          getValue: (Package c) => c.enclosingElement,
+        ),
+        'enclosingName': Property(
+          getValue: (Package c) => c.enclosingName,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'filePath': Property(
+          getValue: (Package c) => c.filePath,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'fileType': Property(
+          getValue: (Package c) => c.fileType,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'fullyQualifiedName': Property(
+          getValue: (Package c) => c.fullyQualifiedName,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'hasCategories': Property(
+          getValue: (Package c) => c.hasCategories,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.hasCategories == true,
+        ),
+        'hasDocumentation': Property(
+          getValue: (Package c) => c.hasDocumentation,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.hasDocumentation == true,
+        ),
+        'hasDocumentationFile': Property(
+          getValue: (Package c) => c.hasDocumentationFile,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.hasDocumentationFile == true,
+        ),
+        'hasDocumentedCategories': Property(
+          getValue: (Package c) => c.hasDocumentedCategories,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.hasDocumentedCategories == true,
+        ),
+        'hasExtendedDocumentation': Property(
+          getValue: (Package c) => c.hasExtendedDocumentation,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.hasExtendedDocumentation == true,
+        ),
+        'hasHomepage': Property(
+          getValue: (Package c) => c.hasHomepage,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.hasHomepage == true,
+        ),
+        'homepage': Property(
+          getValue: (Package c) => c.homepage,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'href': Property(
+          getValue: (Package c) => c.href,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'isCanonical': Property(
+          getValue: (Package c) => c.isCanonical,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.isCanonical == true,
+        ),
+        'isDocumented': Property(
+          getValue: (Package c) => c.isDocumented,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.isDocumented == true,
+        ),
+        'isFirstPackage': Property(
+          getValue: (Package c) => c.isFirstPackage,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.isFirstPackage == true,
+        ),
+        'isLocal': Property(
+          getValue: (Package c) => c.isLocal,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.isLocal == true,
+        ),
+        'isPublic': Property(
+          getValue: (Package c) => c.isPublic,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.isPublic == true,
+        ),
+        'isSdk': Property(
+          getValue: (Package c) => c.isSdk,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Package c) => c.isSdk == true,
+        ),
+        'kind': Property(
+          getValue: (Package c) => c.kind,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'location': Property(
+          getValue: (Package c) => c.location,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'locationPieces': Property(
+          getValue: (Package c) => c.locationPieces,
+        ),
+        'name': Property(
+          getValue: (Package c) => c.name,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'nameToCategory': Property(
+          getValue: (Package c) => c.nameToCategory,
+        ),
+        'oneLineDoc': Property(
+          getValue: (Package c) => c.oneLineDoc,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'package': Property(
+          getValue: (Package c) => c.package,
+          getProperties: _Renderer_Package.propertyMap,
+        ),
+        'packageGraph': Property(
+          getValue: (Package c) => c.packageGraph,
+        ),
+        'packageMeta': Property(
+          getValue: (Package c) => c.packageMeta,
+        ),
+        'packagePath': Property(
+          getValue: (Package c) => c.packagePath,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'publicLibraries': Property(
+          getValue: (Package c) => c.publicLibraries,
+        ),
+        'toolInvocationIndex': Property(
+          getValue: (Package c) => c.toolInvocationIndex,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'usedAnimationIdsByHref': Property(
+          getValue: (Package c) => c.usedAnimationIdsByHref,
+        ),
+        'version': Property(
+          getValue: (Package c) => c.version,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        ..._Renderer_LibraryContainer.propertyMap(),
+      };
+
   _Renderer_Package(Package context) : super(context);
 }
 
@@ -37,6 +272,40 @@ String _render_LibraryContainer(
 }
 
 class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
+  static Map<String, Property<LibraryContainer>> propertyMap() => {
+        'containerOrder': Property(
+          getValue: (LibraryContainer c) => c.containerOrder,
+        ),
+        'enclosingName': Property(
+          getValue: (LibraryContainer c) => c.enclosingName,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'hasPublicLibraries': Property(
+          getValue: (LibraryContainer c) => c.hasPublicLibraries,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (LibraryContainer c) => c.hasPublicLibraries == true,
+        ),
+        'isSdk': Property(
+          getValue: (LibraryContainer c) => c.isSdk,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (LibraryContainer c) => c.isSdk == true,
+        ),
+        'libraries': Property(
+          getValue: (LibraryContainer c) => c.libraries,
+        ),
+        'packageGraph': Property(
+          getValue: (LibraryContainer c) => c.packageGraph,
+        ),
+        'publicLibraries': Property(
+          getValue: (LibraryContainer c) => c.publicLibraries,
+        ),
+        'sortKey': Property(
+          getValue: (LibraryContainer c) => c.sortKey,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_LibraryContainer(LibraryContainer context) : super(context);
 }
 
@@ -47,6 +316,17 @@ String _render_Object(Object context, List<MustachioNode> ast) {
 }
 
 class _Renderer_Object extends RendererBase<Object> {
+  static Map<String, Property<Object>> propertyMap() => {
+        'hashCode': Property(
+          getValue: (Object c) => c.hashCode,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'runtimeType': Property(
+          getValue: (Object c) => c.runtimeType,
+          getProperties: _Renderer_Type.propertyMap,
+        ),
+      };
+
   _Renderer_Object(Object context) : super(context);
 }
 
@@ -57,6 +337,14 @@ String _render_bool(bool context, List<MustachioNode> ast) {
 }
 
 class _Renderer_bool extends RendererBase<bool> {
+  static Map<String, Property<bool>> propertyMap() => {
+        'hashCode': Property(
+          getValue: (bool c) => c.hashCode,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_bool(bool context) : super(context);
 }
 
@@ -67,6 +355,17 @@ String _render_List<E>(List<E> context, List<MustachioNode> ast) {
 }
 
 class _Renderer_List<E> extends RendererBase<List<E>> {
+  static Map<String, Property<List<E>>> propertyMap<E>() => {
+        'length': Property(
+          getValue: (List<E> c) => c.length,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'reversed': Property(
+          getValue: (List<E> c) => c.reversed,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_List(List<E> context) : super(context);
 }
 
@@ -77,6 +376,34 @@ String _render_String(String context, List<MustachioNode> ast) {
 }
 
 class _Renderer_String extends RendererBase<String> {
+  static Map<String, Property<String>> propertyMap() => {
+        'codeUnits': Property(
+          getValue: (String c) => c.codeUnits,
+        ),
+        'hashCode': Property(
+          getValue: (String c) => c.hashCode,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'isEmpty': Property(
+          getValue: (String c) => c.isEmpty,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (String c) => c.isEmpty == true,
+        ),
+        'isNotEmpty': Property(
+          getValue: (String c) => c.isNotEmpty,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (String c) => c.isNotEmpty == true,
+        ),
+        'length': Property(
+          getValue: (String c) => c.length,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'runes': Property(
+          getValue: (String c) => c.runes,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_String(String context) : super(context);
 }
 
@@ -89,6 +416,87 @@ String _render_TemplateData<T extends Documentable>(
 
 class _Renderer_TemplateData<T extends Documentable>
     extends RendererBase<TemplateData<T>> {
+  static Map<String, Property<TemplateData<T>>>
+      propertyMap<T extends Documentable>() => {
+            'bareHref': Property(
+              getValue: (TemplateData<T> c) => c.bareHref,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'defaultPackage': Property(
+              getValue: (TemplateData<T> c) => c.defaultPackage,
+              getProperties: _Renderer_Package.propertyMap,
+            ),
+            'hasFooterVersion': Property(
+              getValue: (TemplateData<T> c) => c.hasFooterVersion,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (TemplateData<T> c) => c.hasFooterVersion == true,
+            ),
+            'hasHomepage': Property(
+              getValue: (TemplateData<T> c) => c.hasHomepage,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (TemplateData<T> c) => c.hasHomepage == true,
+            ),
+            'homepage': Property(
+              getValue: (TemplateData<T> c) => c.homepage,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'htmlBase': Property(
+              getValue: (TemplateData<T> c) => c.htmlBase,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'htmlOptions': Property(
+              getValue: (TemplateData<T> c) => c.htmlOptions,
+              getProperties: _Renderer_TemplateOptions.propertyMap,
+            ),
+            'includeVersion': Property(
+              getValue: (TemplateData<T> c) => c.includeVersion,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (TemplateData<T> c) => c.includeVersion == true,
+            ),
+            'layoutTitle': Property(
+              getValue: (TemplateData<T> c) => c.layoutTitle,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'localPackages': Property(
+              getValue: (TemplateData<T> c) => c.localPackages,
+            ),
+            'metaDescription': Property(
+              getValue: (TemplateData<T> c) => c.metaDescription,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'navLinks': Property(
+              getValue: (TemplateData<T> c) => c.navLinks,
+            ),
+            'navLinksWithGenerics': Property(
+              getValue: (TemplateData<T> c) => c.navLinksWithGenerics,
+            ),
+            'parent': Property(
+              getValue: (TemplateData<T> c) => c.parent,
+              getProperties: _Renderer_Documentable.propertyMap,
+            ),
+            'relCanonicalPrefix': Property(
+              getValue: (TemplateData<T> c) => c.relCanonicalPrefix,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'self': Property(
+              getValue: (TemplateData<T> c) => c.self,
+            ),
+            'title': Property(
+              getValue: (TemplateData<T> c) => c.title,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'useBaseHref': Property(
+              getValue: (TemplateData<T> c) => c.useBaseHref,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (TemplateData<T> c) => c.useBaseHref == true,
+            ),
+            'version': Property(
+              getValue: (TemplateData<T> c) => c.version,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            ..._Renderer_Object.propertyMap(),
+          };
+
   _Renderer_TemplateData(TemplateData<T> context) : super(context);
 }
 
@@ -100,6 +508,23 @@ String _render_TemplateOptions(
 }
 
 class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
+  static Map<String, Property<TemplateOptions>> propertyMap() => {
+        'relCanonicalPrefix': Property(
+          getValue: (TemplateOptions c) => c.relCanonicalPrefix,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'toolVersion': Property(
+          getValue: (TemplateOptions c) => c.toolVersion,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'useBaseHref': Property(
+          getValue: (TemplateOptions c) => c.useBaseHref,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (TemplateOptions c) => c.useBaseHref == true,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_TemplateOptions(TemplateOptions context) : super(context);
 }
 
@@ -110,6 +535,51 @@ String _render_Documentable(Documentable context, List<MustachioNode> ast) {
 }
 
 class _Renderer_Documentable extends RendererBase<Documentable> {
+  static Map<String, Property<Documentable>> propertyMap() => {
+        'config': Property(
+          getValue: (Documentable c) => c.config,
+        ),
+        'documentation': Property(
+          getValue: (Documentable c) => c.documentation,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'documentationAsHtml': Property(
+          getValue: (Documentable c) => c.documentationAsHtml,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'hasDocumentation': Property(
+          getValue: (Documentable c) => c.hasDocumentation,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Documentable c) => c.hasDocumentation == true,
+        ),
+        'hasExtendedDocumentation': Property(
+          getValue: (Documentable c) => c.hasExtendedDocumentation,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Documentable c) => c.hasExtendedDocumentation == true,
+        ),
+        'href': Property(
+          getValue: (Documentable c) => c.href,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'isDocumented': Property(
+          getValue: (Documentable c) => c.isDocumented,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Documentable c) => c.isDocumented == true,
+        ),
+        'kind': Property(
+          getValue: (Documentable c) => c.kind,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'oneLineDoc': Property(
+          getValue: (Documentable c) => c.oneLineDoc,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'packageGraph': Property(
+          getValue: (Documentable c) => c.packageGraph,
+        ),
+        ..._Renderer_Nameable.propertyMap(),
+      };
+
   _Renderer_Documentable(Documentable context) : super(context);
 }
 
@@ -120,6 +590,25 @@ String _render_Nameable(Nameable context, List<MustachioNode> ast) {
 }
 
 class _Renderer_Nameable extends RendererBase<Nameable> {
+  static Map<String, Property<Nameable>> propertyMap() => {
+        'fullyQualifiedName': Property(
+          getValue: (Nameable c) => c.fullyQualifiedName,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'name': Property(
+          getValue: (Nameable c) => c.name,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'namePart': Property(
+          getValue: (Nameable c) => c.namePart,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+        'namePieces': Property(
+          getValue: (Nameable c) => c.namePieces,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_Nameable(Nameable context) : super(context);
 }
 
@@ -130,6 +619,28 @@ String _render_int(int context, List<MustachioNode> ast) {
 }
 
 class _Renderer_int extends RendererBase<int> {
+  static Map<String, Property<int>> propertyMap() => {
+        'bitLength': Property(
+          getValue: (int c) => c.bitLength,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'isEven': Property(
+          getValue: (int c) => c.isEven,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (int c) => c.isEven == true,
+        ),
+        'isOdd': Property(
+          getValue: (int c) => c.isOdd,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (int c) => c.isOdd == true,
+        ),
+        'sign': Property(
+          getValue: (int c) => c.sign,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        ..._Renderer_num.propertyMap(),
+      };
+
   _Renderer_int(int context) : super(context);
 }
 
@@ -140,6 +651,38 @@ String _render_num(num context, List<MustachioNode> ast) {
 }
 
 class _Renderer_num extends RendererBase<num> {
+  static Map<String, Property<num>> propertyMap() => {
+        'hashCode': Property(
+          getValue: (num c) => c.hashCode,
+          getProperties: _Renderer_int.propertyMap,
+        ),
+        'isFinite': Property(
+          getValue: (num c) => c.isFinite,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (num c) => c.isFinite == true,
+        ),
+        'isInfinite': Property(
+          getValue: (num c) => c.isInfinite,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (num c) => c.isInfinite == true,
+        ),
+        'isNaN': Property(
+          getValue: (num c) => c.isNaN,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (num c) => c.isNaN == true,
+        ),
+        'isNegative': Property(
+          getValue: (num c) => c.isNegative,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (num c) => c.isNegative == true,
+        ),
+        'sign': Property(
+          getValue: (num c) => c.sign,
+          getProperties: _Renderer_num.propertyMap,
+        ),
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_num(num context) : super(context);
 }
 
@@ -150,5 +693,9 @@ String _render_Type(Type context, List<MustachioNode> ast) {
 }
 
 class _Renderer_Type extends RendererBase<Type> {
+  static Map<String, Property<Type>> propertyMap() => {
+        ..._Renderer_Object.propertyMap(),
+      };
+
   _Renderer_Type(Type context) : super(context);
 }

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -321,10 +321,6 @@ class _Renderer_Object extends RendererBase<Object> {
           getValue: (Object c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
-        'runtimeType': Property(
-          getValue: (Object c) => c.runtimeType,
-          getProperties: _Renderer_Type.propertyMap,
-        ),
       };
 
   _Renderer_Object(Object context) : super(context);
@@ -684,18 +680,4 @@ class _Renderer_num extends RendererBase<num> {
       };
 
   _Renderer_num(num context) : super(context);
-}
-
-String _render_Type(Type context, List<MustachioNode> ast) {
-  var renderer = _Renderer_Type(context);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class _Renderer_Type extends RendererBase<Type> {
-  static Map<String, Property<Type>> propertyMap() => {
-        ..._Renderer_Object.propertyMap(),
-      };
-
-  _Renderer_Type(Type context) : super(context);
 }

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
 import 'parser.dart';
 
 /// The base class for a generated Mustache renderer.
@@ -38,4 +39,17 @@ abstract class RendererBase<T> {
   void partial(Partial node) {
     // TODO(srawlins): Implement.
   }
+}
+
+/// An individual property of objects of type [T], including functions for
+/// rendering various types of Mustache nodes.
+class Property<T> {
+  final Object /*?*/ Function(T) /*!*/ getValue;
+  final Map<String /*!*/, Property<Object> /*!*/ >
+      Function() /*?*/ getProperties;
+  final bool /*!*/ Function(T) /*?*/ getBool;
+  // TODO(srawlins): Add functions for rendering Iterable properties and other
+  // properties.
+
+  Property({@required this.getValue, this.getProperties, this.getBool});
 }

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -44,10 +44,17 @@ abstract class RendererBase<T> {
 /// An individual property of objects of type [T], including functions for
 /// rendering various types of Mustache nodes.
 class Property<T> {
-  final Object /*?*/ Function(T) /*!*/ getValue;
+  /// Gets the value of this property on the object [context].
+  final Object /*?*/ Function(T context) /*!*/ getValue;
+
+  /// Gets the property map of the type of this property.
   final Map<String /*!*/, Property<Object> /*!*/ >
       Function() /*?*/ getProperties;
-  final bool /*!*/ Function(T) /*?*/ getBool;
+
+  /// Gets the bool value (true or false, never null) of this property on the
+  /// object [context].
+  final bool /*!*/ Function(T context) /*?*/ getBool;
+
   // TODO(srawlins): Add functions for rendering Iterable properties and other
   // properties.
 

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -28,19 +28,6 @@ library foo;
 import 'package:mustachio/annotations.dart';
 ''';
 
-TypeMatcher<List<int>> _containsAllOf(Object a,
-    [Object b, Object c, Object d]) {
-  if (d != null) {
-    return decodedMatches(
-        allOf(contains(a), contains(b), contains(c), contains(d)));
-  } else if (c != null) {
-    return decodedMatches(allOf(contains(a), contains(b), contains(c)));
-  } else {
-    return decodedMatches(
-        b != null ? allOf(contains(a), contains(b)) : allOf(contains(a)));
-  }
-}
-
 void main() {
   InMemoryAssetWriter writer;
 
@@ -75,39 +62,88 @@ $sourceLibraryContent
     writer = InMemoryAssetWriter();
   });
 
-  test('builds a renderer for a class which extends Object', () async {
-    await testMustachioBuilder('''
-class Foo {}
-''', outputs: {
-      'foo|lib/foo.renderers.dart': _containsAllOf(
-          // The requested 'renderFoo' function
-          '''
-String renderFoo(Foo context, List<MustachioNode> ast) {
-  var renderer = _Renderer_Foo(context);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
+  group('builds a renderer class', () {
+    LibraryElement renderersLibrary;
+    String generatedContent;
+
+    // Builders are fairly expensive (about 4 seconds per `testBuilder` call),
+    // so this [setUpAll] saves significant time over [setUp].
+    setUpAll(() async {
+      writer = InMemoryAssetWriter();
+      await testMustachioBuilder('''
+abstract class FooBase {
+  Bar get bar;
 }
-''',
-          // The renderer class for Foo
-          '''
-class _Renderer_Foo extends RendererBase<Foo> {
-  _Renderer_Foo(Foo context) : super(context);
+class Foo extends FooBase {
+  String s1 = "s1";
+  bool b1 = false;
 }
-''',
-          // The render function for Object
-          '''
-String _render_Object(Object context, List<MustachioNode> ast) {
-  var renderer = _Renderer_Object(context);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-''',
-          // The renderer class for Object
-          '''
-class _Renderer_Object extends RendererBase<Object> {
-  _Renderer_Object(Object context) : super(context);
-}
-''')
+class Bar {}
+''');
+      renderersLibrary = await resolveGeneratedLibrary(writer);
+      var rendererAsset = AssetId.parse('foo|lib/foo.renderers.dart');
+      generatedContent = utf8.decode(writer.assets[rendererAsset]);
+    });
+
+    test('for a class which implicitly extends Object', () {
+      // The render function for Foo
+      expect(
+          generatedContent,
+          contains(
+              'String _render_FooBase(FooBase context, List<MustachioNode> ast)'));
+      // The renderer class for Foo
+      expect(generatedContent,
+          contains('class _Renderer_FooBase extends RendererBase<FooBase>'));
+    });
+
+    test('for Object', () {
+      // The render function for Object
+      expect(
+          generatedContent,
+          contains(
+              'String _render_Object(Object context, List<MustachioNode> ast) {'));
+      // The renderer class for Object
+      expect(generatedContent,
+          contains('class _Renderer_Object extends RendererBase<Object> {'));
+    });
+
+    test('for a class which is extended by a rendered class', () {
+      expect(
+          renderersLibrary.getTopLevelFunction('_render_FooBase'), isNotNull);
+      expect(renderersLibrary.getType('_Renderer_FooBase'), isNotNull);
+    });
+
+    test('for a type found in a getter', () {
+      expect(renderersLibrary.getTopLevelFunction('_render_Bar'), isNotNull);
+      expect(renderersLibrary.getType('_Renderer_Bar'), isNotNull);
+    });
+
+    test('with a property map', () {
+      expect(generatedContent,
+          contains('static Map<String, Property<Foo>> propertyMap() => {'));
+    });
+
+    test('with a property map with a String property', () {
+      expect(generatedContent, contains('''
+        's1': Property(
+          getValue: (Foo c) => c.s1,
+          getProperties: _Renderer_String.propertyMap,
+        ),
+'''));
+    });
+
+    test('with a property map which references the superclass', () {
+      expect(generatedContent, contains('..._Renderer_FooBase.propertyMap(),'));
+    });
+
+    test('with a property map with a bool property', () {
+      expect(generatedContent, contains('''
+        'b1': Property(
+          getValue: (Foo c) => c.b1,
+          getProperties: _Renderer_bool.propertyMap,
+          getBool: (Foo c) => c.b1 == true,
+        ),
+'''));
     });
   });
 
@@ -129,69 +165,53 @@ import 'package:mustachio/annotations.dart';
     expect(renderersLibrary.getType('_Renderer_Bar'), isNotNull);
   });
 
-  test('builds a renderer for a class which is extended by a rendered class',
-      () async {
-    await testMustachioBuilder('''
-class FooBase {}
-class Foo extends FooBase {}
+  group('builds a renderer class for a generic type', () {
+    String generatedContent;
+
+    // Builders are fairly expensive (about 4 seconds per `testBuilder` call),
+    // so this [setUpAll] saves significant time over [setUp].
+    setUpAll(() async {
+      writer = InMemoryAssetWriter();
+      await testMustachioBuilder('''
+class FooBase<T> {}
+class Foo<T> extends FooBase<T> {}
+class BarBase<T> {}
+class Bar<T> extends BarBase<int> {}
+''', libraryFrontMatter: '''
+@Renderer(#renderFoo, Context<Foo>())
+@Renderer(#renderBar, Context<Bar>())
+library foo;
+import 'package:mustachio/annotations.dart';
 ''');
-    var renderersLibrary = await resolveGeneratedLibrary(writer);
-
-    expect(renderersLibrary.getTopLevelFunction('_render_FooBase'), isNotNull);
-    expect(renderersLibrary.getType('_Renderer_FooBase'), isNotNull);
-  });
-
-  test('builds a renderer for a generic type', () async {
-    await testMustachioBuilder('''
-class Foo<T> {}
-''', outputs: {
-      'foo|lib/foo.renderers.dart': _containsAllOf(
-          // The requested 'renderFoo' function
-          'String renderFoo<T>(Foo<T> context, List<MustachioNode> ast)',
-          // The renderer class for Foo
-          'class _Renderer_Foo<T> extends RendererBase<Foo<T>>')
+      var rendererAsset = AssetId.parse('foo|lib/foo.renderers.dart');
+      generatedContent = utf8.decode(writer.assets[rendererAsset]);
     });
-  });
 
-  test('builds a renderer for a type found in a getter', () async {
-    await testMustachioBuilder('''
-abstract class Foo {
-  Bar get bar;
-}
-class Bar {}
-''');
-    var renderersLibrary = await resolveGeneratedLibrary(writer);
+    test('with a corresponding render function', () async {
+      expect(
+          generatedContent,
+          contains(
+              'String renderFoo<T>(Foo<T> context, List<MustachioNode> ast)'));
+    });
 
-    expect(renderersLibrary.getTopLevelFunction('_render_Bar'), isNotNull);
-    expect(renderersLibrary.getType('_Renderer_Bar'), isNotNull);
-  });
+    test('with a generic supertype type argument', () async {
+      expect(generatedContent,
+          contains('class _Renderer_Foo<T> extends RendererBase<Foo<T>>'));
+    });
 
-  test('skips a type found in a static or private getter', () async {
-    await testMustachioBuilder('''
-class Foo {
-  static Bar get bar1 => Bar();
-  Bar get _bar2 => Bar();
-}
-class Bar {}
-''');
-    var renderersLibrary = await resolveGeneratedLibrary(writer);
+    test(
+        'with a property map which references the superclass with a type '
+        'variable', () {
+      expect(
+          generatedContent, contains('..._Renderer_FooBase.propertyMap<T>(),'));
+    });
 
-    expect(renderersLibrary.getTopLevelFunction('_render_Bar'), isNull);
-    expect(renderersLibrary.getType('_Renderer_Bar'), isNull);
-  });
-
-  test('skips a type found in a setter or method', () async {
-    await testMustachioBuilder('''
-abstract class Foo {
-  void set bar1(Bar b);
-  Bar bar2(Bar b);
-}
-class Bar {}
-''');
-    var renderersLibrary = await resolveGeneratedLibrary(writer);
-
-    expect(renderersLibrary.getTopLevelFunction('_render_Bar'), isNull);
-    expect(renderersLibrary.getType('_Renderer_Bar'), isNull);
+    test(
+        'with a property map which references the superclass with an interface '
+        'type', () {
+      expect(generatedContent,
+          contains('..._Renderer_BarBase.propertyMap<int>(),'));
+    });
   });
 
   test('builds a renderer for a generic, bounded type', () async {
@@ -212,6 +232,47 @@ class Foo<T extends num> {}
 
     expect(renderersLibrary.getTopLevelFunction('_render_num'), isNotNull);
     expect(renderersLibrary.getType('_Renderer_num'), isNotNull);
+  });
+
+  group('does not generate a renderer', () {
+    LibraryElement renderersLibrary;
+
+    setUpAll(() async {
+      writer = InMemoryAssetWriter();
+      await testMustachioBuilder('''
+class Foo {
+  static Static get static1 => Bar();
+  Private get _private1 => Bar();
+  void set setter1(Setter s);
+  Method method1(Method m);
+}
+class Static {}
+class Private {}
+class Setter {}
+class Method {}
+''');
+      renderersLibrary = await resolveGeneratedLibrary(writer);
+    });
+
+    test('found in a static getter', () {
+      expect(renderersLibrary.getTopLevelFunction('_render_Static'), isNull);
+      expect(renderersLibrary.getType('_Renderer_Static'), isNull);
+    });
+
+    test('found in a private getter', () {
+      expect(renderersLibrary.getTopLevelFunction('_render_Private'), isNull);
+      expect(renderersLibrary.getType('_Renderer_Private'), isNull);
+    });
+
+    test('found in a setter', () {
+      expect(renderersLibrary.getTopLevelFunction('_render_Setter'), isNull);
+      expect(renderersLibrary.getType('_Renderer_Setter'), isNull);
+    });
+
+    test('found in a method', () {
+      expect(renderersLibrary.getTopLevelFunction('_render_Method'), isNull);
+      expect(renderersLibrary.getType('_Renderer_Method'), isNull);
+    });
   });
 }
 

--- a/tool/mustachio/builder.dart
+++ b/tool/mustachio/builder.dart
@@ -26,7 +26,8 @@ class MustachioBuilder implements Builder {
     var contents = '';
 
     if (rendererGatherer._rendererSpecs.isNotEmpty) {
-      contents += buildTemplateRenderers(rendererGatherer._rendererSpecs);
+      contents += buildTemplateRenderers(
+          rendererGatherer._rendererSpecs, entryLib.typeProvider);
 
       await buildStep.writeAsString(renderersLibrary, contents);
     }

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -182,7 +182,8 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
     var getterType = property.type.returnType;
     var getterName = property.name;
 
-    // Only add a `getProperties` function, which returns the
+    // Only add a `getProperties` function, which returns the property map for
+    // [getterType], if [getterType] is a renderable type.
     if (_typeToRendererClassName.containsKey(getterType)) {
       var rendererClassName = _typeToRendererClassName[getterType];
       _buffer.writeln('getProperties: $rendererClassName.propertyMap,');


### PR DESCRIPTION
These property maps provide functions for each valid property of a given type.
Currently the maps only reveal how to get a value (for a variable node) and
resolve a bool (for a conditional section). Still needed are Iterable functions
and value functions, for repeated and value sections, respectively.