### PR TITLE
Remove unnecessary use of list view

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -5,8 +5,6 @@
 /// The models used to represent Dart code.
 library dartdoc.element_type;
 
-import 'dart:collection';
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -93,7 +91,8 @@ abstract class ElementType extends Privacy {
     return '';
   }
 
-  List<Parameter> get parameters => [];
+  /// An unmodifiable list of this [ElementType]'s parameters.
+  List<Parameter> get parameters => const <Parameter>[];
 
   DartType get instantiatedType;
 
@@ -163,12 +162,9 @@ class FunctionTypeElementType extends UndefinedElementType {
   FunctionType get type => super.type;
 
   @override
-  List<Parameter> get parameters {
-    var params = type.parameters;
-    return UnmodifiableListView<Parameter>(params
-        .map((p) => ModelElement.from(p, library, packageGraph) as Parameter)
-        .toList());
-  }
+  List<Parameter> get parameters => type.parameters
+      .map((p) => ModelElement.from(p, library, packageGraph) as Parameter)
+      .toList(growable: false);
 
   ElementType get returnType =>
       ElementType.from(type.returnType, library, packageGraph, this);
@@ -190,13 +186,10 @@ class FunctionTypeElementType extends UndefinedElementType {
     return _nameWithGenerics;
   }
 
-  List<TypeParameter> get typeFormals {
-    var typeFormals = type.typeFormals;
-    return UnmodifiableListView<TypeParameter>(typeFormals
-        .map(
-            (p) => ModelElement.from(p, library, packageGraph) as TypeParameter)
-        .toList());
-  }
+  /// An unmodifiable list of this [FunctionTypeElementType]'s type parameters.
+  List<TypeParameter> get typeFormals => type.typeFormals
+      .map((p) => ModelElement.from(p, library, packageGraph) as TypeParameter)
+      .toList(growable: false);
 
   @override
   String get name => 'Function';

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -91,7 +91,7 @@ abstract class ElementType extends Privacy {
     return '';
   }
 
-  /// An unmodifiable list of this [ElementType]'s parameters.
+  /// An unmodifiable list of this element type's parameters.
   List<Parameter> get parameters => const <Parameter>[];
 
   DartType get instantiatedType;
@@ -186,7 +186,7 @@ class FunctionTypeElementType extends UndefinedElementType {
     return _nameWithGenerics;
   }
 
-  /// An unmodifiable list of this [FunctionTypeElementType]'s type parameters.
+  /// An unmodifiable list of this function element's type parameters.
   List<TypeParameter> get typeFormals => type.typeFormals
       .map((p) => ModelElement.from(p, library, packageGraph) as TypeParameter)
       .toList(growable: false);
@@ -286,11 +286,13 @@ abstract class DefinedElementType extends ElementType {
   String createLinkedReturnTypeName() => returnType.linkedName;
 
   Iterable<ElementType> _typeArguments;
+
+  /// An unmodifiable list of this element type's parameters.
   Iterable<ElementType> get typeArguments {
     _typeArguments ??= (type as ParameterizedType)
         .typeArguments
         .map((f) => ElementType.from(f, library, packageGraph))
-        .toList();
+        .toList(growable: false);
     return _typeArguments;
   }
 

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -288,13 +288,11 @@ abstract class DefinedElementType extends ElementType {
   Iterable<ElementType> _typeArguments;
 
   /// An unmodifiable list of this element type's parameters.
-  Iterable<ElementType> get typeArguments {
-    _typeArguments ??= (type as ParameterizedType)
-        .typeArguments
-        .map((f) => ElementType.from(f, library, packageGraph))
-        .toList(growable: false);
-    return _typeArguments;
-  }
+  Iterable<ElementType> get typeArguments =>
+      _typeArguments ??= (type as ParameterizedType)
+          .typeArguments
+          .map((f) => ElementType.from(f, library, packageGraph))
+          .toList(growable: false);
 
   DartType get _bound => type;
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -5,7 +5,6 @@
 /// The models used to represent Dart code.
 library dartdoc.models;
 
-import 'dart:collection' show UnmodifiableListView;
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
@@ -1097,9 +1096,9 @@ abstract class ModelElement extends Canonicalization
         params = (element as FunctionTypeAliasElement).function.parameters;
       }
 
-      _parameters = UnmodifiableListView<Parameter>(params
+      _parameters = UnmodifiableListView(params
           .map((p) => ModelElement.from(p, library, packageGraph) as Parameter)
-          .toList());
+          .toList(growable: false));
     }
     return _parameters;
   }


### PR DESCRIPTION
We don't need to use a list view in these cases as we are creating the list as needed so the caller won't share it. I've also made them not `growable` as they don't need to be modified afterwards.