### PR TITLE
Mustachio: consider types of properties of property types

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -717,79 +717,6 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String _render_Nameable(
-    Nameable context, List<MustachioNode> ast, Template template,
-    {RendererBase<Object> parent}) {
-  var renderer = _Renderer_Nameable(context, parent, template);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class _Renderer_Nameable extends RendererBase<Nameable> {
-  static Map<String, Property<CT_>> propertyMap<CT_ extends Nameable>() => {
-        ..._Renderer_Object.propertyMap<CT_>(),
-        'fullyQualifiedName': Property(
-          getValue: (CT_ c) => c.fullyQualifiedName,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'String'),
-          isNullValue: (CT_ c) => c.fullyQualifiedName == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return renderSimple(c.fullyQualifiedName, ast, r.template,
-                parent: r);
-          },
-        ),
-        'name': Property(
-          getValue: (CT_ c) => c.name,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'String'),
-          isNullValue: (CT_ c) => c.name == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return renderSimple(c.name, ast, r.template, parent: r);
-          },
-        ),
-        'namePart': Property(
-          getValue: (CT_ c) => c.namePart,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'String'),
-          isNullValue: (CT_ c) => c.namePart == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return renderSimple(c.namePart, ast, r.template, parent: r);
-          },
-        ),
-        'namePieces': Property(
-          getValue: (CT_ c) => c.namePieces,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
-          isEmptyIterable: (CT_ c) => c.namePieces?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.namePieces) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-      };
-
-  _Renderer_Nameable(
-      Nameable context, RendererBase<Object> parent, Template template)
-      : super(context, parent, template);
-
-  @override
-  Property<Nameable> getProperty(String key) {
-    if (propertyMap<Nameable>().containsKey(key)) {
-      return propertyMap<Nameable>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
 String _render_Locatable(
     Locatable context, List<MustachioNode> ast, Template template,
     {RendererBase<Object> parent}) {
@@ -864,150 +791,6 @@ class _Renderer_Locatable extends RendererBase<Locatable> {
   Property<Locatable> getProperty(String key) {
     if (propertyMap<Locatable>().containsKey(key)) {
       return propertyMap<Locatable>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
-String _render_Canonicalization(
-    Canonicalization context, List<MustachioNode> ast, Template template,
-    {RendererBase<Object> parent}) {
-  var renderer = _Renderer_Canonicalization(context, parent, template);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
-  static Map<String, Property<CT_>> propertyMap<
-          CT_ extends Canonicalization>() =>
-      {
-        ..._Renderer_Object.propertyMap<CT_>(),
-        'canonicalLibrary': Property(
-          getValue: (CT_ c) => c.canonicalLibrary,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'Library'),
-          isNullValue: (CT_ c) => c.canonicalLibrary == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return renderSimple(c.canonicalLibrary, ast, r.template, parent: r);
-          },
-        ),
-        'commentRefs': Property(
-          getValue: (CT_ c) => c.commentRefs,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(
-                      c, remainingNames, 'List<ModelCommentReference>'),
-          isEmptyIterable: (CT_ c) => c.commentRefs?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.commentRefs) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-        'isCanonical': Property(
-          getValue: (CT_ c) => c.isCanonical,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'bool'),
-          getBool: (CT_ c) => c.isCanonical == true,
-        ),
-        'locationPieces': Property(
-          getValue: (CT_ c) => c.locationPieces,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
-          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
-          renderIterable:
-              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.locationPieces) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
-          },
-        ),
-      };
-
-  _Renderer_Canonicalization(
-      Canonicalization context, RendererBase<Object> parent, Template template)
-      : super(context, parent, template);
-
-  @override
-  Property<Canonicalization> getProperty(String key) {
-    if (propertyMap<Canonicalization>().containsKey(key)) {
-      return propertyMap<Canonicalization>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
-String _render_Warnable(
-    Warnable context, List<MustachioNode> ast, Template template,
-    {RendererBase<Object> parent}) {
-  var renderer = _Renderer_Warnable(context, parent, template);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class _Renderer_Warnable extends RendererBase<Warnable> {
-  static Map<String, Property<CT_>> propertyMap<CT_ extends Warnable>() => {
-        'element': Property(
-          getValue: (CT_ c) => c.element,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                  self.renderSimpleVariable(c, remainingNames, 'Element'),
-          isNullValue: (CT_ c) => c.element == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return renderSimple(c.element, ast, r.template, parent: r);
-          },
-        ),
-        'enclosingElement': Property(
-          getValue: (CT_ c) => c.enclosingElement,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) {
-            if (remainingNames.isEmpty) return self.getValue(c).toString();
-            var name = remainingNames.first;
-            var nextProperty = _Renderer_Warnable.propertyMap().getValue(name);
-            return nextProperty.renderVariable(
-                self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
-          },
-          isNullValue: (CT_ c) => c.enclosingElement == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return _render_Warnable(c.enclosingElement, ast, r.template,
-                parent: r);
-          },
-        ),
-        'package': Property(
-          getValue: (CT_ c) => c.package,
-          renderVariable:
-              (CT_ c, Property<CT_> self, List<String> remainingNames) {
-            if (remainingNames.isEmpty) return self.getValue(c).toString();
-            var name = remainingNames.first;
-            var nextProperty = _Renderer_Package.propertyMap().getValue(name);
-            return nextProperty.renderVariable(
-                self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
-          },
-          isNullValue: (CT_ c) => c.package == null,
-          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            return _render_Package(c.package, ast, r.template, parent: r);
-          },
-        ),
-      };
-
-  _Renderer_Warnable(
-      Warnable context, RendererBase<Object> parent, Template template)
-      : super(context, parent, template);
-
-  @override
-  Property<Warnable> getProperty(String key) {
-    if (propertyMap<Warnable>().containsKey(key)) {
-      return propertyMap<Warnable>()[key];
     } else {
       return null;
     }
@@ -1141,6 +924,223 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
   Property<LibraryContainer> getProperty(String key) {
     if (propertyMap<LibraryContainer>().containsKey(key)) {
       return propertyMap<LibraryContainer>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_Warnable(
+    Warnable context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_Warnable(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_Warnable extends RendererBase<Warnable> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Warnable>() => {
+        'element': Property(
+          getValue: (CT_ c) => c.element,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'Element'),
+          isNullValue: (CT_ c) => c.element == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.element, ast, r.template, parent: r);
+          },
+        ),
+        'enclosingElement': Property(
+          getValue: (CT_ c) => c.enclosingElement,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            var nextProperty = _Renderer_Warnable.propertyMap().getValue(name);
+            return nextProperty.renderVariable(
+                self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+          },
+          isNullValue: (CT_ c) => c.enclosingElement == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_Warnable(c.enclosingElement, ast, r.template,
+                parent: r);
+          },
+        ),
+        'package': Property(
+          getValue: (CT_ c) => c.package,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            var nextProperty = _Renderer_Package.propertyMap().getValue(name);
+            return nextProperty.renderVariable(
+                self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+          },
+          isNullValue: (CT_ c) => c.package == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_Package(c.package, ast, r.template, parent: r);
+          },
+        ),
+      };
+
+  _Renderer_Warnable(
+      Warnable context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<Warnable> getProperty(String key) {
+    if (propertyMap<Warnable>().containsKey(key)) {
+      return propertyMap<Warnable>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_Nameable(
+    Nameable context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_Nameable(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_Nameable extends RendererBase<Nameable> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Nameable>() => {
+        ..._Renderer_Object.propertyMap<CT_>(),
+        'fullyQualifiedName': Property(
+          getValue: (CT_ c) => c.fullyQualifiedName,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'String'),
+          isNullValue: (CT_ c) => c.fullyQualifiedName == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.fullyQualifiedName, ast, r.template,
+                parent: r);
+          },
+        ),
+        'name': Property(
+          getValue: (CT_ c) => c.name,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'String'),
+          isNullValue: (CT_ c) => c.name == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.name, ast, r.template, parent: r);
+          },
+        ),
+        'namePart': Property(
+          getValue: (CT_ c) => c.namePart,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'String'),
+          isNullValue: (CT_ c) => c.namePart == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.namePart, ast, r.template, parent: r);
+          },
+        ),
+        'namePieces': Property(
+          getValue: (CT_ c) => c.namePieces,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
+          isEmptyIterable: (CT_ c) => c.namePieces?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.namePieces) {
+              buffer.write(renderSimple(e, ast, r.template, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+      };
+
+  _Renderer_Nameable(
+      Nameable context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<Nameable> getProperty(String key) {
+    if (propertyMap<Nameable>().containsKey(key)) {
+      return propertyMap<Nameable>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_Canonicalization(
+    Canonicalization context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_Canonicalization(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
+  static Map<String, Property<CT_>> propertyMap<
+          CT_ extends Canonicalization>() =>
+      {
+        ..._Renderer_Object.propertyMap<CT_>(),
+        'canonicalLibrary': Property(
+          getValue: (CT_ c) => c.canonicalLibrary,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'Library'),
+          isNullValue: (CT_ c) => c.canonicalLibrary == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.canonicalLibrary, ast, r.template, parent: r);
+          },
+        ),
+        'commentRefs': Property(
+          getValue: (CT_ c) => c.commentRefs,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(
+                      c, remainingNames, 'List<ModelCommentReference>'),
+          isEmptyIterable: (CT_ c) => c.commentRefs?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.commentRefs) {
+              buffer.write(renderSimple(e, ast, r.template, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+        'isCanonical': Property(
+          getValue: (CT_ c) => c.isCanonical,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'bool'),
+          getBool: (CT_ c) => c.isCanonical == true,
+        ),
+        'locationPieces': Property(
+          getValue: (CT_ c) => c.locationPieces,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
+          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
+          renderIterable:
+              (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            var buffer = StringBuffer();
+            for (var e in c.locationPieces) {
+              buffer.write(renderSimple(e, ast, r.template, parent: r));
+            }
+            return buffer.toString();
+          },
+        ),
+      };
+
+  _Renderer_Canonicalization(
+      Canonicalization context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<Canonicalization> getProperty(String key) {
+    if (propertyMap<Canonicalization>().containsKey(key)) {
+      return propertyMap<Canonicalization>()[key];
     } else {
       return null;
     }

--- a/test/mustachio/foo.dart
+++ b/test/mustachio/foo.dart
@@ -1,4 +1,4 @@
-@Renderer(#renderFoo, Context<Foo>())
+@Renderer(#renderFoo, Context<Foo>(), visibleTypes: {Property1, Property2})
 @Renderer(#renderBar, Context<Bar>())
 @Renderer(#renderBaz, Context<Baz>())
 library dartdoc.testing.foo;
@@ -15,6 +15,7 @@ class Foo extends FooBase<Baz> {
   List<int> l1;
   @override
   Baz baz;
+  Property1 p1;
 }
 
 class Bar {
@@ -26,4 +27,12 @@ class Bar {
 
 class Baz {
   Bar bar;
+}
+
+class Property1 {
+  Property2 p2;
+}
+
+class Property2 {
+  String s;
 }

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -63,6 +63,21 @@ class Renderer_Foo extends RendererBase<Foo> {
             return buffer.toString();
           },
         ),
+        'p1': Property(
+          getValue: (CT_ c) => c.p1,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            var nextProperty = Renderer_Property1.propertyMap().getValue(name);
+            return nextProperty.renderVariable(
+                self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+          },
+          isNullValue: (CT_ c) => c.p1 == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_Property1(c.p1, ast, r.template, parent: r);
+          },
+        ),
         's1': Property(
           getValue: (CT_ c) => c.s1,
           renderVariable:
@@ -128,6 +143,85 @@ class Renderer_Object extends RendererBase<Object> {
   Property<Object> getProperty(String key) {
     if (propertyMap<Object>().containsKey(key)) {
       return propertyMap<Object>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_Property1(
+    Property1 context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Property1(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class Renderer_Property1 extends RendererBase<Property1> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Property1>() => {
+        ...Renderer_Object.propertyMap<CT_>(),
+        'p2': Property(
+          getValue: (CT_ c) => c.p2,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) {
+            if (remainingNames.isEmpty) return self.getValue(c).toString();
+            var name = remainingNames.first;
+            var nextProperty = Renderer_Property2.propertyMap().getValue(name);
+            return nextProperty.renderVariable(
+                self.getValue(c), nextProperty, [...remainingNames.skip(1)]);
+          },
+          isNullValue: (CT_ c) => c.p2 == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return _render_Property2(c.p2, ast, r.template, parent: r);
+          },
+        ),
+      };
+
+  Renderer_Property1(
+      Property1 context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<Property1> getProperty(String key) {
+    if (propertyMap<Property1>().containsKey(key)) {
+      return propertyMap<Property1>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_Property2(
+    Property2 context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = Renderer_Property2(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class Renderer_Property2 extends RendererBase<Property2> {
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Property2>() => {
+        ...Renderer_Object.propertyMap<CT_>(),
+        's': Property(
+          getValue: (CT_ c) => c.s,
+          renderVariable:
+              (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                  self.renderSimpleVariable(c, remainingNames, 'String'),
+          isNullValue: (CT_ c) => c.s == null,
+          renderValue: (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+            return renderSimple(c.s, ast, r.template, parent: r);
+          },
+        ),
+      };
+
+  Renderer_Property2(
+      Property2 context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<Property2> getProperty(String key) {
+    if (propertyMap<Property2>().containsKey(key)) {
+      return propertyMap<Property2>()[key];
     } else {
       return null;
     }

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -21,11 +21,12 @@ void main() {
 
   test('property map contains all public getters', () {
     var propertyMap = Renderer_Foo.propertyMap();
-    expect(propertyMap.keys, hasLength(6));
+    expect(propertyMap.keys, hasLength(7));
     expect(propertyMap['b1'], isNotNull);
     expect(propertyMap['s1'], isNotNull);
     expect(propertyMap['l1'], isNotNull);
     expect(propertyMap['baz'], isNotNull);
+    expect(propertyMap['p1'], isNotNull);
     expect(propertyMap['hashCode'], isNotNull);
     expect(propertyMap['runtimeType'], isNotNull);
   });
@@ -261,13 +262,21 @@ void main() {
   });
 
   test('Renderer resolves variable with key with multiple names', () async {
-    var barTemplateFile = getFile('/project/foo.mustache')
+    var barTemplateFile = getFile('/project/bar.mustache')
       ..writeAsStringSync('Text {{foo.s1}}');
     var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()
       ..foo = (Foo()..s1 = 'hello')
       ..s2 = 'goodbye';
     expect(renderBar(bar, barTemplate), equals('Text hello'));
+  });
+
+  test('Renderer resolves variable with properties not in @Renderer', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
+      ..writeAsStringSync('Text {{p1.p2.s}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
+    var foo = Foo()..p1 = (Property1()..p2 = (Property2()..s = 'hello'));
+    expect(renderFoo(foo, fooTemplate), equals('Text hello'));
   });
 
   test('Renderer resolves outer variable with key with two names', () async {

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -160,8 +160,8 @@ import '${p.basename(_sourceUri.path)}';
       return;
     }
 
-    var isFullRenderer = _isVisibleToMustache(type.element);
-    _addTypeHierarchyToProcess(type, isFullRenderer: isFullRenderer);
+    _addTypeHierarchyToProcess(type,
+        isFullRenderer: _isVisibleToMustache(type.element));
   }
 
   /// Returns an [InterfaceType] which may be relevant for generating a

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -150,47 +150,78 @@ import '${p.basename(_sourceUri.path)}';
   void _addPropertyToProcess(PropertyAccessorElement property) {
     if (property.isPrivate || property.isStatic || property.isSetter) return;
     if (property.hasProtected || property.hasVisibleForTesting) return;
-    var type = property.type.returnType;
-    if (type is TypeParameterType) {
-      var bound = (type as TypeParameterType).bound;
+    var type = _relevantTypeFrom(property.type.returnType);
+    if (type == null) return;
+
+    var types = _typesToProcess.where((rs) => rs._contextClass == type.element);
+    if (types.isNotEmpty) {
+      // [type] has already been added to [_typesToProcess], and all of its
+      // supertypes and properties have been visited.
+      return;
+    }
+
+    var isFullRenderer = _isVisibleToMustache(type.element);
+    _addTypeHierarchyToProcess(type, isFullRenderer: isFullRenderer);
+  }
+
+  /// Returns an [InterfaceType] which may be relevant for generating a
+  /// renderer, given a [type]:
+  ///
+  /// * If [type] is assignable to [Iterable<T>], returns the relevant type from
+  ///   `T`.
+  /// * If [type] is a [TypeParameterType] with a bound other than `dynamic`,
+  ///   returns the relevant type from the bound.
+  /// * If [type] is an [InterfaceType] (not assignable to [Iterable]), returns
+  ///   [type].
+  /// * Otherwise, returns `null`, indicating there is no relevant type.
+  InterfaceType _relevantTypeFrom(DartType type) {
+    if (type is InterfaceType) {
+      if (_typeSystem.isAssignableTo(type, _typeProvider.iterableDynamicType)) {
+        var iterableElement = _typeProvider.iterableElement;
+        var iterableType = type.asInstanceOf(iterableElement);
+        var innerType = iterableType.typeArguments.first;
+
+        return _relevantTypeFrom(innerType);
+      } else {
+        return type;
+      }
+    } else if (type is TypeParameterType) {
+      var bound = type.bound;
       if (bound == null || bound.isDynamic) {
         // Don't add functions for a generic type, for example
         // `List<E>.first` has type `E`, which we don't have a specific
         // renderer for.
         // TODO(srawlins): Find a solution for this. We can track all of the
         // concrete types substituted for `E` for example.
-        return;
+        return null;
+      } else {
+        return _relevantTypeFrom(bound);
       }
-      type = bound;
-    }
-
-    if (type is InterfaceType) {
-      if (_typeSystem.isAssignableTo(type, _typeProvider.iterableDynamicType)) {
-        var iterableElement = _typeProvider.iterableElement;
-        var iterableType = type.asInstanceOf(iterableElement);
-        var innerType = iterableType.typeArguments.first;
-        if (innerType is InterfaceType) {
-          // Don't add Iterable functions for a generic type, for example
-          // `List<E>.reversed` has inner type `E`, which we don't have a
-          // specific renderer for.
-          // TODO(srawlins): Find a solution for this. We can track all of the
-          // concrete types substituted for `E` for example.
-          var isFullRenderer = _isVisibleToMustache(innerType.element);
-          _addTypeHierarchyToProcess(innerType, isFullRenderer: isFullRenderer);
-        }
-      }
-
-      var isFullRenderer = _isVisibleToMustache(type.element);
-      _addTypeHierarchyToProcess(type, isFullRenderer: isFullRenderer);
+    } else {
+      // We can do nothing with function types, etc.
+      return null;
     }
   }
 
-  /// Adds [type] to the queue of types to process, as well as its supertypes
-  /// (if a class), mixed in types, and superclass constraints (if a mixin).
+  /// Adds [type] to the queue of types to process, as well as related types:
+  ///
+  /// * its supertypes (if [type] is not a mixin),
+  /// * mixed in types,
+  /// * superclass constraints (if [type] a mixin),
+  /// * types of relevant properties (recursively).
   void _addTypeHierarchyToProcess(InterfaceType type,
       {@required bool isFullRenderer}) {
     while (type != null) {
       _addTypeToProcess(type.element, isFullRenderer: isFullRenderer);
+      if (isFullRenderer) {
+        for (var accessor in type.accessors) {
+          var accessorType = _relevantTypeFrom(accessor.type.returnType);
+          if (accessorType == null) continue;
+          var accessorElement = accessorType.element;
+          _addTypeToProcess(accessorElement,
+              isFullRenderer: _isVisibleToMustache(accessorElement));
+        }
+      }
       for (var mixin in type.element.mixins) {
         _addTypeToProcess(mixin.element, isFullRenderer: isFullRenderer);
       }


### PR DESCRIPTION
This change allows mustachio to search properties of properties in order to build all of the necessary renderers.

A common functionality of extracting a meaningful InterfaceType from a Dart type is moved into a helper method, `_getRelevantTypeFrom`. If there is a better name for this, or a better word than `relevant`, I'm all ears.

For all of the refactoring in this change, the meat is around line 225 of codegen_runtime_renderer.dart, where we newly add types to process.