### PR TITLE
Correctly handle intermediate abstract classes containing (external?) implementations

### DIFF
--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1315,8 +1315,8 @@ void main() {
   group('Class edge cases', () {
     test('Overrides from intermediate abstract classes are picked up correctly', () {
       var IntermediateAbstractSubclass = fakeLibrary.allClasses.firstWhere((c) => c.name == 'IntermediateAbstractSubclass');
-      var concreteMethod = IntermediateAbstractSubclass.inheritedMethods.firstWhere((m) => m.name == 'concreteMethod');
-      expect(concreteMethod.definingEnclosingContainer.name, equals('IntermediateAbstract'));
+      var operatorEquals = IntermediateAbstractSubclass.inheritedOperators.firstWhere((m) => m.name == 'operator ==');
+      expect(operatorEquals.definingEnclosingContainer.name, equals('IntermediateAbstract'));
     });
 
     test('Factories from unrelated classes are linked correctly', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1313,6 +1313,12 @@ void main() {
   });
 
   group('Class edge cases', () {
+    test('Overrides from intermediate abstract classes are picked up correctly', () {
+      var IntermediateAbstractSubclass = fakeLibrary.allClasses.firstWhere((c) => c.name == 'IntermediateAbstractSubclass');
+      var concreteMethod = IntermediateAbstractSubclass.inheritedMethods.firstWhere((m) => m.name == 'concreteMethod');
+      expect(concreteMethod.definingEnclosingContainer.name, equals('IntermediateAbstract'));
+    });
+
     test('Factories from unrelated classes are linked correctly', () {
       var A = packageGraph.localPublicLibraries
           .firstWhere((l) => l.name == 'unrelated_factories')

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1313,14 +1313,24 @@ void main() {
   });
 
   group('Class edge cases', () {
-    test('Overrides from intermediate abstract classes are picked up correctly', () {
-      var IntermediateAbstractSubclass = fakeLibrary.allClasses.firstWhere((c) => c.name == 'IntermediateAbstractSubclass');
-      var operatorEquals = IntermediateAbstractSubclass.inheritedOperators.firstWhere((o) => o.name == 'operator ==');
-      expect(operatorEquals.definingEnclosingContainer.name, equals('IntermediateAbstract'));
+    test('Overrides from intermediate abstract classes are picked up correctly',
+        () {
+      var IntermediateAbstractSubclass = fakeLibrary.allClasses
+          .firstWhere((c) => c.name == 'IntermediateAbstractSubclass');
+      var operatorEquals = IntermediateAbstractSubclass.inheritedOperators
+          .firstWhere((o) => o.name == 'operator ==');
+      expect(operatorEquals.definingEnclosingContainer.name,
+          equals('IntermediateAbstract'));
+    });
 
-      var dartCore = packageGraph.libraries.firstWhere((l) => l.name == 'dart:core');
+    test(
+        'Overrides from intermediate abstract classes that have external implementations via the SDK are picked up correctly',
+        () {
+      var dartCore =
+          packageGraph.libraries.firstWhere((l) => l.name == 'dart:core');
       var intClass = dartCore.allClasses.firstWhere((c) => c.name == 'int');
-      var operatorEqualsInt = intClass.inheritedOperators.firstWhere((o) => o.name == 'operator ==');
+      var operatorEqualsInt = intClass.inheritedOperators
+          .firstWhere((o) => o.name == 'operator ==');
       expect(operatorEqualsInt.definingEnclosingContainer.name, equals('num'));
     });
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1315,8 +1315,13 @@ void main() {
   group('Class edge cases', () {
     test('Overrides from intermediate abstract classes are picked up correctly', () {
       var IntermediateAbstractSubclass = fakeLibrary.allClasses.firstWhere((c) => c.name == 'IntermediateAbstractSubclass');
-      var operatorEquals = IntermediateAbstractSubclass.inheritedOperators.firstWhere((m) => m.name == 'operator ==');
+      var operatorEquals = IntermediateAbstractSubclass.inheritedOperators.firstWhere((o) => o.name == 'operator ==');
       expect(operatorEquals.definingEnclosingContainer.name, equals('IntermediateAbstract'));
+
+      var dartCore = packageGraph.libraries.firstWhere((l) => l.name == 'dart:core');
+      var intClass = dartCore.allClasses.firstWhere((c) => c.name == 'int');
+      var operatorEqualsInt = intClass.inheritedOperators.firstWhere((o) => o.name == 'operator ==');
+      expect(operatorEqualsInt.definingEnclosingContainer.name, equals('num'));
     });
 
     test('Factories from unrelated classes are linked correctly', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1230,15 +1230,11 @@ class _Super5 implements _Super2 {}
 class Super6 implements _Super5 {}
 
 
-class IntermediateAbstractBase {
-  void concreteMethod() {}
-}
-
-abstract class IntermediateAbstract extends IntermediateAbstractBase {
+abstract class IntermediateAbstract extends Object {
   /// This is an override.
   @override
-  void concreteMethod() {}
+  bool operator==(Object other) {}
 }
 
-/// This should inherit [concreteMethod] from [IntermediateAbstract].
+/// This should inherit [==] from [IntermediateAbstract].
 class IntermediateAbstractSubclass extends IntermediateAbstract {}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1228,3 +1228,17 @@ class Super4 implements Super1 {}
 class _Super5 implements _Super2 {}
 
 class Super6 implements _Super5 {}
+
+
+class IntermediateAbstractBase {
+  void concreteMethod() {}
+}
+
+abstract class IntermediateAbstract extends IntermediateAbstractBase {
+  /// This is an override.
+  @override
+  void concreteMethod() {}
+}
+
+/// This should inherit [concreteMethod] from [IntermediateAbstract].
+class IntermediateAbstractSubclass extends IntermediateAbstract {}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1230,7 +1230,7 @@ class _Super5 implements _Super2 {}
 class Super6 implements _Super5 {}
 
 
-abstract class IntermediateAbstract extends Object {
+abstract class IntermediateAbstract implements Object {
   /// This is an override.
   @override
   bool operator==(Object other) {}


### PR DESCRIPTION
Fixes #2251.

This was very tricky.  I think that the analyzer's "concrete" map is buggy in not correctly identifying the implementation in `num`, but I can see why as the "implementation" doesn't exist in the Dart source and is magically injected.

Added a test that verifies the specific case.  In case there are other special magical injections like this, the implementation of the fix is generic enough to pick them up.

@scheglov If you agree it's a bug that `InheritanceManager3.getInheritedConcreteMap2` doesn't handle this for dartdoc, I'll file that and try to fix it there, then undo this workaround.