### PR TITLE
_fe_analyzer_shared at head no longer works on 2.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       # it is unlikely to work and produces uninteresting
       # results.
       dart: stable
+    - env: DARTDOC_BOT=sdk-analyzer
+      dart: stable
 
 env:
   jobs:


### PR DESCRIPTION
Fixes #2462.

Post migration we can't test the head analyzer at stable.
