### PR TITLE
Switch from Source Code Pro to Roboto Mono

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -245,7 +245,7 @@ a:hover {
 }
 
 pre.prettyprint {
-  font-family: 'Source Code Pro', Menlo, monospace;
+  font-family: 'Roboto Mono', Menlo, monospace;
   color: black;
   border-radius: 0;
   font-size: 15px;
@@ -273,7 +273,7 @@ pre {
 }
 
 code {
-  font-family: 'Source Code Pro', Menlo, monospace;
+  font-family: 'Roboto Mono', Menlo, monospace;
   /* overriding bootstrap */
   color: inherit;
   padding: 0.2em 0.4em;

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -21,7 +21,8 @@
   {{/useBaseHref}}
 
   {{! TODO(jdkoren): unwrap ^useBaseHref sections when the option is removed.}}
-  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/github.css">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/styles.css">

--- a/testing/test_package_custom_templates/templates/_head.html
+++ b/testing/test_package_custom_templates/templates/_head.html
@@ -21,7 +21,8 @@
   {{/useBaseHref}}
 
   {{! TODO(jdkoren): unwrap ^useBaseHref sections when the option is removed.}}
-  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/github.css">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/styles.css">


### PR DESCRIPTION
The previous monospace font is a little blurry and many characters feel slightly squished. To standardize with other Dart web tools and improve clarity I suggest switching to Roboto Mono which is licensed under Apache License, Version 2.0.

This also removes Source Sans Pro which was not used at all as far as I could tell.

The rendering result on Chrome Dev (Linux): 

**Previously(Source Code Pro):**
![image](https://user-images.githubusercontent.com/18372958/101999383-12a36a00-3ca2-11eb-8f73-4fbe35cbf06b.png)


**Suggested(Roboto Mono):**
![image](https://user-images.githubusercontent.com/18372958/102406791-b6498e80-3fb0-11eb-96d1-fbdfb2102c9d.png)

SO much better <3