### PR TITLE
Fix members not being marked as inherited in sidebars - Fixes #2472

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -87,7 +87,7 @@ class Class extends Container
 
   @override
   bool get publicInheritedInstanceOperators =>
-      instanceOperators.every((f) => f.isInherited);
+      publicInstanceOperators.every((f) => f.isInherited);
 
   List<ModelElement> _allModelElements;
 

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -85,6 +85,10 @@ class Class extends Container
   Iterable<Operator> get instanceOperators =>
       quiver.concat([super.instanceOperators, inheritedOperators]);
 
+  @override
+  bool get publicInheritedInstanceOperators =>
+      instanceOperators.every((f) => f.isInherited);
+
   List<ModelElement> _allModelElements;
 
   @override
@@ -248,10 +252,6 @@ class Class extends Container
     }
     return _inheritedOperators;
   }
-
-  @override
-  Iterable<Operator> get publicInheritedInstanceOperators =>
-      model_utils.filterNonPublic(inheritedOperators);
 
   Iterable<Field> get inheritedFields => allFields.where((f) => f.isInherited);
 

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -41,6 +41,7 @@ abstract class Container extends ModelElement with TypeParameters {
   bool get isClassOrExtension => isClass || isExtension;
   bool get isEnum =>
       element is ClassElement && (element as ClassElement).isEnum;
+  bool get isClassOrEnum => isClass || isEnum;
   bool get isMixin =>
       element is ClassElement && (element as ClassElement).isMixin;
 

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -75,7 +75,10 @@ abstract class Container extends ModelElement with TypeParameters {
   /// This is only used in mustache templates.
   bool get publicInheritedInstanceMethods => false;
 
-  Iterable<Operator> get publicInheritedInstanceOperators => [];
+  /// Whether all instance operators are inherited.
+  ///
+  /// This is only used in mustache templates.
+  bool get publicInheritedInstanceOperators => false;
 
   @nonVirtual
   bool get hasPublicInstanceMethods =>

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -66,18 +66,12 @@ abstract class Container extends ModelElement with TypeParameters {
       .toList(growable: false);
 
   /// Whether all instance fields are inherited.
-  ///
-  /// This is only used in mustache templates.
   bool get publicInheritedInstanceFields => false;
 
   /// Whether all instance methods are inherited.
-  ///
-  /// This is only used in mustache templates.
   bool get publicInheritedInstanceMethods => false;
 
   /// Whether all instance operators are inherited.
-  ///
-  /// This is only used in mustache templates.
   bool get publicInheritedInstanceOperators => false;
 
   @nonVirtual

--- a/lib/templates/html/_sidebar_for_container.html
+++ b/lib/templates/html/_sidebar_for_container.html
@@ -1,6 +1,15 @@
 <ol>
     {{#container}}
 
+    {{#isClass}}
+    {{#hasPublicConstructors}}
+    <li class="section-title"><a href="{{{href}}}#constructors">Constructors</a></li>
+    {{#publicConstructorsSorted}}
+    <li><a{{#isDeprecated}} class="deprecated"{{/isDeprecated}} href="{{{href}}}">{{shortName}}</a></li>
+    {{/publicConstructorsSorted}}
+    {{/hasPublicConstructors}}
+    {{/isClass}}
+
     {{#isEnum}}
     {{#hasPublicConstantFields}}
     <li class="section-title"><a href="{{{href}}}#constants">Constants</a></li>
@@ -8,7 +17,9 @@
     <li>{{{linkedName}}}</li>
     {{/publicConstantFieldsSorted}}
     {{/hasPublicConstantFields}}
+    {{/isEnum}}
 
+    {{#isClassOrEnum}}
     {{#hasPublicInstanceFields}}
     <li class="section-title{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}">
       <a href="{{{href}}}#instance-properties">Properties</a>
@@ -31,18 +42,9 @@
     <li{{ #isInherited }} class="inherited"{{ /isInherited}}>{{{ linkedName }}}</li>
     {{/publicInstanceOperatorsSorted}}
     {{/hasPublicInstanceOperators}}
-    {{/isEnum}}
+    {{/isClassOrEnum}}
 
-    {{#isClass}}
-    {{#hasPublicConstructors}}
-    <li class="section-title"><a href="{{{href}}}#constructors">Constructors</a></li>
-    {{#publicConstructorsSorted}}
-    <li><a{{#isDeprecated}} class="deprecated"{{/isDeprecated}} href="{{{href}}}">{{shortName}}</a></li>
-    {{/publicConstructorsSorted}}
-    {{/hasPublicConstructors}}
-    {{/isClass}}
-
-    {{#isClassOrExtension}}
+    {{#isExtension}}
     {{#hasPublicInstanceFields}}
     <li class="section-title"> <a href="{{{href}}}#instance-properties">Properties</a>
     </li>
@@ -64,7 +66,9 @@
     <li>{{{ linkedName }}}</li>
     {{/publicInstanceOperatorsSorted}}
     {{/hasPublicInstanceOperators}}
+    {{/isExtension}}
 
+    {{#isClassOrExtension}}
     {{#hasPublicVariableStaticFields}}
     <li class="section-title"><a href="{{{href}}}#static-properties">Static properties</a></li>
     {{#publicVariableStaticFieldsSorted}}

--- a/lib/templates/html/_sidebar_for_container.html
+++ b/lib/templates/html/_sidebar_for_container.html
@@ -37,7 +37,7 @@
     {{/hasPublicInstanceMethods}}
 
     {{#hasPublicInstanceOperators}}
-    <li class="section-title{{ #publicInheritedInstanceOperators }} inherited{{ /publicInheritedInstanceOperators}}"><a href="{{{href}}}#operators">Operators</a></li>
+    <li class="section-title{{ #publicInheritedInstanceOperators }} inherited{{ /publicInheritedInstanceOperators }}"><a href="{{{href}}}#operators">Operators</a></li>
     {{#publicInstanceOperatorsSorted}}
     <li{{ #isInherited }} class="inherited"{{ /isInherited}}>{{{ linkedName }}}</li>
     {{/publicInstanceOperatorsSorted}}

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1632,8 +1632,17 @@ void main() {
     });
 
     test('get operators', () {
-      expect(Dog.publicInstanceOperators, hasLength(1));
+      expect(Dog.publicInstanceOperators, hasLength(2));
       expect(Dog.publicInstanceOperators.first.name, 'operator ==');
+      expect(Dog.publicInstanceOperators.last.name, 'operator +');
+    });
+
+    test('has non-inherited instance operators', () {
+      expect(Dog.publicInheritedInstanceOperators, isFalse);
+    });
+
+    test('has only inherited instance operators', () {
+      expect(Cat.publicInheritedInstanceOperators, isTrue);
     });
 
     test('inherited methods, including from Object ', () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -332,6 +332,8 @@ class Dog implements Cat, E {
   @override
   operator ==(other) => other is Dog && name == other.name;
 
+  Dog operator +(Dog other) => Dog()..name = name + other.name;
+
   foo() async => 42;
 
   @deprecated


### PR DESCRIPTION
**Inherited issue:**
This switches to sharing the sections with inherited features between `class` and `enum`. 

Fixes #2472 


**Operator issue:**

Handling of checking if all instance operators are inherited was messed up, resulting in the operators section always being marked as inherited(multiple times in fact) and being italicized. This standardizes it to match the behavior of methods.

The second commit addresses this issue.