### PR TITLE
Add a link to the null safety feature indicator

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -478,6 +478,10 @@ h1 .category {
   margin: 0 8px 0 0;
 }
 
+a.feature:hover {
+  border-color: #13B9FD;
+}
+
 h1 .feature {
   vertical-align: middle;
 }

--- a/lib/src/model/language_feature.dart
+++ b/lib/src/model/language_feature.dart
@@ -8,10 +8,15 @@ const Map<String, String> _featureDescriptions = {
   'Null safety': 'Supports the null safety language feature.',
 };
 
+const Map<String, String> _featureUrls = {
+  'Null safety': 'https://dart.dev/null-safety',
+};
+
 /// An abstraction for a language feature; used to render tags to notify
 /// the user that the documentation should be specially interpreted.
 class LanguageFeature {
   String get featureDescription => _featureDescriptions[name];
+  String get featureUrl => _featureUrls[name];
   String get featureLabel => _featureRenderer.renderFeatureLabel(this);
 
   final String name;

--- a/lib/src/render/feature_renderer.dart
+++ b/lib/src/render/feature_renderer.dart
@@ -10,6 +10,7 @@ abstract class FeatureRenderer {
 
 class FeatureRendererHtml extends FeatureRenderer {
   static final FeatureRendererHtml _instance = FeatureRendererHtml._();
+
   factory FeatureRendererHtml() {
     return _instance;
   }
@@ -18,27 +19,35 @@ class FeatureRendererHtml extends FeatureRenderer {
 
   @override
   String renderFeatureLabel(LanguageFeature feature) {
-    var spanClasses = <String>[];
-    spanClasses.add('feature');
-    spanClasses
-        .add('feature-${feature.name.split(' ').join('-').toLowerCase()}');
+    final classesText = [
+      'feature',
+      'feature-${feature.name.split(' ').join('-').toLowerCase()}'
+    ].join(' ');
 
-    var buf = StringBuffer();
-    buf.write(
-        '<span class="${spanClasses.join(' ')}" title="${feature.featureDescription}">${feature.name}</span>');
-    return buf.toString();
+    if (feature.featureUrl != null) {
+      return '<a href="${feature.featureUrl}" class="${classesText}"'
+          ' title="${feature.featureDescription}">${feature.name}</a>';
+    }
+
+    return '<span class="${classesText}" '
+        'title="${feature.featureDescription}">${feature.name}</span>';
   }
 }
 
 class FeatureRendererMd extends FeatureRenderer {
   static final FeatureRendererMd _instance = FeatureRendererMd._();
+
   factory FeatureRendererMd() {
     return _instance;
   }
 
   FeatureRendererMd._();
+
   @override
   String renderFeatureLabel(LanguageFeature feature) {
+    if (feature.featureUrl != null) {
+      return '*[\<${feature.name}\>](${feature.featureUrl})*';
+    }
     return '*\<${feature.name}\>*';
   }
 }


### PR DESCRIPTION
This allows users to click the "Null safety" feature and open the [documentation about null safety](https://dart.dev/null-safety). I think this is especially useful currently as not all users are familiar with the new functionality yet.

This implements the change by adding an optional URL for the feature which will, if present, cause the HTML renderer to use an anchor tag instead of a span and the Markdown renderer to use a normal Markdown link. 

I added a special border style on hover to match other similar buttons such as the source code button.

**Default:**
![image](https://user-images.githubusercontent.com/18372958/101726579-6cc0e700-3a78-11eb-9ae4-8afd03bfadfb.png)


**On hover(if has an associated URL):**
![image](https://user-images.githubusercontent.com/18372958/101726673-9aa62b80-3a78-11eb-8221-cbcd5e9be5b0.png)
