### PR TITLE
adjust the text of dartdoc exit messages

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -206,8 +206,8 @@ class Dartdoc {
     if (warnings == 0 && errors == 0) {
       logInfo('no issues found');
     } else {
-      logWarning("found ${warnings} ${pluralize('warning', warnings)} "
-          "and ${errors} ${pluralize('error', errors)}");
+      logWarning("Found ${warnings} ${pluralize('warning', warnings)} "
+          "and ${errors} ${pluralize('error', errors)}.");
     }
 
     seconds = _stopwatch.elapsedMilliseconds / 1000.0;
@@ -229,8 +229,7 @@ class Dartdoc {
       final errorCount =
           dartdocResults.packageGraph.packageWarningCounter.errorCount;
       if (errorCount > 0) {
-        throw DartdocFailure(
-            'dartdoc encountered $errorCount errors while processing.');
+        throw DartdocFailure('encountered $errorCount errors');
       }
       var outDirPath = config.resourceProvider.pathContext
           .absolute(dartdocResults.outDir.path);
@@ -504,9 +503,6 @@ class Dartdoc {
       (e, chain) {
         if (e is DartdocFailure) {
           stderr.writeln('\ndartdoc failed: ${e}.');
-          if (config.verboseWarnings) {
-            stderr.writeln(chain);
-          }
           exitCode = 1;
         } else {
           stderr.writeln('\ndartdoc failed: ${e}\n${chain}');

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -71,7 +71,7 @@ void main() {
           perLine: outputLines.add, workingDirectory: _testPackagePath);
       expect(outputLines, isNot(contains(matches('^parsing'))));
       expect(outputLines, contains(matches('^  warning:')));
-      expect(outputLines.last, matches(r'^found \d+ warnings and \d+ errors'));
+      expect(outputLines.last, matches(r'^Found \d+ warnings and \d+ errors'));
       expect(outputDir.listSync(), isEmpty);
     }, timeout: Timeout.factor(2));
 
@@ -84,7 +84,7 @@ void main() {
           perLine: outputLines.add, workingDirectory: _testPackagePath);
       expect(outputLines, isNot(contains(matches('^parsing'))));
       expect(outputLines, contains(matches('^  warning:')));
-      expect(outputLines.last, matches(r'^found \d+ warnings and \d+ errors'));
+      expect(outputLines.last, matches(r'^Found \d+ warnings and \d+ errors'));
       expect(outputDir.listSync(), isNotEmpty);
     }, timeout: Timeout.factor(2));
 


### PR DESCRIPTION
adjust the text of dartdoc exit messages:
- avoid printing a stack trace for exceptions used to signal an exit code
- have the 'found xxx issues' message use sentence case
- remove a double period for the 'dartdoc failed' message
- avoid saying 'dartdoc' twice in the 'dartdoc failed' message

Before these changes:

```
found 50 warnings and 107 errors

dartdoc failed: dartdoc encountered 107 errors while processing..
#0      Dartdoc.generateDocs (package:dartdoc/dartdoc.dart:231:9)
<asynchronous suspension>
#1      Dartdoc.executeGuarded.<anonymous closure> (package:dartdoc/dartdoc.dart:500:9)
<asynchronous suspension>
```

and after:

```
Found 50 warnings and 107 errors.

dartdoc failed: encountered 107 errors.
```
