### PR TITLE
Fix most current canonical score lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,21 +21,39 @@ linter:
     - avoid_unused_constructor_parameters
     - annotate_overrides
     - avoid_init_to_null
-    - avoid_types_as_parameter_names
-    - camel_case_types
     - directives_ordering
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - package_api_docs
     - prefer_final_fields
-    - prefer_generic_function_type_aliases
     - prefer_initializing_formals
     - prefer_void_to_null
-    - provide_deprecation_message
     - slash_for_doc_comments
     - type_annotate_public_apis
-    - unawaited_futures
     #    - unnecessary_brace_in_string_interps
+    # Work in progress canonical score lints
+    - avoid_empty_else
+    - avoid_relative_lib_imports
+    - avoid_shadowing_type_parameters
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - file_names
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - no_duplicate_case_values
+    #    - non_constant_identifier_names
+    - package_prefixed_library_names
+    - prefer_generic_function_type_aliases
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+    - unawaited_futures
     - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - valid_regexps
     - void_checks

--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -20,15 +20,43 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
+    - avoid_single_cascade_in_expression_statements
+    - avoid_unused_constructor_parameters
     - annotate_overrides
     - avoid_init_to_null
-    - avoid_types_as_parameter_names
     - directives_ordering
     - no_adjacent_strings_in_list
     - package_api_docs
     - prefer_final_fields
-    - prefer_generic_function_type_aliases
+    - prefer_initializing_formals
+    - prefer_void_to_null
     - slash_for_doc_comments
     - type_annotate_public_apis
+    #    - unnecessary_brace_in_string_interps
+    # Work in progress canonical score lints
+    - avoid_empty_else
+    - avoid_relative_lib_imports
+    - avoid_shadowing_type_parameters
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - file_names
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - no_duplicate_case_values
+    #    - non_constant_identifier_names
+    - package_prefixed_library_names
+    - prefer_generic_function_type_aliases
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
     - unawaited_futures
-#    - unnecessary_brace_in_string_interps
+    - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - valid_regexps
+    - void_checks

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -392,8 +392,8 @@ class Dartdoc {
       }
     }
     // Missing from search index
-    var missing_from_search = visited.difference(found);
-    for (var s in missing_from_search) {
+    var missingFromSearch = visited.difference(found);
+    for (var s in missingFromSearch) {
       _warn(packageGraph, PackageWarning.missingFromSearchIndex, s,
           path.normalize(origin),
           referredFrom: fullPath);

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -335,7 +335,7 @@ class ToolConfiguration {
     for (var entry in yamlMap.entries) {
       var name = entry.key.toString();
       var toolMap = entry.value;
-      var description;
+      String description;
       List<String> command;
       List<String> setupCommand;
       if (toolMap is Map) {
@@ -1130,7 +1130,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
       yamlData = yamlData[key] ?? {};
     }
 
-    var returnData;
+    dynamic returnData;
     if (_isListString) {
       if (yamlData is YamlList) {
         returnData = <String>[];

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -228,5 +228,5 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   }
 
   @override
-  void generateAdditionalFiles(FileWriter writer, PackageGraph graph) {}
+  Future<void> generateAdditionalFiles(FileWriter writer, PackageGraph graph) async {}
 }

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -228,5 +228,6 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   }
 
   @override
-  Future<void> generateAdditionalFiles(FileWriter writer, PackageGraph graph) async {}
+  Future<void> generateAdditionalFiles(
+      FileWriter writer, PackageGraph graph) async {}
 }

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -77,7 +77,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
       TemplateData data) {
     var content = template.renderString(data);
     if (!options.useBaseHref) {
-      content = content.replaceAll(HTMLBASE_PLACEHOLDER, data.htmlBase);
+      content = content.replaceAll(htmlBasePlaceholder, data.htmlBase);
     }
     writer.write(filename, content,
         element: data.self is Warnable ? data.self : null);
@@ -89,7 +89,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
     var json = generator_util.generateCategoryJson(
         categories, options.prettyIndexJson);
     if (!options.useBaseHref) {
-      json = json.replaceAll(HTMLBASE_PLACEHOLDER, '');
+      json = json.replaceAll(htmlBasePlaceholder, '');
     }
     writer.write(_pathContext.join('categories.json'), '${json}\n');
   }
@@ -99,7 +99,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
     var json = generator_util.generateSearchIndexJson(
         indexedElements, options.prettyIndexJson);
     if (!options.useBaseHref) {
-      json = json.replaceAll(HTMLBASE_PLACEHOLDER, '');
+      json = json.replaceAll(htmlBasePlaceholder, '');
     }
     writer.write(_pathContext.join('index.json'), '${json}\n');
   }

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -19,7 +19,7 @@ class GeneratorFrontEnd implements Generator {
   Future<void> generate(PackageGraph packageGraph, FileWriter writer) async {
     var indexElements = <Indexable>[];
     _generateDocs(packageGraph, writer, indexElements);
-    await _generatorBackend.generateAdditionalFiles(writer, packageGraph);
+    _generatorBackend.generateAdditionalFiles(writer, packageGraph);
 
     var categories = indexElements
         .whereType<Categorization>()

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -19,7 +19,7 @@ class GeneratorFrontEnd implements Generator {
   Future<void> generate(PackageGraph packageGraph, FileWriter writer) async {
     var indexElements = <Indexable>[];
     _generateDocs(packageGraph, writer, indexElements);
-    _generatorBackend.generateAdditionalFiles(writer, packageGraph);
+    await _generatorBackend.generateAdditionalFiles(writer, packageGraph);
 
     var categories = indexElements
         .whereType<Categorization>()
@@ -329,5 +329,5 @@ abstract class GeneratorBackend {
       FileWriter writer, PackageGraph graph, Library library, Typedef typedef);
 
   /// Emit files not specific to a Dart language element.
-  void generateAdditionalFiles(FileWriter writer, PackageGraph graph);
+  Future<void> generateAdditionalFiles(FileWriter writer, PackageGraph graph);
 }

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -38,7 +38,8 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
   }
 
   @override
-  Future<void> generateAdditionalFiles(FileWriter writer, PackageGraph graph) async {
+  Future<void> generateAdditionalFiles(
+      FileWriter writer, PackageGraph graph) async {
     await _copyResources(writer);
     if (options.favicon != null) {
       // Allow overwrite of favicon.

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -38,7 +38,7 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
   }
 
   @override
-  void generateAdditionalFiles(FileWriter writer, PackageGraph graph) async {
+  Future<void> generateAdditionalFiles(FileWriter writer, PackageGraph graph) async {
     await _copyResources(writer);
     if (options.favicon != null) {
       // Allow overwrite of favicon.

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -46,7 +46,7 @@ abstract class TemplateData<T extends Documentable> {
 
   String get bareHref {
     if (self is Indexable) {
-      return (self as Indexable).href.replaceAll(HTMLBASE_PLACEHOLDER, '');
+      return (self as Indexable).href.replaceAll(htmlBasePlaceholder, '');
     }
     return '';
   }

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -3,7 +3,7 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/dartdoc.dart';

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -163,7 +163,7 @@ final RegExp operatorPrefix = RegExp(r'^operator[ ]*');
 
 final HtmlEscape htmlEscape = const HtmlEscape(HtmlEscapeMode.element);
 
-final List<md.InlineSyntax> _markdown_syntaxes = [
+final List<md.InlineSyntax> _markdownSyntaxes = [
   _InlineCodeSyntax(),
   _AutolinkWithoutScheme(),
   md.InlineHtmlSyntax(),
@@ -171,7 +171,7 @@ final List<md.InlineSyntax> _markdown_syntaxes = [
   md.AutolinkExtensionSyntax(),
 ];
 
-final List<md.BlockSyntax> _markdown_block_syntaxes = [
+final List<md.BlockSyntax> _markdownBlockSyntaxes = [
   const md.FencedCodeBlockSyntax(),
   const md.HeaderWithIdSyntax(),
   const md.SetextHeaderWithIdSyntax(),
@@ -179,7 +179,7 @@ final List<md.BlockSyntax> _markdown_block_syntaxes = [
 ];
 
 // Remove these schemas from the display text for hyperlinks.
-final RegExp _hide_schemes = RegExp('^(http|https)://');
+final RegExp _hideSchemes = RegExp('^(http|https)://');
 
 class MatchingLinkResult {
   final ModelElement element;
@@ -951,8 +951,8 @@ class MarkdownDocument extends md.Document {
     }
 
     return MarkdownDocument(
-        inlineSyntaxes: _markdown_syntaxes,
-        blockSyntaxes: _markdown_block_syntaxes,
+        inlineSyntaxes: _markdownSyntaxes,
+        blockSyntaxes: _markdownBlockSyntaxes,
         linkResolver: linkResolver);
   }
 
@@ -1020,7 +1020,7 @@ class _AutolinkWithoutScheme extends md.AutolinkSyntax {
   @override
   bool onMatch(md.InlineParser parser, Match match) {
     var url = match[1];
-    var text = htmlEscape.convert(url).replaceFirst(_hide_schemes, '');
+    var text = htmlEscape.convert(url).replaceFirst(_hideSchemes, '');
     var anchor = md.Element.text('a', text);
     anchor.attributes['href'] = url;
     parser.addNode(anchor);

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -376,7 +376,7 @@ class Class extends Container
       var cmap = inheritance.getInheritedConcreteMap2(element);
       var imap = inheritance.getInheritedMap2(element);
 
-      var inheritanceChainElements;
+      List<ClassElement> inheritanceChainElements;
 
       var combinedMap = <String, ExecutableElement>{};
       for (var nameObj in cmap.keys) {
@@ -566,4 +566,7 @@ class Class extends Container
       name == o.name &&
       o.library.name == library.name &&
       o.library.package.name == library.package.name;
+
+  @override
+  int get hashCode => quiver.hash3(name, library.name, library.package.name);
 }

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -595,14 +595,4 @@ class Class extends Container
 
   @override
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
-
-  @override
-  bool operator ==(Object o) =>
-      o is Class &&
-      name == o.name &&
-      o.library.name == library.name &&
-      o.library.package.name == library.package.name;
-
-  @override
-  int get hashCode => quiver.hash3(name, library.name, library.package.name);
 }

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -9,6 +9,7 @@ import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path show Context;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -25,7 +26,13 @@ RegExp get substituteNameVersion => Package._substituteNameVersion;
 // TODO: Find an approach that doesn't require doing this.
 // Unlikely to be mistaken for an identifier, html tag, or something else that
 // might reasonably exist normally.
-final String HTMLBASE_PLACEHOLDER = '\%\%__HTMLBASE_dartdoc_internal__\%\%';
+@internal
+const String htmlBasePlaceholder = '\%\%__HTMLBASE_dartdoc_internal__\%\%';
+
+@Deprecated('Public variable intended to be private; will be removed as early '
+    'as Dartdoc 1.0.0')
+// ignore: non_constant_identifier_names
+const String HTMLBASE_PLACEHOLDER = htmlBasePlaceholder;
 
 /// A [LibraryContainer] that contains [Library] objects related to a particular
 /// package.
@@ -233,7 +240,7 @@ class Package extends LibraryContainer
       _baseHref = _remoteBaseHref;
       if (!_baseHref.endsWith('/')) _baseHref = '${_baseHref}/';
     } else {
-      _baseHref = config.useBaseHref ? '' : HTMLBASE_PLACEHOLDER;
+      _baseHref = config.useBaseHref ? '' : htmlBasePlaceholder;
     }
 
     return _baseHref;

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -60,7 +60,7 @@ class PubPackageBuilder implements PackageBuilder {
 
     await _calculatePackageMap();
 
-    var newGraph = PackageGraph.UninitializedPackageGraph(
+    var newGraph = PackageGraph.uninitialized(
       config,
       sdk,
       hasEmbedderSdkFiles,

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -24,12 +24,12 @@ import 'package:dartdoc/src/model_utils.dart' show matchGlobs;
 
 class PackageGraph {
   PackageGraph.uninitialized(
-      this.config,
-      this.sdk,
-      this.hasEmbedderSdk,
-      this.rendererFactory,
-      this.packageMetaProvider,
-      ) : packageMeta = config.topLevelPackageMeta {
+    this.config,
+    this.sdk,
+    this.hasEmbedderSdk,
+    this.rendererFactory,
+    this.packageMetaProvider,
+  ) : packageMeta = config.topLevelPackageMeta {
     _packageWarningCounter = PackageWarningCounter(this);
     // Make sure the default package exists, even if it has no libraries.
     // This can happen for packages that only contain embedder SDKs.

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -37,20 +37,15 @@ class PackageGraph {
   }
 
   @Deprecated('Use with [PackageGraph.uninitialized] instead')
-
   // ignore: non_constant_identifier_names
-  PackageGraph.UninitializedPackageGraph(
-    this.config,
-    this.sdk,
-    this.hasEmbedderSdk,
-    this.rendererFactory,
-    this.packageMetaProvider,
-  ) : packageMeta = config.topLevelPackageMeta {
-    _packageWarningCounter = PackageWarningCounter(this);
-    // Make sure the default package exists, even if it has no libraries.
-    // This can happen for packages that only contain embedder SDKs.
-    Package.fromPackageMeta(packageMeta, this);
-  }
+  factory PackageGraph.UninitializedPackageGraph(
+          DartdocOptionContext config,
+          DartSdk sdk,
+          bool hasEmbedderSdk,
+          RendererFactory rendererFactory,
+          PackageMetaProvider packageMetaProvider) =>
+      PackageGraph.uninitialized(
+          config, sdk, hasEmbedderSdk, rendererFactory, packageMetaProvider);
 
   /// Call during initialization to add a library to this [PackageGraph].
   ///
@@ -634,8 +629,8 @@ class PackageGraph {
       for (var type in clazz.interfaces) {
         checkAndAddClass(type.element, clazz);
       }
-      for (var type in class_.publicInterfaces) {
-        checkAndAddClass(type.element, class_);
+      for (var type in clazz.publicInterfaces) {
+        checkAndAddClass(type.element, clazz);
       }
     }
 

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -23,6 +23,22 @@ import 'package:dartdoc/src/warnings.dart';
 import 'package:dartdoc/src/model_utils.dart' show matchGlobs;
 
 class PackageGraph {
+  PackageGraph.uninitialized(
+      this.config,
+      this.sdk,
+      this.hasEmbedderSdk,
+      this.rendererFactory,
+      this.packageMetaProvider,
+      ) : packageMeta = config.topLevelPackageMeta {
+    _packageWarningCounter = PackageWarningCounter(this);
+    // Make sure the default package exists, even if it has no libraries.
+    // This can happen for packages that only contain embedder SDKs.
+    Package.fromPackageMeta(packageMeta, this);
+  }
+
+  @Deprecated('Use with [PackageGraph.uninitialized] instead')
+
+  // ignore: non_constant_identifier_names
   PackageGraph.UninitializedPackageGraph(
     this.config,
     this.sdk,
@@ -221,7 +237,7 @@ class PackageGraph {
   /// A mapping of the list of classes which implement each class.
   final _implementors = LinkedHashMap<Class, List<Class>>(
       equals: (Class a, Class b) => a.definingClass == b.definingClass,
-      hashCode: (Class class_) => class_.definingClass.hashCode);
+      hashCode: (Class clazz) => clazz.definingClass.hashCode);
 
   /// A list of extensions that exist in the package graph.
   final List<Extension> _extensions = [];
@@ -608,15 +624,15 @@ class PackageGraph {
       }
     }
 
-    void addImplementor(Class class_) {
-      for (var type in class_.mixedInTypes) {
-        checkAndAddClass(type.element, class_);
+    void addImplementor(Class clazz) {
+      for (var type in clazz.mixedInTypes) {
+        checkAndAddClass(type.element, clazz);
       }
-      if (class_.supertype != null) {
-        checkAndAddClass(class_.supertype.element, class_);
+      if (clazz.supertype != null) {
+        checkAndAddClass(clazz.supertype.element, clazz);
       }
-      for (var type in class_.interfaces) {
-        checkAndAddClass(type.element, class_);
+      for (var type in clazz.interfaces) {
+        checkAndAddClass(type.element, clazz);
       }
     }
 
@@ -685,8 +701,8 @@ class PackageGraph {
   Set<Class> get invisibleAnnotations =>
       _invisibleAnnotations ??= {specialClasses[SpecialClass.pragma]};
 
-  bool isAnnotationVisible(Class class_) =>
-      !invisibleAnnotations.contains(class_);
+  bool isAnnotationVisible(Class clazz) =>
+      !invisibleAnnotations.contains(clazz);
 
   @override
   String toString() {

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -46,7 +46,7 @@ class ToolTempFileTracker {
     var tempFile = resourceProvider.getFile(resourceProvider.pathContext.join(
         resourceProvider.pathContext.absolute(temporaryDirectory.path),
         'input_$_temporaryFileCount'));
-    await tempFile.writeAsStringSync('');
+    tempFile.writeAsStringSync('');
     return tempFile;
   }
 
@@ -202,7 +202,7 @@ class ToolRunner {
     }
 
     if (toolDefinition.setupCommand != null && !toolDefinition.setupComplete) {
-      await _runSetup(tool, toolDefinition, envWithInput, toolErrorCallback);
+      _runSetup(tool, toolDefinition, envWithInput, toolErrorCallback);
     }
 
     argsWithInput = toolArgs + argsWithInput;

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -69,7 +69,7 @@ class ToolRunner {
 
   final ToolConfiguration toolConfiguration;
 
-  void _runSetup(
+  Future<void> _runSetup(
       String name,
       ToolDefinition tool,
       Map<String, String> environment,
@@ -202,7 +202,7 @@ class ToolRunner {
     }
 
     if (toolDefinition.setupCommand != null && !toolDefinition.setupComplete) {
-      _runSetup(tool, toolDefinition, envWithInput, toolErrorCallback);
+      await _runSetup(tool, toolDefinition, envWithInput, toolErrorCallback);
     }
 
     argsWithInput = toolArgs + argsWithInput;

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -153,9 +153,9 @@ void main() {
     test('Validate missing FLUTTER_ROOT exception is clean', () async {
       var output = StringBuffer();
       var args = <String>[dartdocPath];
-      var dart_tool =
+      var dartTool =
           Directory(path.join(_testPackageFlutterPluginPath, '.dart_tool'));
-      if (dart_tool.existsSync()) dart_tool.deleteSync(recursive: true);
+      if (dartTool.existsSync()) dartTool.deleteSync(recursive: true);
       Future run = subprocessLauncher.runStreamed(
           Platform.resolvedExecutable, args,
           environment: Map.from(Platform.environment)..remove('FLUTTER_ROOT'),

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -450,9 +450,9 @@ void main() {
     test('Verify Interceptor is hidden from inheritance in docs', () {
       var htmlLibrary =
           sdkAsPackageGraph.libraries.singleWhere((l) => l.name == 'dart:html');
-      var EventTarget =
+      var eventTarget =
           htmlLibrary.allClasses.singleWhere((c) => c.name == 'EventTarget');
-      var hashCode = EventTarget.publicInstanceFields
+      var hashCode = eventTarget.publicInstanceFields
           .singleWhere((f) => f.name == 'hashCode');
       var objectModelElement =
           sdkAsPackageGraph.specialClasses[SpecialClass.object];
@@ -463,10 +463,10 @@ void main() {
       // If EventTarget really does start implementing hashCode, this will
       // fail.
       expect(hashCode.href,
-          equals('${HTMLBASE_PLACEHOLDER}dart-core/Object/hashCode.html'));
+          equals('${htmlBasePlaceholder}dart-core/Object/hashCode.html'));
       expect(hashCode.canonicalEnclosingContainer, equals(objectModelElement));
       expect(
-          EventTarget.publicSuperChainReversed
+          eventTarget.publicSuperChainReversed
               .any((et) => et.name == 'Interceptor'),
           isFalse);
     });

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -264,11 +264,11 @@ void main() {
       expect(
           invokeTool.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/ToolUser-class.html">ToolUser</a>'));
+              '<a href="${htmlBasePlaceholder}ex/ToolUser-class.html">ToolUser</a>'));
       expect(
           invokeTool.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/Dog-class.html">Dog</a>'));
+              '<a href="${htmlBasePlaceholder}ex/Dog-class.html">Dog</a>'));
     });
     test(r'can invoke a tool with no $INPUT or args', () {
       expect(invokeToolNoInput.documentation, contains('Args: []'));
@@ -278,7 +278,7 @@ void main() {
       expect(
           invokeToolNoInput.documentationAsHtml,
           isNot(contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/Dog-class.html">Dog</a>')));
+              '<a href="${htmlBasePlaceholder}ex/Dog-class.html">Dog</a>')));
     });
     test('can invoke a tool multiple times in one comment block', () {
       var envLine = RegExp(r'^Env: \{', multiLine: true);
@@ -367,28 +367,28 @@ void main() {
       expect(
           renderer.renderCategoryLabel(category),
           '<span class="category superb cp-0 linked" title="This is part of the Superb Topic.">'
-          '<a href="${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html">Superb</a></span>');
+          '<a href="${htmlBasePlaceholder}topics/Superb-topic.html">Superb</a></span>');
     });
 
     test('CategoryRendererHtml renders linkedName', () {
       var category = packageGraph.publicPackages.first.categories.first;
       var renderer = CategoryRendererHtml();
       expect(renderer.renderLinkedName(category),
-          '<a href="${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html">Superb</a>');
+          '<a href="${htmlBasePlaceholder}topics/Superb-topic.html">Superb</a>');
     });
 
     test('CategoryRendererMd renders category label', () {
       var category = packageGraph.publicPackages.first.categories.first;
       var renderer = CategoryRendererMd();
       expect(renderer.renderCategoryLabel(category),
-          '[Superb](${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html)');
+          '[Superb](${htmlBasePlaceholder}topics/Superb-topic.html)');
     });
 
     test('CategoryRendererMd renders linkedName', () {
       var category = packageGraph.publicPackages.first.categories.first;
       var renderer = CategoryRendererMd();
       expect(renderer.renderLinkedName(category),
-          '[Superb](${HTMLBASE_PLACEHOLDER}topics/Superb-topic.html)');
+          '[Superb](${htmlBasePlaceholder}topics/Superb-topic.html)');
     });
   });
 
@@ -852,14 +852,14 @@ void main() {
       test('Verify links inside of table headers', () {
         expect(
             docsAsHtml.contains(
-                '<th><a href="${HTMLBASE_PLACEHOLDER}fake/Annotation-class.html">Annotation</a></th>'),
+                '<th><a href="${htmlBasePlaceholder}fake/Annotation-class.html">Annotation</a></th>'),
             isTrue);
       });
 
       test('Verify links inside of table body', () {
         expect(
             docsAsHtml.contains(
-                '<tbody><tr><td><a href="${HTMLBASE_PLACEHOLDER}fake/DocumentWithATable/foo-constant.html">foo</a></td>'),
+                '<tbody><tr><td><a href="${htmlBasePlaceholder}fake/DocumentWithATable/foo-constant.html">foo</a></td>'),
             isTrue);
       });
 
@@ -898,7 +898,7 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/ImplicitProperties/forInheriting.html">ClassWithUnusualProperties.forInheriting</a>'));
+                '<a href="${htmlBasePlaceholder}fake/ImplicitProperties/forInheriting.html">ClassWithUnusualProperties.forInheriting</a>'));
         expect(
             docsAsHtml,
             contains(
@@ -918,49 +918,49 @@ void main() {
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to library: <a href="${HTMLBASE_PLACEHOLDER}mylibpub/mylibpub-library.html">renamedLib</a>'));
+                'Link to library: <a href="${htmlBasePlaceholder}mylibpub/mylibpub-library.html">renamedLib</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to constructor (implied): <a href="${HTMLBASE_PLACEHOLDER}mylibpub/YetAnotherHelper/YetAnotherHelper.html">new renamedLib.YetAnotherHelper()</a>'));
+                'Link to constructor (implied): <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">new renamedLib.YetAnotherHelper()</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to constructor (implied, no new): <a href="${HTMLBASE_PLACEHOLDER}mylibpub/YetAnotherHelper/YetAnotherHelper.html">renamedLib.YetAnotherHelper()</a>'));
+                'Link to constructor (implied, no new): <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">renamedLib.YetAnotherHelper()</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to class: <a href="${HTMLBASE_PLACEHOLDER}mylibpub/YetAnotherHelper-class.html">renamedLib.YetAnotherHelper</a>'));
+                'Link to class: <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper-class.html">renamedLib.YetAnotherHelper</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to constructor (direct): <a href="${HTMLBASE_PLACEHOLDER}mylibpub/YetAnotherHelper/YetAnotherHelper.html">renamedLib.YetAnotherHelper.YetAnotherHelper</a>'));
+                'Link to constructor (direct): <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">renamedLib.YetAnotherHelper.YetAnotherHelper</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to class member: <a href="${HTMLBASE_PLACEHOLDER}mylibpub/YetAnotherHelper/getMoreContents.html">renamedLib.YetAnotherHelper.getMoreContents</a>'));
+                'Link to class member: <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/getMoreContents.html">renamedLib.YetAnotherHelper.getMoreContents</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to function: <a href="${HTMLBASE_PLACEHOLDER}mylibpub/helperFunction.html">renamedLib.helperFunction</a>'));
+                'Link to function: <a href="${htmlBasePlaceholder}mylibpub/helperFunction.html">renamedLib.helperFunction</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to overlapping prefix: <a href="${HTMLBASE_PLACEHOLDER}csspub/theOnlyThingInTheLibrary.html">renamedLib2.theOnlyThingInTheLibrary</a>'));
+                'Link to overlapping prefix: <a href="${htmlBasePlaceholder}csspub/theOnlyThingInTheLibrary.html">renamedLib2.theOnlyThingInTheLibrary</a>'));
       });
 
       test('operator [] reference within a class works', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/BaseForDocComments/operator_get.html">operator []</a> '));
+                '<a href="${htmlBasePlaceholder}fake/BaseForDocComments/operator_get.html">operator []</a> '));
       });
 
       test('operator [] reference outside of a class works', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/SpecialList/operator_get.html">SpecialList.operator []</a> '));
+                '<a href="${htmlBasePlaceholder}fake/SpecialList/operator_get.html">SpecialList.operator []</a> '));
       }, skip: 'https://github.com/dart-lang/dartdoc/issues/1285');
 
       test('adds <code> tag to a class from the SDK', () {
@@ -975,7 +975,7 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/BaseForDocComments-class.html">BaseForDocComments</a>'));
+                '<a href="${htmlBasePlaceholder}fake/BaseForDocComments-class.html">BaseForDocComments</a>'));
       });
 
       test(
@@ -984,7 +984,7 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}anonymous_library/doesStuff.html">doesStuff</a>'));
+                '<a href="${htmlBasePlaceholder}anonymous_library/doesStuff.html">doesStuff</a>'));
       });
 
       test(
@@ -995,11 +995,11 @@ void main() {
         expect(
             helperClass.documentationAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple</a>'));
+                '<a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>'));
         expect(
             helperClass.documentationAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}ex/B-class.html">ex.B</a>'));
+                '<a href="${htmlBasePlaceholder}ex/B-class.html">ex.B</a>'));
       });
 
       test('link to override method in implementer from base class', () {
@@ -1008,7 +1008,7 @@ void main() {
         expect(
             helperClass.documentationAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}override_class/BoxConstraints/debugAssertIsValid.html">BoxConstraints.debugAssertIsValid</a>'));
+                '<a href="${htmlBasePlaceholder}override_class/BoxConstraints/debugAssertIsValid.html">BoxConstraints.debugAssertIsValid</a>'));
       });
 
       test(
@@ -1017,7 +1017,7 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}two_exports/BaseClass-class.html">BaseClass</a>'));
+                '<a href="${htmlBasePlaceholder}two_exports/BaseClass-class.html">BaseClass</a>'));
       });
 
       test(
@@ -1026,35 +1026,35 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a>'));
+                '<a href="${htmlBasePlaceholder}fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a>'));
       });
 
       test('links to a method in this class', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/BaseForDocComments/anotherMethod.html">anotherMethod</a>'));
+                '<a href="${htmlBasePlaceholder}fake/BaseForDocComments/anotherMethod.html">anotherMethod</a>'));
       });
 
       test('links to a top-level function in this library', () {
         expect(
             docsAsHtml,
             contains(
-                '<a class="deprecated" href="${HTMLBASE_PLACEHOLDER}fake/topLevelFunction.html">topLevelFunction</a>'));
+                '<a class="deprecated" href="${htmlBasePlaceholder}fake/topLevelFunction.html">topLevelFunction</a>'));
       });
 
       test('links to top-level function from an imported library', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}ex/function1.html">function1</a>'));
+                '<a href="${htmlBasePlaceholder}ex/function1.html">function1</a>'));
       });
 
       test('links to a class from an imported lib', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple</a>'));
+                '<a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>'));
       });
 
       test(
@@ -1063,14 +1063,14 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/incorrectDocReference-constant.html">incorrectDocReference</a>'));
+                '<a href="${htmlBasePlaceholder}fake/incorrectDocReference-constant.html">incorrectDocReference</a>'));
       });
 
       test('links to a top-level const from an imported lib', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}ex/incorrectDocReferenceFromEx-constant.html">incorrectDocReferenceFromEx</a>'));
+                '<a href="${htmlBasePlaceholder}ex/incorrectDocReferenceFromEx-constant.html">incorrectDocReferenceFromEx</a>'));
       });
 
       test('links to a top-level variable with a prefix from an imported lib',
@@ -1078,21 +1078,21 @@ void main() {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}csspub/theOnlyThingInTheLibrary.html">css.theOnlyThingInTheLibrary</a>'));
+                '<a href="${htmlBasePlaceholder}csspub/theOnlyThingInTheLibrary.html">css.theOnlyThingInTheLibrary</a>'));
       });
 
       test('links to a name with a single underscore', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a>'));
+                '<a href="${htmlBasePlaceholder}fake/NAME_SINGLEUNDERSCORE-constant.html">NAME_SINGLEUNDERSCORE</a>'));
       });
 
       test('correctly escapes type parameters in links', () {
         expect(
             docsAsHtml,
             contains(
-                '<a href="${HTMLBASE_PLACEHOLDER}fake/ExtraSpecialList-class.html">ExtraSpecialList&lt;Object&gt;</a>'));
+                '<a href="${htmlBasePlaceholder}fake/ExtraSpecialList-class.html">ExtraSpecialList&lt;Object&gt;</a>'));
       });
 
       test('correctly escapes type parameters in broken links', () {
@@ -1121,7 +1121,7 @@ void main() {
       expect(
           short.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a>'));
+              '<a href="${htmlBasePlaceholder}fake/NAME_WITH_TWO_UNDERSCORES-constant.html">NAME_WITH_TWO_UNDERSCORES</a>'));
     });
 
     test('still has brackets inside code blocks', () {
@@ -1172,7 +1172,7 @@ void main() {
     test('single ref to class', () {
       expect(
           B.documentationAsHtml.contains(
-              '<p>Extends class <a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple</a>, use <a href="${HTMLBASE_PLACEHOLDER}ex/Apple/Apple.html">new Apple</a> or <a href="${HTMLBASE_PLACEHOLDER}ex/Apple/Apple.fromString.html">new Apple.fromString</a></p>'),
+              '<p>Extends class <a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>, use <a href="${htmlBasePlaceholder}ex/Apple/Apple.html">new Apple</a> or <a href="${htmlBasePlaceholder}ex/Apple/Apple.fromString.html">new Apple.fromString</a></p>'),
           isTrue);
     });
 
@@ -1191,11 +1191,11 @@ void main() {
       expect(
           resolved,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}two_exports/BaseClass-class.html">BaseClass</a>'));
+              '<a href="${htmlBasePlaceholder}two_exports/BaseClass-class.html">BaseClass</a>'));
       expect(
           resolved,
           contains(
-              'Linking over to <a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple</a>'));
+              'Linking over to <a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>'));
     });
 
     test('references to class and constructors', () {
@@ -1203,15 +1203,15 @@ void main() {
       expect(
           comment,
           contains(
-              'Extends class <a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple</a>'));
+              'Extends class <a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>'));
       expect(
           comment,
           contains(
-              'use <a href="${HTMLBASE_PLACEHOLDER}ex/Apple/Apple.html">new Apple</a>'));
+              'use <a href="${htmlBasePlaceholder}ex/Apple/Apple.html">new Apple</a>'));
       expect(
           comment,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/Apple/Apple.fromString.html">new Apple.fromString</a>'));
+              '<a href="${htmlBasePlaceholder}ex/Apple/Apple.fromString.html">new Apple.fromString</a>'));
     });
 
     test('references to nullable type and null-checked variable', () {
@@ -1221,11 +1221,11 @@ void main() {
       expect(
           comment,
           contains(
-              'nullable type: <a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple?</a>'));
+              'nullable type: <a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple?</a>'));
       expect(
           comment,
           contains(
-              'null-checked variable <a href="${HTMLBASE_PLACEHOLDER}ex/myNumber.html">myNumber!</a>'));
+              'null-checked variable <a href="${htmlBasePlaceholder}ex/myNumber.html">myNumber!</a>'));
     });
 
     test('reference to constructor named the same as a field', () {
@@ -1235,7 +1235,7 @@ void main() {
       expect(
           comment,
           contains('Reference to '
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/FieldAndCtorWithSameName/FieldAndCtorWithSameName.named.html">'
+              '<a href="${htmlBasePlaceholder}ex/FieldAndCtorWithSameName/FieldAndCtorWithSameName.named.html">'
               'FieldAndCtorWithSameName.named()</a>'));
     });
 
@@ -1244,7 +1244,7 @@ void main() {
       expect(
           comment,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/Apple-class.html">Apple</a>'));
+              '<a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>'));
     });
 
     test('reference to method', () {
@@ -1252,7 +1252,7 @@ void main() {
       expect(
           comment,
           equals(
-              '<p>link to method from class <a href="${HTMLBASE_PLACEHOLDER}ex/Apple/m.html">Apple.m</a></p>'));
+              '<p>link to method from class <a href="${htmlBasePlaceholder}ex/Apple/m.html">Apple.m</a></p>'));
     });
 
     test(
@@ -1265,11 +1265,11 @@ void main() {
       expect(
           notAMethodFromPrivateClass.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>'));
+              '<a href="${htmlBasePlaceholder}fake/InheritingClassOne/aMethod.html">fake.InheritingClassOne.aMethod</a>'));
       expect(
           notAMethodFromPrivateClass.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>'));
+              '<a href="${htmlBasePlaceholder}fake/InheritingClassTwo/aMethod.html">fake.InheritingClassTwo.aMethod</a>'));
     });
 
     test('legacy code blocks render correctly', () {
@@ -1479,35 +1479,35 @@ void main() {
       expect(
           overrideByModifierClass.oneLineDoc,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ModifierClass-class.html">ModifierClass</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ModifierClass-class.html">ModifierClass</a>'));
       expect(
           overrideByModifierClass.canonicalModelElement.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ModifierClass-class.html">ModifierClass</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ModifierClass-class.html">ModifierClass</a>'));
       expect(
           overrideByGenericMixin.oneLineDoc,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/GenericMixin-mixin.html">GenericMixin</a>'));
+              '<a href="${htmlBasePlaceholder}fake/GenericMixin-mixin.html">GenericMixin</a>'));
       expect(
           overrideByGenericMixin.canonicalModelElement.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/GenericMixin-mixin.html">GenericMixin</a>'));
+              '<a href="${htmlBasePlaceholder}fake/GenericMixin-mixin.html">GenericMixin</a>'));
       expect(
           overrideByBoth.oneLineDoc,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ModifierClass-class.html">ModifierClass</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ModifierClass-class.html">ModifierClass</a>'));
       expect(
           overrideByBoth.oneLineDoc,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/GenericMixin-mixin.html">GenericMixin</a>'));
+              '<a href="${htmlBasePlaceholder}fake/GenericMixin-mixin.html">GenericMixin</a>'));
       expect(
           overrideByBoth.canonicalModelElement.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ModifierClass-class.html">ModifierClass</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ModifierClass-class.html">ModifierClass</a>'));
       expect(
           overrideByBoth.canonicalModelElement.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/GenericMixin-mixin.html">GenericMixin</a>'));
+              '<a href="${htmlBasePlaceholder}fake/GenericMixin-mixin.html">GenericMixin</a>'));
     });
   });
 
@@ -1666,11 +1666,11 @@ void main() {
 
     test('exported class should have hrefs from the current library', () {
       expect(
-          Dep.href, equals('${HTMLBASE_PLACEHOLDER}ex/Deprecated-class.html'));
+          Dep.href, equals('${htmlBasePlaceholder}ex/Deprecated-class.html'));
       expect(Dep.instanceMethods.firstWhere((m) => m.name == 'toString').href,
-          equals('${HTMLBASE_PLACEHOLDER}ex/Deprecated/toString.html'));
+          equals('${htmlBasePlaceholder}ex/Deprecated/toString.html'));
       expect(Dep.instanceFields.firstWhere((m) => m.name == 'expires').href,
-          equals('${HTMLBASE_PLACEHOLDER}ex/Deprecated/expires.html'));
+          equals('${htmlBasePlaceholder}ex/Deprecated/expires.html'));
     });
 
     test('exported class should have linkedReturnType for the current library',
@@ -1681,7 +1681,7 @@ void main() {
       expect(
           returnCool.linkedReturnType,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/Cool-class.html">Cool</a>'));
+              '<a href="${htmlBasePlaceholder}fake/Cool-class.html">Cool</a>'));
     });
 
     test('F has a single instance method', () {
@@ -1964,15 +1964,15 @@ void main() {
       expect(
           extensionReferencer.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/FancyList.html">FancyList</a>'));
+              '<a href="${htmlBasePlaceholder}ex/FancyList.html">FancyList</a>'));
       expect(
           extensionReferencer.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/AnExtension/call.html">AnExtension.call</a>'));
+              '<a href="${htmlBasePlaceholder}ex/AnExtension/call.html">AnExtension.call</a>'));
       expect(
           extensionReferencer.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}reexport_two/DocumentThisExtensionOnce.html">DocumentThisExtensionOnce</a>'));
+              '<a href="${htmlBasePlaceholder}reexport_two/DocumentThisExtensionOnce.html">DocumentThisExtensionOnce</a>'));
     });
 
     test('has a fully qualified name', () {
@@ -1989,7 +1989,7 @@ void main() {
 
     test('member method has href', () {
       s = ext.instanceMethods.firstWhere((m) => m.name == 's');
-      expect(s.href, '${HTMLBASE_PLACEHOLDER}ex/AppleExtension/s.html');
+      expect(s.href, '${htmlBasePlaceholder}ex/AppleExtension/s.html');
     });
 
     test('has extended type', () {
@@ -2260,7 +2260,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           params,
           '<span class="parameter" id="addCallback-param-callback">'
-          '<span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}fake/VoidCallback.html">VoidCallback</a></span> '
+          '<span class="type-annotation"><a href="${htmlBasePlaceholder}fake/VoidCallback.html">VoidCallback</a></span> '
           '<span class="parameter-name">callback</span></span>');
 
       function =
@@ -2269,7 +2269,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           params,
           '<span class="parameter" id="addCallback2-param-callback">'
-          '<span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}fake/Callback2.html">Callback2</a></span> '
+          '<span class="type-annotation"><a href="${htmlBasePlaceholder}fake/Callback2.html">Callback2</a></span> '
           '<span class="parameter-name">callback</span></span>');
     });
 
@@ -2309,7 +2309,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           explicitSetter.linkedReturnType,
           '<span class="parameter" id="explicitSetter=-param-f"><span class="type-annotation">dynamic</span> <span class="parameter-name">Function</span>(<span class="parameter" id="param-bar"><span class="type-annotation">int</span>, </span>'
-          '<span class="parameter" id="param-baz"><span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}fake/Cool-class.html">Cool</a></span>, </span>'
+          '<span class="parameter" id="param-baz"><span class="type-annotation"><a href="${htmlBasePlaceholder}fake/Cool-class.html">Cool</a></span>, </span>'
           '<span class="parameter" id="param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span></span>)</span>');
     });
 
@@ -2317,14 +2317,14 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       var aField = TemplatedInterface.instanceFields
           .singleWhere((f) => f.name == 'aField');
       expect(aField.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
     });
 
     test('parameterized type from inherited field is correctly displayed', () {
       var aInheritedField = TemplatedInterface.inheritedFields
           .singleWhere((f) => f.name == 'aInheritedField');
       expect(aInheritedField.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -2334,7 +2334,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((f) => f.name == 'aGetter')
           .getter;
       expect(aGetter.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -2344,7 +2344,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((f) => f.name == 'aInheritedGetter')
           .getter;
       expect(aInheritedGetter.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -2354,11 +2354,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((f) => f.name == 'aInheritedSetter')
           .setter;
       expect(aInheritedSetter.allParameters.first.modelType.linkedName,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
       // TODO(jcollins-g): really, these shouldn't be called "parameters" in
       // the span class.
       expect(aInheritedSetter.enclosingCombo.linkedReturnType,
-          '<span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span></span>');
+          '<span class="parameter" id="aInheritedSetter=-param-thingToSet"><span class="type-annotation"><a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span></span>');
     });
 
     test(
@@ -2367,7 +2367,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       var aMethodInterface = TemplatedInterface.instanceMethods
           .singleWhere((m) => m.name == 'aMethodInterface');
       expect(aMethodInterface.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -2376,7 +2376,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       var aInheritedMethod = TemplatedInterface.instanceMethods
           .singleWhere((m) => m.name == 'aInheritedMethod');
       expect(aInheritedMethod.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -2385,7 +2385,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       var aTypedefReturningMethodInterface = TemplatedInterface.instanceMethods
           .singleWhere((m) => m.name == 'aTypedefReturningMethodInterface');
       expect(aTypedefReturningMethodInterface.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span>');
     });
 
     test(
@@ -2394,7 +2394,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       var aInheritedTypedefReturningMethod = TemplatedInterface.instanceMethods
           .singleWhere((m) => m.name == 'aInheritedTypedefReturningMethod');
       expect(aInheritedTypedefReturningMethod.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
     });
 
     test('parameterized types for inherited operator is correctly displayed',
@@ -2402,11 +2402,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       var aInheritedAdditionOperator = TemplatedInterface.inheritedOperators
           .singleWhere((m) => m.name == 'operator +');
       expect(aInheritedAdditionOperator.linkedReturnType,
-          '<a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
+          '<a href="${htmlBasePlaceholder}ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
       expect(
           ParameterRendererHtml()
               .renderLinkedParams(aInheritedAdditionOperator.parameters),
-          '<span class="parameter" id="+-param-other"><span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">other</span></span>');
+          '<span class="parameter" id="+-param-other"><span class="type-annotation"><a href="${htmlBasePlaceholder}ex/ParameterizedClass-class.html">ParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span> <span class="parameter-name">other</span></span>');
     });
 
     test('', () {});
@@ -2512,7 +2512,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
         'an inherited method from the core SDK has a href relative to the package class',
         () {
       expect(inheritedClear.href,
-          equals('${HTMLBASE_PLACEHOLDER}ex/CatString/clear.html'));
+          equals('${htmlBasePlaceholder}ex/CatString/clear.html'));
     });
 
     test(
@@ -2521,7 +2521,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           inheritedClear.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/CatString/clear.html">clear</a>'));
+              '<a href="${htmlBasePlaceholder}ex/CatString/clear.html">clear</a>'));
     });
 
     test('has enclosing element', () {
@@ -2627,7 +2627,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           plus.href,
           equals(
-              '${HTMLBASE_PLACEHOLDER}ex/SpecializedDuration/operator_plus.html'));
+              '${htmlBasePlaceholder}ex/SpecializedDuration/operator_plus.html'));
     });
 
     test('if inherited and superclass not in package, link to enclosed class',
@@ -2635,7 +2635,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           plus.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/SpecializedDuration/operator_plus.html">operator +</a>'));
+              '<a href="${htmlBasePlaceholder}ex/SpecializedDuration/operator_plus.html">operator +</a>'));
     });
   });
 
@@ -2872,7 +2872,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           lengthX.extendedDocLink,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/WithGetterAndSetter/lengthX.html">[...]</a>'));
+              '<a href="${htmlBasePlaceholder}fake/WithGetterAndSetter/lengthX.html">[...]</a>'));
       expect(lengthX.documentation, contains('the fourth dimension'));
       expect(lengthX.documentation, isNot(contains('[...]')));
     });
@@ -2884,7 +2884,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('inherited property has a linked name to superclass in package', () {
       expect(mInB.linkedName,
-          equals('<a href="${HTMLBASE_PLACEHOLDER}ex/Apple/m.html">m</a>'));
+          equals('<a href="${htmlBasePlaceholder}ex/Apple/m.html">m</a>'));
     });
 
     test(
@@ -2893,7 +2893,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           isEmpty.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/CatString/isEmpty.html">isEmpty</a>'));
+              '<a href="${htmlBasePlaceholder}ex/CatString/isEmpty.html">isEmpty</a>'));
     });
 
     test('inherited property has the enclosing class', () {
@@ -3031,7 +3031,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           fieldWithTypedef.linkedReturnType,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span>'));
+              '<a href="${htmlBasePlaceholder}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">bool</span>&gt;</span>'));
     });
   });
 
@@ -3104,7 +3104,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           complicatedReturn.linkedReturnType,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span>'));
+              '<a href="${htmlBasePlaceholder}fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">String Function<span class="signature">(<span class="parameter" id="param-"><span class="type-annotation">int</span></span>)</span></span>&gt;</span>'));
     });
 
     test('@nodoc on simple property works', () {
@@ -3214,7 +3214,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('substrings of the constant values type are not linked (#1535)', () {
       expect(aName.constantValue,
-          'const <a href="${HTMLBASE_PLACEHOLDER}ex/ExtendedShortName/ExtendedShortName.html">ExtendedShortName</a>(&quot;hello there&quot;)');
+          'const <a href="${htmlBasePlaceholder}ex/ExtendedShortName/ExtendedShortName.html">ExtendedShortName</a>(&quot;hello there&quot;)');
     });
 
     test('constant field values are escaped', () {
@@ -3258,7 +3258,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('MY_CAT is linked', () {
       expect(cat.constantValue,
-          'const <a href="${HTMLBASE_PLACEHOLDER}ex/ConstantCat/ConstantCat.html">ConstantCat</a>(&#39;tabby&#39;)');
+          'const <a href="${htmlBasePlaceholder}ex/ConstantCat/ConstantCat.html">ConstantCat</a>(&#39;tabby&#39;)');
     });
 
     test('exported property', () {
@@ -3302,11 +3302,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           referToADefaultConstructor.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a>'));
       expect(
           referToADefaultConstructor.documentationAsHtml,
           contains(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor.ReferToADefaultConstructor</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor.ReferToADefaultConstructor</a>'));
     });
 
     test('displays generic parameters correctly', () {
@@ -3396,7 +3396,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           ExtendsFutureVoid.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a>'));
       var FutureVoid = ExtendsFutureVoid.publicSuperChain
           .firstWhere((c) => c.name == 'Future');
       expect(
@@ -3409,7 +3409,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           ImplementsFutureVoid.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ImplementsFutureVoid-class.html">ImplementsFutureVoid</a>'));
       var FutureVoid = ImplementsFutureVoid.publicInterfaces
           .firstWhere((c) => c.name == 'Future');
       expect(
@@ -3422,13 +3422,13 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           ATypeTakingClassMixedIn.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a>'));
+              '<a href="${htmlBasePlaceholder}fake/ATypeTakingClassMixedIn-class.html">ATypeTakingClassMixedIn</a>'));
       var ATypeTakingClassVoid = ATypeTakingClassMixedIn.mixedInTypes
           .firstWhere((c) => c.name == 'ATypeTakingClass');
       expect(
           ATypeTakingClassVoid.linkedName,
           equals(
-              '<a href="${HTMLBASE_PLACEHOLDER}fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span>'));
+              '<a href="${htmlBasePlaceholder}fake/ATypeTakingClass-class.html">ATypeTakingClass</a><span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span>'));
     });
   });
 
@@ -3471,7 +3471,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           ParameterRendererHtml().renderLinkedParams(theConstructor.parameters),
           equals(
-              '<span class="parameter" id="-param-x"><span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span> <span class="parameter-name">x</span></span>'));
+              '<span class="parameter" id="-param-x"><span class="type-annotation"><a href="${htmlBasePlaceholder}ex/ParameterizedTypedef.html">ParameterizedTypedef</a><span class="signature">&lt;<wbr><span class="type-parameter">double</span>&gt;</span></span> <span class="parameter-name">x</span></span>'));
     });
 
     test('anonymous nested functions inside typedefs are handled', () {
@@ -3646,7 +3646,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           params,
           contains(
-              '@<a href="${HTMLBASE_PLACEHOLDER}fake/required-constant.html">required</a>'));
+              '@<a href="${htmlBasePlaceholder}fake/required-constant.html">required</a>'));
     });
 
     test('param exported in library', () {
@@ -3661,7 +3661,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           params,
           equals('<span class="parameter" id="methodWithTypedefParam-param-p">'
-              '<span class="type-annotation"><a href="${HTMLBASE_PLACEHOLDER}ex/processMessage.html">processMessage</a></span> '
+              '<span class="type-annotation"><a href="${htmlBasePlaceholder}ex/processMessage.html">processMessage</a></span> '
               '<span class="parameter-name">p</span></span>'));
     });
   });
@@ -3780,7 +3780,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           forAnnotation.annotations.first,
           equals(
-              '@<a href="${HTMLBASE_PLACEHOLDER}ex/ForAnnotation-class.html">ForAnnotation</a>'
+              '@<a href="${htmlBasePlaceholder}ex/ForAnnotation-class.html">ForAnnotation</a>'
               '(&#39;my value&#39;)'));
     });
 
@@ -3790,14 +3790,14 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           m.annotations.first,
           equals(
-              '@<a href="${HTMLBASE_PLACEHOLDER}ex/deprecated-constant.html">deprecated</a>'));
+              '@<a href="${htmlBasePlaceholder}ex/deprecated-constant.html">deprecated</a>'));
     });
 
     test('constructor annotations have the right link and are escaped', () {
       expect(
           ctr.annotations[0],
           equals(
-              '@<a href="${HTMLBASE_PLACEHOLDER}ex/Deprecated-class.html">Deprecated</a>'
+              '@<a href="${htmlBasePlaceholder}ex/Deprecated-class.html">Deprecated</a>'
               '(&quot;Internal use&quot;)'));
     });
 
@@ -3807,7 +3807,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           createDog2.annotations[0],
           equals(
-              '@<a href="${HTMLBASE_PLACEHOLDER}ex/deprecated-constant.html">deprecated</a>'));
+              '@<a href="${htmlBasePlaceholder}ex/deprecated-constant.html">deprecated</a>'));
     });
   });
 

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -40,6 +40,6 @@ void main() {
     expect(dartAsyncLib.name, 'dart:async');
     expect(dartAsyncLib.dirName, 'dart-async');
     expect(dartAsyncLib.href,
-        '${HTMLBASE_PLACEHOLDER}dart-async/dart-async-library.html');
+        '${htmlBasePlaceholder}dart-async/dart-async-library.html');
   }, onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')});
 }

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -3,7 +3,7 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/dartdoc.dart';

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -16,7 +16,7 @@ import 'package:yaml/yaml.dart';
 final Directory _testPackageDir = Directory('testing/test_package');
 
 void main() {
-  var toolMap;
+  ToolConfiguration toolMap;
   Directory tempDir;
   File setupFile;
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -8,14 +8,14 @@ import 'package:dartdoc/src/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var comment;
-  var documentation;
+  String comment;
+  String documentation;
 
   // For readability, the multiline strings below have a left margin. This
   // is the length of that left margin.
   var multilineStringMargin = ' ' * 6;
 
-  String trimMargin(s) => s
+  String trimMargin(String s) => s
       // Trim the left margin of the first line.
       .replaceFirst('$multilineStringMargin  ', '')
       // Trim the left margin of every following line.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -909,7 +909,7 @@ Future<void> checkChangelogHasVersion() async {
 
 String _getPackageVersion() {
   var pubspec = File('pubspec.yaml');
-  var yamlDoc;
+  dynamic yamlDoc;
   if (pubspec.existsSync()) {
     yamlDoc = yaml.loadYaml(pubspec.readAsStringSync());
   }
@@ -928,8 +928,8 @@ Future<void> build() async {
 
   // TODO(jcollins-g): port to build system?
   var version = _getPackageVersion();
-  var dartdoc_options = File('dartdoc_options.yaml');
-  await dartdoc_options.writeAsString('''dartdoc:
+  var dartdocOptions = File('dartdoc_options.yaml');
+  await dartdocOptions.writeAsString('''dartdoc:
   linkToSource:
     root: '.'
     uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v${version}/%f%#L%l%'
@@ -937,7 +937,7 @@ Future<void> build() async {
 }
 
 /// Paths in this list are relative to lib/.
-final _generated_files_list = <String>[
+final _generatedFilesList = <String>[
   '../dartdoc_options.yaml',
   'src/generator/html_resources.g.dart',
   'src/generator/templates.renderers.dart',
@@ -952,7 +952,7 @@ Future<void> checkBuild() async {
 
   // Load original file contents into memory before running the builder;
   // it modifies them in place.
-  for (var relPath in _generated_files_list) {
+  for (var relPath in _generatedFilesList) {
     var origPath = path.joinAll(['lib', relPath]);
     var oldVersion = File(origPath);
     if (oldVersion.existsSync()) {
@@ -961,7 +961,7 @@ Future<void> checkBuild() async {
   }
 
   await build();
-  for (var relPath in _generated_files_list) {
+  for (var relPath in _generatedFilesList) {
     var newVersion = File(path.join('lib', relPath));
     if (!await newVersion.exists()) {
       log('${newVersion.path} does not exist\n');

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -85,7 +85,7 @@ class RuntimeRenderersBuilder {
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/dartdoc.dart';


### PR DESCRIPTION
You can find the current set here: https://github.com/dart-lang/linter/blob/master/tool/canonical/score.yaml

I disabled `non_constant_identifier_names` for now due to how our tests are written, but I did fix a few cases of this line.

**This PR also deprecates two members.**

`HTMLBASE_PLACEHOLDER` - Replaced with `htmlBasePlaceholder` which is marked as `@internal`. This is due to the old constant naming scheme as well as it doesn't seem like this member(or the behavior it enables) should be used externally.

`PackageGraph.UninitializedPackageGraph` -> Replaced with `PackageGraph.uninitialized` to fit the appropriate naming style and since the second `PackageGraph` is unnecessary. 