### PR TITLE
Mustachio: Fix multi-name keys and other bugs encountered so far.

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -3373,9 +3373,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
             return buffer.toString();
           },
         ),
-        'modelElementRenderer': Property(
-          getValue: (CT_ c) => c.modelElementRenderer,
-        ),
         'modelNode': Property(
           getValue: (CT_ c) => c.modelNode,
         ),

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -23,12 +23,34 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
       {
         'hasHomepage': Property(
           getValue: (CT_ c) => c.hasHomepage,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasHomepage == true,
         ),
         'homepage': Property(
           getValue: (CT_ c) => c.homepage,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.homepage == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.homepage, ast, parent: r);
@@ -36,7 +58,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'htmlBase': Property(
           getValue: (CT_ c) => c.htmlBase,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.htmlBase == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.htmlBase, ast, parent: r);
@@ -44,12 +77,34 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'includeVersion': Property(
           getValue: (CT_ c) => c.includeVersion,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.includeVersion == true,
         ),
         'layoutTitle': Property(
           getValue: (CT_ c) => c.layoutTitle,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.layoutTitle == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.layoutTitle, ast, parent: r);
@@ -57,7 +112,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'metaDescription': Property(
           getValue: (CT_ c) => c.metaDescription,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.metaDescription == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.metaDescription, ast, parent: r);
@@ -65,7 +131,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'navLinks': Property(
           getValue: (CT_ c) => c.navLinks,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.navLinks?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -78,7 +155,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'package': Property(
           getValue: (CT_ c) => c.package,
-          getProperties: _Renderer_Package.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_Package.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_Package.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.package == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_Package(c.package, ast, parent: r);
@@ -86,7 +174,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'self': Property(
           getValue: (CT_ c) => c.self,
-          getProperties: _Renderer_Package.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_Package.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_Package.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.self == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_Package(c.self, ast, parent: r);
@@ -94,7 +193,18 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ),
         'title': Property(
           getValue: (CT_ c) => c.title,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.title == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.title, ast, parent: r);
@@ -128,19 +238,21 @@ class _Renderer_Package extends RendererBase<Package> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Package>() => {
         'allLibraries': Property(
           getValue: (CT_ c) => c.allLibraries,
-          isEmptyIterable: (CT_ c) => c.allLibraries?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.allLibraries) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
         ),
         'baseHref': Property(
           getValue: (CT_ c) => c.baseHref,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.baseHref == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.baseHref, ast, parent: r);
@@ -148,22 +260,20 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'canonicalLibrary': Property(
           getValue: (CT_ c) => c.canonicalLibrary,
-          isNullValue: (CT_ c) => c.canonicalLibrary == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.canonicalLibrary, ast, parent: r);
-          },
         ),
         'categories': Property(
           getValue: (CT_ c) => c.categories,
-          getProperties: _Renderer_List.propertyMap,
-          isEmptyIterable: (CT_ c) => c.categories?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.categories) {
-              buffer.write(null(e, ast, parent: r));
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
             }
-            return buffer.toString();
           },
         ),
         'categoriesWithPublicLibraries': Property(
@@ -181,14 +291,21 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'config': Property(
           getValue: (CT_ c) => c.config,
-          isNullValue: (CT_ c) => c.config == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.config, ast, parent: r);
-          },
         ),
         'containerOrder': Property(
           getValue: (CT_ c) => c.containerOrder,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.containerOrder?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -201,7 +318,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'defaultCategory': Property(
           getValue: (CT_ c) => c.defaultCategory,
-          getProperties: _Renderer_LibraryContainer.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_LibraryContainer.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_LibraryContainer.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.defaultCategory == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_LibraryContainer(c.defaultCategory, ast, parent: r);
@@ -209,7 +337,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'documentation': Property(
           getValue: (CT_ c) => c.documentation,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.documentation == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.documentation, ast, parent: r);
@@ -217,7 +356,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'documentationAsHtml': Property(
           getValue: (CT_ c) => c.documentationAsHtml,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.documentationAsHtml == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.documentationAsHtml, ast, parent: r);
@@ -225,73 +375,51 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'documentationFile': Property(
           getValue: (CT_ c) => c.documentationFile,
-          isNullValue: (CT_ c) => c.documentationFile == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.documentationFile, ast, parent: r);
-          },
         ),
         'documentationFrom': Property(
           getValue: (CT_ c) => c.documentationFrom,
-          getProperties: _Renderer_List.propertyMap,
-          isEmptyIterable: (CT_ c) => c.documentationFrom?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentationFrom) {
-              buffer.write(null(e, ast, parent: r));
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
             }
-            return buffer.toString();
           },
         ),
         'documentedCategories': Property(
           getValue: (CT_ c) => c.documentedCategories,
-          isEmptyIterable: (CT_ c) => c.documentedCategories?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentedCategories) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
         ),
         'documentedCategoriesSorted': Property(
           getValue: (CT_ c) => c.documentedCategoriesSorted,
-          isEmptyIterable: (CT_ c) =>
-              c.documentedCategoriesSorted?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentedCategoriesSorted) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
         ),
         'documentedWhere': Property(
           getValue: (CT_ c) => c.documentedWhere,
-          isNullValue: (CT_ c) => c.documentedWhere == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.documentedWhere, ast, parent: r);
-          },
         ),
         'element': Property(
           getValue: (CT_ c) => c.element,
-          isNullValue: (CT_ c) => c.element == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.element, ast, parent: r);
-          },
         ),
         'enclosingElement': Property(
           getValue: (CT_ c) => c.enclosingElement,
-          isNullValue: (CT_ c) => c.enclosingElement == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.enclosingElement, ast, parent: r);
-          },
         ),
         'enclosingName': Property(
           getValue: (CT_ c) => c.enclosingName,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.enclosingName == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.enclosingName, ast, parent: r);
@@ -299,7 +427,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'filePath': Property(
           getValue: (CT_ c) => c.filePath,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.filePath == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.filePath, ast, parent: r);
@@ -307,7 +446,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'fileType': Property(
           getValue: (CT_ c) => c.fileType,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.fileType == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.fileType, ast, parent: r);
@@ -315,7 +465,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'fullyQualifiedName': Property(
           getValue: (CT_ c) => c.fullyQualifiedName,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.fullyQualifiedName == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.fullyQualifiedName, ast, parent: r);
@@ -323,37 +484,114 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'hasCategories': Property(
           getValue: (CT_ c) => c.hasCategories,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasCategories == true,
         ),
         'hasDocumentation': Property(
           getValue: (CT_ c) => c.hasDocumentation,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasDocumentation == true,
         ),
         'hasDocumentationFile': Property(
           getValue: (CT_ c) => c.hasDocumentationFile,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasDocumentationFile == true,
         ),
         'hasDocumentedCategories': Property(
           getValue: (CT_ c) => c.hasDocumentedCategories,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasDocumentedCategories == true,
         ),
         'hasExtendedDocumentation': Property(
           getValue: (CT_ c) => c.hasExtendedDocumentation,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasExtendedDocumentation == true,
         ),
         'hasHomepage': Property(
           getValue: (CT_ c) => c.hasHomepage,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasHomepage == true,
         ),
         'homepage': Property(
           getValue: (CT_ c) => c.homepage,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.homepage == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.homepage, ast, parent: r);
@@ -361,7 +599,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'href': Property(
           getValue: (CT_ c) => c.href,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.href == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.href, ast, parent: r);
@@ -369,37 +618,114 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'isCanonical': Property(
           getValue: (CT_ c) => c.isCanonical,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isCanonical == true,
         ),
         'isDocumented': Property(
           getValue: (CT_ c) => c.isDocumented,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isDocumented == true,
         ),
         'isFirstPackage': Property(
           getValue: (CT_ c) => c.isFirstPackage,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isFirstPackage == true,
         ),
         'isLocal': Property(
           getValue: (CT_ c) => c.isLocal,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isLocal == true,
         ),
         'isPublic': Property(
           getValue: (CT_ c) => c.isPublic,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isPublic == true,
         ),
         'isSdk': Property(
           getValue: (CT_ c) => c.isSdk,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isSdk == true,
         ),
         'kind': Property(
           getValue: (CT_ c) => c.kind,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.kind == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.kind, ast, parent: r);
@@ -407,7 +733,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'location': Property(
           getValue: (CT_ c) => c.location,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.location == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.location, ast, parent: r);
@@ -427,7 +764,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'name': Property(
           getValue: (CT_ c) => c.name,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.name == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.name, ast, parent: r);
@@ -435,14 +783,21 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'nameToCategory': Property(
           getValue: (CT_ c) => c.nameToCategory,
-          isNullValue: (CT_ c) => c.nameToCategory == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.nameToCategory, ast, parent: r);
-          },
         ),
         'oneLineDoc': Property(
           getValue: (CT_ c) => c.oneLineDoc,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.oneLineDoc == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.oneLineDoc, ast, parent: r);
@@ -450,7 +805,18 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'package': Property(
           getValue: (CT_ c) => c.package,
-          getProperties: _Renderer_Package.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_Package.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_Package.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.package == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_Package(c.package, ast, parent: r);
@@ -458,21 +824,24 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'packageGraph': Property(
           getValue: (CT_ c) => c.packageGraph,
-          isNullValue: (CT_ c) => c.packageGraph == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.packageGraph, ast, parent: r);
-          },
         ),
         'packageMeta': Property(
           getValue: (CT_ c) => c.packageMeta,
-          isNullValue: (CT_ c) => c.packageMeta == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.packageMeta, ast, parent: r);
-          },
         ),
         'packagePath': Property(
           getValue: (CT_ c) => c.packagePath,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.packagePath == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.packagePath, ast, parent: r);
@@ -480,19 +849,21 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'publicLibraries': Property(
           getValue: (CT_ c) => c.publicLibraries,
-          isEmptyIterable: (CT_ c) => c.publicLibraries?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibraries) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
         ),
         'toolInvocationIndex': Property(
           getValue: (CT_ c) => c.toolInvocationIndex,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.toolInvocationIndex == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.toolInvocationIndex, ast, parent: r);
@@ -500,14 +871,21 @@ class _Renderer_Package extends RendererBase<Package> {
         ),
         'usedAnimationIdsByHref': Property(
           getValue: (CT_ c) => c.usedAnimationIdsByHref,
-          isNullValue: (CT_ c) => c.usedAnimationIdsByHref == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.usedAnimationIdsByHref, ast, parent: r);
-          },
         ),
         'version': Property(
           getValue: (CT_ c) => c.version,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.version == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.version, ast, parent: r);
@@ -543,7 +921,18 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
       {
         'containerOrder': Property(
           getValue: (CT_ c) => c.containerOrder,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.containerOrder?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -556,7 +945,18 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
         ),
         'enclosingName': Property(
           getValue: (CT_ c) => c.enclosingName,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.enclosingName == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.enclosingName, ast, parent: r);
@@ -564,61 +964,74 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
         ),
         'hasPublicLibraries': Property(
           getValue: (CT_ c) => c.hasPublicLibraries,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasPublicLibraries == true,
         ),
         'isSdk': Property(
           getValue: (CT_ c) => c.isSdk,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isSdk == true,
         ),
         'libraries': Property(
           getValue: (CT_ c) => c.libraries,
-          getProperties: _Renderer_List.propertyMap,
-          isEmptyIterable: (CT_ c) => c.libraries?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.libraries) {
-              buffer.write(null(e, ast, parent: r));
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
             }
-            return buffer.toString();
           },
         ),
         'packageGraph': Property(
           getValue: (CT_ c) => c.packageGraph,
-          isNullValue: (CT_ c) => c.packageGraph == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.packageGraph, ast, parent: r);
-          },
         ),
         'publicLibraries': Property(
           getValue: (CT_ c) => c.publicLibraries,
-          isEmptyIterable: (CT_ c) => c.publicLibraries?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibraries) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
         ),
         'publicLibrariesSorted': Property(
           getValue: (CT_ c) => c.publicLibrariesSorted,
-          isEmptyIterable: (CT_ c) => c.publicLibrariesSorted?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibrariesSorted) {
-              buffer.write(null(e, ast, parent: r));
-            }
-            return buffer.toString();
-          },
         ),
         'sortKey': Property(
           getValue: (CT_ c) => c.sortKey,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.sortKey == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.sortKey, ast, parent: r);
@@ -652,7 +1065,18 @@ class _Renderer_Object extends RendererBase<Object> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Object>() => {
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -684,7 +1108,18 @@ class _Renderer_bool extends RendererBase<bool> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends bool>() => {
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -706,6 +1141,274 @@ class _Renderer_bool extends RendererBase<bool> {
   }
 }
 
+String _render_Documentable(Documentable context, List<MustachioNode> ast,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_Documentable(context, parent);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_Documentable extends RendererBase<Documentable> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Documentable>() => {
+        'config': Property(
+          getValue: (CT_ c) => c.config,
+        ),
+        'documentation': Property(
+          getValue: (CT_ c) => c.documentation,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.documentation == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.documentation, ast, parent: r);
+          },
+        ),
+        'documentationAsHtml': Property(
+          getValue: (CT_ c) => c.documentationAsHtml,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.documentationAsHtml == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.documentationAsHtml, ast, parent: r);
+          },
+        ),
+        'hasDocumentation': Property(
+          getValue: (CT_ c) => c.hasDocumentation,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasDocumentation == true,
+        ),
+        'hasExtendedDocumentation': Property(
+          getValue: (CT_ c) => c.hasExtendedDocumentation,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasExtendedDocumentation == true,
+        ),
+        'href': Property(
+          getValue: (CT_ c) => c.href,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.href == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.href, ast, parent: r);
+          },
+        ),
+        'isDocumented': Property(
+          getValue: (CT_ c) => c.isDocumented,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isDocumented == true,
+        ),
+        'kind': Property(
+          getValue: (CT_ c) => c.kind,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.kind == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.kind, ast, parent: r);
+          },
+        ),
+        'oneLineDoc': Property(
+          getValue: (CT_ c) => c.oneLineDoc,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.oneLineDoc == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.oneLineDoc, ast, parent: r);
+          },
+        ),
+        'packageGraph': Property(
+          getValue: (CT_ c) => c.packageGraph,
+        ),
+        ..._Renderer_Nameable.propertyMap<CT_>(),
+      };
+
+  _Renderer_Documentable(Documentable context, RendererBase<Object> parent)
+      : super(context, parent);
+
+  @override
+  Property<Documentable> getProperty(String key) {
+    if (propertyMap<Documentable>().containsKey(key)) {
+      return propertyMap<Documentable>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_Nameable(Nameable context, List<MustachioNode> ast,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_Nameable(context, parent);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_Nameable extends RendererBase<Nameable> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Nameable>() => {
+        'fullyQualifiedName': Property(
+          getValue: (CT_ c) => c.fullyQualifiedName,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.fullyQualifiedName == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.fullyQualifiedName, ast, parent: r);
+          },
+        ),
+        'name': Property(
+          getValue: (CT_ c) => c.name,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.name == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.name, ast, parent: r);
+          },
+        ),
+        'namePart': Property(
+          getValue: (CT_ c) => c.namePart,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.namePart == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.namePart, ast, parent: r);
+          },
+        ),
+        'namePieces': Property(
+          getValue: (CT_ c) => c.namePieces,
+          isEmptyIterable: (CT_ c) => c.namePieces?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.namePieces) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        ..._Renderer_Object.propertyMap<CT_>(),
+      };
+
+  _Renderer_Nameable(Nameable context, RendererBase<Object> parent)
+      : super(context, parent);
+
+  @override
+  Property<Nameable> getProperty(String key) {
+    if (propertyMap<Nameable>().containsKey(key)) {
+      return propertyMap<Nameable>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
 String _render_List<E>(List<E> context, List<MustachioNode> ast,
     {RendererBase<Object> parent}) {
   var renderer = _Renderer_List(context, parent);
@@ -717,7 +1420,18 @@ class _Renderer_List<E> extends RendererBase<List<E>> {
   static Map<String, Property<CT_>> propertyMap<E, CT_ extends List<E>>() => {
         'length': Property(
           getValue: (CT_ c) => c.length,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.length == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.length, ast, parent: r);
@@ -753,7 +1467,18 @@ class _Renderer_String extends RendererBase<String> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends String>() => {
         'codeUnits': Property(
           getValue: (CT_ c) => c.codeUnits,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.codeUnits?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -766,7 +1491,18 @@ class _Renderer_String extends RendererBase<String> {
         ),
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -774,17 +1510,50 @@ class _Renderer_String extends RendererBase<String> {
         ),
         'isEmpty': Property(
           getValue: (CT_ c) => c.isEmpty,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isEmpty == true,
         ),
         'isNotEmpty': Property(
           getValue: (CT_ c) => c.isNotEmpty,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isNotEmpty == true,
         ),
         'length': Property(
           getValue: (CT_ c) => c.length,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.length == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.length, ast, parent: r);
@@ -833,7 +1602,18 @@ class _Renderer_TemplateData<T extends Documentable>
       {
         'bareHref': Property(
           getValue: (CT_ c) => c.bareHref,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.bareHref == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.bareHref, ast, parent: r);
@@ -841,7 +1621,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'defaultPackage': Property(
           getValue: (CT_ c) => c.defaultPackage,
-          getProperties: _Renderer_Package.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_Package.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_Package.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.defaultPackage == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_Package(c.defaultPackage, ast, parent: r);
@@ -849,17 +1640,50 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'hasFooterVersion': Property(
           getValue: (CT_ c) => c.hasFooterVersion,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasFooterVersion == true,
         ),
         'hasHomepage': Property(
           getValue: (CT_ c) => c.hasHomepage,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasHomepage == true,
         ),
         'homepage': Property(
           getValue: (CT_ c) => c.homepage,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.homepage == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.homepage, ast, parent: r);
@@ -867,7 +1691,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'htmlBase': Property(
           getValue: (CT_ c) => c.htmlBase,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.htmlBase == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.htmlBase, ast, parent: r);
@@ -875,7 +1710,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'htmlOptions': Property(
           getValue: (CT_ c) => c.htmlOptions,
-          getProperties: _Renderer_TemplateOptions.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_TemplateOptions.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_TemplateOptions.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.htmlOptions == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_TemplateOptions(c.htmlOptions, ast, parent: r);
@@ -883,12 +1729,34 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'includeVersion': Property(
           getValue: (CT_ c) => c.includeVersion,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.includeVersion == true,
         ),
         'layoutTitle': Property(
           getValue: (CT_ c) => c.layoutTitle,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.layoutTitle == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.layoutTitle, ast, parent: r);
@@ -896,7 +1764,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'localPackages': Property(
           getValue: (CT_ c) => c.localPackages,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.localPackages?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -909,7 +1788,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'metaDescription': Property(
           getValue: (CT_ c) => c.metaDescription,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.metaDescription == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.metaDescription, ast, parent: r);
@@ -917,7 +1807,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'navLinks': Property(
           getValue: (CT_ c) => c.navLinks,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.navLinks?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -930,20 +1831,42 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'navLinksWithGenerics': Property(
           getValue: (CT_ c) => c.navLinksWithGenerics,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.navLinksWithGenerics?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
             for (var e in c.navLinksWithGenerics) {
-              buffer.write(null(e, ast, parent: r));
+              buffer.write(_render_Container(e, ast, parent: r));
             }
             return buffer.toString();
           },
         ),
         'parent': Property(
           getValue: (CT_ c) => c.parent,
-          getProperties: _Renderer_Documentable.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_Documentable.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_Documentable.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.parent == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_Documentable(c.parent, ast, parent: r);
@@ -951,7 +1874,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'relCanonicalPrefix': Property(
           getValue: (CT_ c) => c.relCanonicalPrefix,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.relCanonicalPrefix == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.relCanonicalPrefix, ast, parent: r);
@@ -959,7 +1893,18 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'title': Property(
           getValue: (CT_ c) => c.title,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.title == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.title, ast, parent: r);
@@ -967,12 +1912,34 @@ class _Renderer_TemplateData<T extends Documentable>
         ),
         'useBaseHref': Property(
           getValue: (CT_ c) => c.useBaseHref,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.useBaseHref == true,
         ),
         'version': Property(
           getValue: (CT_ c) => c.version,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.version == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.version, ast, parent: r);
@@ -1007,7 +1974,18 @@ class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
       {
         'relCanonicalPrefix': Property(
           getValue: (CT_ c) => c.relCanonicalPrefix,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.relCanonicalPrefix == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.relCanonicalPrefix, ast, parent: r);
@@ -1015,7 +1993,18 @@ class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
         ),
         'toolVersion': Property(
           getValue: (CT_ c) => c.toolVersion,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.toolVersion == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.toolVersion, ast, parent: r);
@@ -1023,7 +2012,18 @@ class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
         ),
         'useBaseHref': Property(
           getValue: (CT_ c) => c.useBaseHref,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.useBaseHref == true,
         ),
         ..._Renderer_Object.propertyMap<CT_>(),
@@ -1043,25 +2043,610 @@ class _Renderer_TemplateOptions extends RendererBase<TemplateOptions> {
   }
 }
 
-String _render_Documentable(Documentable context, List<MustachioNode> ast,
+String _render_Container(Container context, List<MustachioNode> ast,
     {RendererBase<Object> parent}) {
-  var renderer = _Renderer_Documentable(context, parent);
+  var renderer = _Renderer_Container(context, parent);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
 
-class _Renderer_Documentable extends RendererBase<Documentable> {
-  static Map<String, Property<CT_>> propertyMap<CT_ extends Documentable>() => {
+class _Renderer_Container extends RendererBase<Container> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Container>() => {
+        'allElements': Property(
+          getValue: (CT_ c) => c.allElements,
+        ),
+        'allModelElements': Property(
+          getValue: (CT_ c) => c.allModelElements,
+          isEmptyIterable: (CT_ c) => c.allModelElements?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.allModelElements) {
+              buffer.write(_render_ModelElement(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        'allModelElementsByNamePart': Property(
+          getValue: (CT_ c) => c.allModelElementsByNamePart,
+        ),
+        'constantFields': Property(
+          getValue: (CT_ c) => c.constantFields,
+        ),
+        'declaredFields': Property(
+          getValue: (CT_ c) => c.declaredFields,
+        ),
+        'declaredMethods': Property(
+          getValue: (CT_ c) => c.declaredMethods,
+        ),
+        'declaredOperators': Property(
+          getValue: (CT_ c) => c.declaredOperators,
+        ),
+        'hasInstanceFields': Property(
+          getValue: (CT_ c) => c.hasInstanceFields,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasInstanceFields == true,
+        ),
+        'hasPublicConstantFields': Property(
+          getValue: (CT_ c) => c.hasPublicConstantFields,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicConstantFields == true,
+        ),
+        'hasPublicInstanceFields': Property(
+          getValue: (CT_ c) => c.hasPublicInstanceFields,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicInstanceFields == true,
+        ),
+        'hasPublicInstanceMethods': Property(
+          getValue: (CT_ c) => c.hasPublicInstanceMethods,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicInstanceMethods == true,
+        ),
+        'hasPublicInstanceOperators': Property(
+          getValue: (CT_ c) => c.hasPublicInstanceOperators,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicInstanceOperators == true,
+        ),
+        'hasPublicStaticFields': Property(
+          getValue: (CT_ c) => c.hasPublicStaticFields,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicStaticFields == true,
+        ),
+        'hasPublicStaticMethods': Property(
+          getValue: (CT_ c) => c.hasPublicStaticMethods,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicStaticMethods == true,
+        ),
+        'hasPublicVariableStaticFields': Property(
+          getValue: (CT_ c) => c.hasPublicVariableStaticFields,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasPublicVariableStaticFields == true,
+        ),
+        'instanceAccessors': Property(
+          getValue: (CT_ c) => c.instanceAccessors,
+        ),
+        'instanceFields': Property(
+          getValue: (CT_ c) => c.instanceFields,
+        ),
+        'instanceMethods': Property(
+          getValue: (CT_ c) => c.instanceMethods,
+        ),
+        'instanceOperators': Property(
+          getValue: (CT_ c) => c.instanceOperators,
+        ),
+        'isClass': Property(
+          getValue: (CT_ c) => c.isClass,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isClass == true,
+        ),
+        'isClassOrExtension': Property(
+          getValue: (CT_ c) => c.isClassOrExtension,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isClassOrExtension == true,
+        ),
+        'isEnum': Property(
+          getValue: (CT_ c) => c.isEnum,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isEnum == true,
+        ),
+        'isExtension': Property(
+          getValue: (CT_ c) => c.isExtension,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isExtension == true,
+        ),
+        'isMixin': Property(
+          getValue: (CT_ c) => c.isMixin,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isMixin == true,
+        ),
+        'publicConstantFields': Property(
+          getValue: (CT_ c) => c.publicConstantFields,
+        ),
+        'publicConstantFieldsSorted': Property(
+          getValue: (CT_ c) => c.publicConstantFieldsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'publicInheritedInstanceFields': Property(
+          getValue: (CT_ c) => c.publicInheritedInstanceFields,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.publicInheritedInstanceFields == true,
+        ),
+        'publicInheritedInstanceMethods': Property(
+          getValue: (CT_ c) => c.publicInheritedInstanceMethods,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.publicInheritedInstanceMethods == true,
+        ),
+        'publicInheritedInstanceOperators': Property(
+          getValue: (CT_ c) => c.publicInheritedInstanceOperators,
+        ),
+        'publicInstanceFields': Property(
+          getValue: (CT_ c) => c.publicInstanceFields,
+        ),
+        'publicInstanceFieldsSorted': Property(
+          getValue: (CT_ c) => c.publicInstanceFieldsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'publicInstanceMethods': Property(
+          getValue: (CT_ c) => c.publicInstanceMethods,
+        ),
+        'publicInstanceMethodsSorted': Property(
+          getValue: (CT_ c) => c.publicInstanceMethodsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'publicInstanceOperators': Property(
+          getValue: (CT_ c) => c.publicInstanceOperators,
+        ),
+        'publicInstanceOperatorsSorted': Property(
+          getValue: (CT_ c) => c.publicInstanceOperatorsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'publicStaticFields': Property(
+          getValue: (CT_ c) => c.publicStaticFields,
+        ),
+        'publicStaticFieldsSorted': Property(
+          getValue: (CT_ c) => c.publicStaticFieldsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'publicStaticMethods': Property(
+          getValue: (CT_ c) => c.publicStaticMethods,
+        ),
+        'publicStaticMethodsSorted': Property(
+          getValue: (CT_ c) => c.publicStaticMethodsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'publicVariableStaticFields': Property(
+          getValue: (CT_ c) => c.publicVariableStaticFields,
+        ),
+        'publicVariableStaticFieldsSorted': Property(
+          getValue: (CT_ c) => c.publicVariableStaticFieldsSorted,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'staticAccessors': Property(
+          getValue: (CT_ c) => c.staticAccessors,
+        ),
+        'staticFields': Property(
+          getValue: (CT_ c) => c.staticFields,
+        ),
+        'staticMethods': Property(
+          getValue: (CT_ c) => c.staticMethods,
+        ),
+        'variableStaticFields': Property(
+          getValue: (CT_ c) => c.variableStaticFields,
+        ),
+        ..._Renderer_ModelElement.propertyMap<CT_>(),
+      };
+
+  _Renderer_Container(Container context, RendererBase<Object> parent)
+      : super(context, parent);
+
+  @override
+  Property<Container> getProperty(String key) {
+    if (propertyMap<Container>().containsKey(key)) {
+      return propertyMap<Container>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_ModelElement(ModelElement context, List<MustachioNode> ast,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_ModelElement(context, parent);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_ModelElement extends RendererBase<ModelElement> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends ModelElement>() => {
+        'allParameters': Property(
+          getValue: (CT_ c) => c.allParameters,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'annotations': Property(
+          getValue: (CT_ c) => c.annotations,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isEmptyIterable: (CT_ c) => c.annotations?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.annotations) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        'canHaveParameters': Property(
+          getValue: (CT_ c) => c.canHaveParameters,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.canHaveParameters == true,
+        ),
+        'canonicalLibrary': Property(
+          getValue: (CT_ c) => c.canonicalLibrary,
+        ),
+        'canonicalModelElement': Property(
+          getValue: (CT_ c) => c.canonicalModelElement,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_ModelElement.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_ModelElement.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.canonicalModelElement == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_ModelElement(c.canonicalModelElement, ast,
+                parent: r);
+          },
+        ),
+        'characterLocation': Property(
+          getValue: (CT_ c) => c.characterLocation,
+        ),
+        'commentRefs': Property(
+          getValue: (CT_ c) => c.commentRefs,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'compilationUnitElement': Property(
+          getValue: (CT_ c) => c.compilationUnitElement,
+        ),
+        'computeDocumentationFrom': Property(
+          getValue: (CT_ c) => c.computeDocumentationFrom,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isEmptyIterable: (CT_ c) =>
+              c.computeDocumentationFrom?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.computeDocumentationFrom) {
+              buffer.write(_render_ModelElement(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
         'config': Property(
           getValue: (CT_ c) => c.config,
-          isNullValue: (CT_ c) => c.config == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.config, ast, parent: r);
-          },
+        ),
+        'definingLibrary': Property(
+          getValue: (CT_ c) => c.definingLibrary,
+        ),
+        'displayedCategories': Property(
+          getValue: (CT_ c) => c.displayedCategories,
         ),
         'documentation': Property(
           getValue: (CT_ c) => c.documentation,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.documentation == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.documentation, ast, parent: r);
@@ -1069,114 +2654,941 @@ class _Renderer_Documentable extends RendererBase<Documentable> {
         ),
         'documentationAsHtml': Property(
           getValue: (CT_ c) => c.documentationAsHtml,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.documentationAsHtml == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.documentationAsHtml, ast, parent: r);
           },
         ),
+        'documentationFrom': Property(
+          getValue: (CT_ c) => c.documentationFrom,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isEmptyIterable: (CT_ c) => c.documentationFrom?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.documentationFrom) {
+              buffer.write(_render_ModelElement(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        'documentationLocal': Property(
+          getValue: (CT_ c) => c.documentationLocal,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.documentationLocal == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.documentationLocal, ast, parent: r);
+          },
+        ),
+        'element': Property(
+          getValue: (CT_ c) => c.element,
+        ),
+        'exportedInLibraries': Property(
+          getValue: (CT_ c) => c.exportedInLibraries,
+        ),
+        'extendedDocLink': Property(
+          getValue: (CT_ c) => c.extendedDocLink,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.extendedDocLink == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.extendedDocLink, ast, parent: r);
+          },
+        ),
+        'features': Property(
+          getValue: (CT_ c) => c.features,
+          isEmptyIterable: (CT_ c) => c.features?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.features) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        'featuresAsString': Property(
+          getValue: (CT_ c) => c.featuresAsString,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.featuresAsString == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.featuresAsString, ast, parent: r);
+          },
+        ),
+        'fileName': Property(
+          getValue: (CT_ c) => c.fileName,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.fileName == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.fileName, ast, parent: r);
+          },
+        ),
+        'filePath': Property(
+          getValue: (CT_ c) => c.filePath,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.filePath == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.filePath, ast, parent: r);
+          },
+        ),
+        'fileType': Property(
+          getValue: (CT_ c) => c.fileType,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.fileType == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.fileType, ast, parent: r);
+          },
+        ),
+        'fullyQualifiedName': Property(
+          getValue: (CT_ c) => c.fullyQualifiedName,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.fullyQualifiedName == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.fullyQualifiedName, ast, parent: r);
+          },
+        ),
+        'fullyQualifiedNameWithoutLibrary': Property(
+          getValue: (CT_ c) => c.fullyQualifiedNameWithoutLibrary,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.fullyQualifiedNameWithoutLibrary == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.fullyQualifiedNameWithoutLibrary, ast,
+                parent: r);
+          },
+        ),
+        'hasAnnotations': Property(
+          getValue: (CT_ c) => c.hasAnnotations,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasAnnotations == true,
+        ),
+        'hasCategoryNames': Property(
+          getValue: (CT_ c) => c.hasCategoryNames,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasCategoryNames == true,
+        ),
         'hasDocumentation': Property(
           getValue: (CT_ c) => c.hasDocumentation,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasDocumentation == true,
         ),
         'hasExtendedDocumentation': Property(
           getValue: (CT_ c) => c.hasExtendedDocumentation,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.hasExtendedDocumentation == true,
+        ),
+        'hasParameters': Property(
+          getValue: (CT_ c) => c.hasParameters,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasParameters == true,
+        ),
+        'hasSourceHref': Property(
+          getValue: (CT_ c) => c.hasSourceHref,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.hasSourceHref == true,
         ),
         'href': Property(
           getValue: (CT_ c) => c.href,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.href == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.href, ast, parent: r);
           },
         ),
+        'htmlId': Property(
+          getValue: (CT_ c) => c.htmlId,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.htmlId == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.htmlId, ast, parent: r);
+          },
+        ),
+        'isAsynchronous': Property(
+          getValue: (CT_ c) => c.isAsynchronous,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isAsynchronous == true,
+        ),
+        'isCanonical': Property(
+          getValue: (CT_ c) => c.isCanonical,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isCanonical == true,
+        ),
+        'isConst': Property(
+          getValue: (CT_ c) => c.isConst,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isConst == true,
+        ),
+        'isDeprecated': Property(
+          getValue: (CT_ c) => c.isDeprecated,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isDeprecated == true,
+        ),
         'isDocumented': Property(
           getValue: (CT_ c) => c.isDocumented,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isDocumented == true,
+        ),
+        'isExecutable': Property(
+          getValue: (CT_ c) => c.isExecutable,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isExecutable == true,
+        ),
+        'isFinal': Property(
+          getValue: (CT_ c) => c.isFinal,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isFinal == true,
+        ),
+        'isLate': Property(
+          getValue: (CT_ c) => c.isLate,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isLate == true,
+        ),
+        'isLocalElement': Property(
+          getValue: (CT_ c) => c.isLocalElement,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isLocalElement == true,
+        ),
+        'isPropertyAccessor': Property(
+          getValue: (CT_ c) => c.isPropertyAccessor,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isPropertyAccessor == true,
+        ),
+        'isPropertyInducer': Property(
+          getValue: (CT_ c) => c.isPropertyInducer,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isPropertyInducer == true,
+        ),
+        'isPublic': Property(
+          getValue: (CT_ c) => c.isPublic,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isPublic == true,
+        ),
+        'isPublicAndPackageDocumented': Property(
+          getValue: (CT_ c) => c.isPublicAndPackageDocumented,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isPublicAndPackageDocumented == true,
+        ),
+        'isStatic': Property(
+          getValue: (CT_ c) => c.isStatic,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          getBool: (CT_ c) => c.isStatic == true,
         ),
         'kind': Property(
           getValue: (CT_ c) => c.kind,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.kind == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.kind, ast, parent: r);
           },
         ),
+        'library': Property(
+          getValue: (CT_ c) => c.library,
+        ),
+        'linkedName': Property(
+          getValue: (CT_ c) => c.linkedName,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.linkedName == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.linkedName, ast, parent: r);
+          },
+        ),
+        'linkedParams': Property(
+          getValue: (CT_ c) => c.linkedParams,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.linkedParams == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.linkedParams, ast, parent: r);
+          },
+        ),
+        'linkedParamsLines': Property(
+          getValue: (CT_ c) => c.linkedParamsLines,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.linkedParamsLines == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.linkedParamsLines, ast, parent: r);
+          },
+        ),
+        'linkedParamsNoMetadata': Property(
+          getValue: (CT_ c) => c.linkedParamsNoMetadata,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.linkedParamsNoMetadata == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.linkedParamsNoMetadata, ast, parent: r);
+          },
+        ),
+        'linkedParamsNoMetadataOrNames': Property(
+          getValue: (CT_ c) => c.linkedParamsNoMetadataOrNames,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.linkedParamsNoMetadataOrNames == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.linkedParamsNoMetadataOrNames, ast,
+                parent: r);
+          },
+        ),
+        'location': Property(
+          getValue: (CT_ c) => c.location,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.location == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.location, ast, parent: r);
+          },
+        ),
+        'locationPieces': Property(
+          getValue: (CT_ c) => c.locationPieces,
+          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.locationPieces) {
+              buffer.write(_render_String(e, ast, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        'modelElementRenderer': Property(
+          getValue: (CT_ c) => c.modelElementRenderer,
+        ),
+        'modelNode': Property(
+          getValue: (CT_ c) => c.modelNode,
+        ),
+        'modelType': Property(
+          getValue: (CT_ c) => c.modelType,
+        ),
+        'name': Property(
+          getValue: (CT_ c) => c.name,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.name == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.name, ast, parent: r);
+          },
+        ),
         'oneLineDoc': Property(
           getValue: (CT_ c) => c.oneLineDoc,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.oneLineDoc == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.oneLineDoc, ast, parent: r);
           },
         ),
-        'packageGraph': Property(
-          getValue: (CT_ c) => c.packageGraph,
-          isNullValue: (CT_ c) => c.packageGraph == null,
+        'originalMember': Property(
+          getValue: (CT_ c) => c.originalMember,
+        ),
+        'package': Property(
+          getValue: (CT_ c) => c.package,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_Package.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_Package.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.package == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return null(c.packageGraph, ast, parent: r);
+            return _render_Package(c.package, ast, parent: r);
           },
         ),
-        ..._Renderer_Nameable.propertyMap<CT_>(),
+        'packageGraph': Property(
+          getValue: (CT_ c) => c.packageGraph,
+        ),
+        'parameters': Property(
+          getValue: (CT_ c) => c.parameters,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+        ),
+        'pathContext': Property(
+          getValue: (CT_ c) => c.pathContext,
+        ),
+        'sourceCode': Property(
+          getValue: (CT_ c) => c.sourceCode,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.sourceCode == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.sourceCode, ast, parent: r);
+          },
+        ),
+        'sourceFileName': Property(
+          getValue: (CT_ c) => c.sourceFileName,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.sourceFileName == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.sourceFileName, ast, parent: r);
+          },
+        ),
+        'sourceHref': Property(
+          getValue: (CT_ c) => c.sourceHref,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.sourceHref == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.sourceHref, ast, parent: r);
+          },
+        ),
+        ..._Renderer_Canonicalization.propertyMap<CT_>(),
       };
 
-  _Renderer_Documentable(Documentable context, RendererBase<Object> parent)
+  _Renderer_ModelElement(ModelElement context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Documentable> getProperty(String key) {
-    if (propertyMap<Documentable>().containsKey(key)) {
-      return propertyMap<Documentable>()[key];
+  Property<ModelElement> getProperty(String key) {
+    if (propertyMap<ModelElement>().containsKey(key)) {
+      return propertyMap<ModelElement>()[key];
     } else {
       return null;
     }
   }
 }
 
-String _render_Nameable(Nameable context, List<MustachioNode> ast,
+String _render_Canonicalization(
+    Canonicalization context, List<MustachioNode> ast,
     {RendererBase<Object> parent}) {
-  var renderer = _Renderer_Nameable(context, parent);
+  var renderer = _Renderer_Canonicalization(context, parent);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
 
-class _Renderer_Nameable extends RendererBase<Nameable> {
-  static Map<String, Property<CT_>> propertyMap<CT_ extends Nameable>() => {
-        'fullyQualifiedName': Property(
-          getValue: (CT_ c) => c.fullyQualifiedName,
-          getProperties: _Renderer_String.propertyMap,
-          isNullValue: (CT_ c) => c.fullyQualifiedName == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return _render_String(c.fullyQualifiedName, ast, parent: r);
+class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
+  static Map<String, Property<CT_>> propertyMap<
+          CT_ extends Canonicalization>() =>
+      {
+        'canonicalLibrary': Property(
+          getValue: (CT_ c) => c.canonicalLibrary,
+        ),
+        'commentRefs': Property(
+          getValue: (CT_ c) => c.commentRefs,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
           },
         ),
-        'name': Property(
-          getValue: (CT_ c) => c.name,
-          getProperties: _Renderer_String.propertyMap,
-          isNullValue: (CT_ c) => c.name == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return _render_String(c.name, ast, parent: r);
+        'isCanonical': Property(
+          getValue: (CT_ c) => c.isCanonical,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
           },
+          getBool: (CT_ c) => c.isCanonical == true,
         ),
-        'namePart': Property(
-          getValue: (CT_ c) => c.namePart,
-          getProperties: _Renderer_String.propertyMap,
-          isNullValue: (CT_ c) => c.namePart == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return _render_String(c.namePart, ast, parent: r);
-          },
-        ),
-        'namePieces': Property(
-          getValue: (CT_ c) => c.namePieces,
-          isEmptyIterable: (CT_ c) => c.namePieces?.isEmpty ?? true,
+        'locationPieces': Property(
+          getValue: (CT_ c) => c.locationPieces,
+          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             var buffer = StringBuffer();
-            for (var e in c.namePieces) {
+            for (var e in c.locationPieces) {
               buffer.write(_render_String(e, ast, parent: r));
             }
             return buffer.toString();
@@ -1185,13 +3597,14 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
         ..._Renderer_Object.propertyMap<CT_>(),
       };
 
-  _Renderer_Nameable(Nameable context, RendererBase<Object> parent)
+  _Renderer_Canonicalization(
+      Canonicalization context, RendererBase<Object> parent)
       : super(context, parent);
 
   @override
-  Property<Nameable> getProperty(String key) {
-    if (propertyMap<Nameable>().containsKey(key)) {
-      return propertyMap<Nameable>()[key];
+  Property<Canonicalization> getProperty(String key) {
+    if (propertyMap<Canonicalization>().containsKey(key)) {
+      return propertyMap<Canonicalization>()[key];
     } else {
       return null;
     }
@@ -1209,7 +3622,18 @@ class _Renderer_int extends RendererBase<int> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends int>() => {
         'bitLength': Property(
           getValue: (CT_ c) => c.bitLength,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.bitLength == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.bitLength, ast, parent: r);
@@ -1217,17 +3641,50 @@ class _Renderer_int extends RendererBase<int> {
         ),
         'isEven': Property(
           getValue: (CT_ c) => c.isEven,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isEven == true,
         ),
         'isOdd': Property(
           getValue: (CT_ c) => c.isOdd,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isOdd == true,
         ),
         'sign': Property(
           getValue: (CT_ c) => c.sign,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.sign == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.sign, ast, parent: r);
@@ -1260,7 +3717,18 @@ class _Renderer_num extends RendererBase<num> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends num>() => {
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: _Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -1268,27 +3736,82 @@ class _Renderer_num extends RendererBase<num> {
         ),
         'isFinite': Property(
           getValue: (CT_ c) => c.isFinite,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isFinite == true,
         ),
         'isInfinite': Property(
           getValue: (CT_ c) => c.isInfinite,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isInfinite == true,
         ),
         'isNaN': Property(
           getValue: (CT_ c) => c.isNaN,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isNaN == true,
         ),
         'isNegative': Property(
           getValue: (CT_ c) => c.isNegative,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isNegative == true,
         ),
         'sign': Property(
           getValue: (CT_ c) => c.sign,
-          getProperties: _Renderer_num.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_num.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_num.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.sign == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_num(c.sign, ast, parent: r);

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -135,7 +135,18 @@ class Bar {}
       expect(generatedContent, contains('''
         'b1': Property(
           getValue: (CT_ c) => c.b1,
-          getProperties: _Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.b1 == true,
         ),
 '''));
@@ -145,7 +156,18 @@ class Bar {}
       expect(generatedContent, contains('''
         'l1': Property(
           getValue: (CT_ c) => c.l1,
-          getProperties: _Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.l1?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -163,7 +185,18 @@ class Bar {}
       expect(generatedContent, contains('''
         's1': Property(
           getValue: (CT_ c) => c.s1,
-          getProperties: _Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (_Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = _Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.s1 == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.s1, ast, parent: r);

--- a/test/mustachio/foo.dart
+++ b/test/mustachio/foo.dart
@@ -1,4 +1,5 @@
 @Renderer(#renderFoo, Context<Foo>())
+@Renderer(#renderBar, Context<Bar>())
 library dartdoc.testing.foo;
 
 import 'package:dartdoc/src/mustachio/annotations.dart';
@@ -7,4 +8,9 @@ class Foo {
   String s1;
   bool b1;
   List<int> l1;
+}
+
+class Bar {
+  Foo foo;
+  String s2;
 }

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -21,12 +21,34 @@ class Renderer_Foo extends RendererBase<Foo> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Foo>() => {
         'b1': Property(
           getValue: (CT_ c) => c.b1,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.b1 == true,
         ),
         'l1': Property(
           getValue: (CT_ c) => c.l1,
-          getProperties: Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.l1?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -39,7 +61,18 @@ class Renderer_Foo extends RendererBase<Foo> {
         ),
         's1': Property(
           getValue: (CT_ c) => c.s1,
-          getProperties: Renderer_String.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.s1 == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_String(c.s1, ast, parent: r);
@@ -72,7 +105,18 @@ class Renderer_String extends RendererBase<String> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends String>() => {
         'codeUnits': Property(
           getValue: (CT_ c) => c.codeUnits,
-          getProperties: Renderer_List.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_List.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_List.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isEmptyIterable: (CT_ c) => c.codeUnits?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
@@ -85,7 +129,18 @@ class Renderer_String extends RendererBase<String> {
         ),
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -93,17 +148,50 @@ class Renderer_String extends RendererBase<String> {
         ),
         'isEmpty': Property(
           getValue: (CT_ c) => c.isEmpty,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isEmpty == true,
         ),
         'isNotEmpty': Property(
           getValue: (CT_ c) => c.isNotEmpty,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isNotEmpty == true,
         ),
         'length': Property(
           getValue: (CT_ c) => c.length,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.length == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.length, ast, parent: r);
@@ -148,7 +236,18 @@ class Renderer_Object extends RendererBase<Object> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Object>() => {
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -180,7 +279,18 @@ class Renderer_bool extends RendererBase<bool> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends bool>() => {
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -202,42 +312,6 @@ class Renderer_bool extends RendererBase<bool> {
   }
 }
 
-String _render_List<E>(List<E> context, List<MustachioNode> ast,
-    {RendererBase<Object> parent}) {
-  var renderer = Renderer_List(context, parent);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class Renderer_List<E> extends RendererBase<List<E>> {
-  static Map<String, Property<CT_>> propertyMap<E, CT_ extends List<E>>() => {
-        'length': Property(
-          getValue: (CT_ c) => c.length,
-          getProperties: Renderer_int.propertyMap,
-          isNullValue: (CT_ c) => c.length == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return _render_int(c.length, ast, parent: r);
-          },
-        ),
-        'reversed': Property(
-          getValue: (CT_ c) => c.reversed,
-        ),
-        ...Renderer_Object.propertyMap<CT_>(),
-      };
-
-  Renderer_List(List<E> context, RendererBase<Object> parent)
-      : super(context, parent);
-
-  @override
-  Property<List<E>> getProperty(String key) {
-    if (propertyMap<E, List<E>>().containsKey(key)) {
-      return propertyMap<E, List<E>>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
 String _render_int(int context, List<MustachioNode> ast,
     {RendererBase<Object> parent}) {
   var renderer = Renderer_int(context, parent);
@@ -249,7 +323,18 @@ class Renderer_int extends RendererBase<int> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends int>() => {
         'bitLength': Property(
           getValue: (CT_ c) => c.bitLength,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.bitLength == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.bitLength, ast, parent: r);
@@ -257,17 +342,50 @@ class Renderer_int extends RendererBase<int> {
         ),
         'isEven': Property(
           getValue: (CT_ c) => c.isEven,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isEven == true,
         ),
         'isOdd': Property(
           getValue: (CT_ c) => c.isOdd,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isOdd == true,
         ),
         'sign': Property(
           getValue: (CT_ c) => c.sign,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.sign == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.sign, ast, parent: r);
@@ -300,7 +418,18 @@ class Renderer_num extends RendererBase<num> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends num>() => {
         'hashCode': Property(
           getValue: (CT_ c) => c.hashCode,
-          getProperties: Renderer_int.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.hashCode == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_int(c.hashCode, ast, parent: r);
@@ -308,27 +437,82 @@ class Renderer_num extends RendererBase<num> {
         ),
         'isFinite': Property(
           getValue: (CT_ c) => c.isFinite,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isFinite == true,
         ),
         'isInfinite': Property(
           getValue: (CT_ c) => c.isInfinite,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isInfinite == true,
         ),
         'isNaN': Property(
           getValue: (CT_ c) => c.isNaN,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isNaN == true,
         ),
         'isNegative': Property(
           getValue: (CT_ c) => c.isNegative,
-          getProperties: Renderer_bool.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_bool.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_bool.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           getBool: (CT_ c) => c.isNegative == true,
         ),
         'sign': Property(
           getValue: (CT_ c) => c.sign,
-          getProperties: Renderer_num.propertyMap,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_num.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_num.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
           isNullValue: (CT_ c) => c.sign == null,
           renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
             return _render_num(c.sign, ast, parent: r);
@@ -344,6 +528,116 @@ class Renderer_num extends RendererBase<num> {
   Property<num> getProperty(String key) {
     if (propertyMap<num>().containsKey(key)) {
       return propertyMap<num>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_List<E>(List<E> context, List<MustachioNode> ast,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_List(context, parent);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class Renderer_List<E> extends RendererBase<List<E>> {
+  static Map<String, Property<CT_>> propertyMap<E, CT_ extends List<E>>() => {
+        'length': Property(
+          getValue: (CT_ c) => c.length,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_int.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_int.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.length == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_int(c.length, ast, parent: r);
+          },
+        ),
+        'reversed': Property(
+          getValue: (CT_ c) => c.reversed,
+        ),
+        ...Renderer_Object.propertyMap<CT_>(),
+      };
+
+  Renderer_List(List<E> context, RendererBase<Object> parent)
+      : super(context, parent);
+
+  @override
+  Property<List<E>> getProperty(String key) {
+    if (propertyMap<E, List<E>>().containsKey(key)) {
+      return propertyMap<E, List<E>>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String renderBar(Bar context, List<MustachioNode> ast,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Bar(context, parent);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class Renderer_Bar extends RendererBase<Bar> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Bar>() => {
+        'foo': Property(
+          getValue: (CT_ c) => c.foo,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_Foo.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_Foo.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.foo == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderFoo(c.foo, ast, parent: r);
+          },
+        ),
+        's2': Property(
+          getValue: (CT_ c) => c.s2,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            if (Renderer_String.propertyMap().containsKey(name)) {
+              var nextProperty = Renderer_String.propertyMap()[name];
+              return nextProperty.renderVariable(
+                  self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+            } else {
+              throw MustachioResolutionError();
+            }
+          },
+          isNullValue: (CT_ c) => c.s2 == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_String(c.s2, ast, parent: r);
+          },
+        ),
+        ...Renderer_Object.propertyMap<CT_>(),
+      };
+
+  Renderer_Bar(Bar context, RendererBase<Object> parent)
+      : super(context, parent);
+
+  @override
+  Property<Bar> getProperty(String key) {
+    if (propertyMap<Bar>().containsKey(key)) {
+      return propertyMap<Bar>()[key];
     } else {
       return null;
     }

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -116,6 +116,7 @@ import '${p.basename(_sourceUri.path)}';
   /// return type.
   void _addPropertyToProcess(PropertyAccessorElement property) {
     if (property.isPrivate || property.isStatic || property.isSetter) return;
+    if (property.hasProtected || property.hasVisibleForTesting) return;
     var type = property.type.returnType;
 
     if (_typeSystem.isAssignableTo(type, _typeProvider.iterableDynamicType)) {
@@ -243,6 +244,7 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
     }
 
     if (property.isPrivate || property.isStatic || property.isSetter) return;
+    if (property.hasProtected || property.hasVisibleForTesting) return;
     _buffer.writeln("'${property.name}': Property(");
     _buffer
         .writeln('getValue: ($_contextTypeVariable c) => c.${property.name},');


### PR DESCRIPTION
Janice noticed there were a lot of `null(...)` snippets in the generated renderers. I've guarded against it and written a TODO.

Also, additional tests of runtime behavior uncovered that `getProperties` was unsound at runtime; it results in failed attempts to cast `(Object) => Object` to `(Foo) => Object`, etc. `renderVariable` solves this runtime bug.