### PR TITLE
Fix searching by URL for SDK docs

### DIFF
--- a/lib/resources/script.js
+++ b/lib/resources/script.js
@@ -181,7 +181,7 @@ function initSearch(name) {
     if (search) {
       var matches = findMatches(search);
       if (matches.length != 0) {
-        window.location = matches[0].href;
+        window.location = baseHref + matches[0].href;
         return;
       }
     }


### PR DESCRIPTION
If I'm understanding its usage correctly, the search URL query parameter does not work properly as is illustrated by the following links. This is likely caused by some of the base href changes, but specifying the entire location seems to work fine in this situation as well as for the Flutter docs which worked before this change.

**Typed URL:**
https://api.dart.dev/stable/2.10.4/dart-async/dart-async-library.html?search=completer

### Result

**Before change(broken):**
https://api.dart.dev/stable/2.10.4/dart-async/dart-async/Completer-class.html

**After change:**
https://api.dart.dev/stable/2.10.4/dart-async/Completer-class.html

