### PR TITLE
Mustachio: fix getter override order, and bounds bug

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -28,6 +28,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   static Map<String, Property<CT_>> propertyMap<
           CT_ extends PackageTemplateData>() =>
       {
+        ..._Renderer_TemplateData.propertyMap<Package, CT_>(),
         'hasHomepage': Property(
           getValue: (CT_ c) => c.hasHomepage,
           renderVariable:
@@ -138,7 +139,6 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
             return renderSimple(c.title, ast, r.template, parent: r);
           },
         ),
-        ..._Renderer_TemplateData.propertyMap<Package, CT_>(),
       };
 
   _Renderer_PackageTemplateData(PackageTemplateData context,
@@ -165,6 +165,11 @@ String _render_Package(
 
 class _Renderer_Package extends RendererBase<Package> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Package>() => {
+        ..._Renderer_LibraryContainer.propertyMap<CT_>(),
+        ..._Renderer_Nameable.propertyMap<CT_>(),
+        ..._Renderer_Locatable.propertyMap<CT_>(),
+        ..._Renderer_Canonicalization.propertyMap<CT_>(),
+        ..._Renderer_Warnable.propertyMap<CT_>(),
         'allLibraries': Property(
           getValue: (CT_ c) => c.allLibraries,
           renderVariable:
@@ -696,11 +701,6 @@ class _Renderer_Package extends RendererBase<Package> {
             return renderSimple(c.version, ast, r.template, parent: r);
           },
         ),
-        ..._Renderer_LibraryContainer.propertyMap<CT_>(),
-        ..._Renderer_Nameable.propertyMap<CT_>(),
-        ..._Renderer_Locatable.propertyMap<CT_>(),
-        ..._Renderer_Canonicalization.propertyMap<CT_>(),
-        ..._Renderer_Warnable.propertyMap<CT_>(),
       };
 
   _Renderer_Package(
@@ -727,6 +727,7 @@ String _render_Nameable(
 
 class _Renderer_Nameable extends RendererBase<Nameable> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Nameable>() => {
+        ..._Renderer_Object.propertyMap<CT_>(),
         'fullyQualifiedName': Property(
           getValue: (CT_ c) => c.fullyQualifiedName,
           renderVariable:
@@ -773,7 +774,6 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
             return buffer.toString();
           },
         ),
-        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_Nameable(
@@ -800,6 +800,7 @@ String _render_Locatable(
 
 class _Renderer_Locatable extends RendererBase<Locatable> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Locatable>() => {
+        ..._Renderer_Object.propertyMap<CT_>(),
         'documentationFrom': Property(
           getValue: (CT_ c) => c.documentationFrom,
           renderVariable: (CT_ c, Property<CT_> self,
@@ -853,7 +854,6 @@ class _Renderer_Locatable extends RendererBase<Locatable> {
             return renderSimple(c.location, ast, r.template, parent: r);
           },
         ),
-        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_Locatable(
@@ -882,6 +882,7 @@ class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
   static Map<String, Property<CT_>> propertyMap<
           CT_ extends Canonicalization>() =>
       {
+        ..._Renderer_Object.propertyMap<CT_>(),
         'canonicalLibrary': Property(
           getValue: (CT_ c) => c.canonicalLibrary,
           renderVariable:
@@ -930,7 +931,6 @@ class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
             return buffer.toString();
           },
         ),
-        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_Canonicalization(
@@ -1026,6 +1026,7 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
   static Map<String, Property<CT_>> propertyMap<
           CT_ extends LibraryContainer>() =>
       {
+        ..._Renderer_Object.propertyMap<CT_>(),
         'containerOrder': Property(
           getValue: (CT_ c) => c.containerOrder,
           renderVariable:
@@ -1130,7 +1131,6 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
             return renderSimple(c.sortKey, ast, r.template, parent: r);
           },
         ),
-        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_LibraryContainer(
@@ -1196,6 +1196,7 @@ class _Renderer_TemplateData<T extends Documentable>
   static Map<String, Property<CT_>> propertyMap<T extends Documentable,
           CT_ extends TemplateData>() =>
       {
+        ..._Renderer_Object.propertyMap<CT_>(),
         'bareHref': Property(
           getValue: (CT_ c) => c.bareHref,
           renderVariable:
@@ -1360,6 +1361,16 @@ class _Renderer_TemplateData<T extends Documentable>
                 parent: r);
           },
         ),
+        'self': Property(
+          getValue: (CT_ c) => c.self,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'Documentable'),
+          isNullValue: (CT_ c) => c.self == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.self, ast, r.template, parent: r);
+          },
+        ),
         'title': Property(
           getValue: (CT_ c) => c.title,
           renderVariable:
@@ -1387,7 +1398,6 @@ class _Renderer_TemplateData<T extends Documentable>
             return renderSimple(c.version, ast, r.template, parent: r);
           },
         ),
-        ..._Renderer_Object.propertyMap<CT_>(),
       };
 
   _Renderer_TemplateData(

--- a/test/mustachio/foo.dart
+++ b/test/mustachio/foo.dart
@@ -5,10 +5,15 @@ library dartdoc.testing.foo;
 
 import 'package:dartdoc/src/mustachio/annotations.dart';
 
-class Foo {
+class FooBase<T extends Object> {
+  T baz;
+}
+
+class Foo extends FooBase<Baz> {
   String s1;
   bool b1;
   List<int> l1;
+  @override
   Baz baz;
 }
 

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -25,6 +25,7 @@ String _render_Foo(Foo context, List<MustachioNode> ast, Template template,
 
 class Renderer_Foo extends RendererBase<Foo> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Foo>() => {
+        ...Renderer_FooBase.propertyMap<Baz, CT_>(),
         'b1': Property(
           getValue: (CT_ c) => c.b1,
           renderVariable:
@@ -72,7 +73,6 @@ class Renderer_Foo extends RendererBase<Foo> {
             return renderSimple(c.s1, ast, r.template, parent: r);
           },
         ),
-        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_Foo(Foo context, RendererBase<Object> parent, Template template)
@@ -124,6 +124,45 @@ class Renderer_Object extends RendererBase<Object> {
   }
 }
 
+String _render_FooBase<T extends Object>(
+    FooBase<T> context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_FooBase(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class Renderer_FooBase<T extends Object> extends RendererBase<FooBase<T>> {
+  static Map<String, Property<CT_>>
+      propertyMap<T extends Object, CT_ extends FooBase>() => {
+            ...Renderer_Object.propertyMap<CT_>(),
+            'baz': Property(
+              getValue: (CT_ c) => c.baz,
+              renderVariable:
+                  (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                if (remainingNames.isEmpty) return self.getValue(c).toString();
+                var name = remainingNames.first;
+                var nextProperty = Renderer_Object.propertyMap().getValue(name);
+                return nextProperty.renderVariable(self.getValue(c),
+                    nextProperty, [...remainingNames.skip(1)]);
+              },
+            ),
+          };
+
+  Renderer_FooBase(
+      FooBase<T> context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<FooBase<T>> getProperty(String key) {
+    if (propertyMap<T, FooBase>().containsKey(key)) {
+      return propertyMap<T, FooBase>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
 String renderBar(Bar context, Template template) {
   return _render_Bar(context, template.ast, template);
 }
@@ -137,6 +176,7 @@ String _render_Bar(Bar context, List<MustachioNode> ast, Template template,
 
 class Renderer_Bar extends RendererBase<Bar> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Bar>() => {
+        ...Renderer_Object.propertyMap<CT_>(),
         'baz': Property(
           getValue: (CT_ c) => c.baz,
           renderVariable:
@@ -184,7 +224,6 @@ class Renderer_Bar extends RendererBase<Bar> {
             return renderSimple(c.s2, ast, r.template, parent: r);
           },
         ),
-        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_Bar(Bar context, RendererBase<Object> parent, Template template)
@@ -213,6 +252,7 @@ String _render_Baz(Baz context, List<MustachioNode> ast, Template template,
 
 class Renderer_Baz extends RendererBase<Baz> {
   static Map<String, Property<CT_>> propertyMap<CT_ extends Baz>() => {
+        ...Renderer_Object.propertyMap<CT_>(),
         'bar': Property(
           getValue: (CT_ c) => c.bar,
           renderVariable:
@@ -228,7 +268,6 @@ class Renderer_Baz extends RendererBase<Baz> {
             return _render_Bar(c.bar, ast, r.template, parent: r);
           },
         ),
-        ...Renderer_Object.propertyMap<CT_>(),
       };
 
   Renderer_Baz(Baz context, RendererBase<Object> parent, Template template)

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -367,7 +367,6 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
 
   void _writeProperty(_RendererInfo renderer, PropertyAccessorElement property,
       InterfaceType getterType) {
-    //var getterType = property.type.returnType as InterfaceType;
     if (getterType == _typeProvider.typeType) {
       // The [Type] type is the first case of a type we don't want to traverse.
       return;


### PR DESCRIPTION
There aren't any new test cases, but the existing tests would fail with the changes to foo.dart, without the other changes to the codegen.

The main fix here is to apply _local_ getters _after_ inherited getters, in the property map, so that they override any inherited getters.

But in creating the test situation in foo.dart, I saw we had a bug with type parameter bounds as well. This is important for real cases like `ClassTemplateData<T extends Class> extends TemplateData<T>`.