### PR TITLE
Convert originalMember to an optional parameter of ModelElement

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -14,7 +14,8 @@ class Accessor extends ModelElement implements EnclosedElement {
   GetterSetterCombo enclosingCombo;
 
   Accessor(PropertyAccessorElement element, Library library,
-      PackageGraph packageGraph, Member originalMember)
+      PackageGraph packageGraph,
+      [Member /*?*/ originalMember])
       : super(element, library, packageGraph, originalMember);
 
   String get linkedReturnType {
@@ -149,7 +150,7 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
 
   ContainerAccessor(PropertyAccessorElement element, Library library,
       PackageGraph packageGraph)
-      : super(element, library, packageGraph, null);
+      : super(element, library, packageGraph);
 
   ContainerAccessor.inherited(PropertyAccessorElement element, Library library,
       PackageGraph packageGraph, this._enclosingElement,

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -12,7 +12,7 @@ class Constructor extends ModelElement
     implements EnclosedElement {
   Constructor(
       ConstructorElement element, Library library, PackageGraph packageGraph)
-      : super(element, library, packageGraph, null);
+      : super(element, library, packageGraph);
 
   @override
   CharacterLocation get characterLocation {

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -29,7 +29,7 @@ import 'package:meta/meta.dart';
 /// **all** : Referring to all children.
 abstract class Container extends ModelElement with TypeParameters {
   Container(Element element, Library library, PackageGraph packageGraph)
-      : super(element, library, packageGraph, null);
+      : super(element, library, packageGraph);
 
   /// Is this a class (but not an enum)?
   bool get isClass =>

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -7,7 +7,7 @@ import 'package:dartdoc/src/model/model.dart';
 
 class Dynamic extends ModelElement {
   Dynamic(Element element, PackageGraph packageGraph)
-      : super(element, null, packageGraph, null);
+      : super(element, null, packageGraph);
 
   /// [dynamic] is not a real object, and so we can't document it, so there
   /// can be nothing canonical for it.

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -20,7 +20,7 @@ class Field extends ModelElement
 
   Field(FieldElement element, Library library, PackageGraph packageGraph,
       this.getter, this.setter)
-      : super(element, library, packageGraph, null) {
+      : super(element, library, packageGraph) {
     assert(getter != null || setter != null);
     if (getter != null) getter.enclosingCombo = this;
     if (setter != null) setter.enclosingCombo = this;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -66,7 +66,7 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
 
   Library._(LibraryElement element, PackageGraph packageGraph, this.package,
       this._restoredUri, this._exportedAndLocalElements)
-      : super(element, null, packageGraph, null);
+      : super(element, null, packageGraph);
 
   factory Library.fromLibraryResult(DartDocResolvedLibrary resolvedLibrary,
       PackageGraph packageGraph, Package package) {

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -16,7 +16,7 @@ class Method extends ModelElement
   List<TypeParameter> typeParameters = [];
 
   Method(MethodElement element, Library library, PackageGraph packageGraph)
-      : super(element, library, packageGraph, null) {
+      : super(element, library, packageGraph) {
     _calcTypeParameters();
   }
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -140,8 +140,8 @@ abstract class ModelElement extends Canonicalization
   final Element _element;
 
   // TODO(jcollins-g): This really wants a "member that has a type" class.
-  final Member _originalMember;
-  final Library _library;
+  final Member /*?*/ _originalMember;
+  final Library /*?*/ _library;
 
   ElementType _modelType;
   String _rawDocs;
@@ -149,10 +149,8 @@ abstract class ModelElement extends Canonicalization
   UnmodifiableListView<Parameter> _parameters;
   String _linkedName;
 
-  // TODO(jcollins-g): make _originalMember optional after dart-lang/sdk#15101
-  // is fixed.
-  ModelElement(
-      this._element, this._library, this._packageGraph, this._originalMember);
+  ModelElement(this._element, this._library, this._packageGraph,
+      [this._originalMember]);
 
   /// Creates a [ModelElement] from [e].
   factory ModelElement.fromElement(Element e, PackageGraph p) {
@@ -372,7 +370,7 @@ abstract class ModelElement extends Canonicalization
               originalMember: originalMember);
         }
       } else {
-        return Accessor(e, library, packageGraph, null);
+        return Accessor(e, library, packageGraph);
       }
     }
     if (e is TypeParameterElement) {

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -45,7 +45,7 @@ class ModelFunctionTyped extends ModelElement
           for (var p in element.typeParameters)
             ModelElement.from(p, library, packageGraph),
         ],
-        super(element, library, packageGraph, null);
+        super(element, library, packageGraph);
 
   @override
   ModelElement get enclosingElement => library;

--- a/lib/src/model/never.dart
+++ b/lib/src/model/never.dart
@@ -7,7 +7,7 @@ import 'package:dartdoc/src/model/model.dart';
 
 class NeverType extends ModelElement {
   NeverType(Element element, PackageGraph packageGraph)
-      : super(element, null, packageGraph, null);
+      : super(element, null, packageGraph);
 
   /// `Never` is not a real object, and so we can't document it, so there
   /// can be nothing canonical for it.

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -17,7 +17,7 @@ class TopLevelVariable extends ModelElement
 
   TopLevelVariable(TopLevelVariableElement element, Library library,
       PackageGraph packageGraph, this.getter, this.setter)
-      : super(element, library, packageGraph, null) {
+      : super(element, library, packageGraph) {
     if (getter != null) {
       getter.enclosingCombo = this;
     }

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -10,7 +10,7 @@ import 'package:dartdoc/src/render/type_parameters_renderer.dart';
 class TypeParameter extends ModelElement {
   TypeParameter(
       TypeParameterElement element, Library library, PackageGraph packageGraph)
-      : super(element, library, packageGraph, null);
+      : super(element, library, packageGraph);
 
   @override
   ModelElement get enclosingElement => (element.enclosingElement != null)

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -12,7 +12,7 @@ class Typedef extends ModelElement
     implements EnclosedElement {
   Typedef(FunctionTypeAliasElement element, Library library,
       PackageGraph packageGraph)
-      : super(element, library, packageGraph, null);
+      : super(element, library, packageGraph);
 
   @override
   ModelElement get enclosingElement => library;


### PR DESCRIPTION
We're now in a world with https://github.com/dart-lang/sdk/issues/15101 and https://github.com/dart-lang/sdk/issues/31543 fixed, so this change should be fine.