### PR TITLE
Introduce TemplateDataWithLibrary and TemplateDataWithContainer.

### DIFF
--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -4,8 +4,9 @@
 
 import 'package:dartdoc/src/model/model.dart';
 
-typedef ContainerSidebar = String Function(Container, TemplateData);
-typedef LibrarySidebar = String Function(Library, TemplateData);
+typedef ContainerSidebar = String Function(
+    Container, TemplateDataWithContainer);
+typedef LibrarySidebar = String Function(Library, TemplateDataWithLibrary);
 
 abstract class TemplateOptions {
   String get relCanonicalPrefix;
@@ -60,6 +61,20 @@ abstract class TemplateData<T extends Documentable> {
   String _layoutTitle(String name, String kind, bool isDeprecated) =>
       _packageGraph.rendererFactory.templateRenderer
           .composeLayoutTitle(name, kind, isDeprecated);
+}
+
+/// A [TemplateData] which contains a library, for rendering the
+/// sidebar-for-library.
+abstract class TemplateDataWithLibrary<T extends Documentable>
+    implements TemplateData<T> {
+  Library get library;
+}
+
+/// A [TemplateData] which contains a container, for rendering the
+/// sidebar-for-container.
+abstract class TemplateDataWithContainer<T extends Documentable>
+    implements TemplateData<T> {
+  Container get container;
 }
 
 class PackageTemplateData extends TemplateData<Package> {
@@ -119,7 +134,9 @@ class CategoryTemplateData extends TemplateData<Category> {
   Category get self => category;
 }
 
-class LibraryTemplateData extends TemplateData<Library> {
+class LibraryTemplateData extends TemplateData<Library>
+    implements TemplateDataWithLibrary<Library> {
+  @override
   final Library library;
   final LibrarySidebar _sidebarForLibrary;
 
@@ -165,8 +182,10 @@ class MixinTemplateData extends ClassTemplateData<Mixin> {
 }
 
 /// Base template data class for [Class], [Enum], and [Mixin].
-class ClassTemplateData<T extends Class> extends TemplateData<T> {
+class ClassTemplateData<T extends Class> extends TemplateData<T>
+    implements TemplateDataWithLibrary<T>, TemplateDataWithContainer<T> {
   final Class clazz;
+  @override
   final Library library;
   Class _objectType;
   final LibrarySidebar _sidebarForLibrary;
@@ -184,6 +203,7 @@ class ClassTemplateData<T extends Class> extends TemplateData<T> {
   String get sidebarForLibrary => _sidebarForLibrary(library, this);
   String get sidebarForContainer => _sidebarForContainer(container, this);
 
+  @override
   Container get container => clazz;
 
   @override
@@ -219,8 +239,10 @@ class ClassTemplateData<T extends Class> extends TemplateData<T> {
 }
 
 /// Base template data class for [Extension].
-class ExtensionTemplateData<T extends Extension> extends TemplateData<T> {
+class ExtensionTemplateData<T extends Extension> extends TemplateData<T>
+    implements TemplateDataWithLibrary<T>, TemplateDataWithContainer<T> {
   final T extension;
+  @override
   final Library library;
   final ContainerSidebar _sidebarForContainer;
   final LibrarySidebar _sidebarForLibrary;
@@ -237,6 +259,7 @@ class ExtensionTemplateData<T extends Extension> extends TemplateData<T> {
   String get sidebarForContainer => _sidebarForContainer(container, this);
   String get sidebarForLibrary => _sidebarForLibrary(library, this);
 
+  @override
   Container get container => extension;
 
   @override
@@ -258,7 +281,11 @@ class ExtensionTemplateData<T extends Extension> extends TemplateData<T> {
   String get htmlBase => '../';
 }
 
-class ConstructorTemplateData extends TemplateData<Constructor> {
+class ConstructorTemplateData extends TemplateData<Constructor>
+    implements
+        TemplateDataWithLibrary<Constructor>,
+        TemplateDataWithContainer<Constructor> {
+  @override
   final Library library;
   final Class clazz;
   final Constructor constructor;
@@ -275,6 +302,7 @@ class ConstructorTemplateData extends TemplateData<Constructor> {
 
   String get sidebarForContainer => _sidebarForContainer(container, this);
 
+  @override
   Container get container => clazz;
   @override
   Constructor get self => constructor;
@@ -314,8 +342,10 @@ class EnumTemplateData extends ClassTemplateData<Enum> {
   Enum get self => eNum;
 }
 
-class FunctionTemplateData extends TemplateData<ModelFunction> {
+class FunctionTemplateData extends TemplateData<ModelFunction>
+    implements TemplateDataWithLibrary<ModelFunction> {
   final ModelFunction function;
+  @override
   final Library library;
   final LibrarySidebar _sidebarForLibrary;
 
@@ -343,9 +373,14 @@ class FunctionTemplateData extends TemplateData<ModelFunction> {
   String get htmlBase => '../';
 }
 
-class MethodTemplateData extends TemplateData<Method> {
+class MethodTemplateData extends TemplateData<Method>
+    implements
+        TemplateDataWithLibrary<Method>,
+        TemplateDataWithContainer<Method> {
+  @override
   final Library library;
   final Method method;
+  @override
   final Container container;
   final ContainerSidebar _sidebarForContainer;
 
@@ -380,8 +415,13 @@ class MethodTemplateData extends TemplateData<Method> {
   String get htmlBase => '../../';
 }
 
-class PropertyTemplateData extends TemplateData<Field> {
+class PropertyTemplateData extends TemplateData<Field>
+    implements
+        TemplateDataWithLibrary<Field>,
+        TemplateDataWithContainer<Field> {
+  @override
   final Library library;
+  @override
   final Container container;
   final Field property;
   final ContainerSidebar _sidebarForContainer;
@@ -417,7 +457,9 @@ class PropertyTemplateData extends TemplateData<Field> {
   String get htmlBase => '../../';
 }
 
-class TypedefTemplateData extends TemplateData<Typedef> {
+class TypedefTemplateData extends TemplateData<Typedef>
+    implements TemplateDataWithLibrary<Typedef> {
+  @override
   final Library library;
   final Typedef typeDef;
   final LibrarySidebar _sidebarForLibrary;
@@ -447,7 +489,9 @@ class TypedefTemplateData extends TemplateData<Typedef> {
   String get htmlBase => '../';
 }
 
-class TopLevelPropertyTemplateData extends TemplateData<TopLevelVariable> {
+class TopLevelPropertyTemplateData extends TemplateData<TopLevelVariable>
+    implements TemplateDataWithLibrary<TopLevelVariable> {
+  @override
   final Library library;
   final TopLevelVariable property;
   final LibrarySidebar _sidebarForLibrary;

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -113,6 +113,7 @@ class Class extends Container
   Iterable<Constructor> get constructors => element.constructors
       .map((e) => ModelElement.from(e, library, packageGraph) as Constructor);
 
+  @override
   bool get hasPublicConstructors => publicConstructors.isNotEmpty;
 
   @visibleForTesting
@@ -120,6 +121,8 @@ class Class extends Container
       model_utils.filterNonPublic(constructors);
 
   List<Constructor> _publicConstructorsSorted;
+
+  @override
   Iterable<Constructor> get publicConstructorsSorted =>
       _publicConstructorsSorted ??= publicConstructors.toList()..sort(byName);
 

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -74,6 +74,10 @@ abstract class Container extends ModelElement with TypeParameters {
   /// Whether all instance operators are inherited.
   bool get publicInheritedInstanceOperators => false;
 
+  bool get hasPublicConstructors;
+
+  Iterable<Constructor> get publicConstructorsSorted;
+
   @nonVirtual
   bool get hasPublicInstanceMethods =>
       model_utils.filterNonPublic(instanceMethods).isNotEmpty;

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -120,4 +120,10 @@ class Extension extends Container
     assert(canonicalLibrary == library);
     return '${package.baseHref}$filePath';
   }
+
+  @override
+  bool get hasPublicConstructors => false;
+
+  @override
+  Iterable<Constructor> get publicConstructorsSorted => [];
 }


### PR DESCRIPTION
These two interfaces are necessary in order to render certain TemplateData
subtypes into _sidebar_for_library.html and _sidebar_for_container.html,
respectively.

Since _sidebar_for_library.html references `{{#library}}`, the static type
rendered into this template needs a `library` getter. Same for the other
sidebar.

Additionally, _sidebar_for_container.html accesses `hasPublicConstructors` and
`publicConstructorsSorted` on Container, so that type needs those getters.