### PR TITLE
Fix indentation in category.html

### DIFF
--- a/lib/templates/html/category.html
+++ b/lib/templates/html/category.html
@@ -1,128 +1,129 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
-    {{>packages}}
-  </div>
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  {{>search_sidebar}}
+  <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
+  {{>packages}}
+</div>
 
-  <div id="dartdoc-main-content" class="main-content">
-    {{#self}}
-      <h1><span class="kind-category">{{name}}</span> {{kind}}</h1>
-      {{>documentation}}
+<div id="dartdoc-main-content" class="main-content">
+  {{#self}}
+  <h1><span class="kind-category">{{name}}</span> {{kind}}</h1>
+  {{>documentation}}
 
-      {{#hasPublicLibraries}}
-        <section class="summary offset-anchor" id="libraries">
-        <h2>Libraries</h2>
+  {{#hasPublicLibraries}}
+  <section class="summary offset-anchor" id="libraries">
+    <h2>Libraries</h2>
 
-        <dl>
-          {{#publicLibrariesSorted}}
-            {{>library}}
-          {{/publicLibrariesSorted}}
-        </dl>
-        </section>
-      {{/hasPublicLibraries}}
+    <dl>
+      {{#publicLibrariesSorted}}
+      {{>library}}
+      {{/publicLibrariesSorted}}
+    </dl>
+  </section>
+  {{/hasPublicLibraries}}
 
-      {{#hasPublicClasses}}
-        <section class="summary offset-anchor" id="classes">
-        <h2>Classes</h2>
+  {{#hasPublicClasses}}
+  <section class="summary offset-anchor" id="classes">
+    <h2>Classes</h2>
 
-        <dl>
-          {{#publicClassesSorted}}
-            {{>class}}
-          {{/publicClassesSorted}}
-        </dl>
-      </section>
-      {{/hasPublicClasses}}
+    <dl>
+      {{#publicClassesSorted}}
+      {{>class}}
+      {{/publicClassesSorted}}
+    </dl>
+  </section>
+  {{/hasPublicClasses}}
 
-      {{#hasPublicMixins}}
-      <section class="summary offset-anchor" id="mixins">
-        <h2>Mixins</h2>
+  {{#hasPublicMixins}}
+  <section class="summary offset-anchor" id="mixins">
+    <h2>Mixins</h2>
 
-        <dl>
-          {{#publicMixinsSorted}}
-          {{>mixin}}
-          {{/publicMixinsSorted}}
-        </dl>
-      </section>
-      {{/hasPublicMixins}}
+    <dl>
+      {{#publicMixinsSorted}}
+      {{>mixin}}
+      {{/publicMixinsSorted}}
+    </dl>
+  </section>
+  {{/hasPublicMixins}}
 
-      {{#hasPublicConstants}}
-      <section class="summary offset-anchor" id="constants">
-        <h2>Constants</h2>
+  {{#hasPublicConstants}}
+  <section class="summary offset-anchor" id="constants">
+    <h2>Constants</h2>
 
-        <dl class="properties">
-          {{#publicConstantsSorted}}
-            {{>constant}}
-          {{/publicConstantsSorted}}
-        </dl>
-      </section>
-      {{/hasPublicConstants}}
+    <dl class="properties">
+      {{#publicConstantsSorted}}
+      {{>constant}}
+      {{/publicConstantsSorted}}
+    </dl>
+  </section>
+  {{/hasPublicConstants}}
 
-      {{#hasPublicProperties}}
-      <section class="summary offset-anchor" id="properties">
-        <h2>Properties</h2>
+  {{#hasPublicProperties}}
+  <section class="summary offset-anchor" id="properties">
+    <h2>Properties</h2>
 
-        <dl class="properties">
-          {{#publicPropertiesSorted}}
-            {{>property}}
-          {{/publicPropertiesSorted}}
-        </dl>
-      </section>
-      {{/hasPublicProperties}}
+    <dl class="properties">
+      {{#publicPropertiesSorted}}
+      {{>property}}
+      {{/publicPropertiesSorted}}
+    </dl>
+  </section>
+  {{/hasPublicProperties}}
 
-      {{#hasPublicFunctions}}
-      <section class="summary offset-anchor" id="functions">
-        <h2>Functions</h2>
+  {{#hasPublicFunctions}}
+  <section class="summary offset-anchor" id="functions">
+    <h2>Functions</h2>
 
-        <dl class="callables">
-          {{#publicFunctionsSorted}}
-            {{>callable}}
-          {{/publicFunctionsSorted}}
-        </dl>
-      </section>
-      {{/hasPublicFunctions}}
+    <dl class="callables">
+      {{#publicFunctionsSorted}}
+      {{>callable}}
+      {{/publicFunctionsSorted}}
+    </dl>
+  </section>
+  {{/hasPublicFunctions}}
 
-      {{#hasPublicEnums}}
-      <section class="summary offset-anchor" id="enums">
-        <h2>Enums</h2>
+  {{#hasPublicEnums}}
+  <section class="summary offset-anchor" id="enums">
+    <h2>Enums</h2>
 
-        <dl>
-          {{#publicEnumsSorted}}
-            {{>class}}
-          {{/publicEnumsSorted}}
-        </dl>
-      </section>
-      {{/hasPublicEnums}}
+    <dl>
+      {{#publicEnumsSorted}}
+      {{>class}}
+      {{/publicEnumsSorted}}
+    </dl>
+  </section>
+  {{/hasPublicEnums}}
 
-      {{#hasPublicTypedefs}}
-      <section class="summary offset-anchor" id="typedefs">
-        <h2>Typedefs</h2>
+  {{#hasPublicTypedefs}}
+  <section class="summary offset-anchor" id="typedefs">
+    <h2>Typedefs</h2>
 
-        <dl class="callables">
-          {{#publicTypedefsSorted}}
-            {{>callable}}
-          {{/publicTypedefsSorted}}
-        </dl>
-      </section>
-      {{/hasPublicTypedefs}}
+    <dl class="callables">
+      {{#publicTypedefsSorted}}
+      {{>callable}}
+      {{/publicTypedefsSorted}}
+    </dl>
+  </section>
+  {{/hasPublicTypedefs}}
 
-      {{#hasPublicExceptions}}
-      <section class="summary offset-anchor" id="exceptions">
-        <h2>Exceptions / Errors</h2>
+  {{#hasPublicExceptions}}
+  <section class="summary offset-anchor" id="exceptions">
+    <h2>Exceptions / Errors</h2>
 
-        <dl>
-          {{#publicExceptionsSorted}}
-            {{>class}}
-          {{/publicExceptionsSorted}}
-        </dl>
-      </section>
-      {{/hasPublicExceptions}}
-    {{/self}}
+    <dl>
+      {{#publicExceptionsSorted}}
+      {{>class}}
+      {{/publicExceptionsSorted}}
+    </dl>
+  </section>
+  {{/hasPublicExceptions}}
+  {{/self}}
 
-  </div> <!-- /.main-content -->
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-    <h5>{{self.name}} {{self.kind}}</h5>
-    {{>sidebar_for_category}}
-  </div><!--/sidebar-offcanvas-right-->
+</div> <!-- /.main-content -->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+  <h5>{{self.name}} {{self.kind}}</h5>
+  {{>sidebar_for_category}}
+</div>
+<!--/sidebar-offcanvas-right-->
 {{>footer}}


### PR DESCRIPTION
Use GitHub's` ?w=1` to ignore whitespace:

https://github.com/dart-lang/dartdoc/pull/2521/files?w=1

This indentation was bugging me; previously it looked like everything was in the header partial, but not so.