### PR TITLE
Give the correct exception even if someone has run pub get already

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -51,8 +51,7 @@ class PubPackageBuilder implements PackageBuilder {
   @override
   Future<PackageGraph> buildPackageGraph() async {
     if (!config.sdkDocs) {
-      if (config.topLevelPackageMeta.needsPubGet &&
-          config.topLevelPackageMeta.requiresFlutter &&
+      if (config.topLevelPackageMeta.requiresFlutter &&
           config.flutterRoot == null) {
         throw DartdocOptionError(
             'Top level package requires Flutter but FLUTTER_ROOT environment variable not set');


### PR DESCRIPTION
Fixes #2407.

Previous code attempting to explain to the user what was wrong here gets missed if the user has run pub get before on their package (which isn't uncommon).