### PR TITLE
Fix three little issues in mustachio codegen

### DIFF
--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -25,7 +25,7 @@ class Context<T> {
 };
 
 const _libraryFrontMatter = '''
-@Renderer(#renderFoo, Context<Foo>(), visibleTypes: {Bar})
+@Renderer(#renderFoo, Context<Foo>(), visibleTypes: {Bar, Baz})
 library foo;
 import 'package:mustachio/annotations.dart';
 ''';
@@ -73,15 +73,19 @@ $sourceLibraryContent
     setUpAll(() async {
       writer = InMemoryAssetWriter();
       await testMustachioBuilder('''
-abstract class FooBase {
+abstract class FooBase2<T> {
+  T get generic;
+}
+abstract class FooBase<T extends Baz> extends FooBase2<T> {
   Bar get bar;
 }
-class Foo extends FooBase {
+abstract class Foo extends FooBase {
   String s1 = "s1";
   bool b1 = false;
   List<int> l1 = [1, 2, 3];
 }
 class Bar {}
+class Baz {}
 ''');
       renderersLibrary = await resolveGeneratedLibrary(writer);
       var rendererAsset = AssetId.parse('foo|lib/foo.renderers.dart');
@@ -92,11 +96,13 @@ class Bar {}
       // The render function for Foo
       expect(
           generatedContent,
-          contains('String _render_FooBase(\n'
-              '    FooBase context, List<MustachioNode> ast, Template template,'));
+          contains('String _render_FooBase<T extends Baz>(\n'
+              '    FooBase<T> context, List<MustachioNode> ast, Template template,'));
       // The renderer class for Foo
-      expect(generatedContent,
-          contains('class _Renderer_FooBase extends RendererBase<FooBase>'));
+      expect(
+          generatedContent,
+          contains(
+              'class _Renderer_FooBase<T extends Baz> extends RendererBase<FooBase<T>>'));
     });
 
     test('for Object', () {
@@ -121,6 +127,11 @@ class Bar {}
       expect(renderersLibrary.getType('_Renderer_Bar'), isNotNull);
     });
 
+    test('for a generic, bounded type found in a getter', () {
+      expect(renderersLibrary.getTopLevelFunction('_render_Baz'), isNotNull);
+      expect(renderersLibrary.getType('_Renderer_Baz'), isNotNull);
+    });
+
     test('with a property map', () {
       expect(
           generatedContent,
@@ -130,7 +141,7 @@ class Bar {}
 
     test('with a property map which references the superclass', () {
       expect(generatedContent,
-          contains('..._Renderer_FooBase.propertyMap<CT_>(),'));
+          contains('..._Renderer_FooBase.propertyMap<Baz, CT_>(),'));
     });
 
     test('with a property map with a bool property', () {
@@ -203,6 +214,7 @@ class Bar {}
     await testMustachioBuilder('''
 class Foo {}
 class Bar {}
+class Baz {}
 ''', libraryFrontMatter: '''
 @Renderer(#renderFoo, Context<Foo>())
 @Renderer(#renderBar, Context<Bar>())
@@ -229,6 +241,7 @@ class FooBase<T> {}
 class Foo<T> extends FooBase<T> {}
 class BarBase<T> {}
 class Bar<T> extends BarBase<int> {}
+class Baz {}
 ''', libraryFrontMatter: '''
 @Renderer(#renderFoo, Context<Foo>())
 @Renderer(#renderBar, Context<Bar>())
@@ -275,6 +288,7 @@ import 'package:mustachio/annotations.dart';
     await testMustachioBuilder('''
 class Foo<T extends num> {}
 class Bar {}
+class Baz {}
 ''');
     var renderersLibrary = await resolveGeneratedLibrary(writer);
 
@@ -295,13 +309,14 @@ class Bar {}
     setUpAll(() async {
       writer = InMemoryAssetWriter();
       await testMustachioBuilder('''
-class Foo {
+abstract class Foo<T> {
   static Static get static1 => Bar();
   Private get _private1 => Bar();
   void set setter1(Setter s);
   Method method1(Method m);
 }
 class Bar {}
+class Baz {}
 class Static {}
 class Private {}
 class Setter {}

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -146,8 +146,8 @@ String _simpleResolveErrorMessage(List<String> key, String type) =>
     if (property.hasProtected || property.hasVisibleForTesting) return;
     var type = property.type.returnType;
     if (type is TypeParameterType) {
-      if ((type as TypeParameterType).bound == null ||
-          (type as TypeParameterType).bound.isDynamic) {
+      var bound = (type as TypeParameterType).bound;
+      if (bound == null || bound.isDynamic) {
         // Don't add functions for a generic type, for example
         // `List<E>.first` has type `E`, which we don't have a specific
         // renderer for.
@@ -155,7 +155,7 @@ String _simpleResolveErrorMessage(List<String> key, String type) =>
         // concrete types substituted for `E` for example.
         return;
       }
-      type = (type as TypeParameterType).bound;
+      type = bound;
     }
     var isFullRenderer = _isVisibleToMustache(type.element);
 


### PR DESCRIPTION
* Allow duplicate types in different `@Renderer` specifications.
* Only build each render class and renderer method once; you cannot declare two
  classes or functions with the same name.
* Do not attempt to add generators for type parameters; instead, use the bound
  if it is not `dynamic`.