### PR TITLE
Move templates.dart to use ResourceProvider.

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -50,7 +50,8 @@ class DartdocGeneratorOptionContext extends DartdocOptionContext
 
 class DartdocFileWriter implements FileWriter {
   final String outputDir;
-  ResourceProvider resourceProvider;
+  @override
+  final ResourceProvider resourceProvider;
   final Map<String, Warnable> _fileElementMap = {};
   @override
   final Set<String> writtenFiles = {};

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -5,12 +5,15 @@
 /// A library containing an abstract documentation generator.
 library dartdoc.generator;
 
+import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/model.dart' show PackageGraph;
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';
 
 abstract class FileWriter {
+  ResourceProvider get resourceProvider;
+
   /// All filenames written by this generator.
   Set<String> get writtenFiles;
 

--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -6,35 +6,43 @@
 library dartdoc.resource_loader;
 
 import 'dart:convert' show utf8;
-import 'dart:io' show File;
 import 'dart:isolate' show Isolate;
+import 'package:analyzer/file_system/file_system.dart';
+import 'package:meta/meta.dart';
 
-/// Loads a `package:` resource as a String.
-Future<String> loadAsString(String path) async {
-  var bytes = await loadAsBytes(path);
+class ResourceLoader {
+  final ResourceProvider provider;
 
-  return utf8.decode(bytes);
-}
+  ResourceLoader(this.provider);
 
-/// Loads a `package:` resource as an [List<int>].
-Future<List<int>> loadAsBytes(String path) async {
-  if (!path.startsWith('package:')) {
-    throw ArgumentError('path must begin with package:');
+  /// Loads a `package:` resource as a String.
+  Future<String> loadAsString(String path) async {
+    var bytes = await loadAsBytes(path);
+
+    return utf8.decode(bytes);
   }
 
-  var uri = await _resolveUri(Uri.parse(path));
-  return File.fromUri(uri).readAsBytes();
-}
+  /// Loads a `package:` resource as an [List<int>].
+  Future<List<int>> loadAsBytes(String path) async {
+    if (!path.startsWith('package:')) {
+      throw ArgumentError('path must begin with package:');
+    }
 
-/// Helper function for resolving to a non-relative, non-package URI.
-Future<Uri> _resolveUri(Uri uri) {
-  if (uri.scheme == 'package') {
-    return Isolate.resolvePackageUri(uri).then((resolvedUri) {
-      if (resolvedUri == null) {
-        throw ArgumentError.value(uri, 'uri', 'Unknown package');
-      }
-      return resolvedUri;
-    });
+    var uri = await resolveUri(Uri.parse(path));
+    return provider.getFile(uri.toFilePath()).readAsBytesSync();
   }
-  return Future<Uri>.value(Uri.base.resolveUri(uri));
+
+  /// Helper function for resolving to a non-relative, non-package URI.
+  @visibleForTesting
+  Future<Uri> resolveUri(Uri uri) {
+    if (uri.scheme == 'package') {
+      return Isolate.resolvePackageUri(uri).then((resolvedUri) {
+        if (resolvedUri == null) {
+          throw ArgumentError.value(uri, 'uri', 'Unknown package');
+        }
+        return resolvedUri;
+      });
+    }
+    return Future<Uri>.value(Uri.base.resolveUri(uri));
+  }
 }

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -8,6 +8,7 @@ import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/generator_frontend.dart';
 import 'package:dartdoc/src/generator/html_generator.dart';
 import 'package:dartdoc/src/generator/html_resources.g.dart';
+import 'package:dartdoc/src/generator/resource_loader.dart';
 import 'package:dartdoc/src/generator/templates.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -37,8 +38,66 @@ void main() {
     pathContext = resourceProvider.pathContext;
     packageConfigProvider = utils
         .getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
+    var resourceLoader = ResourceLoader(resourceProvider);
+    for (var template in [
+      '_accessor_getter',
+      '_accessor_setter',
+      '_callable',
+      '_callable_multiline',
+      '_categorization',
+      '_class',
+      '_constant',
+      '_documentation',
+      '_extension',
+      '_features',
+      '_feature_set',
+      '_footer',
+      '_head',
+      '_library',
+      '_mixin',
+      '_name_summary',
+      '_packages',
+      '_property',
+      '_search_sidebar',
+      '_sidebar_for_category',
+      '_sidebar_for_container',
+      '_sidebar_for_library',
+      '_source_code',
+      '_source_link',
+      '404error',
+      'category',
+      'class',
+      'constructor',
+      'enum',
+      'extension',
+      'function',
+      'index',
+      'library',
+      'method',
+      'mixin',
+      'property',
+      'top_level_property',
+      'typedef',
+    ]) {
+      await resourceLoader.writeDartdocResource(
+          'templates/html/$template.html', 'CONTENT');
+    }
 
-    templates = await Templates.createDefault('html');
+    for (var resource in [
+      'favicon.png',
+      'github.css',
+      'highlight.pack.js',
+      'play_button.svg',
+      'readme.md',
+      'script.js',
+      'styles.css',
+      'typeahead.bundle.min.js',
+    ]) {
+      await resourceLoader.writeDartdocResource(
+          'resources/$resource', 'CONTENT');
+    }
+
+    templates = await Templates.createDefault('html', loader: resourceLoader);
     generator = GeneratorFrontEnd(HtmlGeneratorBackend(null, templates));
 
     projectRoot = utils.writePackage(
@@ -125,5 +184,14 @@ class _DoesExist extends Matcher {
     } else {
       return mismatchDescription.add(' does not exist');
     }
+  }
+}
+
+/// Extension methods just for tests.
+extension on ResourceLoader {
+  Future<void> writeDartdocResource(String path, String content) async {
+    var filePath =
+        (await resolveUri(Uri.parse('package:dartdoc/$path'))).toFilePath();
+    provider.getFile(filePath).writeAsStringSync(content);
   }
 }

--- a/test/resource_loader_test.dart
+++ b/test/resource_loader_test.dart
@@ -4,7 +4,7 @@
 
 library dartdoc.resource_loader_test;
 
-import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:dartdoc/src/generator/resource_loader.dart';
 import 'package:test/test.dart';
 
@@ -13,7 +13,7 @@ void main() {
     ResourceLoader loader;
 
     setUp(() {
-      loader = ResourceLoader(MemoryResourceProvider());
+      loader = ResourceLoader(PhysicalResourceProvider());
     });
 
     test('load from packages', () async {

--- a/test/resource_loader_test.dart
+++ b/test/resource_loader_test.dart
@@ -4,11 +4,18 @@
 
 library dartdoc.resource_loader_test;
 
-import 'package:dartdoc/src/generator/resource_loader.dart' as loader;
+import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:dartdoc/src/generator/resource_loader.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Resource Loader', () {
+    ResourceLoader loader;
+
+    setUp(() {
+      loader = ResourceLoader(MemoryResourceProvider());
+    });
+
     test('load from packages', () async {
       var contents = await loader
           .loadAsString('package:dartdoc/templates/html/index.html');


### PR DESCRIPTION
* The top-level functions in resource_loader.dart were wrapped in a class, ResourceLoader, to account for ResourceProvider.
* **Breaking Change**: Templates.fromDirectory is made private and now requires
  a ResourceLoader.
* Templates.createDefault is made `@visibleForTesting` and now requires a
  ResourceLoader.

This includes a few minor cleanups as well.