### PR TITLE
Use dependency overrides to make dartdoc work with sdk head analyzer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [dev, stable]
+        # Add stable back in after 2.12 is published.
+        sdk: [dev]
         job: [main, flutter, sdk-analyzer, packages, sdk-docs]
         include:
           - os: macos-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         sdk: [dev, stable]
-        # Add sdk-analyzer once #2500 is addressed
-        job: [main, flutter, packages, sdk-docs]
+        job: [main, flutter, sdk-analyzer, packages, sdk-docs]
         include:
           - os: macos-latest
             sdk: dev

--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.bin;
 
 import 'dart:async';

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// A documentation generator for Dart.
 ///
 /// Library interface is currently under heavy construction and may change

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 import 'dart:io' show stderr, exitCode;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 ///
 /// dartdoc's dartdoc_options.yaml configuration file follows similar loading
 /// semantics to that of analysis_options.yaml,

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// The models used to represent Dart code.
 library dartdoc.element_type;
 

--- a/lib/src/experiment_options.dart
+++ b/lib/src/experiment_options.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 ///
 /// Implementation of Dart language experiment option handling for dartdoc.
 /// See https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md.

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/generator_frontend.dart';
 import 'package:dartdoc/src/generator/generator_utils.dart' as generator_util;

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 library dartdoc.empty_generator;
 
 import 'package:dartdoc/src/dartdoc_options.dart';

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// A library containing an abstract documentation generator.
 library dartdoc.generator;
 

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:convert';
 
 import 'package:collection/collection.dart';

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.html_generator;
 
 import 'package:dartdoc/dartdoc.dart';

--- a/lib/src/generator/html_resources.g.dart
+++ b/lib/src/generator/html_resources.g.dart
@@ -1,5 +1,7 @@
 // WARNING: This file is auto-generated. Do not taunt.
 
+// @dart=2.9
+
 const List<String> resource_names = [
   'package:dartdoc/resources/favicon.png',
   'package:dartdoc/resources/github.css',

--- a/lib/src/generator/markdown_generator.dart
+++ b/lib/src/generator/markdown_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/dartdoc_generator_backend.dart';
 import 'package:dartdoc/src/generator/generator.dart';

--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Make it possible to load resources from the dartdoc code repository.
 library dartdoc.resource_loader;
 

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 typedef ContainerSidebar = String Function(Container, TemplateData);

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 // TODO(srawlins): Add Renderer annotations for more types as the mustachio
 // implementation matures.
 @Renderer(#renderIndex, Context<PackageTemplateData>())

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -3,6 +3,8 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
+// @dart=2.9
+
 // ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// This is a helper library to make working with io easier.
 library dartdoc.io_utils;
 

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:convert';
 import 'dart:io' show stderr, stdout;
 

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Utility code to convert markdown comments to html.
 library dartdoc.markdown_processor;
 

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 /// Classes extending this class have canonicalization support in Dartdoc.

--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 final RegExp _categoryRegExp = RegExp(

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/element_type.dart';

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 /// A [ModelElement] that is a [Container] member.

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/documentation_renderer.dart';

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 import 'package:args/args.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 

--- a/lib/src/model/enclosed_element.dart
+++ b/lib/src/model/enclosed_element.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 /// An element that is enclosed by some other element.

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 // TODO(jcollins-g): Consider Enum as subclass of Container?
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/extendable.dart
+++ b/lib/src/model/extendable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 /// Mixin for subclasses of [ModelElement] representing Elements that can be

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/extension_target.dart';

--- a/lib/src/model/extension_target.dart
+++ b/lib/src/model/extension_target.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 // TODO(jcollins-g): Mix-in ExtensionTarget on Method, ModelFunction, Typedef,

--- a/lib/src/model/feature_set.dart
+++ b/lib/src/model/feature_set.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/language_feature.dart';
 import 'package:dartdoc/src/model/model.dart';
 

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:convert';
 
 import 'package:analyzer/dart/ast/ast.dart';

--- a/lib/src/model/indexable.dart
+++ b/lib/src/model/indexable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 
 /// Something able to be indexed.

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/special_elements.dart';
 

--- a/lib/src/model/language_feature.dart
+++ b/lib/src/model/language_feature.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/render/feature_renderer.dart';
 
 const Map<String, String> _featureDescriptions = {

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:collection';
 
 import 'package:analyzer/dart/analysis/results.dart';

--- a/lib/src/model/library_container.dart
+++ b/lib/src/model/library_container.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;

--- a/lib/src/model/locatable.dart
+++ b/lib/src/model/locatable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart' show Element;
 
 /// Something that can be located for warning purposes.

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 export 'accessor.dart';
 export 'canonicalization.dart';
 export 'categorization.dart';

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// The models used to represent Dart code.
 library dartdoc.models;
 

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:collection/collection.dart';
 
 import 'locatable.dart';

--- a/lib/src/model/never.dart
+++ b/lib/src/model/never.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 

--- a/lib/src/model/operator.dart
+++ b/lib/src/model/operator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:collection';
 
 import 'package:analyzer/dart/ast/ast.dart';

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/privacy.dart
+++ b/lib/src/model/privacy.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Classes implementing this have a public/private distinction.
 abstract class Privacy {
   bool get isPublic;

--- a/lib/src/model/source_code_mixin.dart
+++ b/lib/src/model/source_code_mixin.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.model_utils;
 
 import 'dart:convert';

--- a/lib/src/mustachio/annotations.dart
+++ b/lib/src/mustachio/annotations.dart
@@ -1,5 +1,8 @@
 /// Specifies information for generating a Mustache renderer for a [context]
 /// object, using a Mustache template at [templateUri]
+
+// @dart=2.9
+
 class Renderer {
   /// The name of the render function to generate.
   final Symbol name;

--- a/lib/src/mustachio/parser.dart
+++ b/lib/src/mustachio/parser.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:charcode/charcode.dart';
 import 'package:meta/meta.dart';
 

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:collection';
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.package_meta;
 
 import 'dart:convert';

--- a/lib/src/quiver.dart
+++ b/lib/src/quiver.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Methods in-lined from package:quiver.
 
 // From lib/iterables.dart:

--- a/lib/src/render/category_renderer.dart
+++ b/lib/src/render/category_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/category.dart';
 
 abstract class CategoryRenderer {

--- a/lib/src/render/documentation_renderer.dart
+++ b/lib/src/render/documentation_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/tuple.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:markdown/markdown.dart' as md;

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/render/parameter_renderer.dart';
 

--- a/lib/src/render/enum_field_renderer.dart
+++ b/lib/src/render/enum_field_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/enum.dart';
 
 abstract class EnumFieldRenderer {

--- a/lib/src/render/feature_renderer.dart
+++ b/lib/src/render/feature_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/language_feature.dart';
 
 abstract class FeatureRenderer {

--- a/lib/src/render/model_element_renderer.dart
+++ b/lib/src/render/model_element_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/model_element.dart';
 
 abstract class ModelElementRenderer {

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/type.dart';

--- a/lib/src/render/renderer_factory.dart
+++ b/lib/src/render/renderer_factory.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/render/category_renderer.dart';
 import 'package:dartdoc/src/render/documentation_renderer.dart';

--- a/lib/src/render/source_code_renderer.dart
+++ b/lib/src/render/source_code_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:convert';
 
 /// Renderer for source code snippets extracted from source files.

--- a/lib/src/render/template_renderer.dart
+++ b/lib/src/render/template_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 abstract class TemplateRenderer {
   String composeLayoutTitle(String name, String kind, bool isDeprecated);
 }

--- a/lib/src/render/type_parameters_renderer.dart
+++ b/lib/src/render/type_parameters_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/type_parameter.dart';
 
 abstract class TypeParametersRenderer {

--- a/lib/src/render/typedef_renderer.dart
+++ b/lib/src/render/typedef_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/model/typedef.dart';
 
 abstract class TypedefRenderer {

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// A library for getting external source code links for Dartdoc.
 library dartdoc.source_linker;
 

--- a/lib/src/special_elements.dart
+++ b/lib/src/special_elements.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Handling for special elements within Dart.  When identified these
 /// may alter the interpretation and documentation generated for other
 /// [ModelElement]s.

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.tool_runner;
 
 import 'dart:io' show Process, ProcessException;

--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -1,5 +1,7 @@
 // Copied from source at github.com/kseo/tuple/blob/470ed3aeb/lib/src/tuple.dart
 
+// @dart=2.9
+
 // Original copyright:
 // Copyright (c) 2014, the tuple project authors. Please see the AUTHORS
 // file for details. All rights reserved. Use of this source code is governed

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.9
+
 library dartdoc.utils;
 
 final RegExp leadingWhiteSpace = RegExp(r'^([ \t]*)[^ ]');

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,5 @@
 // Generated code. Do not modify.
+
+// @dart=2.9
+
 const packageVersion = '0.39.0';

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^0.41.1
-  args: '>=2.0.0-nullsafety.0'
+  args: '<=2.0.0-nullsafety.0'
   charcode: ^1.1.2
   collection: ^1.15.0-nullsafety.4
   cli_util: '>=0.1.4 <0.3.0'
@@ -16,23 +16,22 @@ dependencies:
   glob: '>=1.1.2 <2.0.0'
   html: '>=0.12.1 <0.15.0'
   logging: ^0.11.3+1
-  markdown: '>=2.1.5 <4.0.0'
+  markdown: '>=2.1.5 <=4.0.0-nullsafety.0'
   meta: ^1.2.4
   mustache: ^1.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
-  pub_semver: ^1.3.7
+  pub_semver: ^2.0.0-nullsafety.0
   yaml: ^3.0.0-nullsafety.0
 
 dev_dependencies:
   async: '>=2.0.8'
-  build: ^1.5.0
-  build_runner: ^1.10.0
-  build_test: ^1.3.0
-  build_version: ^2.0.1
-  coverage: ^0.14.0
-  dart_style: ^1.3.9
-  dhttpd: ^3.0.0
+  #build: ^1.5.0
+  #build_runner: ^1.10.0
+  #build_test: ^1.3.0
+  #build_version: ^2.0.1
+  #coverage: ^0.15.0
+  #dart_style: ^1.3.9
   grinder: ^0.8.2
   http: ^0.12.0
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ version: 0.39.0
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   analyzer: ^0.41.1
-  args: '>=1.5.0 <2.0.0'
+  args: '>=2.0.0-nullsafety.0'
   charcode: ^1.1.2
-  collection: ^1.2.0
+  collection: ^1.15.0-nullsafety.4
   cli_util: '>=0.1.4 <0.3.0'
   crypto: ^2.0.6
   glob: '>=1.1.2 <2.0.0'
@@ -22,7 +22,7 @@ dependencies:
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
   pub_semver: ^1.3.7
-  yaml: ^2.1.0
+  yaml: ^3.0.0-nullsafety.0
 
 dev_dependencies:
   async: '>=2.0.8'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,30 +8,30 @@ environment:
 
 dependencies:
   analyzer: ^0.41.1
-  args: '<=2.0.0-nullsafety.0'
+  args: '>=1.5.0 <2.0.0'
   charcode: ^1.1.2
-  collection: ^1.15.0-nullsafety.4
+  collection: ^1.2.0
   cli_util: '>=0.1.4 <0.3.0'
   crypto: ^2.0.6
   glob: '>=1.1.2 <2.0.0'
   html: '>=0.12.1 <0.15.0'
   logging: ^0.11.3+1
-  markdown: '>=2.1.5 <=4.0.0-nullsafety.0'
+  markdown: '>=2.1.5 <4.0.0'
   meta: ^1.2.4
   mustache: ^1.1.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
-  pub_semver: ^2.0.0-nullsafety.0
-  yaml: ^3.0.0-nullsafety.0
+  pub_semver: ^1.3.7
+  yaml: ^2.1.0
 
 dev_dependencies:
   async: '>=2.0.8'
-  #build: ^1.5.0
-  #build_runner: ^1.10.0
-  #build_test: ^1.3.0
-  #build_version: ^2.0.1
-  #coverage: ^0.15.0
-  #dart_style: ^1.3.9
+  build: ^1.5.0
+  build_runner: ^1.10.0
+  build_test: ^1.3.0
+  build_version: ^2.0.1
+  coverage: ^0.14.0
+  dart_style: ^1.3.9
   grinder: ^0.8.2
   http: ^0.12.0
   pedantic: ^1.9.0

--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.options_test;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.dartdoc_integration_test;
 
 import 'dart:async';

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.dartdoc_test;
 
 import 'dart:async';

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// This test library handles checks against the model for configurations
 /// that require different PackageGraph configurations.  Since those
 /// take a long time to initialize, isolate them here to keep model_test

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.model_test;
 
 import 'dart:io';

--- a/test/grind_test.dart
+++ b/test/grind_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.io_utils_test;
 
 import 'package:test/test.dart';

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/dartdoc.dart';

--- a/test/io_utils_test.dart
+++ b/test/io_utils_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.io_utils_test;
 
 import 'package:dartdoc/src/io_utils.dart';

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';

--- a/test/markdown_processor_test.dart
+++ b/test/markdown_processor_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.markdown_processor_test;
 
 import 'package:dartdoc/src/markdown_processor.dart';

--- a/test/model_utils_test.dart
+++ b/test/model_utils_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.model_utils_test;
 
 import 'package:dartdoc/src/model_utils.dart';

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 import 'dart:convert';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';

--- a/test/mustachio/foo.dart
+++ b/test/mustachio/foo.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 @Renderer(#renderFoo, Context<Foo>())
 @Renderer(#renderBar, Context<Bar>())
 @Renderer(#renderBaz, Context<Baz>())

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -3,6 +3,8 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
+// @dart=2.9
+
 // ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/test/mustachio/parser_test.dart
+++ b/test/mustachio/parser_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 import 'package:dartdoc/src/mustachio/parser.dart';
 import 'package:test/test.dart';
 

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/mustachio/renderer_base.dart';

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.package_utils_test;
 
 import 'package:dartdoc/src/io_utils.dart';

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';

--- a/test/quiver_test.dart
+++ b/test/quiver_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:test/test.dart';
 import 'package:dartdoc/src/quiver.dart';
 

--- a/test/render/template_renderer_test.dart
+++ b/test/render/template_renderer_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:dartdoc/src/render/template_renderer.dart';
 import 'package:test/test.dart';
 

--- a/test/resource_loader_test.dart
+++ b/test/resource_loader_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.resource_loader_test;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/test/source_linker_test.dart
+++ b/test/source_linker_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.source_linker_test;
 
 import 'package:dartdoc/src/dartdoc_options.dart';

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library test_utils;
 
 import 'package:analyzer/file_system/file_system.dart';

--- a/test/template_test.dart
+++ b/test/template_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.template_test;
 
 import 'dart:io';

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.model_test;
 
 import 'dart:io';

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 library dartdoc.utils_test;
 
 import 'package:dartdoc/src/utils.dart';

--- a/test/warnings_test.dart
+++ b/test/warnings_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Unit tests for lib/src/warnings.dart.
 library dartdoc.warnings_test;
 

--- a/tool/builder.dart
+++ b/tool/builder.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 
 import 'package:build/build.dart';

--- a/tool/doc_packages.dart
+++ b/tool/doc_packages.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// A CLI tool to generate documentation for packages from pub.dartlang.org.
 library dartdoc.doc_packages;
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -472,6 +472,11 @@ Future<String> createSdkDartdoc(bool overrideMeta) async {
   dartdocPubspec.writeAsStringSync('''
 
 dependency_overrides:
+  args: ^2.0.0-nullsafety.0
+  cli_util: ^0.3.0-nullsafety.0
+  crypto: ^3.0.0-nullsafety.0
+  glob: ^2.0.0-nullsafety.0
+  package_config: ^2.0.0-nullsafety.0
   analyzer:
     path: '${sdkClone.path}/pkg/analyzer'
   _fe_analyzer_shared:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:io' hide ProcessException;
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -600,6 +600,7 @@ Future<void> startTestPackageDocsServer() async {
   log('launching dhttpd on port 8002 for SDK');
   var launcher = SubprocessLauncher('serve-test-package-docs');
   await launcher.runStreamed(sdkBin('pub'), [
+    'global',
     'run',
     'dhttpd',
     '--port',
@@ -620,7 +621,7 @@ Future<void> _serveDocsFrom(String servePath, int port, String context) async {
     _serveReady = true;
   }
   await launcher.runStreamed(
-      sdkBin('pub'), ['run', 'dhttpd', '--port', '$port', '--path', servePath]);
+      sdkBin('pub'), ['global', 'run', 'dhttpd', '--port', '$port', '--path', servePath]);
 }
 
 @Task('Serve generated SDK docs locally with dhttpd on port 8000')
@@ -629,6 +630,7 @@ Future<void> serveSdkDocs() async {
   log('launching dhttpd on port 8000 for SDK');
   var launcher = SubprocessLauncher('serve-sdk-docs');
   await launcher.runStreamed(sdkBin('pub'), [
+    'global',
     'run',
     'dhttpd',
     '--port',
@@ -670,6 +672,7 @@ Future<void> compareFlutterWarnings() async {
     var launcher = SubprocessLauncher('serve-flutter-docs');
     await launcher.runStreamed(sdkBin('pub'), ['get']);
     Future original = launcher.runStreamed(sdkBin('pub'), [
+      'global',
       'run',
       'dhttpd',
       '--port',
@@ -678,6 +681,7 @@ Future<void> compareFlutterWarnings() async {
       path.join(originalDartdocFlutter.absolute.path, 'dev', 'docs', 'doc'),
     ]);
     Future current = launcher.runStreamed(sdkBin('pub'), [
+      'global',
       'run',
       'dhttpd',
       '--port',
@@ -696,6 +700,7 @@ Future<void> serveFlutterDocs() async {
   var launcher = SubprocessLauncher('serve-flutter-docs');
   await launcher.runStreamed(sdkBin('pub'), ['get']);
   await launcher.runStreamed(sdkBin('pub'), [
+    'global',
     'run',
     'dhttpd',
     '--port',

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -477,6 +477,8 @@ dependency_overrides:
   crypto: ^3.0.0-nullsafety.0
   glob: ^2.0.0-nullsafety.0
   package_config: ^2.0.0-nullsafety.0
+  pub_semver: ^2.0.0-nullsafety.0
+  yaml: ^3.0.0-nullsafety.0
   analyzer:
     path: '${sdkClone.path}/pkg/analyzer'
   _fe_analyzer_shared:

--- a/tool/mustachio/builder.dart
+++ b/tool/mustachio/builder.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart';
 import 'package:build/build.dart';

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:collection';
 
 import 'package:analyzer/dart/element/element.dart';

--- a/tool/subprocess_launcher.dart
+++ b/tool/subprocess_launcher.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
Hot-wire the dependency graph so we can reenable usage with sdk-analyzer.

This is not a complete fix for #2500 but may be the best we can do until analyzer is published.