### PR TITLE
Mustachio: Add support for Iterable types in Property, some fixes

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -18,70 +18,80 @@ String renderIndex(PackageTemplateData context, List<MustachioNode> ast,
 }
 
 class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
-  static Map<String, Property> propertyMap() => {
-        'hasHomepage': Property(
-          getValue: (Object c) => (c as PackageTemplateData).hasHomepage,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as PackageTemplateData).hasHomepage == true,
-        ),
-        'homepage': Property(
-          getValue: (Object c) => (c as PackageTemplateData).homepage,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'htmlBase': Property(
-          getValue: (Object c) => (c as PackageTemplateData).htmlBase,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'includeVersion': Property(
-          getValue: (Object c) => (c as PackageTemplateData).includeVersion,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) =>
-              (c as PackageTemplateData).includeVersion == true,
-        ),
-        'layoutTitle': Property(
-          getValue: (Object c) => (c as PackageTemplateData).layoutTitle,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'metaDescription': Property(
-          getValue: (Object c) => (c as PackageTemplateData).metaDescription,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'navLinks': Property(
-          getValue: (Object c) => (c as PackageTemplateData).navLinks,
-          isEmptyIterable: (Object c) =>
-              (c as PackageTemplateData).navLinks?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<PackageTemplateData> r,
-              List<WhiskersNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in (c as PackageTemplateData).navLinks) {
-              buffer.write(_render_Documentable(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'package': Property(
-          getValue: (Object c) => (c as PackageTemplateData).package,
-          getProperties: _Renderer_Package.propertyMap,
-        ),
-        'self': Property(
-          getValue: (Object c) => (c as PackageTemplateData).self,
-          getProperties: _Renderer_Package.propertyMap,
-        ),
-        'title': Property(
-          getValue: (Object c) => (c as PackageTemplateData).title,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        ..._Renderer_TemplateData.propertyMap<Package>(),
-      };
+  static Map<String, Property<X_>>
+      propertyMap<X_ extends PackageTemplateData>() => {
+            'hasHomepage': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.hasHomepage,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (X_ c) => c.hasHomepage == true,
+            ),
+            'homepage': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.homepage,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'htmlBase': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.htmlBase,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'includeVersion': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.includeVersion,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (X_ c) => c.includeVersion == true,
+            ),
+            'layoutTitle': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.layoutTitle,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'metaDescription': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.metaDescription,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'navLinks': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.navLinks,
+              isEmptyIterable: (X_ c) => c.navLinks?.isEmpty ?? false,
+
+              renderIterable:
+                  (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.navLinks) {
+                  buffer.write(_render_Documentable(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'package': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.package,
+              getProperties: _Renderer_Package.propertyMap,
+            ),
+            'self': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.self,
+              getProperties: _Renderer_Package.propertyMap,
+            ),
+            'title': Property(
+              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+              getValue: (X_ c) => c.title,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            ..._Renderer_TemplateData.propertyMap<Package, X_>(),
+          };
 
   _Renderer_PackageTemplateData(
       PackageTemplateData context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<PackageTemplateData> getProperty(String key) {
+    if (propertyMap<PackageTemplateData>().containsKey(key)) {
+      return propertyMap<PackageTemplateData>()[key];
     } else {
       return null;
     }
@@ -96,105 +106,113 @@ String _render_Package(Package context, List<MustachioNode> ast,
 }
 
 class _Renderer_Package extends RendererBase<Package> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends Package>() => {
         'allLibraries': Property(
-          getValue: (Object c) => (c as Package).allLibraries,
-          isEmptyIterable: (Object c) =>
-              (c as Package).allLibraries?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.allLibraries,
+          isEmptyIterable: (X_ c) => c.allLibraries?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).allLibraries) {
+            for (var e in c.allLibraries) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'baseHref': Property(
-          getValue: (Object c) => (c as Package).baseHref,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.baseHref,
           getProperties: _Renderer_String.propertyMap,
         ),
         'canonicalLibrary': Property(
-          getValue: (Object c) => (c as Package).canonicalLibrary,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.canonicalLibrary,
         ),
         'categories': Property(
-          getValue: (Object c) => (c as Package).categories,
-          isEmptyIterable: (Object c) =>
-              (c as Package).categories?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.categories,
+          isEmptyIterable: (X_ c) => c.categories?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).categories) {
+            for (var e in c.categories) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'categoriesWithPublicLibraries': Property(
-          getValue: (Object c) => (c as Package).categoriesWithPublicLibraries,
-          isEmptyIterable: (Object c) =>
-              (c as Package).categoriesWithPublicLibraries?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.categoriesWithPublicLibraries,
+          isEmptyIterable: (X_ c) =>
+              c.categoriesWithPublicLibraries?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).categoriesWithPublicLibraries) {
+            for (var e in c.categoriesWithPublicLibraries) {
               buffer.write(_render_LibraryContainer(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'config': Property(
-          getValue: (Object c) => (c as Package).config,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.config,
         ),
         'containerOrder': Property(
-          getValue: (Object c) => (c as Package).containerOrder,
-          isEmptyIterable: (Object c) =>
-              (c as Package).containerOrder?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.containerOrder,
+          isEmptyIterable: (X_ c) => c.containerOrder?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).containerOrder) {
+            for (var e in c.containerOrder) {
               buffer.write(_render_String(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'defaultCategory': Property(
-          getValue: (Object c) => (c as Package).defaultCategory,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.defaultCategory,
           getProperties: _Renderer_LibraryContainer.propertyMap,
         ),
         'documentation': Property(
-          getValue: (Object c) => (c as Package).documentation,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentation,
           getProperties: _Renderer_String.propertyMap,
         ),
         'documentationAsHtml': Property(
-          getValue: (Object c) => (c as Package).documentationAsHtml,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentationAsHtml,
           getProperties: _Renderer_String.propertyMap,
         ),
         'documentationFile': Property(
-          getValue: (Object c) => (c as Package).documentationFile,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentationFile,
         ),
         'documentationFrom': Property(
-          getValue: (Object c) => (c as Package).documentationFrom,
-          isEmptyIterable: (Object c) =>
-              (c as Package).documentationFrom?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentationFrom,
+          isEmptyIterable: (X_ c) => c.documentationFrom?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).documentationFrom) {
+            for (var e in c.documentationFrom) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'documentedCategories': Property(
-          getValue: (Object c) => (c as Package).documentedCategories,
-          isEmptyIterable: (Object c) =>
-              (c as Package).documentedCategories?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentedCategories,
+          isEmptyIterable: (X_ c) => c.documentedCategories?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).documentedCategories) {
+            for (var e in c.documentedCategories) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
@@ -204,179 +222,211 @@ class _Renderer_Package extends RendererBase<Package> {
           getValue: (Object c) => (c as Package).documentedCategoriesSorted,
         ),
         'documentedWhere': Property(
-          getValue: (Object c) => (c as Package).documentedWhere,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentedWhere,
         ),
         'element': Property(
-          getValue: (Object c) => (c as Package).element,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.element,
         ),
         'enclosingElement': Property(
-          getValue: (Object c) => (c as Package).enclosingElement,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.enclosingElement,
         ),
         'enclosingName': Property(
-          getValue: (Object c) => (c as Package).enclosingName,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.enclosingName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'filePath': Property(
-          getValue: (Object c) => (c as Package).filePath,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.filePath,
           getProperties: _Renderer_String.propertyMap,
         ),
         'fileType': Property(
-          getValue: (Object c) => (c as Package).fileType,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.fileType,
           getProperties: _Renderer_String.propertyMap,
         ),
         'fullyQualifiedName': Property(
-          getValue: (Object c) => (c as Package).fullyQualifiedName,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.fullyQualifiedName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'hasCategories': Property(
-          getValue: (Object c) => (c as Package).hasCategories,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasCategories,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).hasCategories == true,
+          getBool: (X_ c) => c.hasCategories == true,
         ),
         'hasDocumentation': Property(
-          getValue: (Object c) => (c as Package).hasDocumentation,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).hasDocumentation == true,
+          getBool: (X_ c) => c.hasDocumentation == true,
         ),
         'hasDocumentationFile': Property(
-          getValue: (Object c) => (c as Package).hasDocumentationFile,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasDocumentationFile,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).hasDocumentationFile == true,
+          getBool: (X_ c) => c.hasDocumentationFile == true,
         ),
         'hasDocumentedCategories': Property(
-          getValue: (Object c) => (c as Package).hasDocumentedCategories,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasDocumentedCategories,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).hasDocumentedCategories == true,
+          getBool: (X_ c) => c.hasDocumentedCategories == true,
         ),
         'hasExtendedDocumentation': Property(
-          getValue: (Object c) => (c as Package).hasExtendedDocumentation,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasExtendedDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) =>
-              (c as Package).hasExtendedDocumentation == true,
+          getBool: (X_ c) => c.hasExtendedDocumentation == true,
         ),
         'hasHomepage': Property(
-          getValue: (Object c) => (c as Package).hasHomepage,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasHomepage,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).hasHomepage == true,
+          getBool: (X_ c) => c.hasHomepage == true,
         ),
         'homepage': Property(
-          getValue: (Object c) => (c as Package).homepage,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.homepage,
           getProperties: _Renderer_String.propertyMap,
         ),
         'href': Property(
-          getValue: (Object c) => (c as Package).href,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.href,
           getProperties: _Renderer_String.propertyMap,
         ),
         'isCanonical': Property(
-          getValue: (Object c) => (c as Package).isCanonical,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isCanonical,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).isCanonical == true,
+          getBool: (X_ c) => c.isCanonical == true,
         ),
         'isDocumented': Property(
-          getValue: (Object c) => (c as Package).isDocumented,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isDocumented,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).isDocumented == true,
+          getBool: (X_ c) => c.isDocumented == true,
         ),
         'isFirstPackage': Property(
-          getValue: (Object c) => (c as Package).isFirstPackage,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isFirstPackage,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).isFirstPackage == true,
+          getBool: (X_ c) => c.isFirstPackage == true,
         ),
         'isLocal': Property(
-          getValue: (Object c) => (c as Package).isLocal,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isLocal,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).isLocal == true,
+          getBool: (X_ c) => c.isLocal == true,
         ),
         'isPublic': Property(
-          getValue: (Object c) => (c as Package).isPublic,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isPublic,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).isPublic == true,
+          getBool: (X_ c) => c.isPublic == true,
         ),
         'isSdk': Property(
-          getValue: (Object c) => (c as Package).isSdk,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isSdk,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Package).isSdk == true,
+          getBool: (X_ c) => c.isSdk == true,
         ),
         'kind': Property(
-          getValue: (Object c) => (c as Package).kind,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.kind,
           getProperties: _Renderer_String.propertyMap,
         ),
         'location': Property(
-          getValue: (Object c) => (c as Package).location,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.location,
           getProperties: _Renderer_String.propertyMap,
         ),
         'locationPieces': Property(
-          getValue: (Object c) => (c as Package).locationPieces,
-          isEmptyIterable: (Object c) =>
-              (c as Package).locationPieces?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.locationPieces,
+          isEmptyIterable: (X_ c) => c.locationPieces?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).locationPieces) {
+            for (var e in c.locationPieces) {
               buffer.write(_render_String(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'name': Property(
-          getValue: (Object c) => (c as Package).name,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.name,
           getProperties: _Renderer_String.propertyMap,
         ),
         'nameToCategory': Property(
-          getValue: (Object c) => (c as Package).nameToCategory,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.nameToCategory,
         ),
         'oneLineDoc': Property(
-          getValue: (Object c) => (c as Package).oneLineDoc,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.oneLineDoc,
           getProperties: _Renderer_String.propertyMap,
         ),
         'package': Property(
-          getValue: (Object c) => (c as Package).package,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.package,
           getProperties: _Renderer_Package.propertyMap,
         ),
         'packageGraph': Property(
-          getValue: (Object c) => (c as Package).packageGraph,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.packageGraph,
         ),
         'packageMeta': Property(
-          getValue: (Object c) => (c as Package).packageMeta,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.packageMeta,
         ),
         'packagePath': Property(
-          getValue: (Object c) => (c as Package).packagePath,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.packagePath,
           getProperties: _Renderer_String.propertyMap,
         ),
         'publicLibraries': Property(
-          getValue: (Object c) => (c as Package).publicLibraries,
-          isEmptyIterable: (Object c) =>
-              (c as Package).publicLibraries?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.publicLibraries,
+          isEmptyIterable: (X_ c) => c.publicLibraries?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Package).publicLibraries) {
+            for (var e in c.publicLibraries) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'toolInvocationIndex': Property(
-          getValue: (Object c) => (c as Package).toolInvocationIndex,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.toolInvocationIndex,
           getProperties: _Renderer_int.propertyMap,
         ),
         'usedAnimationIdsByHref': Property(
-          getValue: (Object c) => (c as Package).usedAnimationIdsByHref,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.usedAnimationIdsByHref,
         ),
         'version': Property(
-          getValue: (Object c) => (c as Package).version,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.version,
           getProperties: _Renderer_String.propertyMap,
         ),
-        ..._Renderer_LibraryContainer.propertyMap(),
+        ..._Renderer_LibraryContainer.propertyMap<X_>(),
       };
 
   _Renderer_Package(Package context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<Package> getProperty(String key) {
+    if (propertyMap<Package>().containsKey(key)) {
+      return propertyMap<Package>()[key];
     } else {
       return null;
     }
@@ -392,59 +442,63 @@ String _render_LibraryContainer(
 }
 
 class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends LibraryContainer>() =>
+      {
         'containerOrder': Property(
-          getValue: (Object c) => (c as LibraryContainer).containerOrder,
-          isEmptyIterable: (Object c) =>
-              (c as LibraryContainer).containerOrder?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<LibraryContainer> r,
-              List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.containerOrder,
+          isEmptyIterable: (X_ c) => c.containerOrder?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as LibraryContainer).containerOrder) {
+            for (var e in c.containerOrder) {
               buffer.write(_render_String(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'enclosingName': Property(
-          getValue: (Object c) => (c as LibraryContainer).enclosingName,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.enclosingName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'hasPublicLibraries': Property(
-          getValue: (Object c) => (c as LibraryContainer).hasPublicLibraries,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasPublicLibraries,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) =>
-              (c as LibraryContainer).hasPublicLibraries == true,
+          getBool: (X_ c) => c.hasPublicLibraries == true,
         ),
         'isSdk': Property(
-          getValue: (Object c) => (c as LibraryContainer).isSdk,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isSdk,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as LibraryContainer).isSdk == true,
+          getBool: (X_ c) => c.isSdk == true,
         ),
         'libraries': Property(
-          getValue: (Object c) => (c as LibraryContainer).libraries,
-          isEmptyIterable: (Object c) =>
-              (c as LibraryContainer).libraries?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<LibraryContainer> r,
-              List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.libraries,
+          isEmptyIterable: (X_ c) => c.libraries?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as LibraryContainer).libraries) {
+            for (var e in c.libraries) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'packageGraph': Property(
-          getValue: (Object c) => (c as LibraryContainer).packageGraph,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.packageGraph,
         ),
         'publicLibraries': Property(
-          getValue: (Object c) => (c as LibraryContainer).publicLibraries,
-          isEmptyIterable: (Object c) =>
-              (c as LibraryContainer).publicLibraries?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<LibraryContainer> r,
-              List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.publicLibraries,
+          isEmptyIterable: (X_ c) => c.publicLibraries?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as LibraryContainer).publicLibraries) {
+            for (var e in c.publicLibraries) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
@@ -454,10 +508,11 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
           getValue: (Object c) => (c as LibraryContainer).publicLibrariesSorted,
         ),
         'sortKey': Property(
-          getValue: (Object c) => (c as LibraryContainer).sortKey,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.sortKey,
           getProperties: _Renderer_String.propertyMap,
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_LibraryContainer(
@@ -465,9 +520,9 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<LibraryContainer> getProperty(String key) {
+    if (propertyMap<LibraryContainer>().containsKey(key)) {
+      return propertyMap<LibraryContainer>()[key];
     } else {
       return null;
     }
@@ -482,9 +537,10 @@ String _render_Object(Object context, List<MustachioNode> ast,
 }
 
 class _Renderer_Object extends RendererBase<Object> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends Object>() => {
         'hashCode': Property(
-          getValue: (Object c) => (c as Object).hashCode,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
       };
@@ -494,8 +550,8 @@ class _Renderer_Object extends RendererBase<Object> {
 
   @override
   Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+    if (propertyMap<Object>().containsKey(key)) {
+      return propertyMap<Object>()[key];
     } else {
       return null;
     }
@@ -510,21 +566,22 @@ String _render_bool(bool context, List<MustachioNode> ast,
 }
 
 class _Renderer_bool extends RendererBase<bool> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends bool>() => {
         'hashCode': Property(
-          getValue: (Object c) => (c as bool).hashCode,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_bool(bool context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<bool> getProperty(String key) {
+    if (propertyMap<bool>().containsKey(key)) {
+      return propertyMap<bool>()[key];
     } else {
       return null;
     }
@@ -539,34 +596,26 @@ String _render_List<E>(List<E> context, List<MustachioNode> ast,
 }
 
 class _Renderer_List<E> extends RendererBase<List<E>> {
-  static Map<String, Property> propertyMap<E>() => {
+  static Map<String, Property<X_>> propertyMap<E, X_ extends List<E>>() => {
         'length': Property(
-          getValue: (Object c) => (c as List<E>).length,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.length,
           getProperties: _Renderer_int.propertyMap,
         ),
         'reversed': Property(
-          getValue: (Object c) => (c as List<E>).reversed,
-          isEmptyIterable: (Object c) =>
-              (c as List<E>).reversed?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<List<E>> r, List<WhiskersNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in (c as List<E>).reversed) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.reversed,
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_List(List<E> context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap<E>().containsKey(key)) {
-      return propertyMap<E>()[key];
+  Property<List<E>> getProperty(String key) {
+    if (propertyMap<E, List<E>>().containsKey(key)) {
+      return propertyMap<E, List<E>>()[key];
     } else {
       return null;
     }
@@ -581,60 +630,65 @@ String _render_String(String context, List<MustachioNode> ast,
 }
 
 class _Renderer_String extends RendererBase<String> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends String>() => {
         'codeUnits': Property(
-          getValue: (Object c) => (c as String).codeUnits,
-          isEmptyIterable: (Object c) =>
-              (c as String).codeUnits?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.codeUnits,
+          isEmptyIterable: (X_ c) => c.codeUnits?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as String).codeUnits) {
+            for (var e in c.codeUnits) {
               buffer.write(_render_int(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'hashCode': Property(
-          getValue: (Object c) => (c as String).hashCode,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
         'isEmpty': Property(
-          getValue: (Object c) => (c as String).isEmpty,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isEmpty,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as String).isEmpty == true,
+          getBool: (X_ c) => c.isEmpty == true,
         ),
         'isNotEmpty': Property(
-          getValue: (Object c) => (c as String).isNotEmpty,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isNotEmpty,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as String).isNotEmpty == true,
+          getBool: (X_ c) => c.isNotEmpty == true,
         ),
         'length': Property(
-          getValue: (Object c) => (c as String).length,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.length,
           getProperties: _Renderer_int.propertyMap,
         ),
         'runes': Property(
-          getValue: (Object c) => (c as String).runes,
-          isEmptyIterable: (Object c) => (c as String).runes?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.runes,
+          isEmptyIterable: (X_ c) => c.runes?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as String).runes) {
+            for (var e in c.runes) {
               buffer.write(_render_int(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_String(String context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<String> getProperty(String key) {
+    if (propertyMap<String>().containsKey(key)) {
+      return propertyMap<String>()[key];
     } else {
       return null;
     }
@@ -651,124 +705,137 @@ String _render_TemplateData<T extends Documentable>(
 
 class _Renderer_TemplateData<T extends Documentable>
     extends RendererBase<TemplateData<T>> {
-  static Map<String, Property> propertyMap<T extends Documentable>() => {
+  static Map<String, Property<X_>> propertyMap<T extends Documentable,
+          X_ extends TemplateData<T>>() =>
+      {
         'bareHref': Property(
-          getValue: (Object c) => (c as TemplateData<T>).bareHref,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.bareHref,
           getProperties: _Renderer_String.propertyMap,
         ),
         'defaultPackage': Property(
-          getValue: (Object c) => (c as TemplateData<T>).defaultPackage,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.defaultPackage,
           getProperties: _Renderer_Package.propertyMap,
         ),
         'hasFooterVersion': Property(
-          getValue: (Object c) => (c as TemplateData<T>).hasFooterVersion,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasFooterVersion,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) =>
-              (c as TemplateData<T>).hasFooterVersion == true,
+          getBool: (X_ c) => c.hasFooterVersion == true,
         ),
         'hasHomepage': Property(
-          getValue: (Object c) => (c as TemplateData<T>).hasHomepage,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasHomepage,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as TemplateData<T>).hasHomepage == true,
+          getBool: (X_ c) => c.hasHomepage == true,
         ),
         'homepage': Property(
-          getValue: (Object c) => (c as TemplateData<T>).homepage,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.homepage,
           getProperties: _Renderer_String.propertyMap,
         ),
         'htmlBase': Property(
-          getValue: (Object c) => (c as TemplateData<T>).htmlBase,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.htmlBase,
           getProperties: _Renderer_String.propertyMap,
         ),
         'htmlOptions': Property(
-          getValue: (Object c) => (c as TemplateData<T>).htmlOptions,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.htmlOptions,
           getProperties: _Renderer_TemplateOptions.propertyMap,
         ),
         'includeVersion': Property(
-          getValue: (Object c) => (c as TemplateData<T>).includeVersion,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.includeVersion,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as TemplateData<T>).includeVersion == true,
+          getBool: (X_ c) => c.includeVersion == true,
         ),
         'layoutTitle': Property(
-          getValue: (Object c) => (c as TemplateData<T>).layoutTitle,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.layoutTitle,
           getProperties: _Renderer_String.propertyMap,
         ),
         'localPackages': Property(
-          getValue: (Object c) => (c as TemplateData<T>).localPackages,
-          isEmptyIterable: (Object c) =>
-              (c as TemplateData<T>).localPackages?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<TemplateData<T>> r,
-              List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.localPackages,
+          isEmptyIterable: (X_ c) => c.localPackages?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as TemplateData<T>).localPackages) {
+            for (var e in c.localPackages) {
               buffer.write(_render_Package(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'metaDescription': Property(
-          getValue: (Object c) => (c as TemplateData<T>).metaDescription,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.metaDescription,
           getProperties: _Renderer_String.propertyMap,
         ),
         'navLinks': Property(
-          getValue: (Object c) => (c as TemplateData<T>).navLinks,
-          isEmptyIterable: (Object c) =>
-              (c as TemplateData<T>).navLinks?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<TemplateData<T>> r,
-              List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.navLinks,
+          isEmptyIterable: (X_ c) => c.navLinks?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as TemplateData<T>).navLinks) {
+            for (var e in c.navLinks) {
               buffer.write(_render_Documentable(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'navLinksWithGenerics': Property(
-          getValue: (Object c) => (c as TemplateData<T>).navLinksWithGenerics,
-          isEmptyIterable: (Object c) =>
-              (c as TemplateData<T>).navLinksWithGenerics?.isEmpty ?? false,
-          renderIterable: (Object c, RendererBase<TemplateData<T>> r,
-              List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.navLinksWithGenerics,
+          isEmptyIterable: (X_ c) => c.navLinksWithGenerics?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as TemplateData<T>).navLinksWithGenerics) {
+            for (var e in c.navLinksWithGenerics) {
               buffer.write(null(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'parent': Property(
-          getValue: (Object c) => (c as TemplateData<T>).parent,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.parent,
           getProperties: _Renderer_Documentable.propertyMap,
         ),
         'relCanonicalPrefix': Property(
-          getValue: (Object c) => (c as TemplateData<T>).relCanonicalPrefix,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.relCanonicalPrefix,
           getProperties: _Renderer_String.propertyMap,
         ),
-        'self': Property(
-          getValue: (Object c) => (c as TemplateData<T>).self,
-        ),
         'title': Property(
-          getValue: (Object c) => (c as TemplateData<T>).title,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.title,
           getProperties: _Renderer_String.propertyMap,
         ),
         'useBaseHref': Property(
-          getValue: (Object c) => (c as TemplateData<T>).useBaseHref,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.useBaseHref,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as TemplateData<T>).useBaseHref == true,
+          getBool: (X_ c) => c.useBaseHref == true,
         ),
         'version': Property(
-          getValue: (Object c) => (c as TemplateData<T>).version,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.version,
           getProperties: _Renderer_String.propertyMap,
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_TemplateData(TemplateData<T> context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap<T>().containsKey(key)) {
-      return propertyMap<T>()[key];
+  Property<TemplateData<T>> getProperty(String key) {
+    if (propertyMap<T, TemplateData<T>>().containsKey(key)) {
+      return propertyMap<T, TemplateData<T>>()[key];
     } else {
       return null;
     }
@@ -783,21 +850,25 @@ String _render_TemplateOptions(TemplateOptions context, List<MustachioNode> ast,
 }
 
 class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends TemplateOptions>() =>
+      {
         'relCanonicalPrefix': Property(
-          getValue: (Object c) => (c as TemplateOptions).relCanonicalPrefix,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.relCanonicalPrefix,
           getProperties: _Renderer_String.propertyMap,
         ),
         'toolVersion': Property(
-          getValue: (Object c) => (c as TemplateOptions).toolVersion,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.toolVersion,
           getProperties: _Renderer_String.propertyMap,
         ),
         'useBaseHref': Property(
-          getValue: (Object c) => (c as TemplateOptions).useBaseHref,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.useBaseHref,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as TemplateOptions).useBaseHref == true,
+          getBool: (X_ c) => c.useBaseHref == true,
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_TemplateOptions(
@@ -805,9 +876,9 @@ class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<TemplateOptions> getProperty(String key) {
+    if (propertyMap<TemplateOptions>().containsKey(key)) {
+      return propertyMap<TemplateOptions>()[key];
     } else {
       return null;
     }
@@ -822,59 +893,68 @@ String _render_Documentable(Documentable context, List<MustachioNode> ast,
 }
 
 class _Renderer_Documentable extends RendererBase<Documentable> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends Documentable>() => {
         'config': Property(
-          getValue: (Object c) => (c as Documentable).config,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.config,
         ),
         'documentation': Property(
-          getValue: (Object c) => (c as Documentable).documentation,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentation,
           getProperties: _Renderer_String.propertyMap,
         ),
         'documentationAsHtml': Property(
-          getValue: (Object c) => (c as Documentable).documentationAsHtml,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.documentationAsHtml,
           getProperties: _Renderer_String.propertyMap,
         ),
         'hasDocumentation': Property(
-          getValue: (Object c) => (c as Documentable).hasDocumentation,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Documentable).hasDocumentation == true,
+          getBool: (X_ c) => c.hasDocumentation == true,
         ),
         'hasExtendedDocumentation': Property(
-          getValue: (Object c) => (c as Documentable).hasExtendedDocumentation,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hasExtendedDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) =>
-              (c as Documentable).hasExtendedDocumentation == true,
+          getBool: (X_ c) => c.hasExtendedDocumentation == true,
         ),
         'href': Property(
-          getValue: (Object c) => (c as Documentable).href,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.href,
           getProperties: _Renderer_String.propertyMap,
         ),
         'isDocumented': Property(
-          getValue: (Object c) => (c as Documentable).isDocumented,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isDocumented,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Documentable).isDocumented == true,
+          getBool: (X_ c) => c.isDocumented == true,
         ),
         'kind': Property(
-          getValue: (Object c) => (c as Documentable).kind,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.kind,
           getProperties: _Renderer_String.propertyMap,
         ),
         'oneLineDoc': Property(
-          getValue: (Object c) => (c as Documentable).oneLineDoc,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.oneLineDoc,
           getProperties: _Renderer_String.propertyMap,
         ),
         'packageGraph': Property(
-          getValue: (Object c) => (c as Documentable).packageGraph,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.packageGraph,
         ),
-        ..._Renderer_Nameable.propertyMap(),
+        ..._Renderer_Nameable.propertyMap<X_>(),
       };
 
   _Renderer_Documentable(Documentable context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<Documentable> getProperty(String key) {
+    if (propertyMap<Documentable>().containsKey(key)) {
+      return propertyMap<Documentable>()[key];
     } else {
       return null;
     }
@@ -889,42 +969,45 @@ String _render_Nameable(Nameable context, List<MustachioNode> ast,
 }
 
 class _Renderer_Nameable extends RendererBase<Nameable> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends Nameable>() => {
         'fullyQualifiedName': Property(
-          getValue: (Object c) => (c as Nameable).fullyQualifiedName,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.fullyQualifiedName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'name': Property(
-          getValue: (Object c) => (c as Nameable).name,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.name,
           getProperties: _Renderer_String.propertyMap,
         ),
         'namePart': Property(
-          getValue: (Object c) => (c as Nameable).namePart,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.namePart,
           getProperties: _Renderer_String.propertyMap,
         ),
         'namePieces': Property(
-          getValue: (Object c) => (c as Nameable).namePieces,
-          isEmptyIterable: (Object c) =>
-              (c as Nameable).namePieces?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<Nameable> r, List<WhiskersNode> ast) {
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.namePieces,
+          isEmptyIterable: (X_ c) => c.namePieces?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as Nameable).namePieces) {
+            for (var e in c.namePieces) {
               buffer.write(_render_String(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_Nameable(Nameable context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<Nameable> getProperty(String key) {
+    if (propertyMap<Nameable>().containsKey(key)) {
+      return propertyMap<Nameable>()[key];
     } else {
       return null;
     }
@@ -939,35 +1022,39 @@ String _render_int(int context, List<MustachioNode> ast,
 }
 
 class _Renderer_int extends RendererBase<int> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends int>() => {
         'bitLength': Property(
-          getValue: (Object c) => (c as int).bitLength,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.bitLength,
           getProperties: _Renderer_int.propertyMap,
         ),
         'isEven': Property(
-          getValue: (Object c) => (c as int).isEven,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isEven,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as int).isEven == true,
+          getBool: (X_ c) => c.isEven == true,
         ),
         'isOdd': Property(
-          getValue: (Object c) => (c as int).isOdd,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isOdd,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as int).isOdd == true,
+          getBool: (X_ c) => c.isOdd == true,
         ),
         'sign': Property(
-          getValue: (Object c) => (c as int).sign,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.sign,
           getProperties: _Renderer_int.propertyMap,
         ),
-        ..._Renderer_num.propertyMap(),
+        ..._Renderer_num.propertyMap<X_>(),
       };
 
   _Renderer_int(int context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<int> getProperty(String key) {
+    if (propertyMap<int>().containsKey(key)) {
+      return propertyMap<int>()[key];
     } else {
       return null;
     }
@@ -982,45 +1069,51 @@ String _render_num(num context, List<MustachioNode> ast,
 }
 
 class _Renderer_num extends RendererBase<num> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends num>() => {
         'hashCode': Property(
-          getValue: (Object c) => (c as num).hashCode,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
         'isFinite': Property(
-          getValue: (Object c) => (c as num).isFinite,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isFinite,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isFinite == true,
+          getBool: (X_ c) => c.isFinite == true,
         ),
         'isInfinite': Property(
-          getValue: (Object c) => (c as num).isInfinite,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isInfinite,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isInfinite == true,
+          getBool: (X_ c) => c.isInfinite == true,
         ),
         'isNaN': Property(
-          getValue: (Object c) => (c as num).isNaN,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isNaN,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isNaN == true,
+          getBool: (X_ c) => c.isNaN == true,
         ),
         'isNegative': Property(
-          getValue: (Object c) => (c as num).isNegative,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.isNegative,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isNegative == true,
+          getBool: (X_ c) => c.isNegative == true,
         ),
         'sign': Property(
-          getValue: (Object c) => (c as num).sign,
+          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
+          getValue: (X_ c) => c.sign,
           getProperties: _Renderer_num.propertyMap,
         ),
-        ..._Renderer_Object.propertyMap(),
+        ..._Renderer_Object.propertyMap<X_>(),
       };
 
   _Renderer_num(num context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<num> getProperty(String key) {
+    if (propertyMap<num>().containsKey(key)) {
+      return propertyMap<num>()[key];
     } else {
       return null;
     }

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -48,6 +48,16 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'navLinks': Property(
           getValue: (Object c) => (c as PackageTemplateData).navLinks,
+          isEmptyIterable: (Object c) =>
+              (c as PackageTemplateData).navLinks?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<PackageTemplateData> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as PackageTemplateData).navLinks) {
+              buffer.write(_render_Documentable(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'package': Property(
           getValue: (Object c) => (c as PackageTemplateData).package,
@@ -89,6 +99,16 @@ class _Renderer_Package extends RendererBase<Package> {
   static Map<String, Property> propertyMap() => {
         'allLibraries': Property(
           getValue: (Object c) => (c as Package).allLibraries,
+          isEmptyIterable: (Object c) =>
+              (c as Package).allLibraries?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).allLibraries) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'baseHref': Property(
           getValue: (Object c) => (c as Package).baseHref,
@@ -99,15 +119,45 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'categories': Property(
           getValue: (Object c) => (c as Package).categories,
+          isEmptyIterable: (Object c) =>
+              (c as Package).categories?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).categories) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'categoriesWithPublicLibraries': Property(
           getValue: (Object c) => (c as Package).categoriesWithPublicLibraries,
+          isEmptyIterable: (Object c) =>
+              (c as Package).categoriesWithPublicLibraries?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).categoriesWithPublicLibraries) {
+              buffer.write(_render_LibraryContainer(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'config': Property(
           getValue: (Object c) => (c as Package).config,
         ),
         'containerOrder': Property(
           getValue: (Object c) => (c as Package).containerOrder,
+          isEmptyIterable: (Object c) =>
+              (c as Package).containerOrder?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).containerOrder) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'defaultCategory': Property(
           getValue: (Object c) => (c as Package).defaultCategory,
@@ -126,9 +176,29 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'documentationFrom': Property(
           getValue: (Object c) => (c as Package).documentationFrom,
+          isEmptyIterable: (Object c) =>
+              (c as Package).documentationFrom?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).documentationFrom) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'documentedCategories': Property(
           getValue: (Object c) => (c as Package).documentedCategories,
+          isEmptyIterable: (Object c) =>
+              (c as Package).documentedCategories?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).documentedCategories) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'documentedCategoriesSorted': Property(
           getValue: (Object c) => (c as Package).documentedCategoriesSorted,
@@ -237,6 +307,16 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'locationPieces': Property(
           getValue: (Object c) => (c as Package).locationPieces,
+          isEmptyIterable: (Object c) =>
+              (c as Package).locationPieces?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).locationPieces) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'name': Property(
           getValue: (Object c) => (c as Package).name,
@@ -265,6 +345,16 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'publicLibraries': Property(
           getValue: (Object c) => (c as Package).publicLibraries,
+          isEmptyIterable: (Object c) =>
+              (c as Package).publicLibraries?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Package> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Package).publicLibraries) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'toolInvocationIndex': Property(
           getValue: (Object c) => (c as Package).toolInvocationIndex,
@@ -305,6 +395,16 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
   static Map<String, Property> propertyMap() => {
         'containerOrder': Property(
           getValue: (Object c) => (c as LibraryContainer).containerOrder,
+          isEmptyIterable: (Object c) =>
+              (c as LibraryContainer).containerOrder?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<LibraryContainer> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as LibraryContainer).containerOrder) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'enclosingName': Property(
           getValue: (Object c) => (c as LibraryContainer).enclosingName,
@@ -323,12 +423,32 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
         ),
         'libraries': Property(
           getValue: (Object c) => (c as LibraryContainer).libraries,
+          isEmptyIterable: (Object c) =>
+              (c as LibraryContainer).libraries?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<LibraryContainer> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as LibraryContainer).libraries) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'packageGraph': Property(
           getValue: (Object c) => (c as LibraryContainer).packageGraph,
         ),
         'publicLibraries': Property(
           getValue: (Object c) => (c as LibraryContainer).publicLibraries,
+          isEmptyIterable: (Object c) =>
+              (c as LibraryContainer).publicLibraries?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<LibraryContainer> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as LibraryContainer).publicLibraries) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'publicLibrariesSorted': Property(
           getValue: (Object c) => (c as LibraryContainer).publicLibrariesSorted,
@@ -426,6 +546,16 @@ class _Renderer_List<E> extends RendererBase<List<E>> {
         ),
         'reversed': Property(
           getValue: (Object c) => (c as List<E>).reversed,
+          isEmptyIterable: (Object c) =>
+              (c as List<E>).reversed?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<List<E>> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as List<E>).reversed) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         ..._Renderer_Object.propertyMap(),
       };
@@ -454,6 +584,16 @@ class _Renderer_String extends RendererBase<String> {
   static Map<String, Property> propertyMap() => {
         'codeUnits': Property(
           getValue: (Object c) => (c as String).codeUnits,
+          isEmptyIterable: (Object c) =>
+              (c as String).codeUnits?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as String).codeUnits) {
+              buffer.write(_render_int(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'hashCode': Property(
           getValue: (Object c) => (c as String).hashCode,
@@ -475,6 +615,15 @@ class _Renderer_String extends RendererBase<String> {
         ),
         'runes': Property(
           getValue: (Object c) => (c as String).runes,
+          isEmptyIterable: (Object c) => (c as String).runes?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as String).runes) {
+              buffer.write(_render_int(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         ..._Renderer_Object.propertyMap(),
       };
@@ -545,6 +694,16 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'localPackages': Property(
           getValue: (Object c) => (c as TemplateData<T>).localPackages,
+          isEmptyIterable: (Object c) =>
+              (c as TemplateData<T>).localPackages?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<TemplateData<T>> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as TemplateData<T>).localPackages) {
+              buffer.write(_render_Package(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'metaDescription': Property(
           getValue: (Object c) => (c as TemplateData<T>).metaDescription,
@@ -552,9 +711,29 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'navLinks': Property(
           getValue: (Object c) => (c as TemplateData<T>).navLinks,
+          isEmptyIterable: (Object c) =>
+              (c as TemplateData<T>).navLinks?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<TemplateData<T>> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as TemplateData<T>).navLinks) {
+              buffer.write(_render_Documentable(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'navLinksWithGenerics': Property(
           getValue: (Object c) => (c as TemplateData<T>).navLinksWithGenerics,
+          isEmptyIterable: (Object c) =>
+              (c as TemplateData<T>).navLinksWithGenerics?.isEmpty ?? false,
+          renderIterable: (Object c, RendererBase<TemplateData<T>> r,
+              List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as TemplateData<T>).navLinksWithGenerics) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'parent': Property(
           getValue: (Object c) => (c as TemplateData<T>).parent,
@@ -725,6 +904,16 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
         ),
         'namePieces': Property(
           getValue: (Object c) => (c as Nameable).namePieces,
+          isEmptyIterable: (Object c) =>
+              (c as Nameable).namePieces?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<Nameable> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as Nameable).namePieces) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         ..._Renderer_Object.propertyMap(),
       };

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -18,47 +18,40 @@ String renderIndex(PackageTemplateData context, List<MustachioNode> ast,
 }
 
 class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
-  static Map<String, Property<X_>>
-      propertyMap<X_ extends PackageTemplateData>() => {
+  static Map<String, Property<CT_>>
+      propertyMap<CT_ extends PackageTemplateData>() => {
             'hasHomepage': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.hasHomepage,
+              getValue: (CT_ c) => c.hasHomepage,
               getProperties: _Renderer_bool.propertyMap,
-              getBool: (X_ c) => c.hasHomepage == true,
+              getBool: (CT_ c) => c.hasHomepage == true,
             ),
             'homepage': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.homepage,
+              getValue: (CT_ c) => c.homepage,
               getProperties: _Renderer_String.propertyMap,
             ),
             'htmlBase': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.htmlBase,
+              getValue: (CT_ c) => c.htmlBase,
               getProperties: _Renderer_String.propertyMap,
             ),
             'includeVersion': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.includeVersion,
+              getValue: (CT_ c) => c.includeVersion,
               getProperties: _Renderer_bool.propertyMap,
-              getBool: (X_ c) => c.includeVersion == true,
+              getBool: (CT_ c) => c.includeVersion == true,
             ),
             'layoutTitle': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.layoutTitle,
+              getValue: (CT_ c) => c.layoutTitle,
               getProperties: _Renderer_String.propertyMap,
             ),
             'metaDescription': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.metaDescription,
+              getValue: (CT_ c) => c.metaDescription,
               getProperties: _Renderer_String.propertyMap,
             ),
             'navLinks': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.navLinks,
-              isEmptyIterable: (X_ c) => c.navLinks?.isEmpty ?? false,
-
+              getValue: (CT_ c) => c.navLinks,
+              getProperties: _Renderer_List.propertyMap,
+              isEmptyIterable: (CT_ c) => c.navLinks?.isEmpty ?? true,
               renderIterable:
-                  (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
                 var buffer = StringBuffer();
                 for (var e in c.navLinks) {
                   buffer.write(_render_Documentable(e, ast, parent: r));
@@ -67,21 +60,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
               },
             ),
             'package': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.package,
+              getValue: (CT_ c) => c.package,
               getProperties: _Renderer_Package.propertyMap,
             ),
             'self': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.self,
+              getValue: (CT_ c) => c.self,
               getProperties: _Renderer_Package.propertyMap,
             ),
             'title': Property(
-              // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-              getValue: (X_ c) => c.title,
+              getValue: (CT_ c) => c.title,
               getProperties: _Renderer_String.propertyMap,
             ),
-            ..._Renderer_TemplateData.propertyMap<Package, X_>(),
+            ..._Renderer_TemplateData.propertyMap<Package, CT_>(),
           };
 
   _Renderer_PackageTemplateData(
@@ -106,13 +96,12 @@ String _render_Package(Package context, List<MustachioNode> ast,
 }
 
 class _Renderer_Package extends RendererBase<Package> {
-  static Map<String, Property<X_>> propertyMap<X_ extends Package>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Package>() => {
         'allLibraries': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.allLibraries,
-          isEmptyIterable: (X_ c) => c.allLibraries?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.allLibraries,
+          isEmptyIterable: (CT_ c) => c.allLibraries?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.allLibraries) {
               buffer.write(null(e, ast, parent: r));
@@ -121,20 +110,18 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'baseHref': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.baseHref,
+          getValue: (CT_ c) => c.baseHref,
           getProperties: _Renderer_String.propertyMap,
         ),
         'canonicalLibrary': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.canonicalLibrary,
+          getValue: (CT_ c) => c.canonicalLibrary,
         ),
         'categories': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.categories,
-          isEmptyIterable: (X_ c) => c.categories?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.categories,
+          getProperties: _Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.categories?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.categories) {
               buffer.write(null(e, ast, parent: r));
@@ -143,12 +130,11 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'categoriesWithPublicLibraries': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.categoriesWithPublicLibraries,
-          isEmptyIterable: (X_ c) =>
-              c.categoriesWithPublicLibraries?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.categoriesWithPublicLibraries,
+          isEmptyIterable: (CT_ c) =>
+              c.categoriesWithPublicLibraries?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.categoriesWithPublicLibraries) {
               buffer.write(_render_LibraryContainer(e, ast, parent: r));
@@ -157,15 +143,14 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'config': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.config,
+          getValue: (CT_ c) => c.config,
         ),
         'containerOrder': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.containerOrder,
-          isEmptyIterable: (X_ c) => c.containerOrder?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.containerOrder,
+          getProperties: _Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.containerOrder?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.containerOrder) {
               buffer.write(_render_String(e, ast, parent: r));
@@ -174,30 +159,26 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'defaultCategory': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.defaultCategory,
+          getValue: (CT_ c) => c.defaultCategory,
           getProperties: _Renderer_LibraryContainer.propertyMap,
         ),
         'documentation': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentation,
+          getValue: (CT_ c) => c.documentation,
           getProperties: _Renderer_String.propertyMap,
         ),
         'documentationAsHtml': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentationAsHtml,
+          getValue: (CT_ c) => c.documentationAsHtml,
           getProperties: _Renderer_String.propertyMap,
         ),
         'documentationFile': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentationFile,
+          getValue: (CT_ c) => c.documentationFile,
         ),
         'documentationFrom': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentationFrom,
-          isEmptyIterable: (X_ c) => c.documentationFrom?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.documentationFrom,
+          getProperties: _Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.documentationFrom?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.documentationFrom) {
               buffer.write(null(e, ast, parent: r));
@@ -206,11 +187,10 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'documentedCategories': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentedCategories,
-          isEmptyIterable: (X_ c) => c.documentedCategories?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.documentedCategories,
+          isEmptyIterable: (CT_ c) => c.documentedCategories?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.documentedCategories) {
               buffer.write(null(e, ast, parent: r));
@@ -219,138 +199,124 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'documentedCategoriesSorted': Property(
-          getValue: (Object c) => (c as Package).documentedCategoriesSorted,
+          getValue: (CT_ c) => c.documentedCategoriesSorted,
+          isEmptyIterable: (CT_ c) =>
+              c.documentedCategoriesSorted?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.documentedCategoriesSorted) {
+              buffer.write(null(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'documentedWhere': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentedWhere,
+          getValue: (CT_ c) => c.documentedWhere,
         ),
         'element': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.element,
+          getValue: (CT_ c) => c.element,
         ),
         'enclosingElement': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.enclosingElement,
+          getValue: (CT_ c) => c.enclosingElement,
         ),
         'enclosingName': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.enclosingName,
+          getValue: (CT_ c) => c.enclosingName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'filePath': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.filePath,
+          getValue: (CT_ c) => c.filePath,
           getProperties: _Renderer_String.propertyMap,
         ),
         'fileType': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.fileType,
+          getValue: (CT_ c) => c.fileType,
           getProperties: _Renderer_String.propertyMap,
         ),
         'fullyQualifiedName': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.fullyQualifiedName,
+          getValue: (CT_ c) => c.fullyQualifiedName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'hasCategories': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasCategories,
+          getValue: (CT_ c) => c.hasCategories,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasCategories == true,
+          getBool: (CT_ c) => c.hasCategories == true,
         ),
         'hasDocumentation': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasDocumentation,
+          getValue: (CT_ c) => c.hasDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasDocumentation == true,
+          getBool: (CT_ c) => c.hasDocumentation == true,
         ),
         'hasDocumentationFile': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasDocumentationFile,
+          getValue: (CT_ c) => c.hasDocumentationFile,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasDocumentationFile == true,
+          getBool: (CT_ c) => c.hasDocumentationFile == true,
         ),
         'hasDocumentedCategories': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasDocumentedCategories,
+          getValue: (CT_ c) => c.hasDocumentedCategories,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasDocumentedCategories == true,
+          getBool: (CT_ c) => c.hasDocumentedCategories == true,
         ),
         'hasExtendedDocumentation': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasExtendedDocumentation,
+          getValue: (CT_ c) => c.hasExtendedDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasExtendedDocumentation == true,
+          getBool: (CT_ c) => c.hasExtendedDocumentation == true,
         ),
         'hasHomepage': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasHomepage,
+          getValue: (CT_ c) => c.hasHomepage,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasHomepage == true,
+          getBool: (CT_ c) => c.hasHomepage == true,
         ),
         'homepage': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.homepage,
+          getValue: (CT_ c) => c.homepage,
           getProperties: _Renderer_String.propertyMap,
         ),
         'href': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.href,
+          getValue: (CT_ c) => c.href,
           getProperties: _Renderer_String.propertyMap,
         ),
         'isCanonical': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isCanonical,
+          getValue: (CT_ c) => c.isCanonical,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isCanonical == true,
+          getBool: (CT_ c) => c.isCanonical == true,
         ),
         'isDocumented': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isDocumented,
+          getValue: (CT_ c) => c.isDocumented,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isDocumented == true,
+          getBool: (CT_ c) => c.isDocumented == true,
         ),
         'isFirstPackage': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isFirstPackage,
+          getValue: (CT_ c) => c.isFirstPackage,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isFirstPackage == true,
+          getBool: (CT_ c) => c.isFirstPackage == true,
         ),
         'isLocal': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isLocal,
+          getValue: (CT_ c) => c.isLocal,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isLocal == true,
+          getBool: (CT_ c) => c.isLocal == true,
         ),
         'isPublic': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isPublic,
+          getValue: (CT_ c) => c.isPublic,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isPublic == true,
+          getBool: (CT_ c) => c.isPublic == true,
         ),
         'isSdk': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isSdk,
+          getValue: (CT_ c) => c.isSdk,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isSdk == true,
+          getBool: (CT_ c) => c.isSdk == true,
         ),
         'kind': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.kind,
+          getValue: (CT_ c) => c.kind,
           getProperties: _Renderer_String.propertyMap,
         ),
         'location': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.location,
+          getValue: (CT_ c) => c.location,
           getProperties: _Renderer_String.propertyMap,
         ),
         'locationPieces': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.locationPieces,
-          isEmptyIterable: (X_ c) => c.locationPieces?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.locationPieces,
+          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.locationPieces) {
               buffer.write(_render_String(e, ast, parent: r));
@@ -359,43 +325,35 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'name': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.name,
+          getValue: (CT_ c) => c.name,
           getProperties: _Renderer_String.propertyMap,
         ),
         'nameToCategory': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.nameToCategory,
+          getValue: (CT_ c) => c.nameToCategory,
         ),
         'oneLineDoc': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.oneLineDoc,
+          getValue: (CT_ c) => c.oneLineDoc,
           getProperties: _Renderer_String.propertyMap,
         ),
         'package': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.package,
+          getValue: (CT_ c) => c.package,
           getProperties: _Renderer_Package.propertyMap,
         ),
         'packageGraph': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.packageGraph,
+          getValue: (CT_ c) => c.packageGraph,
         ),
         'packageMeta': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.packageMeta,
+          getValue: (CT_ c) => c.packageMeta,
         ),
         'packagePath': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.packagePath,
+          getValue: (CT_ c) => c.packagePath,
           getProperties: _Renderer_String.propertyMap,
         ),
         'publicLibraries': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.publicLibraries,
-          isEmptyIterable: (X_ c) => c.publicLibraries?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.publicLibraries,
+          isEmptyIterable: (CT_ c) => c.publicLibraries?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.publicLibraries) {
               buffer.write(null(e, ast, parent: r));
@@ -404,20 +362,17 @@ class _Renderer_Package extends RendererBase<Package> {
           },
         ),
         'toolInvocationIndex': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.toolInvocationIndex,
+          getValue: (CT_ c) => c.toolInvocationIndex,
           getProperties: _Renderer_int.propertyMap,
         ),
         'usedAnimationIdsByHref': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.usedAnimationIdsByHref,
+          getValue: (CT_ c) => c.usedAnimationIdsByHref,
         ),
         'version': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.version,
+          getValue: (CT_ c) => c.version,
           getProperties: _Renderer_String.propertyMap,
         ),
-        ..._Renderer_LibraryContainer.propertyMap<X_>(),
+        ..._Renderer_LibraryContainer.propertyMap<CT_>(),
       };
 
   _Renderer_Package(Package context, RendererBase<Object> parent)
@@ -442,78 +397,82 @@ String _render_LibraryContainer(
 }
 
 class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
-  static Map<String, Property<X_>> propertyMap<X_ extends LibraryContainer>() =>
-      {
-        'containerOrder': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.containerOrder,
-          isEmptyIterable: (X_ c) => c.containerOrder?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.containerOrder) {
-              buffer.write(_render_String(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'enclosingName': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.enclosingName,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'hasPublicLibraries': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasPublicLibraries,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasPublicLibraries == true,
-        ),
-        'isSdk': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isSdk,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isSdk == true,
-        ),
-        'libraries': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.libraries,
-          isEmptyIterable: (X_ c) => c.libraries?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.libraries) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'packageGraph': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.packageGraph,
-        ),
-        'publicLibraries': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.publicLibraries,
-          isEmptyIterable: (X_ c) => c.publicLibraries?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibraries) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'publicLibrariesSorted': Property(
-          getValue: (Object c) => (c as LibraryContainer).publicLibrariesSorted,
-        ),
-        'sortKey': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.sortKey,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        ..._Renderer_Object.propertyMap<X_>(),
-      };
+  static Map<String, Property<CT_>>
+      propertyMap<CT_ extends LibraryContainer>() => {
+            'containerOrder': Property(
+              getValue: (CT_ c) => c.containerOrder,
+              getProperties: _Renderer_List.propertyMap,
+              isEmptyIterable: (CT_ c) => c.containerOrder?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.containerOrder) {
+                  buffer.write(_render_String(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'enclosingName': Property(
+              getValue: (CT_ c) => c.enclosingName,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'hasPublicLibraries': Property(
+              getValue: (CT_ c) => c.hasPublicLibraries,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.hasPublicLibraries == true,
+            ),
+            'isSdk': Property(
+              getValue: (CT_ c) => c.isSdk,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.isSdk == true,
+            ),
+            'libraries': Property(
+              getValue: (CT_ c) => c.libraries,
+              getProperties: _Renderer_List.propertyMap,
+              isEmptyIterable: (CT_ c) => c.libraries?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.libraries) {
+                  buffer.write(null(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'packageGraph': Property(
+              getValue: (CT_ c) => c.packageGraph,
+            ),
+            'publicLibraries': Property(
+              getValue: (CT_ c) => c.publicLibraries,
+              isEmptyIterable: (CT_ c) => c.publicLibraries?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.publicLibraries) {
+                  buffer.write(null(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'publicLibrariesSorted': Property(
+              getValue: (CT_ c) => c.publicLibrariesSorted,
+              isEmptyIterable: (CT_ c) =>
+                  c.publicLibrariesSorted?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.publicLibrariesSorted) {
+                  buffer.write(null(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'sortKey': Property(
+              getValue: (CT_ c) => c.sortKey,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            ..._Renderer_Object.propertyMap<CT_>(),
+          };
 
   _Renderer_LibraryContainer(
       LibraryContainer context, RendererBase<Object> parent)
@@ -537,10 +496,9 @@ String _render_Object(Object context, List<MustachioNode> ast,
 }
 
 class _Renderer_Object extends RendererBase<Object> {
-  static Map<String, Property<X_>> propertyMap<X_ extends Object>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Object>() => {
         'hashCode': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
       };
@@ -566,13 +524,12 @@ String _render_bool(bool context, List<MustachioNode> ast,
 }
 
 class _Renderer_bool extends RendererBase<bool> {
-  static Map<String, Property<X_>> propertyMap<X_ extends bool>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends bool>() => {
         'hashCode': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
-        ..._Renderer_Object.propertyMap<X_>(),
+        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_bool(bool context, RendererBase<Object> parent)
@@ -596,17 +553,15 @@ String _render_List<E>(List<E> context, List<MustachioNode> ast,
 }
 
 class _Renderer_List<E> extends RendererBase<List<E>> {
-  static Map<String, Property<X_>> propertyMap<E, X_ extends List<E>>() => {
+  static Map<String, Property<CT_>> propertyMap<E, CT_ extends List<E>>() => {
         'length': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.length,
+          getValue: (CT_ c) => c.length,
           getProperties: _Renderer_int.propertyMap,
         ),
         'reversed': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.reversed,
+          getValue: (CT_ c) => c.reversed,
         ),
-        ..._Renderer_Object.propertyMap<X_>(),
+        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_List(List<E> context, RendererBase<Object> parent)
@@ -630,13 +585,13 @@ String _render_String(String context, List<MustachioNode> ast,
 }
 
 class _Renderer_String extends RendererBase<String> {
-  static Map<String, Property<X_>> propertyMap<X_ extends String>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends String>() => {
         'codeUnits': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.codeUnits,
-          isEmptyIterable: (X_ c) => c.codeUnits?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.codeUnits,
+          getProperties: _Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.codeUnits?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.codeUnits) {
               buffer.write(_render_int(e, ast, parent: r));
@@ -645,33 +600,28 @@ class _Renderer_String extends RendererBase<String> {
           },
         ),
         'hashCode': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
         'isEmpty': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isEmpty,
+          getValue: (CT_ c) => c.isEmpty,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isEmpty == true,
+          getBool: (CT_ c) => c.isEmpty == true,
         ),
         'isNotEmpty': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isNotEmpty,
+          getValue: (CT_ c) => c.isNotEmpty,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isNotEmpty == true,
+          getBool: (CT_ c) => c.isNotEmpty == true,
         ),
         'length': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.length,
+          getValue: (CT_ c) => c.length,
           getProperties: _Renderer_int.propertyMap,
         ),
         'runes': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.runes,
-          isEmptyIterable: (X_ c) => c.runes?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.runes,
+          isEmptyIterable: (CT_ c) => c.runes?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.runes) {
               buffer.write(_render_int(e, ast, parent: r));
@@ -679,7 +629,7 @@ class _Renderer_String extends RendererBase<String> {
             return buffer.toString();
           },
         ),
-        ..._Renderer_Object.propertyMap<X_>(),
+        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_String(String context, RendererBase<Object> parent)
@@ -705,129 +655,114 @@ String _render_TemplateData<T extends Documentable>(
 
 class _Renderer_TemplateData<T extends Documentable>
     extends RendererBase<TemplateData<T>> {
-  static Map<String, Property<X_>> propertyMap<T extends Documentable,
-          X_ extends TemplateData<T>>() =>
-      {
-        'bareHref': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.bareHref,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'defaultPackage': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.defaultPackage,
-          getProperties: _Renderer_Package.propertyMap,
-        ),
-        'hasFooterVersion': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasFooterVersion,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasFooterVersion == true,
-        ),
-        'hasHomepage': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasHomepage,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasHomepage == true,
-        ),
-        'homepage': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.homepage,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'htmlBase': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.htmlBase,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'htmlOptions': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.htmlOptions,
-          getProperties: _Renderer_TemplateOptions.propertyMap,
-        ),
-        'includeVersion': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.includeVersion,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.includeVersion == true,
-        ),
-        'layoutTitle': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.layoutTitle,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'localPackages': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.localPackages,
-          isEmptyIterable: (X_ c) => c.localPackages?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.localPackages) {
-              buffer.write(_render_Package(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'metaDescription': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.metaDescription,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'navLinks': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.navLinks,
-          isEmptyIterable: (X_ c) => c.navLinks?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.navLinks) {
-              buffer.write(_render_Documentable(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'navLinksWithGenerics': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.navLinksWithGenerics,
-          isEmptyIterable: (X_ c) => c.navLinksWithGenerics?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.navLinksWithGenerics) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'parent': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.parent,
-          getProperties: _Renderer_Documentable.propertyMap,
-        ),
-        'relCanonicalPrefix': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.relCanonicalPrefix,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'title': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.title,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'useBaseHref': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.useBaseHref,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.useBaseHref == true,
-        ),
-        'version': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.version,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        ..._Renderer_Object.propertyMap<X_>(),
-      };
+  static Map<String, Property<CT_>>
+      propertyMap<T extends Documentable, CT_ extends TemplateData<T>>() => {
+            'bareHref': Property(
+              getValue: (CT_ c) => c.bareHref,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'defaultPackage': Property(
+              getValue: (CT_ c) => c.defaultPackage,
+              getProperties: _Renderer_Package.propertyMap,
+            ),
+            'hasFooterVersion': Property(
+              getValue: (CT_ c) => c.hasFooterVersion,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.hasFooterVersion == true,
+            ),
+            'hasHomepage': Property(
+              getValue: (CT_ c) => c.hasHomepage,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.hasHomepage == true,
+            ),
+            'homepage': Property(
+              getValue: (CT_ c) => c.homepage,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'htmlBase': Property(
+              getValue: (CT_ c) => c.htmlBase,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'htmlOptions': Property(
+              getValue: (CT_ c) => c.htmlOptions,
+              getProperties: _Renderer_TemplateOptions.propertyMap,
+            ),
+            'includeVersion': Property(
+              getValue: (CT_ c) => c.includeVersion,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.includeVersion == true,
+            ),
+            'layoutTitle': Property(
+              getValue: (CT_ c) => c.layoutTitle,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'localPackages': Property(
+              getValue: (CT_ c) => c.localPackages,
+              getProperties: _Renderer_List.propertyMap,
+              isEmptyIterable: (CT_ c) => c.localPackages?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.localPackages) {
+                  buffer.write(_render_Package(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'metaDescription': Property(
+              getValue: (CT_ c) => c.metaDescription,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'navLinks': Property(
+              getValue: (CT_ c) => c.navLinks,
+              getProperties: _Renderer_List.propertyMap,
+              isEmptyIterable: (CT_ c) => c.navLinks?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.navLinks) {
+                  buffer.write(_render_Documentable(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'navLinksWithGenerics': Property(
+              getValue: (CT_ c) => c.navLinksWithGenerics,
+              getProperties: _Renderer_List.propertyMap,
+              isEmptyIterable: (CT_ c) =>
+                  c.navLinksWithGenerics?.isEmpty ?? true,
+              renderIterable:
+                  (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                var buffer = StringBuffer();
+                for (var e in c.navLinksWithGenerics) {
+                  buffer.write(null(e, ast, parent: r));
+                }
+                return buffer.toString();
+              },
+            ),
+            'parent': Property(
+              getValue: (CT_ c) => c.parent,
+              getProperties: _Renderer_Documentable.propertyMap,
+            ),
+            'relCanonicalPrefix': Property(
+              getValue: (CT_ c) => c.relCanonicalPrefix,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'title': Property(
+              getValue: (CT_ c) => c.title,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'useBaseHref': Property(
+              getValue: (CT_ c) => c.useBaseHref,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.useBaseHref == true,
+            ),
+            'version': Property(
+              getValue: (CT_ c) => c.version,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            ..._Renderer_Object.propertyMap<CT_>(),
+          };
 
   _Renderer_TemplateData(TemplateData<T> context, RendererBase<Object> parent)
       : super(context, parent);
@@ -850,26 +785,23 @@ String _render_TemplateOptions(TemplateOptions context, List<MustachioNode> ast,
 }
 
 class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
-  static Map<String, Property<X_>> propertyMap<X_ extends TemplateOptions>() =>
-      {
-        'relCanonicalPrefix': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.relCanonicalPrefix,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'toolVersion': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.toolVersion,
-          getProperties: _Renderer_String.propertyMap,
-        ),
-        'useBaseHref': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.useBaseHref,
-          getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.useBaseHref == true,
-        ),
-        ..._Renderer_Object.propertyMap<X_>(),
-      };
+  static Map<String, Property<CT_>>
+      propertyMap<CT_ extends TemplateOptions>() => {
+            'relCanonicalPrefix': Property(
+              getValue: (CT_ c) => c.relCanonicalPrefix,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'toolVersion': Property(
+              getValue: (CT_ c) => c.toolVersion,
+              getProperties: _Renderer_String.propertyMap,
+            ),
+            'useBaseHref': Property(
+              getValue: (CT_ c) => c.useBaseHref,
+              getProperties: _Renderer_bool.propertyMap,
+              getBool: (CT_ c) => c.useBaseHref == true,
+            ),
+            ..._Renderer_Object.propertyMap<CT_>(),
+          };
 
   _Renderer_TemplateOptions(
       TemplateOptions context, RendererBase<Object> parent)
@@ -893,59 +825,49 @@ String _render_Documentable(Documentable context, List<MustachioNode> ast,
 }
 
 class _Renderer_Documentable extends RendererBase<Documentable> {
-  static Map<String, Property<X_>> propertyMap<X_ extends Documentable>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Documentable>() => {
         'config': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.config,
+          getValue: (CT_ c) => c.config,
         ),
         'documentation': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentation,
+          getValue: (CT_ c) => c.documentation,
           getProperties: _Renderer_String.propertyMap,
         ),
         'documentationAsHtml': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.documentationAsHtml,
+          getValue: (CT_ c) => c.documentationAsHtml,
           getProperties: _Renderer_String.propertyMap,
         ),
         'hasDocumentation': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasDocumentation,
+          getValue: (CT_ c) => c.hasDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasDocumentation == true,
+          getBool: (CT_ c) => c.hasDocumentation == true,
         ),
         'hasExtendedDocumentation': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hasExtendedDocumentation,
+          getValue: (CT_ c) => c.hasExtendedDocumentation,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.hasExtendedDocumentation == true,
+          getBool: (CT_ c) => c.hasExtendedDocumentation == true,
         ),
         'href': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.href,
+          getValue: (CT_ c) => c.href,
           getProperties: _Renderer_String.propertyMap,
         ),
         'isDocumented': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isDocumented,
+          getValue: (CT_ c) => c.isDocumented,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isDocumented == true,
+          getBool: (CT_ c) => c.isDocumented == true,
         ),
         'kind': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.kind,
+          getValue: (CT_ c) => c.kind,
           getProperties: _Renderer_String.propertyMap,
         ),
         'oneLineDoc': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.oneLineDoc,
+          getValue: (CT_ c) => c.oneLineDoc,
           getProperties: _Renderer_String.propertyMap,
         ),
         'packageGraph': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.packageGraph,
+          getValue: (CT_ c) => c.packageGraph,
         ),
-        ..._Renderer_Nameable.propertyMap<X_>(),
+        ..._Renderer_Nameable.propertyMap<CT_>(),
       };
 
   _Renderer_Documentable(Documentable context, RendererBase<Object> parent)
@@ -969,28 +891,24 @@ String _render_Nameable(Nameable context, List<MustachioNode> ast,
 }
 
 class _Renderer_Nameable extends RendererBase<Nameable> {
-  static Map<String, Property<X_>> propertyMap<X_ extends Nameable>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Nameable>() => {
         'fullyQualifiedName': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.fullyQualifiedName,
+          getValue: (CT_ c) => c.fullyQualifiedName,
           getProperties: _Renderer_String.propertyMap,
         ),
         'name': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.name,
+          getValue: (CT_ c) => c.name,
           getProperties: _Renderer_String.propertyMap,
         ),
         'namePart': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.namePart,
+          getValue: (CT_ c) => c.namePart,
           getProperties: _Renderer_String.propertyMap,
         ),
         'namePieces': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.namePieces,
-          isEmptyIterable: (X_ c) => c.namePieces?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.namePieces,
+          isEmptyIterable: (CT_ c) => c.namePieces?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.namePieces) {
               buffer.write(_render_String(e, ast, parent: r));
@@ -998,7 +916,7 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
             return buffer.toString();
           },
         ),
-        ..._Renderer_Object.propertyMap<X_>(),
+        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_Nameable(Nameable context, RendererBase<Object> parent)
@@ -1022,30 +940,26 @@ String _render_int(int context, List<MustachioNode> ast,
 }
 
 class _Renderer_int extends RendererBase<int> {
-  static Map<String, Property<X_>> propertyMap<X_ extends int>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends int>() => {
         'bitLength': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.bitLength,
+          getValue: (CT_ c) => c.bitLength,
           getProperties: _Renderer_int.propertyMap,
         ),
         'isEven': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isEven,
+          getValue: (CT_ c) => c.isEven,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isEven == true,
+          getBool: (CT_ c) => c.isEven == true,
         ),
         'isOdd': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isOdd,
+          getValue: (CT_ c) => c.isOdd,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isOdd == true,
+          getBool: (CT_ c) => c.isOdd == true,
         ),
         'sign': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.sign,
+          getValue: (CT_ c) => c.sign,
           getProperties: _Renderer_int.propertyMap,
         ),
-        ..._Renderer_num.propertyMap<X_>(),
+        ..._Renderer_num.propertyMap<CT_>(),
       };
 
   _Renderer_int(int context, RendererBase<Object> parent)
@@ -1069,42 +983,36 @@ String _render_num(num context, List<MustachioNode> ast,
 }
 
 class _Renderer_num extends RendererBase<num> {
-  static Map<String, Property<X_>> propertyMap<X_ extends num>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends num>() => {
         'hashCode': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: _Renderer_int.propertyMap,
         ),
         'isFinite': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isFinite,
+          getValue: (CT_ c) => c.isFinite,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isFinite == true,
+          getBool: (CT_ c) => c.isFinite == true,
         ),
         'isInfinite': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isInfinite,
+          getValue: (CT_ c) => c.isInfinite,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isInfinite == true,
+          getBool: (CT_ c) => c.isInfinite == true,
         ),
         'isNaN': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isNaN,
+          getValue: (CT_ c) => c.isNaN,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isNaN == true,
+          getBool: (CT_ c) => c.isNaN == true,
         ),
         'isNegative': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.isNegative,
+          getValue: (CT_ c) => c.isNegative,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isNegative == true,
+          getBool: (CT_ c) => c.isNegative == true,
         ),
         'sign': Property(
-          // (PackageTemplateData*, Package*, LibraryContainer*, Object, bool, ..., int, num)
-          getValue: (X_ c) => c.sign,
+          getValue: (CT_ c) => c.sign,
           getProperties: _Renderer_num.propertyMap,
         ),
-        ..._Renderer_Object.propertyMap<X_>(),
+        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_num(num context, RendererBase<Object> parent)

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -23,7 +23,7 @@ abstract class RendererBase<T> {
   /// Returns the [Property] on this renderer named [name].
   ///
   /// If no property named [name] exists for this renderer, `null` is returned.
-  Property getProperty(String key);
+  Property<T> getProperty(String key);
 
   /// Resolves [names] into one or more field accesses, returning the result as
   /// a String.

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -97,10 +97,20 @@ class Property<T> {
   /// object [context].
   final bool /*!*/ Function(T context) /*?*/ getBool;
 
-  // TODO(srawlins): Add functions for rendering Iterable properties and other
-  // properties.
+  final bool /*!*/ Function(T) /*?*/ isEmptyIterable;
 
-  Property({@required this.getValue, this.getProperties, this.getBool});
+  final String /*!*/ Function(
+          T, RendererBase<T>, List<MustachioNode> /*!*/) /*?*/
+      renderIterable;
+
+  // TODO(srawlins): Add functions for rendering other properties.
+
+  Property(
+      {@required this.getValue,
+      this.getProperties,
+      this.getBool,
+      this.isEmptyIterable,
+      this.renderIterable});
 }
 
 /// An error indicating that a renderer failed to resolve a key.

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -77,6 +77,7 @@ abstract class FooBase {
 class Foo extends FooBase {
   String s1 = "s1";
   bool b1 = false;
+  List<int> l1 = [1, 2, 3];
 }
 class Bar {}
 ''');
@@ -119,29 +120,50 @@ class Bar {}
     });
 
     test('with a property map', () {
-      expect(generatedContent,
-          contains('static Map<String, Property> propertyMap() => {'));
+      expect(
+          generatedContent,
+          contains(
+              'static Map<String, Property<CT_>> propertyMap<CT_ extends Foo>() => {'));
     });
 
     test('with a property map with a String property', () {
       expect(generatedContent, contains('''
         's1': Property(
-          getValue: (Foo c) => c.s1,
+          getValue: (CT_ c) => c.s1,
           getProperties: _Renderer_String.propertyMap,
         ),
 '''));
     });
 
     test('with a property map which references the superclass', () {
-      expect(generatedContent, contains('..._Renderer_FooBase.propertyMap(),'));
+      expect(generatedContent,
+          contains('..._Renderer_FooBase.propertyMap<CT_>(),'));
     });
 
     test('with a property map with a bool property', () {
       expect(generatedContent, contains('''
         'b1': Property(
-          getValue: (Foo c) => c.b1,
+          getValue: (CT_ c) => c.b1,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Foo c) => c.b1 == true,
+          getBool: (CT_ c) => c.b1 == true,
+        ),
+'''));
+    });
+
+    test('with a property map with an Iterable property', () {
+      expect(generatedContent, contains('''
+        'l1': Property(
+          getValue: (CT_ c) => c.l1,
+          getProperties: _Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.l1?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.l1) {
+              buffer.write(_render_int(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
 '''));
     });
@@ -202,15 +224,15 @@ import 'package:mustachio/annotations.dart';
     test(
         'with a property map which references the superclass with a type '
         'variable', () {
-      expect(
-          generatedContent, contains('..._Renderer_FooBase.propertyMap<T>(),'));
+      expect(generatedContent,
+          contains('..._Renderer_FooBase.propertyMap<T, CT_>(),'));
     });
 
     test(
         'with a property map which references the superclass with an interface '
         'type', () {
       expect(generatedContent,
-          contains('..._Renderer_BarBase.propertyMap<int>(),'));
+          contains('..._Renderer_BarBase.propertyMap<int, CT_>(),'));
     });
   });
 

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -126,7 +126,7 @@ class Bar {}
     test('with a property map with a String property', () {
       expect(generatedContent, contains('''
         's1': Property(
-          getValue: (Object c) => (c as Foo).s1,
+          getValue: (Foo c) => c.s1,
           getProperties: _Renderer_String.propertyMap,
         ),
 '''));
@@ -139,9 +139,9 @@ class Bar {}
     test('with a property map with a bool property', () {
       expect(generatedContent, contains('''
         'b1': Property(
-          getValue: (Object c) => (c as Foo).b1,
+          getValue: (Foo c) => c.b1,
           getProperties: _Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Foo).b1 == true,
+          getBool: (Foo c) => c.b1 == true,
         ),
 '''));
     });

--- a/test/mustachio/foo.dart
+++ b/test/mustachio/foo.dart
@@ -4,6 +4,7 @@ library dartdoc.testing.foo;
 import 'package:dartdoc/src/mustachio/annotations.dart';
 
 class Foo {
-  String s1 = 's1';
-  bool b1 = true;
+  String s1;
+  bool b1;
+  List<int> l1;
 }

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -18,26 +18,41 @@ String renderFoo(Foo context, List<MustachioNode> ast,
 }
 
 class Renderer_Foo extends RendererBase<Foo> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends Foo>() => {
         'b1': Property(
-          getValue: (Object c) => (c as Foo).b1,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.b1,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as Foo).b1 == true,
+          getBool: (X_ c) => c.b1 == true,
+        ),
+        'l1': Property(
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.l1,
+          isEmptyIterable: (X_ c) => c.l1?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.l1) {
+              buffer.write(_render_int(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         's1': Property(
-          getValue: (Object c) => (c as Foo).s1,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.s1,
           getProperties: Renderer_String.propertyMap,
         ),
-        ...Renderer_Object.propertyMap(),
+        ...Renderer_Object.propertyMap<X_>(),
       };
 
   Renderer_Foo(Foo context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<Foo> getProperty(String key) {
+    if (propertyMap<Foo>().containsKey(key)) {
+      return propertyMap<Foo>()[key];
     } else {
       return null;
     }
@@ -52,60 +67,65 @@ String _render_String(String context, List<MustachioNode> ast,
 }
 
 class Renderer_String extends RendererBase<String> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends String>() => {
         'codeUnits': Property(
-          getValue: (Object c) => (c as String).codeUnits,
-          isEmptyIterable: (Object c) =>
-              (c as String).codeUnits?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.codeUnits,
+          isEmptyIterable: (X_ c) => c.codeUnits?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as String).codeUnits) {
+            for (var e in c.codeUnits) {
               buffer.write(_render_int(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'hashCode': Property(
-          getValue: (Object c) => (c as String).hashCode,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
         'isEmpty': Property(
-          getValue: (Object c) => (c as String).isEmpty,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isEmpty,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as String).isEmpty == true,
+          getBool: (X_ c) => c.isEmpty == true,
         ),
         'isNotEmpty': Property(
-          getValue: (Object c) => (c as String).isNotEmpty,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isNotEmpty,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as String).isNotEmpty == true,
+          getBool: (X_ c) => c.isNotEmpty == true,
         ),
         'length': Property(
-          getValue: (Object c) => (c as String).length,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.length,
           getProperties: Renderer_int.propertyMap,
         ),
         'runes': Property(
-          getValue: (Object c) => (c as String).runes,
-          isEmptyIterable: (Object c) => (c as String).runes?.isEmpty ?? false,
-          renderIterable:
-              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.runes,
+          isEmptyIterable: (X_ c) => c.runes?.isEmpty ?? false,
+
+          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in (c as String).runes) {
+            for (var e in c.runes) {
               buffer.write(_render_int(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
-        ...Renderer_Object.propertyMap(),
+        ...Renderer_Object.propertyMap<X_>(),
       };
 
   Renderer_String(String context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<String> getProperty(String key) {
+    if (propertyMap<String>().containsKey(key)) {
+      return propertyMap<String>()[key];
     } else {
       return null;
     }
@@ -120,9 +140,10 @@ String _render_Object(Object context, List<MustachioNode> ast,
 }
 
 class Renderer_Object extends RendererBase<Object> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends Object>() => {
         'hashCode': Property(
-          getValue: (Object c) => (c as Object).hashCode,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
       };
@@ -132,8 +153,8 @@ class Renderer_Object extends RendererBase<Object> {
 
   @override
   Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+    if (propertyMap<Object>().containsKey(key)) {
+      return propertyMap<Object>()[key];
     } else {
       return null;
     }
@@ -148,21 +169,56 @@ String _render_bool(bool context, List<MustachioNode> ast,
 }
 
 class Renderer_bool extends RendererBase<bool> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends bool>() => {
         'hashCode': Property(
-          getValue: (Object c) => (c as bool).hashCode,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
-        ...Renderer_Object.propertyMap(),
+        ...Renderer_Object.propertyMap<X_>(),
       };
 
   Renderer_bool(bool context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<bool> getProperty(String key) {
+    if (propertyMap<bool>().containsKey(key)) {
+      return propertyMap<bool>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_List<E>(List<E> context, List<MustachioNode> ast,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_List(context, parent);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class Renderer_List<E> extends RendererBase<List<E>> {
+  static Map<String, Property<X_>> propertyMap<E, X_ extends List<E>>() => {
+        'length': Property(
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.length,
+          getProperties: Renderer_int.propertyMap,
+        ),
+        'reversed': Property(
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.reversed,
+        ),
+        ...Renderer_Object.propertyMap<X_>(),
+      };
+
+  Renderer_List(List<E> context, RendererBase<Object> parent)
+      : super(context, parent);
+
+  @override
+  Property<List<E>> getProperty(String key) {
+    if (propertyMap<E, List<E>>().containsKey(key)) {
+      return propertyMap<E, List<E>>()[key];
     } else {
       return null;
     }
@@ -177,35 +233,39 @@ String _render_int(int context, List<MustachioNode> ast,
 }
 
 class Renderer_int extends RendererBase<int> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends int>() => {
         'bitLength': Property(
-          getValue: (Object c) => (c as int).bitLength,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.bitLength,
           getProperties: Renderer_int.propertyMap,
         ),
         'isEven': Property(
-          getValue: (Object c) => (c as int).isEven,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isEven,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as int).isEven == true,
+          getBool: (X_ c) => c.isEven == true,
         ),
         'isOdd': Property(
-          getValue: (Object c) => (c as int).isOdd,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isOdd,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as int).isOdd == true,
+          getBool: (X_ c) => c.isOdd == true,
         ),
         'sign': Property(
-          getValue: (Object c) => (c as int).sign,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.sign,
           getProperties: Renderer_int.propertyMap,
         ),
-        ...Renderer_num.propertyMap(),
+        ...Renderer_num.propertyMap<X_>(),
       };
 
   Renderer_int(int context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<int> getProperty(String key) {
+    if (propertyMap<int>().containsKey(key)) {
+      return propertyMap<int>()[key];
     } else {
       return null;
     }
@@ -220,45 +280,51 @@ String _render_num(num context, List<MustachioNode> ast,
 }
 
 class Renderer_num extends RendererBase<num> {
-  static Map<String, Property> propertyMap() => {
+  static Map<String, Property<X_>> propertyMap<X_ extends num>() => {
         'hashCode': Property(
-          getValue: (Object c) => (c as num).hashCode,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
         'isFinite': Property(
-          getValue: (Object c) => (c as num).isFinite,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isFinite,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isFinite == true,
+          getBool: (X_ c) => c.isFinite == true,
         ),
         'isInfinite': Property(
-          getValue: (Object c) => (c as num).isInfinite,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isInfinite,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isInfinite == true,
+          getBool: (X_ c) => c.isInfinite == true,
         ),
         'isNaN': Property(
-          getValue: (Object c) => (c as num).isNaN,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isNaN,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isNaN == true,
+          getBool: (X_ c) => c.isNaN == true,
         ),
         'isNegative': Property(
-          getValue: (Object c) => (c as num).isNegative,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.isNegative,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (Object c) => (c as num).isNegative == true,
+          getBool: (X_ c) => c.isNegative == true,
         ),
         'sign': Property(
-          getValue: (Object c) => (c as num).sign,
+          // (Foo*, String, Object, bool, List<E>, int, num)
+          getValue: (X_ c) => c.sign,
           getProperties: Renderer_num.propertyMap,
         ),
-        ...Renderer_Object.propertyMap(),
+        ...Renderer_Object.propertyMap<X_>(),
       };
 
   Renderer_num(num context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Object> getProperty(String key) {
-    if (propertyMap().containsKey(key)) {
-      return propertyMap()[key];
+  Property<num> getProperty(String key) {
+    if (propertyMap<num>().containsKey(key)) {
+      return propertyMap<num>()[key];
     } else {
       return null;
     }

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -18,19 +18,18 @@ String renderFoo(Foo context, List<MustachioNode> ast,
 }
 
 class Renderer_Foo extends RendererBase<Foo> {
-  static Map<String, Property<X_>> propertyMap<X_ extends Foo>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Foo>() => {
         'b1': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.b1,
+          getValue: (CT_ c) => c.b1,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.b1 == true,
+          getBool: (CT_ c) => c.b1 == true,
         ),
         'l1': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.l1,
-          isEmptyIterable: (X_ c) => c.l1?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.l1,
+          getProperties: Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.l1?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.l1) {
               buffer.write(_render_int(e, ast, parent: r));
@@ -39,11 +38,10 @@ class Renderer_Foo extends RendererBase<Foo> {
           },
         ),
         's1': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.s1,
+          getValue: (CT_ c) => c.s1,
           getProperties: Renderer_String.propertyMap,
         ),
-        ...Renderer_Object.propertyMap<X_>(),
+        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_Foo(Foo context, RendererBase<Object> parent)
@@ -67,13 +65,13 @@ String _render_String(String context, List<MustachioNode> ast,
 }
 
 class Renderer_String extends RendererBase<String> {
-  static Map<String, Property<X_>> propertyMap<X_ extends String>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends String>() => {
         'codeUnits': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.codeUnits,
-          isEmptyIterable: (X_ c) => c.codeUnits?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.codeUnits,
+          getProperties: Renderer_List.propertyMap,
+          isEmptyIterable: (CT_ c) => c.codeUnits?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.codeUnits) {
               buffer.write(_render_int(e, ast, parent: r));
@@ -82,33 +80,28 @@ class Renderer_String extends RendererBase<String> {
           },
         ),
         'hashCode': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
         'isEmpty': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isEmpty,
+          getValue: (CT_ c) => c.isEmpty,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isEmpty == true,
+          getBool: (CT_ c) => c.isEmpty == true,
         ),
         'isNotEmpty': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isNotEmpty,
+          getValue: (CT_ c) => c.isNotEmpty,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isNotEmpty == true,
+          getBool: (CT_ c) => c.isNotEmpty == true,
         ),
         'length': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.length,
+          getValue: (CT_ c) => c.length,
           getProperties: Renderer_int.propertyMap,
         ),
         'runes': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.runes,
-          isEmptyIterable: (X_ c) => c.runes?.isEmpty ?? false,
-
-          renderIterable: (X_ c, RendererBase<X_> r, List<MustachioNode> ast) {
+          getValue: (CT_ c) => c.runes,
+          isEmptyIterable: (CT_ c) => c.runes?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.runes) {
               buffer.write(_render_int(e, ast, parent: r));
@@ -116,7 +109,7 @@ class Renderer_String extends RendererBase<String> {
             return buffer.toString();
           },
         ),
-        ...Renderer_Object.propertyMap<X_>(),
+        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_String(String context, RendererBase<Object> parent)
@@ -140,10 +133,9 @@ String _render_Object(Object context, List<MustachioNode> ast,
 }
 
 class Renderer_Object extends RendererBase<Object> {
-  static Map<String, Property<X_>> propertyMap<X_ extends Object>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Object>() => {
         'hashCode': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
       };
@@ -169,13 +161,12 @@ String _render_bool(bool context, List<MustachioNode> ast,
 }
 
 class Renderer_bool extends RendererBase<bool> {
-  static Map<String, Property<X_>> propertyMap<X_ extends bool>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends bool>() => {
         'hashCode': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
-        ...Renderer_Object.propertyMap<X_>(),
+        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_bool(bool context, RendererBase<Object> parent)
@@ -199,17 +190,15 @@ String _render_List<E>(List<E> context, List<MustachioNode> ast,
 }
 
 class Renderer_List<E> extends RendererBase<List<E>> {
-  static Map<String, Property<X_>> propertyMap<E, X_ extends List<E>>() => {
+  static Map<String, Property<CT_>> propertyMap<E, CT_ extends List<E>>() => {
         'length': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.length,
+          getValue: (CT_ c) => c.length,
           getProperties: Renderer_int.propertyMap,
         ),
         'reversed': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.reversed,
+          getValue: (CT_ c) => c.reversed,
         ),
-        ...Renderer_Object.propertyMap<X_>(),
+        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_List(List<E> context, RendererBase<Object> parent)
@@ -233,30 +222,26 @@ String _render_int(int context, List<MustachioNode> ast,
 }
 
 class Renderer_int extends RendererBase<int> {
-  static Map<String, Property<X_>> propertyMap<X_ extends int>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends int>() => {
         'bitLength': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.bitLength,
+          getValue: (CT_ c) => c.bitLength,
           getProperties: Renderer_int.propertyMap,
         ),
         'isEven': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isEven,
+          getValue: (CT_ c) => c.isEven,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isEven == true,
+          getBool: (CT_ c) => c.isEven == true,
         ),
         'isOdd': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isOdd,
+          getValue: (CT_ c) => c.isOdd,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isOdd == true,
+          getBool: (CT_ c) => c.isOdd == true,
         ),
         'sign': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.sign,
+          getValue: (CT_ c) => c.sign,
           getProperties: Renderer_int.propertyMap,
         ),
-        ...Renderer_num.propertyMap<X_>(),
+        ...Renderer_num.propertyMap<CT_>(),
       };
 
   Renderer_int(int context, RendererBase<Object> parent)
@@ -280,42 +265,36 @@ String _render_num(num context, List<MustachioNode> ast,
 }
 
 class Renderer_num extends RendererBase<num> {
-  static Map<String, Property<X_>> propertyMap<X_ extends num>() => {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends num>() => {
         'hashCode': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.hashCode,
+          getValue: (CT_ c) => c.hashCode,
           getProperties: Renderer_int.propertyMap,
         ),
         'isFinite': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isFinite,
+          getValue: (CT_ c) => c.isFinite,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isFinite == true,
+          getBool: (CT_ c) => c.isFinite == true,
         ),
         'isInfinite': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isInfinite,
+          getValue: (CT_ c) => c.isInfinite,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isInfinite == true,
+          getBool: (CT_ c) => c.isInfinite == true,
         ),
         'isNaN': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isNaN,
+          getValue: (CT_ c) => c.isNaN,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isNaN == true,
+          getBool: (CT_ c) => c.isNaN == true,
         ),
         'isNegative': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.isNegative,
+          getValue: (CT_ c) => c.isNegative,
           getProperties: Renderer_bool.propertyMap,
-          getBool: (X_ c) => c.isNegative == true,
+          getBool: (CT_ c) => c.isNegative == true,
         ),
         'sign': Property(
-          // (Foo*, String, Object, bool, List<E>, int, num)
-          getValue: (X_ c) => c.sign,
+          getValue: (CT_ c) => c.sign,
           getProperties: Renderer_num.propertyMap,
         ),
-        ...Renderer_Object.propertyMap<X_>(),
+        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_num(num context, RendererBase<Object> parent)

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -55,6 +55,16 @@ class Renderer_String extends RendererBase<String> {
   static Map<String, Property> propertyMap() => {
         'codeUnits': Property(
           getValue: (Object c) => (c as String).codeUnits,
+          isEmptyIterable: (Object c) =>
+              (c as String).codeUnits?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as String).codeUnits) {
+              buffer.write(_render_int(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         'hashCode': Property(
           getValue: (Object c) => (c as String).hashCode,
@@ -76,6 +86,15 @@ class Renderer_String extends RendererBase<String> {
         ),
         'runes': Property(
           getValue: (Object c) => (c as String).runes,
+          isEmptyIterable: (Object c) => (c as String).runes?.isEmpty ?? false,
+          renderIterable:
+              (Object c, RendererBase<String> r, List<WhiskersNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in (c as String).runes) {
+              buffer.write(_render_int(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
         ),
         ...Renderer_Object.propertyMap(),
       };

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -25,9 +25,10 @@ void main() {
   test('property map contains valid Iterable Properties', () {
     var propertyMap = Renderer_Foo.propertyMap();
     expect(propertyMap['l1'].getValue, isNotNull);
+    expect(propertyMap['l1'].getProperties, isNotNull);
     expect(propertyMap['l1'].getBool, isNull);
-    expect(propertyMap['b1'].isEmptyIterable, isNotNull);
-    expect(propertyMap['b1'].renderIterable, isNotNull);
+    expect(propertyMap['l1'].isEmptyIterable, isNotNull);
+    expect(propertyMap['l1'].renderIterable, isNotNull);
   });
 
   test('property map contains valid non-bool, non-Iterable Properties', () {
@@ -35,6 +36,8 @@ void main() {
     expect(propertyMap['s1'].getValue, isNotNull);
     expect(propertyMap['s1'].getProperties, isNotNull);
     expect(propertyMap['s1'].getBool, isNull);
+    expect(propertyMap['s1'].isEmptyIterable, isNull);
+    expect(propertyMap['s1'].renderIterable, isNull);
   });
 
   test('Property returns a field value by name', () {
@@ -47,6 +50,24 @@ void main() {
     var propertyMap = Renderer_Foo.propertyMap();
     var foo = Foo()..b1 = true;
     expect(propertyMap['b1'].getBool(foo), isTrue);
+  });
+
+  test('isEmptyIterable returns true when an Iterable value is empty', () {
+    var propertyMap = Renderer_Foo.propertyMap();
+    var foo = Foo()..l1 = [];
+    expect(propertyMap['l1'].isEmptyIterable(foo), isTrue);
+  });
+
+  test('isEmptyIterable returns false when an Iterable value is not empty', () {
+    var propertyMap = Renderer_Foo.propertyMap();
+    var foo = Foo()..l1 = [1, 2, 3];
+    expect(propertyMap['l1'].isEmptyIterable(foo), isFalse);
+  });
+
+  test('isEmptyIterable returns true when an Iterable value is null', () {
+    var propertyMap = Renderer_Foo.propertyMap();
+    var foo = Foo()..l1 = null;
+    expect(propertyMap['l1'].isEmptyIterable(foo), isTrue);
   });
 
   test('Property returns false for a null bool field value', () {

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -6,9 +6,10 @@ import 'foo.renderers.dart';
 void main() {
   test('property map contains all public getters', () {
     var propertyMap = Renderer_Foo.propertyMap();
-    expect(propertyMap.keys, hasLength(3));
+    expect(propertyMap.keys, hasLength(4));
     expect(propertyMap['b1'], isNotNull);
     expect(propertyMap['s1'], isNotNull);
+    expect(propertyMap['l1'], isNotNull);
     expect(propertyMap['hashCode'], isNotNull);
   });
 
@@ -17,9 +18,19 @@ void main() {
     expect(propertyMap['b1'].getValue, isNotNull);
     expect(propertyMap['b1'].getProperties, isNotNull);
     expect(propertyMap['b1'].getBool, isNotNull);
+    expect(propertyMap['b1'].isEmptyIterable, isNull);
+    expect(propertyMap['b1'].renderIterable, isNull);
   });
 
-  test('property map contains valid non-bool Properties', () {
+  test('property map contains valid Iterable Properties', () {
+    var propertyMap = Renderer_Foo.propertyMap();
+    expect(propertyMap['l1'].getValue, isNotNull);
+    expect(propertyMap['l1'].getBool, isNull);
+    expect(propertyMap['b1'].isEmptyIterable, isNotNull);
+    expect(propertyMap['b1'].renderIterable, isNotNull);
+  });
+
+  test('property map contains valid non-bool, non-Iterable Properties', () {
     var propertyMap = Renderer_Foo.propertyMap();
     expect(propertyMap['s1'].getValue, isNotNull);
     expect(propertyMap['s1'].getProperties, isNotNull);

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -89,4 +89,11 @@ void main() {
     var foo = Foo()..b1 = true;
     expect(renderFoo(foo, ast), equals('Text true'));
   });
+
+  test('Renderer renders an Iterable variable node', () {
+    var parser = MustachioParser('Text {{l1}}');
+    var ast = parser.parse();
+    var foo = Foo()..l1 = [1, 2, 3];
+    expect(renderFoo(foo, ast), equals('Text [1, 2, 3]'));
+  });
 }

--- a/tool/mustachio/builder.dart
+++ b/tool/mustachio/builder.dart
@@ -34,7 +34,7 @@ class MustachioBuilder implements Builder {
 
     if (rendererGatherer._rendererSpecs.isNotEmpty) {
       contents += buildTemplateRenderers(rendererGatherer._rendererSpecs,
-          entryLib.source.uri, entryLib.typeProvider,
+          entryLib.source.uri, entryLib.typeProvider, entryLib.typeSystem,
           rendererClassesArePublic: _rendererClassesArePublic);
 
       await buildStep.writeAsString(renderersLibrary, contents);

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -169,11 +169,7 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
   ${renderer._rendererClassName}($typeName context, RendererBase<Object> parent)
       : super(context, parent);
 ''');
-    var propertyMapTypeArguments = _asGenerics([
-      ...renderer._contextType.typeArguments
-          .map((t) => t.getDisplayString(withNullability: false)),
-      typeName
-    ]);
+    var propertyMapTypeArguments = renderer._typeArgumentsStringWith(typeName);
     var propertyMapName = 'propertyMap$propertyMapTypeArguments';
     // Write out `getProperty`.
     _buffer.writeln('''
@@ -258,8 +254,7 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
       // concrete types substituted for `E` for example.
       if (innerType is! TypeParameterType) {
         var rendererName = _typeToRenderFunctionName[innerType.element];
-        _buffer.writeln(
-            '''                                                                                                                                                       
+        _buffer.writeln('''
 isEmptyIterable: ($_contextTypeVariable c) => c.$getterName?.isEmpty ?? true,
 
 renderIterable:
@@ -317,26 +312,28 @@ class _RendererInfo {
         .map((tp) => tp.getDisplayString(withNullability: false)));
   }
 
+  /// Returns the type parameters of the context type, and [extra], as they
+  /// appear in a list of generics.
   String _typeParametersStringWith(String extra) {
     return _asGenerics([
       ..._contextType.element.typeParameters
           .map((tp) => tp.getDisplayString(withNullability: false)),
-      extra
+      extra,
     ]);
   }
 
-  /// The type arguments, if any, of [_contextType], as a String, including the
-  /// angled brackets, otherwise a blank String.
-  String get _typeArgumentsString {
-    if (_contextType.typeArguments.isEmpty) {
-      return '';
-    } else {
-      var typeArguments = _contextType.typeArguments
-          .map((t) => t.getDisplayString(withNullability: false));
-      return '<${typeArguments.join(', ')}>';
-    }
+  /// Returns the type parameters of the context type, and [extra], as they
+  /// appear in a list of generics.
+  String _typeArgumentsStringWith(String extra) {
+    return _asGenerics([
+      ..._contextType.typeArguments
+          .map((tp) => tp.getDisplayString(withNullability: false)),
+      extra,
+    ]);
   }
 }
 
+/// Returns [values] as they appear in a list of generics, with angled brackets,
+/// and an empty string when [values] is empty.
 String _asGenerics(Iterable<String> values) =>
     values.isEmpty ? '' : '<${values.join(', ')}>';


### PR DESCRIPTION
* Add two properties to the Property class: `isEmptyIterable` and `renderIterable` which are used for sections and inverted sections.
* Make all Properties of the right type again, avoiding all of the casts. This involved a weird arrangement though: now every propertyMap has at least one type parameter, `CT_` (for context type). The propertyMap on a generic type will also have the other generics, for example `propertyMap<E, CT_>` for Renderer_List, and `propertyMap<K, V, CT_>` for Renderer_Map. This allows us to spread in inherited properties, like Object's `hashMap`. The propertyMap for Foo_Renderer cannot claim that the Property representing `hashCode` has functions that take `Foo` instances; they only take Object. By introducing `CT_`, we can say that Foo_Renderer's propertyMap spreads in Object_Renderer's propertyMap as `propertyMap<Foo>()`.