### PR TITLE
Fix missing null checks for YAML data

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1119,10 +1119,10 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
   _OptionValueWithContext<Object> _valueAtFromFile(Folder dir) {
     var yamlFileData = _yamlAtDirectory(dir);
     var contextPath = yamlFileData.canonicalDirectoryPath;
-    dynamic yamlData = yamlFileData.data;
+    dynamic yamlData = yamlFileData.data ?? {};
     for (var key in keys) {
       if (!yamlData.containsKey(key)) return null;
-      yamlData = yamlData[key];
+      yamlData = yamlData[key] ?? {};
     }
 
     var returnData;


### PR DESCRIPTION
Fixes #2378.

While #2348 eliminated the null dereference exception on path, there were some other unfortunate things going on in the YAML handling where we weren't checking nulls that show up right behind.