### PR TITLE
Change ResourceLoader from a thin wrapper around ResourceProvider …

### DIFF
--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -53,7 +53,6 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
   }
 
   Future<void> _copyResources(FileWriter writer) async {
-    var resourceLoader = ResourceLoader(writer.resourceProvider);
     for (var resourcePath in resources.resource_names) {
       if (!resourcePath.startsWith(_dartdocResourcePrefix)) {
         throw StateError('Resource paths must start with '
@@ -62,8 +61,8 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
       var destFileName = resourcePath.substring(_dartdocResourcePrefix.length);
       var destFilePath = writer.resourceProvider.pathContext
           .join('static-assets', destFileName);
-      writer.write(
-          destFilePath, await resourceLoader.loadAsBytes(resourcePath));
+      writer.write(destFilePath,
+          await writer.resourceProvider.loadResourceAsBytes(resourcePath));
     }
   }
 

--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -10,31 +10,27 @@ import 'dart:isolate' show Isolate;
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:meta/meta.dart';
 
-class ResourceLoader {
-  final ResourceProvider provider;
-
-  ResourceLoader(this.provider);
-
+extension ResourceLoader on ResourceProvider {
   /// Loads a `package:` resource as a String.
-  Future<String> loadAsString(String path) async {
-    var bytes = await loadAsBytes(path);
+  Future<String> loadResourceAsString(String path) async {
+    var bytes = await loadResourceAsBytes(path);
 
     return utf8.decode(bytes);
   }
 
   /// Loads a `package:` resource as an [List<int>].
-  Future<List<int>> loadAsBytes(String path) async {
+  Future<List<int>> loadResourceAsBytes(String path) async {
     if (!path.startsWith('package:')) {
       throw ArgumentError('path must begin with package:');
     }
 
-    var uri = await resolveUri(Uri.parse(path));
-    return provider.getFile(uri.toFilePath()).readAsBytesSync();
+    var uri = await resolveResourceUri(Uri.parse(path));
+    return getFile(uri.toFilePath()).readAsBytesSync();
   }
 
   /// Helper function for resolving to a non-relative, non-package URI.
   @visibleForTesting
-  Future<Uri> resolveUri(Uri uri) {
+  Future<Uri> resolveResourceUri(Uri uri) {
     if (uri.scheme == 'package') {
       return Isolate.resolvePackageUri(uri).then((resolvedUri) {
         if (resolvedUri == null) {

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -38,7 +38,6 @@ void main() {
     pathContext = resourceProvider.pathContext;
     packageConfigProvider = utils
         .getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
-    var resourceLoader = ResourceLoader(resourceProvider);
     for (var template in [
       '_accessor_getter',
       '_accessor_setter',
@@ -79,7 +78,7 @@ void main() {
       'top_level_property',
       'typedef',
     ]) {
-      await resourceLoader.writeDartdocResource(
+      await resourceProvider.writeDartdocResource(
           'templates/html/$template.html', 'CONTENT');
     }
 
@@ -93,11 +92,12 @@ void main() {
       'styles.css',
       'typeahead.bundle.min.js',
     ]) {
-      await resourceLoader.writeDartdocResource(
+      await resourceProvider.writeDartdocResource(
           'resources/$resource', 'CONTENT');
     }
 
-    templates = await Templates.createDefault('html', loader: resourceLoader);
+    templates = await Templates.createDefault('html',
+        resourceProvider: resourceProvider);
     generator =
         GeneratorFrontEnd(HtmlGeneratorBackend(null, templates, pathContext));
 
@@ -189,10 +189,9 @@ class _DoesExist extends Matcher {
 }
 
 /// Extension methods just for tests.
-extension on ResourceLoader {
+extension on ResourceProvider {
   Future<void> writeDartdocResource(String path, String content) async {
-    var filePath =
-        (await resolveUri(Uri.parse('package:dartdoc/$path'))).toFilePath();
-    provider.getFile(filePath).writeAsStringSync(content);
+    var fileUri = await resolveResourceUri(Uri.parse('package:dartdoc/$path'));
+    getFile(fileUri.toFilePath()).writeAsStringSync(content);
   }
 }

--- a/test/resource_loader_test.dart
+++ b/test/resource_loader_test.dart
@@ -4,26 +4,28 @@
 
 library dartdoc.resource_loader_test;
 
+import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:dartdoc/src/generator/resource_loader.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Resource Loader', () {
-    ResourceLoader loader;
+    ResourceProvider resourceProvider;
 
     setUp(() {
-      loader = ResourceLoader(PhysicalResourceProvider());
+      resourceProvider = PhysicalResourceProvider();
     });
 
     test('load from packages', () async {
-      var contents = await loader
-          .loadAsString('package:dartdoc/templates/html/index.html');
+      var contents = await resourceProvider
+          .loadResourceAsString('package:dartdoc/templates/html/index.html');
       expect(contents, isNotNull);
     });
 
     test('throws if non-package', () async {
-      expect(loader.loadAsString('wefoij:something'), throwsArgumentError);
+      expect(resourceProvider.loadResourceAsString('wefoij:something'),
+          throwsArgumentError);
     });
   });
 }


### PR DESCRIPTION
into an extension.

I'm not super married to this change, but I do think it is an improvement. ResourceLoader had turned into this this wrapper around ResourceProvider, and I decided it was silly for classes to be carrying around either a reference to a ResourceProvider, or a ResourceLoader, or both. This change simplifies things.