### PR TITLE
Mustachio: Introduce Template class for pre-parsing template files.

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -16,23 +16,14 @@ String _simpleResolveErrorMessage(List<String> key, String type) =>
     'expose the properties of $type by adding it to the @Renderer '
     "annotation's 'visibleTypes' list";
 
-String renderIndex(PackageTemplateData context, File file,
-    {PartialResolver partialResolver}) {
-  try {
-    var parser = MustachioParser(file.readAsStringSync());
-    return _render_PackageTemplateData(context, parser.parse(), file,
-        partialResolver: partialResolver);
-  } on FileSystemException catch (e) {
-    throw MustachioResolutionError(
-        'FileSystemException when reading template "${file.path}": ${e.message}');
-  }
+String renderIndex(PackageTemplateData context, Template template) {
+  return _render_PackageTemplateData(context, template.ast, template);
 }
 
 String _render_PackageTemplateData(
-    PackageTemplateData context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer = _Renderer_PackageTemplateData(context, parent, file,
-      partialResolver: partialResolver);
+    PackageTemplateData context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_PackageTemplateData(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -203,10 +194,9 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
         ..._Renderer_TemplateData.propertyMap<Package, CT_>(),
       };
 
-  _Renderer_PackageTemplateData(
-      PackageTemplateData context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+  _Renderer_PackageTemplateData(PackageTemplateData context,
+      RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<PackageTemplateData> getProperty(String key) {
@@ -218,10 +208,10 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String _render_Object(Object context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer =
-      _Renderer_Object(context, parent, file, partialResolver: partialResolver);
+String _render_Object(
+    Object context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_Object(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -246,9 +236,9 @@ class _Renderer_Object extends RendererBase<Object> {
         ),
       };
 
-  _Renderer_Object(Object context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+  _Renderer_Object(
+      Object context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<Object> getProperty(String key) {
@@ -261,10 +251,9 @@ class _Renderer_Object extends RendererBase<Object> {
 }
 
 String _render_TemplateData<T extends Documentable>(
-    TemplateData<T> context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer = _Renderer_TemplateData(context, parent, file,
-      partialResolver: partialResolver);
+    TemplateData<T> context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_TemplateData(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -570,9 +559,8 @@ class _Renderer_TemplateData<T extends Documentable>
       };
 
   _Renderer_TemplateData(
-      TemplateData<T> context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+      TemplateData<T> context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<TemplateData<T>> getProperty(String key) {

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -2,17 +2,131 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path;
 import 'parser.dart';
 
 /// The signature of a partial resolver function.
-typedef PartialResolver = String Function(String path);
+typedef PartialResolver = Future<File> Function(String uri);
 
 /// The signature of a generated render function.
-typedef Renderer<T> = String Function(T context, File file,
-    {PartialResolver partialResolver});
+typedef RenderFunction<T> = String Function(T context, Template template);
+
+/// A parsed Mustache template.
+///
+/// This container includes Templates for all partials parsed in the template
+/// file.
+class Template {
+  /// The parsed Mustache syntax tree.
+  final List<MustachioNode> ast;
+
+  /// A mapping of partial keys to partial [File]s.
+  ///
+  /// This may appear redundant with [partialTemplates], the mapping of partial
+  /// files to partial templates. The reason for two mappings is that
+  /// [partialTemplates] functions as a cache, so that each [File] containing a
+  /// partial template is only parsed once, and also so that partial templates
+  /// can reference themselves, or otherwise recurse. The cache is passed down
+  /// from template to partial. Mapping a partial key to a partial [File],
+  /// however, cannot be shared between templates and partials because they
+  /// typically contain relative file paths. Each partial file path is given
+  /// relative to the template or partial making the reference.
+  // TODO(srawlins): Resolving partials from the Parser rather than
+  // [Template.parse] would allow the [File] to be stored on the [Partial] node,
+  // removing the need for this mapping.
+  final Map<String, File> partials;
+
+  /// A mapping of partial [File]s to parsed Mustache templates.
+  final Map<File, Template> partialTemplates;
+
+  Template._(
+      {@required this.ast,
+      @required this.partials,
+      @required this.partialTemplates});
+
+  /// Parses [file] as a Mustache template, returning a [Template].
+  ///
+  /// A [partialResolver] can be passed if custom partial resolution is required
+  /// (for example, to load any partial from a single directory, and to append a
+  /// particular suffix).
+  ///
+  /// By default, a partial key is resolved as a file path which is either
+  /// absolute, or relative to the directory containing the template which
+  /// references the partial.
+  ///
+  /// For example, if the Mustache template at `/foo/template.html` includes a
+  /// Partial node, `{{>partials/p1.html}}`, then the partial file path is
+  /// resolved as `/foo/partials/p1.html`. If this template includes a Partial
+  /// node, `{{>p2.html}}`, then this partial file path is resolved (relative to
+  /// the directory containing `p1.html`, not relative to the top-level
+  /// template), as `/foo/partials/p2.html`.
+  static Future<Template> parse(File file,
+      {PartialResolver partialResolver,
+      @internal Map<File, Template> partialTemplates}) async {
+    partialTemplates ??= <File, Template>{};
+    if (partialResolver == null) {
+      var pathContext = file.provider.pathContext;
+      // By default, resolve partials as absolute file paths, or as relative
+      // file paths, relative to the template directory from which they are
+      // referenced.
+      partialResolver = (String path) async {
+        var partialPath = pathContext.isAbsolute(path)
+            ? path
+            : pathContext.join(file.parent.path, path);
+        var partialFile =
+            file.provider.getFile(pathContext.normalize(partialPath));
+        return partialFile;
+      };
+    }
+
+    // If we fail to read [file], and an exception is thrown, one of two
+    // things happen:
+    // 1) In the case of a reference from a partial, the exception is caught
+    //    below, when parsing partials, and rethrown with information about the
+    //    template with the reference.
+    // 2) In the case of a reference from a top-level template, user code has
+    //    called [Template.parse], and the user is responsible for handling the
+    //    exception.
+    var ast = MustachioParser(file.readAsStringSync()).parse();
+    var nodeQueue = Queue.of(ast);
+    var partials = <String, File>{};
+
+    // Walk the Mustache syntax tree, looking for Partial nodes.
+    while (nodeQueue.isNotEmpty) {
+      var node = nodeQueue.removeFirst();
+      if (node is Text) {
+        // Nothing to do.
+      } else if (node is Variable) {
+        // Nothing to do.
+      } else if (node is Section) {
+        nodeQueue.addAll(node.children);
+      } else if (node is Partial) {
+        var key = node.key;
+        if (!partials.containsKey(key)) {
+          partials[key] = await partialResolver(key);
+        }
+        var partialFile = partials[key];
+        if (!partialTemplates.containsKey(partialFile)) {
+          try {
+            var partialTemplate = await Template.parse(partialFile,
+                partialResolver: partialResolver,
+                partialTemplates: {...partialTemplates});
+            partialTemplates[partialFile] = partialTemplate;
+          } on FileSystemException catch (e) {
+            throw MustachioResolutionError(
+                'FileSystemException when reading partial "$key" found in '
+                'template "${file.path}": ${e.message}');
+          }
+        }
+      }
+    }
+
+    return Template._(
+        ast: ast, partials: partials, partialTemplates: partialTemplates);
+  }
+}
 
 /// The base class for a generated Mustache renderer.
 abstract class RendererBase<T> {
@@ -22,25 +136,12 @@ abstract class RendererBase<T> {
   /// The renderer of the parent context, if any, otherwise `null`.
   final RendererBase parent;
 
-  final File template;
-
-  final PartialResolver partialResolver;
+  final Template template;
 
   /// The output buffer into which [context] is rendered, using a template.
   final buffer = StringBuffer();
 
-  RendererBase(this.context, this.parent, this.template,
-      {this.partialResolver});
-
-  path.Context get pathContext => template.provider.pathContext;
-
-  String _defaultResolver(String path) {
-    var partialPath = pathContext.isAbsolute(path)
-        ? path
-        : pathContext.join(template.parent.path, path);
-    var file = template.provider.getFile(pathContext.normalize(partialPath));
-    return file.readAsStringSync();
-  }
+  RendererBase(this.context, this.parent, this.template);
 
   void write(String text) => buffer.write(text);
 
@@ -143,20 +244,12 @@ abstract class RendererBase<T> {
 
   void partial(Partial node) {
     var key = node.key;
-    try {
-      var partial = (partialResolver ?? _defaultResolver)(key);
-      var parser = MustachioParser(partial);
-      var ast = parser.parse();
-      renderBlock(ast);
-    } on FileSystemException catch (e) {
-      throw MustachioResolutionError(
-          'FileSystemException when reading partial "$key" found in template '
-          '"${template.path}": ${e.message}');
-    }
+    var partialFile = template.partials[key];
+    renderBlock(template.partialTemplates[partialFile].ast);
   }
 }
 
-String renderSimple(Object context, List<MustachioNode> ast, File template,
+String renderSimple(Object context, List<MustachioNode> ast, Template template,
     {RendererBase parent}) {
   var renderer = SimpleRenderer(context, parent, template);
   renderer.renderBlock(ast);
@@ -164,7 +257,7 @@ String renderSimple(Object context, List<MustachioNode> ast, File template,
 }
 
 class SimpleRenderer extends RendererBase<Object> {
-  SimpleRenderer(Object context, RendererBase<Object> parent, File template)
+  SimpleRenderer(Object context, RendererBase<Object> parent, Template template)
       : super(context, parent, template);
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   html: '>=0.12.1 <0.15.0'
   logging: ^0.11.3+1
   markdown: '>=2.1.5 <4.0.0'
-  meta: ^1.1.8
+  meta: ^1.2.4
   mustache: ^1.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -92,8 +92,8 @@ class Bar {}
       // The render function for Foo
       expect(
           generatedContent,
-          contains(
-              'String _render_FooBase(FooBase context, List<MustachioNode> ast,'));
+          contains('String _render_FooBase(\n'
+              '    FooBase context, List<MustachioNode> ast, Template template,'));
       // The renderer class for Foo
       expect(generatedContent,
           contains('class _Renderer_FooBase extends RendererBase<FooBase>'));
@@ -103,8 +103,8 @@ class Bar {}
       // The render function for Object
       expect(
           generatedContent,
-          contains(
-              'String _render_Object(Object context, List<MustachioNode> ast,'));
+          contains('String _render_Object(\n'
+              '    Object context, List<MustachioNode> ast, Template template,'));
       // The renderer class for Object
       expect(generatedContent,
           contains('class _Renderer_Object extends RendererBase<Object> {'));
@@ -241,15 +241,14 @@ import 'package:mustachio/annotations.dart';
 
     test('with a corresponding public API function', () async {
       expect(generatedContent,
-          contains('String renderFoo<T>(Foo<T> context, File file,'));
-      expect(generatedContent, contains('{PartialResolver partialResolver})'));
+          contains('String renderFoo<T>(Foo<T> context, Template template)'));
     });
 
     test('with a corresponding render function', () async {
       expect(
           generatedContent,
-          contains(
-              'String _render_Foo<T>(Foo<T> context, List<MustachioNode> ast, File file,'));
+          contains('String _render_Foo<T>(\n'
+              '    Foo<T> context, List<MustachioNode> ast, Template template,'));
     });
 
     test('with a generic supertype type argument', () async {

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -16,21 +16,13 @@ String _simpleResolveErrorMessage(List<String> key, String type) =>
     'expose the properties of $type by adding it to the @Renderer '
     "annotation's 'visibleTypes' list";
 
-String renderFoo(Foo context, File file, {PartialResolver partialResolver}) {
-  try {
-    var parser = MustachioParser(file.readAsStringSync());
-    return _render_Foo(context, parser.parse(), file,
-        partialResolver: partialResolver);
-  } on FileSystemException catch (e) {
-    throw MustachioResolutionError(
-        'FileSystemException when reading template "${file.path}": ${e.message}');
-  }
+String renderFoo(Foo context, Template template) {
+  return _render_Foo(context, template.ast, template);
 }
 
-String _render_Foo(Foo context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer =
-      Renderer_Foo(context, parent, file, partialResolver: partialResolver);
+String _render_Foo(Foo context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Foo(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -109,9 +101,8 @@ class Renderer_Foo extends RendererBase<Foo> {
         ...Renderer_Object.propertyMap<CT_>(),
       };
 
-  Renderer_Foo(Foo context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+  Renderer_Foo(Foo context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<Foo> getProperty(String key) {
@@ -123,10 +114,10 @@ class Renderer_Foo extends RendererBase<Foo> {
   }
 }
 
-String _render_Object(Object context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer =
-      Renderer_Object(context, parent, file, partialResolver: partialResolver);
+String _render_Object(
+    Object context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Object(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -151,9 +142,9 @@ class Renderer_Object extends RendererBase<Object> {
         ),
       };
 
-  Renderer_Object(Object context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+  Renderer_Object(
+      Object context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<Object> getProperty(String key) {
@@ -165,21 +156,13 @@ class Renderer_Object extends RendererBase<Object> {
   }
 }
 
-String renderBar(Bar context, File file, {PartialResolver partialResolver}) {
-  try {
-    var parser = MustachioParser(file.readAsStringSync());
-    return _render_Bar(context, parser.parse(), file,
-        partialResolver: partialResolver);
-  } on FileSystemException catch (e) {
-    throw MustachioResolutionError(
-        'FileSystemException when reading template "${file.path}": ${e.message}');
-  }
+String renderBar(Bar context, Template template) {
+  return _render_Bar(context, template.ast, template);
 }
 
-String _render_Bar(Bar context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer =
-      Renderer_Bar(context, parent, file, partialResolver: partialResolver);
+String _render_Bar(Bar context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Bar(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -256,9 +239,8 @@ class Renderer_Bar extends RendererBase<Bar> {
         ...Renderer_Object.propertyMap<CT_>(),
       };
 
-  Renderer_Bar(Bar context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+  Renderer_Bar(Bar context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<Bar> getProperty(String key) {
@@ -270,21 +252,13 @@ class Renderer_Bar extends RendererBase<Bar> {
   }
 }
 
-String renderBaz(Baz context, File file, {PartialResolver partialResolver}) {
-  try {
-    var parser = MustachioParser(file.readAsStringSync());
-    return _render_Baz(context, parser.parse(), file,
-        partialResolver: partialResolver);
-  } on FileSystemException catch (e) {
-    throw MustachioResolutionError(
-        'FileSystemException when reading template "${file.path}": ${e.message}');
-  }
+String renderBaz(Baz context, Template template) {
+  return _render_Baz(context, template.ast, template);
 }
 
-String _render_Baz(Baz context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer =
-      Renderer_Baz(context, parent, file, partialResolver: partialResolver);
+String _render_Baz(Baz context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Baz(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -313,9 +287,8 @@ class Renderer_Baz extends RendererBase<Baz> {
         ...Renderer_Object.propertyMap<CT_>(),
       };
 
-  Renderer_Baz(Baz context, RendererBase<Object> parent, File file,
-      {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+  Renderer_Baz(Baz context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 
   @override
   Property<Baz> getProperty(String key) {

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -1,18 +1,22 @@
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/mustachio/renderer_base.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'foo.dart';
 import 'foo.renderers.dart';
 
 void main() {
-  MemoryResourceProvider resourceProvider;
+  /*late*/ MemoryResourceProvider resourceProvider;
+
+  /*late*/ p.Context pathContext;
 
   File getFile(String path) =>
       resourceProvider.getFile(resourceProvider.convertPath(path));
 
   setUp(() {
     resourceProvider = MemoryResourceProvider();
+    pathContext = resourceProvider.pathContext;
   });
 
   test('property map contains all public getters', () {
@@ -106,203 +110,231 @@ void main() {
     expect(propertyMap['b1'].getBool(foo), isFalse);
   });
 
-  test('Renderer renders a non-bool variable node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a non-bool variable node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{s1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..s1 = 'hello';
     expect(renderFoo(foo, fooTemplate), equals('Text hello'));
   });
 
-  test('Renderer renders a bool variable node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a bool variable node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{b1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..b1 = true;
     expect(renderFoo(foo, fooTemplate), equals('Text true'));
   });
 
-  test('Renderer renders an Iterable variable node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an Iterable variable node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{l1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..l1 = [1, 2, 3];
     expect(renderFoo(foo, fooTemplate), equals('Text [1, 2, 3]'));
   });
 
-  test('Renderer renders a conditional section node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a conditional section node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#b1}}Section{{/b1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..b1 = true;
     expect(renderFoo(foo, fooTemplate), equals('Text Section'));
   });
 
-  test('Renderer renders a false conditional section node as blank', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a false conditional section node as blank', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#b1}}Section{{/b1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..b1 = false;
     expect(renderFoo(foo, fooTemplate), equals('Text '));
   });
 
-  test('Renderer renders an inverted conditional section node as empty', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an inverted conditional section node as empty',
+      () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{^b1}}Section{{/b1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..b1 = true;
     expect(renderFoo(foo, fooTemplate), equals('Text '));
   });
 
-  test('Renderer renders an inverted false conditional section node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an inverted false conditional section node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{^b1}}Section{{/b1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..b1 = false;
     expect(renderFoo(foo, fooTemplate), equals('Text Section'));
   });
 
-  test('Renderer renders a repeated section node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a repeated section node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#l1}}Num {{.}}, {{/l1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..l1 = [1, 2, 3];
     expect(renderFoo(foo, fooTemplate), equals('Text Num 1, Num 2, Num 3, '));
   });
 
-  test('Renderer renders an empty repeated section node as blank', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an empty repeated section node as blank', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#l1}}Num {{.}}, {{/l1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..l1 = [];
     expect(renderFoo(foo, fooTemplate), equals('Text '));
   });
 
-  test('Renderer renders an empty inverted repeated section node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an empty inverted repeated section node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{^l1}}Empty{{/l1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..l1 = [];
     expect(renderFoo(foo, fooTemplate), equals('Text Empty'));
   });
 
-  test('Renderer renders an inverted repeated section node as blank', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an inverted repeated section node as blank', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{^l1}}Empty{{/l1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..l1 = [1, 2, 3];
     expect(renderFoo(foo, fooTemplate), equals('Text '));
   });
 
-  test('Renderer renders a value section node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a value section node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#foo}}Foo: {{s1}}{{/foo}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(renderBar(bar, fooTemplate), equals('Text Foo: hello'));
   });
 
-  test('Renderer renders a null value section node as blank', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders a null value section node as blank', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#s1}}"{{.}}" ({{length}}){{/s1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..s1 = null;
     expect(renderFoo(foo, fooTemplate), equals('Text '));
   });
 
-  test('Renderer renders an inverted value section node as blank', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an inverted value section node as blank', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{^s1}}Section{{/s1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..s1 = 'hello';
     expect(renderFoo(foo, fooTemplate), equals('Text '));
   });
 
-  test('Renderer renders an inverted null value section node', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer renders an inverted null value section node', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{^s1}}Section{{/s1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo()..s1 = null;
     expect(renderFoo(foo, fooTemplate), equals('Text Section'));
   });
 
-  test('Renderer resolves variable inside a value section', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer resolves variable inside a value section', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#foo}}{{s1}}{{/foo}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(renderBar(bar, fooTemplate), equals('Text hello'));
   });
 
   test('Renderer resolves variable from outer context inside a value section',
-      () {
-    var fooTemplate = getFile('/project/foo.mustache')
+      () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#foo}}{{s2}}{{/foo}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var bar = Bar()
       ..foo = (Foo()..s1 = 'hello')
       ..s2 = 'goodbye';
     expect(renderBar(bar, fooTemplate), equals('Text goodbye'));
   });
 
-  test('Renderer resolves variable with key with multiple names', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer resolves variable with key with multiple names', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{foo.s1}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var bar = Bar()
       ..foo = (Foo()..s1 = 'hello')
       ..s2 = 'goodbye';
     expect(renderBar(bar, fooTemplate), equals('Text hello'));
   });
 
-  test('Renderer resolves outer variable with key with two names', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer resolves outer variable with key with two names', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#foo}}{{foo.s1}}{{/foo}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var bar = Bar()
       ..foo = (Foo()..s1 = 'hello')
       ..s2 = 'goodbye';
     expect(renderBar(bar, fooTemplate), equals('Text hello'));
   });
 
-  test('Renderer resolves outer variable with key with three names', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer resolves outer variable with key with three names', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#bar}}{{bar.foo.s1}}{{/bar}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var baz = Baz()..bar = (Bar()..foo = (Foo()..s1 = 'hello'));
     expect(renderBaz(baz, fooTemplate), equals('Text hello'));
   });
 
   test('Renderer resolves outer variable with key with more than three names',
-      () {
-    var bazTemplate = getFile('/project/baz.mustache')
+      () async {
+    var bazTemplateFile = getFile('/project/baz.mustache')
       ..writeAsStringSync('Text {{#bar}}{{bar.foo.baz.bar.foo.s1}}{{/bar}}');
     var baz = Baz()..bar = (Bar()..foo = (Foo()..s1 = 'hello'));
+    var bazTemplate = await Template.parse(bazTemplateFile);
     baz.bar.foo.baz = baz;
     expect(renderBaz(baz, bazTemplate), equals('Text hello'));
   });
 
-  test('Renderer renders a partial in the same directory', () {
-    var barTemplate = getFile('/project/bar.mustache')
+  test('Renderer renders a partial in the same directory', () async {
+    var barTemplateFile = getFile('/project/bar.mustache')
       ..writeAsStringSync('Text {{#foo}}{{>foo.mustache}}{{/foo}}');
     getFile('/project/foo.mustache').writeAsStringSync('Partial {{s1}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(renderBar(bar, barTemplate), equals('Text Partial hello'));
   });
 
-  test('Renderer renders a partial in a different directory', () {
-    var barTemplate = getFile('/project/src/bar.mustache')
+  test('Renderer renders a partial in a different directory', () async {
+    var barTemplateFile = getFile('/project/src/bar.mustache')
       ..writeAsStringSync('Text {{#foo}}{{>../foo.mustache}}{{/foo}}');
     getFile('/project/foo.mustache').writeAsStringSync('Partial {{s1}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(renderBar(bar, barTemplate), equals('Text Partial hello'));
   });
 
-  test('Renderer renders a partial in an absolute directory', () {
+  test('Renderer renders a partial in an absolute directory', () async {
     var partialPath = resourceProvider.convertPath('/project/foo.mustache');
-    var barTemplate = getFile('/project/src/bar.mustache')
+    var barTemplateFile = getFile('/project/src/bar.mustache')
       ..writeAsStringSync('Text {{#foo}}{{>$partialPath}}{{/foo}}');
     getFile('/project/foo.mustache').writeAsStringSync('Partial {{s1}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(renderBar(bar, barTemplate), equals('Text Partial hello'));
   });
 
-  test('Renderer renders a partial with context chain', () {
-    var barTemplate = getFile('/project/bar.mustache')
+  test('Renderer renders a partial with context chain', () async {
+    var barTemplateFile = getFile('/project/bar.mustache')
       ..writeAsStringSync('Text {{#foo}}{{>foo.mustache}}{{/foo}}');
     getFile('/project/foo.mustache').writeAsStringSync('Partial {{s2}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()
       ..foo = (Foo()..s1 = 'hello')
       ..s2 = 'goodbye';
     expect(renderBar(bar, barTemplate), equals('Text Partial goodbye'));
   });
 
-  test('Renderer renders a partial with a heterogeneous context chain', () {
-    var barTemplate = getFile('/project/bar.mustache')
+  test('Renderer renders a partial with a heterogeneous context chain',
+      () async {
+    var barTemplateFile = getFile('/project/bar.mustache')
       ..writeAsStringSync('Line 1 {{#foo}}{{>baz.mustache}}{{/foo}}\n'
           'Line 2 {{>baz.mustache}}');
     getFile('/project/baz.mustache')
         .writeAsStringSync('Partial {{#l1}}Section {{.}}{{/l1}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var baz = Baz();
     var bar = Bar()
       ..foo = (Foo()
@@ -323,27 +355,28 @@ void main() {
             'Line 2 Partial Section Instance of \'Bar\''));
   });
 
-  test('Renderer renders a partial using a custom partial renderer', () {
-    var barTemplate = getFile('/project/bar.mustache')
-      ..writeAsStringSync('Text {{#foo}}{{>_foo.mustache}}{{/foo}}');
-    getFile('/project/_foo.mustache').writeAsStringSync('Partial {{s1}}');
-    var bar = Bar()..foo = (Foo()..s1 = 'hello');
-    String partialResolver(String path) {
-      var partialPath = resourceProvider.pathContext.isAbsolute(path)
-          ? path
-          : resourceProvider.pathContext.join('/project', path);
-      var file = resourceProvider
-          .getFile(resourceProvider.pathContext.normalize('_$partialPath'));
-      return file.readAsStringSync();
+  test('Renderer renders a partial using a custom partial renderer', () async {
+    Future<File> partialResolver(String path) async {
+      var partialPath = pathContext.isAbsolute(path)
+          ? '_$path.mustache'
+          : pathContext.join('/project', '_$path.mustache');
+      return resourceProvider.getFile(pathContext.normalize(partialPath));
     }
 
-    expect(renderBar(bar, barTemplate, partialResolver: partialResolver),
-        equals('Text Partial hello'));
+    var barTemplateFile = getFile('/project/bar.mustache')
+      ..writeAsStringSync('Text {{#foo}}{{>foo}}{{/foo}}');
+    getFile('/project/_foo.mustache').writeAsStringSync('Partial {{s1}}');
+    var barTemplate =
+        await Template.parse(barTemplateFile, partialResolver: partialResolver);
+    var bar = Bar()..foo = (Foo()..s1 = 'hello');
+
+    expect(renderBar(bar, barTemplate), equals('Text Partial hello'));
   });
 
-  test('Renderer throws when it cannot resolve a variable key', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer throws when it cannot resolve a variable key', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{s2}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo();
     expect(
         () => renderFoo(foo, fooTemplate),
@@ -354,9 +387,10 @@ void main() {
                 'context chain: Foo'))));
   });
 
-  test('Renderer throws when it cannot resolve a section key', () {
-    var fooTemplate = getFile('/project/foo.mustache')
+  test('Renderer throws when it cannot resolve a section key', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#s2}}Section{{/s2}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo();
     expect(
         () => renderFoo(foo, fooTemplate),
@@ -367,9 +401,11 @@ void main() {
                 'current context'))));
   });
 
-  test('Renderer throws when it cannot resolve a multi-name variable key', () {
-    var barTemplate = getFile('/project/bar.mustache')
+  test('Renderer throws when it cannot resolve a multi-name variable key',
+      () async {
+    var barTemplateFile = getFile('/project/bar.mustache')
       ..writeAsStringSync('Text {{foo.x}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()..foo = Foo();
     expect(
         () => renderBar(bar, barTemplate),
@@ -381,9 +417,11 @@ void main() {
                 "first resolving 'foo' to a property on Bar"))));
   });
 
-  test('Renderer throws when it cannot resolve a multi-name section key', () {
-    var barTemplate = getFile('/project/bar.mustache')
+  test('Renderer throws when it cannot resolve a multi-name section key',
+      () async {
+    var barTemplateFile = getFile('/project/bar.mustache')
       ..writeAsStringSync('Text {{foo.x}}');
+    var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()..foo = Foo();
     expect(
         () => renderBar(bar, barTemplate),
@@ -396,9 +434,10 @@ void main() {
   });
 
   test('Renderer throws when it cannot resolve a key with a SimpleRenderer',
-      () {
-    var fooTemplate = getFile('/project/foo.mustache')
+      () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{s1.length}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
     var foo = Foo();
     expect(
         () => renderFoo(foo, fooTemplate),
@@ -408,27 +447,26 @@ void main() {
             contains('Failed to resolve [length] property chain on String'))));
   });
 
-  test('Renderer throws when it cannot read a template', () {
+  test('Template parser throws when it cannot read a template', () async {
     var templatePath =
         resourceProvider.convertPath('/project/src/bar.mustache');
-    var barTemplate = getFile(templatePath);
+    var barTemplateFile = getFile(templatePath);
+
     expect(
-        () => renderBar(Bar(), barTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        () async => await Template.parse(barTemplateFile),
+        throwsA(const TypeMatcher<FileSystemException>().having(
             (e) => e.message,
             'message',
-            contains('FileSystemException when reading template '
-                '"$templatePath"'))));
+            contains('"$templatePath" does not exist.'))));
   });
 
-  test('Renderer throws when it cannot read a partial', () {
+  test('Template parser throws when it cannot read a partial', () async {
     var templatePath =
         resourceProvider.convertPath('/project/src/bar.mustache');
-    var barTemplate = getFile(templatePath)
+    var barTemplateFile = getFile(templatePath)
       ..writeAsStringSync('Text {{#foo}}{{>missing.mustache}}{{/foo}}');
-    var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(
-        () => renderBar(bar, barTemplate),
+        () async => await Template.parse(barTemplateFile),
         throwsA(const TypeMatcher<MustachioResolutionError>().having(
             (e) => e.message,
             'message',

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -11,8 +11,8 @@ void main() {
 
   /*late*/ p.Context pathContext;
 
-  File getFile(String path) =>
-      resourceProvider.getFile(resourceProvider.convertPath(path));
+  File getFile(String path) => resourceProvider
+      .getFile(pathContext.canonicalize(resourceProvider.convertPath(path)));
 
   setUp(() {
     resourceProvider = MemoryResourceProvider();
@@ -360,7 +360,7 @@ void main() {
       var partialPath = pathContext.isAbsolute(path)
           ? '_$path.mustache'
           : pathContext.join('/project', '_$path.mustache');
-      return resourceProvider.getFile(pathContext.canonicalize(partialPath));
+      return getFile(partialPath);
     }
 
     var barTemplateFile = getFile('/project/bar.mustache')

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -360,7 +360,7 @@ void main() {
       var partialPath = pathContext.isAbsolute(path)
           ? '_$path.mustache'
           : pathContext.join('/project', '_$path.mustache');
-      return resourceProvider.getFile(pathContext.normalize(partialPath));
+      return resourceProvider.getFile(pathContext.canonicalize(partialPath));
     }
 
     var barTemplateFile = getFile('/project/bar.mustache')

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -307,10 +307,10 @@ void main() {
   });
 
   test('Renderer renders a partial in an absolute directory', () async {
-    var partialPath = resourceProvider.convertPath('/project/foo.mustache');
+    var fooTemplateFile = getFile('/project/foo.mustache');
+    fooTemplateFile.writeAsStringSync('Partial {{s1}}');
     var barTemplateFile = getFile('/project/src/bar.mustache')
-      ..writeAsStringSync('Text {{#foo}}{{>$partialPath}}{{/foo}}');
-    getFile('/project/foo.mustache').writeAsStringSync('Partial {{s1}}');
+      ..writeAsStringSync('Text {{#foo}}{{>${fooTemplateFile.path}}}{{/foo}}');
     var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()..foo = (Foo()..s1 = 'hello');
     expect(renderBar(bar, barTemplate), equals('Text Partial hello'));
@@ -448,22 +448,17 @@ void main() {
   });
 
   test('Template parser throws when it cannot read a template', () async {
-    var templatePath =
-        resourceProvider.convertPath('/project/src/bar.mustache');
-    var barTemplateFile = getFile(templatePath);
-
+    var barTemplateFile = getFile('/project/src/bar.mustache');
     expect(
         () async => await Template.parse(barTemplateFile),
         throwsA(const TypeMatcher<FileSystemException>().having(
             (e) => e.message,
             'message',
-            contains('"$templatePath" does not exist.'))));
+            contains('"${barTemplateFile.path}" does not exist.'))));
   });
 
   test('Template parser throws when it cannot read a partial', () async {
-    var templatePath =
-        resourceProvider.convertPath('/project/src/bar.mustache');
-    var barTemplateFile = getFile(templatePath)
+    var barTemplateFile = getFile('/project/src/bar.mustache')
       ..writeAsStringSync('Text {{#foo}}{{>missing.mustache}}{{/foo}}');
     expect(
         () async => await Template.parse(barTemplateFile),
@@ -472,6 +467,6 @@ void main() {
             'message',
             contains(
                 'FileSystemException when reading partial "missing.mustache" '
-                'found in template "$templatePath"'))));
+                'found in template "${barTemplateFile.path}"'))));
   });
 }

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -215,15 +215,8 @@ String _simpleResolveErrorMessage(List<String> key, String type) =>
     if (renderer.publicApiFunctionName != null) {
       _buffer.writeln('''
 String ${renderer.publicApiFunctionName}${renderer._typeParametersString}(
-    $typeWithVariables context, File file, {PartialResolver partialResolver}) {
-  try {
-    var parser = MustachioParser(file.readAsStringSync());
-    return ${renderer._renderFunctionName}(
-        context, parser.parse(), file, partialResolver: partialResolver);
-  } on FileSystemException catch (e) {
-    throw MustachioResolutionError(
-        'FileSystemException when reading template "\${file.path}": \${e.message}');
-  }
+    $typeWithVariables context, Template template) {
+  return ${renderer._renderFunctionName}(context, template.ast, template);
 }
 ''');
     }
@@ -231,10 +224,9 @@ String ${renderer.publicApiFunctionName}${renderer._typeParametersString}(
     // Write out the render function.
     _buffer.writeln('''
 String ${renderer._renderFunctionName}${renderer._typeParametersString}(
-    $typeWithVariables context, List<MustachioNode> ast, File file,
-    {RendererBase<Object> parent, PartialResolver partialResolver}) {
-  var renderer = ${renderer._rendererClassName}(
-      context, parent, file, partialResolver: partialResolver);
+    $typeWithVariables context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = ${renderer._rendererClassName}(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
@@ -249,9 +241,8 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
     // Write out the constructor.
     _buffer.writeln('''
   ${renderer._rendererClassName}(
-        $typeWithVariables context, RendererBase<Object> parent, File file,
-        {PartialResolver partialResolver})
-      : super(context, parent, file, partialResolver: partialResolver);
+        $typeWithVariables context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
 ''');
     var propertyMapTypeArguments = renderer._typeArgumentsStringWith(typeName);
     var propertyMapName = 'propertyMap$propertyMapTypeArguments';


### PR DESCRIPTION
Second, change the signature of a partial resolver to return a Future<File>.
This allows for dartdoc's current partial parsing, which requires use of an
asynchronous Isolate API to get the path of a "package:" URI asset.

Before this change, Mustachio required re-parsing a template file for every
object which was to be rendered with that file. Horribly inefficient. This
change makes Mustachio much more similar to other Mustache parsers which allow
the user to handle a Template object which can be used to render multiple
context objects.

When parsing a Mustache template into a Template object, all partials
(recursive) will also be resolved, read, and parsed into Template objects. This
change has broad and beneficial consequences across the APIs which previously
passesd around Files and PartialResolvers:

* A RenderFunction now takes a Template instead of a File and a
  PartialResolver.
* RenderBase() now takes a Template instead of a File and a PartialResolver,
  and never concerns itself with partial resolution.
* RenderBase.partial now just retreives the pre-parsed partial instead of
  parsing inline.
* SimpleRenderer and renderSimple now take a Template instead of a File and a
  PartialResolver.

Also, the meta package is bumped in order to use `@internal`.