### PR TITLE
Use = to document default values for named parameters - Fixes #2087

### DIFF
--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -208,11 +208,7 @@ abstract class ParameterRenderer {
     }
 
     if (param.hasDefaultValue) {
-      if (param.isNamed) {
-        buf.write(': ');
-      } else {
-        buf.write(' = ');
-      }
+      buf.write(' = ');
       buf.write(defaultValue(param.defaultValue));
     }
     return buf.toString();

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -127,7 +127,7 @@ void main() {
               '<li><span class="parameter" id="m1-param-regular"><span class="type-annotation">dynamic</span> <span class="parameter-name">regular</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-parameters"><span>covariant</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">parameters</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-p1">{<span>required</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">p1</span>, </span></li>\n'
-              '<li><span class="parameter" id="m1-param-p2"><span class="type-annotation">int</span> <span class="parameter-name">p2</span>: <span class="default-value">3</span>, </span></li>\n'
+              '<li><span class="parameter" id="m1-param-p2"><span class="type-annotation">int</span> <span class="parameter-name">p2</span> = <span class="default-value">3</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-p3"><span>required</span> <span>covariant</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">p3</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-p4"><span>required</span> <span>covariant</span> <span class="type-annotation">int</span> <span class="parameter-name">p4</span>}</span></li>\n'
               '</ol>'));

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3601,6 +3601,12 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(intCheckOptional.isNamed, isTrue);
     });
 
+    test('uses = instead of : to set default value', () {
+      final rendered =
+          ParameterRendererHtml().renderLinkedParams([intCheckOptional]);
+      expect(rendered.contains('</span> = <span'), isTrue);
+    });
+
     test('linkedName', () {
       expect(intCheckOptional.modelType.linkedName, 'int');
     });


### PR DESCRIPTION
It is [suggested in Effective Dart](https://dart.dev/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value) to use = for assigning default values for optional named parameters to be consistent with positional ones as well, so this special handling can be removed.

Fixes #2087 