### PR TITLE
correct eol attributes for yaml files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-*.dart eol=lf
+*.dart text eol=lf
+*.yaml text eol=lf
 
 # Don't collapse in github code reviews by default.
 lib/src/version.dart linguist-generated=false


### PR DESCRIPTION
This will make sure that regardless of git global config settings and platform, the dartdoc git repo will use the correct line endings for dart and yaml files.  This can fix problems with the build test.