### PR TITLE
Cleanup some toString methods

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -168,7 +168,7 @@ class ToolDefinition {
   String toString() {
     final commandString =
         '${this is DartToolDefinition ? '(Dart) ' : ''}"${command.join(' ')}"';
-    if (setupCommand == null || setupCommand.isEmpty) {
+    if (setupCommand == null) {
       return '$runtimeType: $commandString ($description)';
     } else {
       return '$runtimeType: $commandString, with setup command '

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -168,7 +168,7 @@ class ToolDefinition {
   String toString() {
     final commandString =
         '${this is DartToolDefinition ? '(Dart) ' : ''}"${command.join(' ')}"';
-    if (setupCommand == null) {
+    if (setupCommand == null || setupCommand.isEmpty) {
       return '$runtimeType: $commandString ($description)';
     } else {
       return '$runtimeType: $commandString, with setup command '

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -704,15 +704,17 @@ class PackageGraph {
 
   @override
   String toString() {
-    final divider = '=========================================================';
-    final buffer =
-        StringBuffer('PackageGraph built from ${defaultPackage.name}');
+    const divider = '=========================================================';
+    final buffer = StringBuffer('PackageGraph built from ');
+    buffer.writeln(defaultPackageName);
     buffer.writeln(divider);
     buffer.writeln();
     for (final name in packageMap.keys) {
       final package = packageMap[name];
-      buffer.writeln('Package $name documented at ${package.documentedWhere} '
-          'with libraries: ${package.allLibraries}');
+      buffer.write('Package $name documented at ${package.documentedWhere} '
+          'with libraries: ');
+      buffer.writeAll(package.allLibraries);
+      buffer.writeln();
     }
     buffer.writeln(divider);
     return buffer.toString();

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -499,10 +499,10 @@ class PackageWarningCounter {
 
   @override
   String toString() {
-    var errors = '$errorCount ${errorCount == 1 ? "error" : "errors"}';
-    var warnings =
+    final errors = '$errorCount ${errorCount == 1 ? "error" : "errors"}';
+    final warnings =
         '$warningCount ${warningCount == 1 ? "warning" : "warnings"}';
-    return [errors, warnings].join(', ');
+    return '$errors, $warnings';
   }
 }
 


### PR DESCRIPTION
Some minor cleanup to a few toString() methods. These changes all result in net-positive, but rather insignificant performance improvements on the VM.

Changes:
- In the `ToolDefinition#toString` only include `setupCommand` piece if it's not empty
- In the `PackageGraph#toString` put the divider on a separate line from the title and only include the libraries section if it is not empty