### PR TITLE
Fix minor focus spacing

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -734,13 +734,13 @@ ul.subnav li:last-of-type {
 .sidebar ol li {
   text-overflow: ellipsis;
   overflow: hidden;
-  padding: 3px 0;
+  padding: 3px 0 3px 3px;
 }
 
 .sidebar h5 {
   color: #727272;
   font-size: 18px;
-  margin: 0 0 25px 0;
+  margin: 0 0 22px 0;
   padding-top: 0;
 }
 
@@ -765,7 +765,7 @@ ul.subnav li:last-of-type {
 }
 
 .sidebar ol li:first-child {
-  padding-top: 0;
+  padding-top: 3px;
   margin-top: 0;
 }
 


### PR DESCRIPTION
On Chrome, the spacing in the sidebars cut off pieces of the focus outlines:

**Previously:**
![image](https://user-images.githubusercontent.com/18372958/102002386-a9335380-3cc1-11eb-8d92-be4aaed0ac73.png)
![image](https://user-images.githubusercontent.com/18372958/102002390-b4867f00-3cc1-11eb-9d99-4149512e84be.png)


**After change:**
![image](https://user-images.githubusercontent.com/18372958/102002394-bd775080-3cc1-11eb-81c1-e3ab6173005b.png)
![image](https://user-images.githubusercontent.com/18372958/102002397-c536f500-3cc1-11eb-9631-122c74ebc498.png)
