### PR TITLE
Cleanup misc list construction

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:collection/collection.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -75,7 +76,7 @@ class Class extends Container
 
   @override
   Iterable<Method> get instanceMethods =>
-      quiver.concat([super.instanceMethods, inheritedMethods]);
+      [...super.instanceMethods, ...inheritedMethods];
 
   @override
   bool get publicInheritedInstanceMethods =>
@@ -83,7 +84,7 @@ class Class extends Container
 
   @override
   Iterable<Operator> get instanceOperators =>
-      quiver.concat([super.instanceOperators, inheritedOperators]);
+      [...super.instanceOperators, ...inheritedOperators];
 
   @override
   bool get publicInheritedInstanceOperators =>
@@ -93,13 +94,8 @@ class Class extends Container
 
   @override
   List<ModelElement> get allModelElements {
-    _allModelElements ??= List.from(
-        quiver.concat<ModelElement>([
-          super.allModelElements,
-          constructors,
-          typeParameters,
-        ]),
-        growable: false);
+    _allModelElements ??= List.unmodifiable(
+        [...super.allModelElements, ...constructors, ...typeParameters]);
     return _allModelElements;
   }
 

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -4,12 +4,10 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:collection/collection.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:meta/meta.dart';
 
 /// A [Container] defined with a `class` declaration in Dart.

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:meta/meta.dart';
 
 /// A [Container] represents a Dart construct that can contain methods,

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -46,15 +46,15 @@ abstract class Container extends ModelElement with TypeParameters {
       element is ClassElement && (element as ClassElement).isMixin;
 
   @mustCallSuper
-  Iterable<ModelElement> get allModelElements => quiver.concat([
-        instanceMethods,
-        instanceFields,
-        instanceOperators,
-        instanceAccessors,
-        staticFields,
-        staticAccessors,
-        staticMethods,
-      ]);
+  Iterable<ModelElement> get allModelElements => [
+        ...instanceMethods,
+        ...instanceFields,
+        ...instanceOperators,
+        ...instanceAccessors,
+        ...staticFields,
+        ...staticAccessors,
+        ...staticMethods,
+      ];
 
   /// All methods, including operators and statics, declared as part of this
   /// [Container].  [declaredMethods] must be the union of [instanceMethods],

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:dartdoc/src/quiver.dart' as quiver;
 
 /// Extension methods
 class Extension extends Container

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -99,12 +99,8 @@ class Extension extends Container
   List<ModelElement> _allModelElements;
   @override
   List<ModelElement> get allModelElements {
-    _allModelElements ??= List.from(
-        quiver.concat<ModelElement>([
-          super.allModelElements,
-          typeParameters,
-        ]),
-        growable: false);
+    _allModelElements ??=
+        List.unmodifiable([...super.allModelElements, ...typeParameters]);
     return _allModelElements;
   }
 

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -99,16 +99,16 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
 
   static Iterable<Element> _getDefinedElements(
       CompilationUnitElement compilationUnit) {
-    return quiver.concat([
-      compilationUnit.accessors,
-      compilationUnit.enums,
-      compilationUnit.extensions,
-      compilationUnit.functions,
-      compilationUnit.functionTypeAliases,
-      compilationUnit.mixins,
-      compilationUnit.topLevelVariables,
-      compilationUnit.types,
-    ]);
+    return [
+      ...compilationUnit.accessors,
+      ...compilationUnit.enums,
+      ...compilationUnit.extensions,
+      ...compilationUnit.functions,
+      ...compilationUnit.functionTypeAliases,
+      ...compilationUnit.mixins,
+      ...compilationUnit.topLevelVariables,
+      ...compilationUnit.types,
+    ];
   }
 
   @Deprecated(
@@ -598,36 +598,24 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
 
   HashMap<Element, Set<ModelElement>> get modelElementsMap {
     if (_modelElementsMap == null) {
-      var results = quiver.concat(<Iterable<ModelElement>>[
-        library.constants,
-        library.functions,
-        library.properties,
-        library.typedefs,
-        library.extensions.expand((e) {
-          return quiver.concat([
-            [e],
-            e.allModelElements
-          ]);
+      final results = [
+        ...library.constants,
+        ...library.functions,
+        ...library.properties,
+        ...library.typedefs,
+        ...library.extensions.expand((e) {
+          return [e, ...e.allModelElements];
         }),
-        library.allClasses.expand((c) {
-          return quiver.concat([
-            [c],
-            c.allModelElements
-          ]);
+        ...library.allClasses.expand((c) {
+          return [c, ...c.allModelElements];
         }),
-        library.enums.expand((e) {
-          return quiver.concat([
-            [e],
-            e.allModelElements
-          ]);
+        ...library.enums.expand((e) {
+          return [e, ...e.allModelElements];
         }),
-        library.mixins.expand((m) {
-          return quiver.concat([
-            [m],
-            m.allModelElements
-          ]);
+        ...library.mixins.expand((m) {
+          return [m, ...m.allModelElements];
         }),
-      ]);
+      ];
       _modelElementsMap = HashMap<Element, Set<ModelElement>>();
       results.forEach((modelElement) {
         _modelElementsMap

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -15,7 +15,6 @@ import 'package:analyzer/src/generated/sdk.dart';
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart' show PackageMeta;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:dartdoc/src/warnings.dart';
 
 /// Find all hashable children of a given element that are defined in the

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -354,7 +354,7 @@ class PubPackageBuilder implements PackageBuilder {
               autoIncludeDependencies: config.autoIncludeDependencies)
           .toList();
     }
-    files = quiver.concat([files, _includeExternalsFrom(files)]);
+    files = [...files, ..._includeExternalsFrom(files)];
     return {
       ...files.map((s) => resourceProvider.pathContext
           .absolute(resourceProvider.getFile(s).path)),

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -18,7 +18,6 @@ import 'package:analyzer/src/generated/source_io.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart' hide Package;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart'
     show PackageMeta, PackageMetaProvider;

--- a/lib/src/quiver.dart
+++ b/lib/src/quiver.dart
@@ -9,6 +9,7 @@
 /// Returns the concatenation of the input iterables.
 ///
 /// The returned iterable is a lazily-evaluated view on the input iterables.
+@Deprecated('Use the spread(...) operator instead')
 Iterable<T> concat<T>(Iterable<Iterable<T>> iterables) =>
     iterables.expand((x) => x);
 

--- a/test/quiver_test.dart
+++ b/test/quiver_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:test/test.dart';
 import 'package:dartdoc/src/quiver.dart';
 


### PR DESCRIPTION
Cleanup some miscellaneous list construction. The main change here is switching from`quiver.concat` to the built-in spread operator when applicable.