### PR TITLE
Minor cleanup to generator utils

### DIFF
--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -86,15 +86,13 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   @override
   void generateCategoryJson(
       FileWriter writer, List<Categorization> categories) {
-    String json;
+    var json = '';
     if (categories.isNotEmpty) {
       json = generator_util.generateCategoryJson(
           categories, options.prettyIndexJson);
       if (!options.useBaseHref) {
         json = json.replaceAll(htmlBasePlaceholder, '');
       }
-    } else {
-      json = '';
     }
 
     writer.write(_pathContext.join('categories.json'), '${json}\n');

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -86,16 +86,17 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   @override
   void generateCategoryJson(
       FileWriter writer, List<Categorization> categories) {
-    if (categories.isEmpty) {
-      writer.write(_pathContext.join('categories.json'), '\n');
-      return;
+    String json;
+    if (categories.isNotEmpty) {
+      json = generator_util.generateCategoryJson(
+          categories, options.prettyIndexJson);
+      if (!options.useBaseHref) {
+        json = json.replaceAll(htmlBasePlaceholder, '');
+      }
+    } else {
+      json = '';
     }
 
-    var json = generator_util.generateCategoryJson(
-        categories, options.prettyIndexJson);
-    if (!options.useBaseHref) {
-      json = json.replaceAll(htmlBasePlaceholder, '');
-    }
     writer.write(_pathContext.join('categories.json'), '${json}\n');
   }
 

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -86,6 +86,11 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   @override
   void generateCategoryJson(
       FileWriter writer, List<Categorization> categories) {
+    if (categories.isEmpty) {
+      writer.write(_pathContext.join('categories.json'), '\n');
+      return;
+    }
+
     var json = generator_util.generateCategoryJson(
         categories, options.prettyIndexJson);
     if (!options.useBaseHref) {

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -14,30 +14,29 @@ import 'package:dartdoc/src/model/model_element.dart';
 /// will likely want the same content for this.
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   // ignore: omit_local_variable_types
-  final List<Map<String, Object>> indexItems = categories
-      .map((Categorization categorization) {
-        final data = <String, Object>{
-          'name': categorization.name,
-          'qualifiedName': categorization.fullyQualifiedName,
-          'href': categorization.href,
-          'type': categorization.kind,
-        };
+  final List<Map<String, Object>> indexItems =
+      categories.map((Categorization categorization) {
+    final data = <String, Object>{
+      'name': categorization.name,
+      'qualifiedName': categorization.fullyQualifiedName,
+      'href': categorization.href,
+      'type': categorization.kind,
+    };
 
-        if (categorization.hasCategoryNames) {
-          data['categories'] = categorization.categoryNames;
-        }
-        if (categorization.hasSubCategoryNames) {
-          data['subcategories'] = categorization.subCategoryNames;
-        }
-        if (categorization.hasImage) {
-          data['image'] = categorization.image;
-        }
-        if (categorization.hasSamples) {
-          data['samples'] = categorization.samples;
-        }
-        return data;
-      })
-      .sorted(_sortElementRepresentations);
+    if (categorization.hasCategoryNames) {
+      data['categories'] = categorization.categoryNames;
+    }
+    if (categorization.hasSubCategoryNames) {
+      data['subcategories'] = categorization.subCategoryNames;
+    }
+    if (categorization.hasImage) {
+      data['image'] = categorization.image;
+    }
+    if (categorization.hasSamples) {
+      data['samples'] = categorization.samples;
+    }
+    return data;
+  }).sorted(_sortElementRepresentations);
 
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
@@ -49,30 +48,28 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
 /// generators will likely want the same content for this.
 String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
-  final indexItems = indexedElements
-      .map((Indexable indexable) {
-        final data = <String, Object>{
-          'name': indexable.name,
-          'qualifiedName': indexable.fullyQualifiedName,
-          'href': indexable.href,
-          'type': indexable.kind,
-          'overriddenDepth': indexable.overriddenDepth,
-        };
-        if (indexable is ModelElement) {
-          data['packageName'] = indexable.package.name;
-        }
-        if (indexable is EnclosedElement) {
-          final ee = indexable as EnclosedElement;
-          data['enclosedBy'] = {
-            'name': ee.enclosingElement.name,
-            'type': ee.enclosingElement.kind
-          };
+  final indexItems = indexedElements.map((Indexable indexable) {
+    final data = <String, Object>{
+      'name': indexable.name,
+      'qualifiedName': indexable.fullyQualifiedName,
+      'href': indexable.href,
+      'type': indexable.kind,
+      'overriddenDepth': indexable.overriddenDepth,
+    };
+    if (indexable is ModelElement) {
+      data['packageName'] = indexable.package.name;
+    }
+    if (indexable is EnclosedElement) {
+      final ee = indexable as EnclosedElement;
+      data['enclosedBy'] = {
+        'name': ee.enclosingElement.name,
+        'type': ee.enclosingElement.kind
+      };
 
-          data['qualifiedName'] = indexable.fullyQualifiedName;
-        }
-        return data;
-      })
-      .sorted(_sortElementRepresentations);
+      data['qualifiedName'] = indexable.fullyQualifiedName;
+    }
+    return data;
+  }).sorted(_sortElementRepresentations);
 
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -13,8 +13,6 @@ import 'package:dartdoc/src/model/model_element.dart';
 /// Convenience function to generate category JSON since different generators
 /// will likely want the same content for this.
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
-  final encoder =
-      pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
   // ignore: omit_local_variable_types
   final List<Map<String, Object>> indexItems = categories
       .map((Categorization cat) {
@@ -42,6 +40,9 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
       .sorted(_sortElements)
       .toList(growable: false);
 
+  final encoder =
+      pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
+
   return encoder.convert(indexItems);
 }
 
@@ -49,8 +50,6 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
 /// generators will likely want the same content for this.
 String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
-  final encoder =
-      pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
   final indexItems = indexedElements
       .map((Indexable ind) {
         final data = <String, Object>{
@@ -76,6 +75,9 @@ String generateSearchIndexJson(
       })
       .sorted(_sortElements)
       .toList(growable: false);
+
+  final encoder =
+      pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
 
   return encoder.convert(indexItems);
 }

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -15,30 +15,29 @@ import 'package:dartdoc/src/model/model_element.dart';
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   // ignore: omit_local_variable_types
   final List<Map<String, Object>> indexItems = categories
-      .map((Categorization cat) {
+      .map((Categorization categorization) {
         final data = <String, Object>{
-          'name': cat.name,
-          'qualifiedName': cat.fullyQualifiedName,
-          'href': cat.href,
-          'type': cat.kind,
+          'name': categorization.name,
+          'qualifiedName': categorization.fullyQualifiedName,
+          'href': categorization.href,
+          'type': categorization.kind,
         };
 
-        if (cat.hasCategoryNames) {
-          data['categories'] = cat.categoryNames;
+        if (categorization.hasCategoryNames) {
+          data['categories'] = categorization.categoryNames;
         }
-        if (cat.hasSubCategoryNames) {
-          data['subcategories'] = cat.subCategoryNames;
+        if (categorization.hasSubCategoryNames) {
+          data['subcategories'] = categorization.subCategoryNames;
         }
-        if (cat.hasImage) {
-          data['image'] = cat.image;
+        if (categorization.hasImage) {
+          data['image'] = categorization.image;
         }
-        if (cat.hasSamples) {
-          data['samples'] = cat.samples;
+        if (categorization.hasSamples) {
+          data['samples'] = categorization.samples;
         }
         return data;
       })
-      .sorted(_sortElements)
-      .toList(growable: false);
+      .sorted(_sortElementRepresentations);
 
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
@@ -51,30 +50,29 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
 String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
   final indexItems = indexedElements
-      .map((Indexable ind) {
+      .map((Indexable indexable) {
         final data = <String, Object>{
-          'name': ind.name,
-          'qualifiedName': ind.fullyQualifiedName,
-          'href': ind.href,
-          'type': ind.kind,
-          'overriddenDepth': ind.overriddenDepth,
+          'name': indexable.name,
+          'qualifiedName': indexable.fullyQualifiedName,
+          'href': indexable.href,
+          'type': indexable.kind,
+          'overriddenDepth': indexable.overriddenDepth,
         };
-        if (ind is ModelElement) {
-          data['packageName'] = ind.package.name;
+        if (indexable is ModelElement) {
+          data['packageName'] = indexable.package.name;
         }
-        if (ind is EnclosedElement) {
-          final ee = ind as EnclosedElement;
+        if (indexable is EnclosedElement) {
+          final ee = indexable as EnclosedElement;
           data['enclosedBy'] = {
             'name': ee.enclosingElement.name,
             'type': ee.enclosingElement.kind
           };
 
-          data['qualifiedName'] = ind.fullyQualifiedName;
+          data['qualifiedName'] = indexable.fullyQualifiedName;
         }
         return data;
       })
-      .sorted(_sortElements)
-      .toList(growable: false);
+      .sorted(_sortElementRepresentations);
 
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
@@ -82,7 +80,7 @@ String generateSearchIndexJson(
   return encoder.convert(indexItems);
 }
 
-int _sortElements(Map<String, Object> a, Map<String, Object> b) {
+int _sortElementRepresentations(Map<String, Object> a, Map<String, Object> b) {
   final value = compareNatural(a['qualifiedName'], b['qualifiedName']);
   if (value == 0) {
     return compareNatural(a['type'], b['type']);


### PR DESCRIPTION
There's no functional change here, just some small cleanup:

- Use a const version of the JsonEncoder as we don't need a new instance
- Sort before turning into a list and abstract the shared sort functionality into a private method
- Specify the lists as non-growable
- Rename some variables to better indicate what they are

Sorry about the crazy formatting changes, I guess moving the sort method out really changed the `dartfmt` output.