### PR TITLE
Deprecate some hasDoc methods

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -48,7 +48,7 @@ class GeneratorFrontEnd implements Generator {
       for (var lib in filterNonDocumented(package.libraries)) {
         logInfo('Generating docs for library ${lib.name} from '
             '${lib.element.source.uri}...');
-        if (!lib.isAnonymous && !lib.hasDocumentation) {
+        if (!lib.isAnonymous && lib.documentation == null) {
           packageGraph.warnOnElement(lib, PackageWarning.noLibraryLevelDocs);
         }
         indexAccumulator.add(lib);

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -3,7 +3,7 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names, deprecated_member_use_from_same_package
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -11,10 +11,12 @@ import 'model.dart';
 /// Bridges the gap between model elements and packages,
 /// both of which have documentation.
 abstract class Documentable extends Nameable {
-  String get documentation;
+  String /*?*/ get documentation;
 
   String get documentationAsHtml;
 
+  @Deprecated(
+      'Instead use [documentation], which will be `null` if it is not present.')
   bool get hasDocumentation;
 
   bool get hasExtendedDocumentation;

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -61,10 +61,10 @@ class Documentation {
 
   /// Returns a tuple of List<md.Node> and hasExtendedDocs
   Tuple2<List<md.Node>, bool> _parseDocumentation(bool processFullDocs) {
-    if (!_element.hasDocumentation) {
+    final text = _element.documentation;
+    if (text == null) {
       return Tuple2([], false);
     }
-    var text = _element.documentation;
     showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
     var document =
         MarkdownDocument.withElementLinkResolver(_element, commentRefs);

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -120,27 +120,33 @@ class Package extends LibraryContainer
 
   @override
   String get documentation {
-    return hasDocumentationFile
+    final docFile = documentationFile;
+    return docFile != null
         ? packageGraph.resourceProvider
-            .readAsMalformedAllowedStringSync(documentationFile)
+            .readAsMalformedAllowedStringSync(docFile)
         : null;
   }
 
   @override
-  bool get hasDocumentation =>
-      documentationFile != null &&
-      packageGraph.resourceProvider
-          .readAsMalformedAllowedStringSync(documentationFile)
-          .isNotEmpty;
+  bool get hasDocumentation {
+    final docFile = documentationFile;
+    return docFile != null &&
+        packageGraph.resourceProvider
+            .readAsMalformedAllowedStringSync(docFile)
+            .isNotEmpty;
+  }
 
   @override
   bool get hasExtendedDocumentation => documentation.isNotEmpty;
 
   // TODO: Clients should use [documentationFile] so they can act differently on
   // plain text or markdown.
+  @Deprecated(
+      'Instead use [documentationFile] which will be `null` if this package does not have one.')
   bool get hasDocumentationFile => documentationFile != null;
 
-  File get documentationFile => packageMeta.getReadmeContents();
+  /// The package's documentation file if present, otherwise `null`.
+  File /*?*/ get documentationFile => packageMeta.getReadmeContents();
 
   @override
   String get oneLineDoc => '';

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -297,7 +297,7 @@ void main() {
       expect(p.defaultPackage.name, 'sky_engine');
       // ignore: deprecated_member_use_from_same_package
       expect(p.defaultPackage.hasDocumentationFile, isFalse);
-      expect(p.defaultPackage.documentationFile, isNotNull);
+      expect(p.defaultPackage.documentationFile, isNull);
       expect(p.libraries, hasLength(3));
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:async'), isTrue);

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -248,7 +248,9 @@ void main() {
         var packageGraph = results.packageGraph;
         var p = packageGraph.defaultPackage;
         expect(p.name, 'test_package');
+        // ignore: deprecated_member_use_from_same_package
         expect(p.hasDocumentationFile, isTrue);
+        expect(p.documentationFile, isNotNull);
         // Total number of public libraries in test_package.
         // +2 since we are not manually excluding anything.
         expect(packageGraph.defaultPackage.publicLibraries,
@@ -293,7 +295,9 @@ void main() {
 
       var p = results.packageGraph;
       expect(p.defaultPackage.name, 'sky_engine');
+      // ignore: deprecated_member_use_from_same_package
       expect(p.defaultPackage.hasDocumentationFile, isFalse);
+      expect(p.defaultPackage.documentationFile, isNotNull);
       expect(p.libraries, hasLength(3));
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:async'), isTrue);

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2903,6 +2903,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('has valid documentation', () {
       expect(mFromApple.hasDocumentation, isTrue);
+      expect(mFromApple.documentation, isNotNull);
       expect(mFromApple.documentation, 'The read-write field `m`.');
     });
 

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -3,7 +3,7 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names, deprecated_member_use_from_same_package
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -146,16 +146,22 @@ int x;
         writeToJoinedPath(['README.md'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
+        // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, true);
+        expect(packageGraph.defaultPackage.documentationFile, isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
+        expect(packageGraph.defaultPackage.documentation, isNotNull);
       });
 
       test('has documentation via text README', () async {
         writeToJoinedPath(['README'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
+        // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, true);
+        expect(packageGraph.defaultPackage.documentationFile, isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
+        expect(packageGraph.defaultPackage.documentation, isNotNull);
       });
 
       test('has documentation content', () async {
@@ -458,6 +464,7 @@ int x;
             projectPath, packageMetaProvider, packageConfigProvider);
 
         expect(packageGraph.defaultPackage.hasDocumentation, isFalse);
+        // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, isFalse);
         expect(packageGraph.defaultPackage.documentationFile, isNull);
         expect(packageGraph.defaultPackage.documentation, isNull);

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -85,7 +85,7 @@ class RuntimeRenderersBuilder {
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names, deprecated_member_use_from_same_package
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';


### PR DESCRIPTION
I think the usefulness of these methods becomes less with null safety as we can indicate the lack of X by instead returning `null` with a nullable-type.

The slight benefit of this comes from avoiding evaluating the documentation again which can read from files.