### PR TITLE
Cleanup some doc methods

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -3,7 +3,7 @@
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names, deprecated_member_use_from_same_package
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -45,12 +45,6 @@ enum DocumentLocation {
 mixin MarkdownFileDocumentation implements Documentable, Canonicalization {
   DocumentLocation get documentedWhere;
 
-  @override
-  String get documentation => documentationFile == null
-      ? null
-      : packageGraph.resourceProvider
-          .readAsMalformedAllowedStringSync(documentationFile);
-
   Documentation __documentation;
 
   Documentation get _documentation {
@@ -63,11 +57,16 @@ mixin MarkdownFileDocumentation implements Documentable, Canonicalization {
   String get documentationAsHtml => _documentation.asHtml;
 
   @override
-  bool get hasDocumentation =>
-      documentationFile != null &&
-      packageGraph.resourceProvider
-          .readAsMalformedAllowedStringSync(documentationFile)
-          .isNotEmpty;
+  String get documentation {
+    final docFile = documentationFile;
+    return docFile == null
+        ? null
+        : packageGraph.resourceProvider
+            .readAsMalformedAllowedStringSync(docFile);
+  }
+
+  @override
+  bool get hasDocumentation => documentation?.isNotEmpty == true;
 
   @override
   bool get hasExtendedDocumentation =>

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -61,10 +61,10 @@ class Documentation {
 
   /// Returns a tuple of List<md.Node> and hasExtendedDocs
   Tuple2<List<md.Node>, bool> _parseDocumentation(bool processFullDocs) {
-    if (!_element.hasDocumentation) {
+    final text = _element.documentation;
+    if (text == null || text.isEmpty) {
       return Tuple2([], false);
     }
-    var text = _element.documentation;
     showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
     var document =
         MarkdownDocument.withElementLinkResolver(_element, commentRefs);

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -120,17 +120,14 @@ mixin GetterSetterCombo on ModelElement {
     return _documentationFrom;
   }
 
-  bool get hasAccessorsWithDocs => (hasPublicGetter &&
-          !getter.isSynthetic &&
-          getter.documentation.isNotEmpty ||
-      hasPublicSetter &&
-          !setter.isSynthetic &&
-          setter.documentation.isNotEmpty);
+  bool get hasAccessorsWithDocs =>
+      (hasPublicGetter && !getter.isSynthetic && getter.hasDocumentation ||
+          hasPublicSetter && !setter.isSynthetic && setter.hasDocumentation);
 
   bool get getterSetterBothAvailable => (hasPublicGetter &&
-      getter.documentation.isNotEmpty &&
+      getter.hasDocumentation &&
       hasPublicSetter &&
-      setter.documentation.isNotEmpty);
+      setter.hasDocumentation);
 
   String _oneLineDoc;
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -879,8 +879,7 @@ abstract class ModelElement extends Canonicalization
   bool get hasAnnotations => annotations.isNotEmpty;
 
   @override
-  bool get hasDocumentation =>
-      documentation != null && documentation.isNotEmpty;
+  bool get hasDocumentation => documentation?.isNotEmpty == true;
 
   @override
   bool get hasExtendedDocumentation =>

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -141,7 +141,7 @@ class Package extends LibraryContainer
   File /*?*/ _documentationFile;
 
   @Deprecated(
-      'Instead use [documentationFile] which will be `null` if this pFackage does not have one.')
+      'Instead use [documentationFile] which will be `null` if this package does not have one.')
   bool get hasDocumentationFile => documentationFile != null;
 
   File /*?*/ get documentationFile =>

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -122,13 +122,12 @@ class Package extends LibraryContainer
 
   @override
   String get documentation {
-    if (_documentation != null) {
-      return _documentation;
-    }
-    final docFile = documentationFile;
-    if (docFile != null) {
-      _documentation = packageGraph.resourceProvider
-          .readAsMalformedAllowedStringSync(docFile);
+    if (_documentation == null) {
+      final docFile = documentationFile;
+      if (docFile != null) {
+        _documentation = packageGraph.resourceProvider
+            .readAsMalformedAllowedStringSync(docFile);
+      }
     }
     return _documentation;
   }
@@ -139,11 +138,14 @@ class Package extends LibraryContainer
   @override
   bool get hasExtendedDocumentation => hasDocumentation;
 
+  File /*?*/ _documentationFile;
+
   @Deprecated(
-      'Instead use [documentationFile] which will be `null` if this package does not have one.')
+      'Instead use [documentationFile] which will be `null` if this pFackage does not have one.')
   bool get hasDocumentationFile => documentationFile != null;
 
-  File /*?*/ get documentationFile => packageMeta.getReadmeContents();
+  File /*?*/ get documentationFile =>
+      _documentationFile ??= packageMeta.getReadmeContents();
 
   @override
   String get oneLineDoc => '';

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -118,29 +118,32 @@ class Package extends LibraryContainer
     return _documentationAsHtml;
   }
 
+  String /*?*/ _documentation;
+
   @override
   String get documentation {
-    return hasDocumentationFile
-        ? packageGraph.resourceProvider
-            .readAsMalformedAllowedStringSync(documentationFile)
-        : null;
+    if (_documentation != null) {
+      return _documentation;
+    }
+    final docFile = documentationFile;
+    if (docFile != null) {
+      _documentation = packageGraph.resourceProvider
+          .readAsMalformedAllowedStringSync(docFile);
+    }
+    return _documentation;
   }
 
   @override
-  bool get hasDocumentation =>
-      documentationFile != null &&
-      packageGraph.resourceProvider
-          .readAsMalformedAllowedStringSync(documentationFile)
-          .isNotEmpty;
+  bool get hasDocumentation => documentation?.isNotEmpty == true;
 
   @override
-  bool get hasExtendedDocumentation => documentation.isNotEmpty;
+  bool get hasExtendedDocumentation => hasDocumentation;
 
-  // TODO: Clients should use [documentationFile] so they can act differently on
-  // plain text or markdown.
+  @Deprecated(
+      'Instead use [documentationFile] which will be `null` if this package does not have one.')
   bool get hasDocumentationFile => documentationFile != null;
 
-  File get documentationFile => packageMeta.getReadmeContents();
+  File /*?*/ get documentationFile => packageMeta.getReadmeContents();
 
   @override
   String get oneLineDoc => '';

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -248,7 +248,9 @@ void main() {
         var packageGraph = results.packageGraph;
         var p = packageGraph.defaultPackage;
         expect(p.name, 'test_package');
+        // ignore: deprecated_member_use_from_same_package
         expect(p.hasDocumentationFile, isTrue);
+        expect(p.documentationFile, isNotNull);
         // Total number of public libraries in test_package.
         // +2 since we are not manually excluding anything.
         expect(packageGraph.defaultPackage.publicLibraries,
@@ -293,7 +295,9 @@ void main() {
 
       var p = results.packageGraph;
       expect(p.defaultPackage.name, 'sky_engine');
+      // ignore: deprecated_member_use_from_same_package
       expect(p.defaultPackage.hasDocumentationFile, isFalse);
+      expect(p.defaultPackage.documentationFile, isNull);
       expect(p.libraries, hasLength(3));
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:async'), isTrue);

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -465,7 +465,7 @@ int x;
         // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, isFalse);
         expect(packageGraph.defaultPackage.documentationFile, isNull);
-        expect(packageGraph.defaultPackage.documentation, isEmpty);
+        expect(packageGraph.defaultPackage.documentation, isNull);
       });
 
       test('package with no homepage in the pubspec has no homepage', () async {

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -146,7 +146,9 @@ int x;
         writeToJoinedPath(['README.md'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
+        // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, true);
+        expect(packageGraph.defaultPackage.documentationFile, isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
       });
 
@@ -154,7 +156,9 @@ int x;
         writeToJoinedPath(['README'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
+        // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, true);
+        expect(packageGraph.defaultPackage.documentationFile, isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
       });
 
@@ -458,9 +462,10 @@ int x;
             projectPath, packageMetaProvider, packageConfigProvider);
 
         expect(packageGraph.defaultPackage.hasDocumentation, isFalse);
+        // ignore: deprecated_member_use_from_same_package
         expect(packageGraph.defaultPackage.hasDocumentationFile, isFalse);
         expect(packageGraph.defaultPackage.documentationFile, isNull);
-        expect(packageGraph.defaultPackage.documentation, isNull);
+        expect(packageGraph.defaultPackage.documentation, isEmpty);
       });
 
       test('package with no homepage in the pubspec has no homepage', () async {

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -85,7 +85,7 @@ class RuntimeRenderersBuilder {
 // To change the contents of this library, make changes to the builder source
 // files in the tool/mustachio/ directory.
 
-// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names
+// ignore_for_file: camel_case_types, unnecessary_cast, unused_element, unused_import, non_constant_identifier_names, deprecated_member_use_from_same_package
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';


### PR DESCRIPTION
Clean up some `documentation` and `hasDocumentation` methods to locally cache values and deprecate `hasDocumentationFile` in favor of `documentationFile` signifying the lack of one with a nullable result. Also make some minor changes to improve type inference once we switch to null safety.