### PR TITLE
Clean up warnings handling

### DIFF
--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -428,12 +428,12 @@ class PackageWarningCounter {
 
   int _errorCount = 0;
 
-  /// The total amount of errors this package has experienced
+  /// The total amount of errors this package has experienced.
   int get errorCount => _errorCount;
 
   int _warningCount = 0;
 
-  /// The total amount of warnings this package has experiences
+  /// The total amount of warnings this package has experienced.
   int get warningCount => _warningCount;
 
   /// An unmodifiable map view of all counted warnings related by their element,
@@ -479,10 +479,11 @@ class PackageWarningCounter {
     _items.clear();
   }
 
-  /// Whether this package had any warnings at all
+  /// If this package has had any warnings counted.
   bool get hasWarnings => _countedWarnings.isNotEmpty;
 
-  /// Gets if we've already warned for this [element], [kind], and [message]
+  /// Returns `true` if we've already warned for this
+  /// combination of [element], [kind], and [message].
   bool hasWarning(Warnable element, PackageWarning kind, String message) {
     final warning = _countedWarnings[element?.element];
     if (warning != null) {

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -32,8 +32,10 @@ void main() {
   Matcher hasMissingExampleWarning(String message) =>
       _HasWarning(PackageWarning.missingExampleFile, message);
 
-  void expectNoWarnings() =>
-      expect(packageGraph.packageWarningCounter.countedWarnings, isEmpty);
+  void expectNoWarnings() {
+    expect(packageGraph.packageWarningCounter.hasWarnings, isFalse);
+    expect(packageGraph.packageWarningCounter.countedWarnings, isEmpty);
+  }
 
   group('documentation_comment tests', () {
     setUp(() async {

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -12,7 +12,6 @@ import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:dartdoc/src/tuple.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -147,10 +146,8 @@ void main() {
       var results = await dartdoc.generateDocsBase();
       var p = results.packageGraph;
       var unresolvedToolErrors = p.packageWarningCounter.countedWarnings.values
-          .expand<String>((Set<Tuple2<PackageWarning, String>> s) => s
-              .where((Tuple2<PackageWarning, String> t) =>
-                  t.item1 == PackageWarning.toolError)
-              .map<String>((Tuple2<PackageWarning, String> t) => t.item2));
+          .map((e) => e[PackageWarning.toolError] ?? {})
+          .expand((element) => element);
 
       expect(p.packageWarningCounter.errorCount, equals(1));
       expect(unresolvedToolErrors.length, equals(1));
@@ -165,10 +162,8 @@ void main() {
       var p = results.packageGraph;
       var unresolvedExportWarnings = p
           .packageWarningCounter.countedWarnings.values
-          .expand<String>((Set<Tuple2<PackageWarning, String>> s) => s
-              .where((Tuple2<PackageWarning, String> t) =>
-                  t.item1 == PackageWarning.unresolvedExport)
-              .map<String>((Tuple2<PackageWarning, String> t) => t.item2));
+          .map((e) => e[PackageWarning.unresolvedExport] ?? {})
+          .expand((element) => element);
 
       expect(unresolvedExportWarnings.length, equals(1));
       expect(unresolvedExportWarnings.first,

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -15,7 +15,6 @@ import 'package:dartdoc/src/render/model_element_renderer.dart';
 import 'package:dartdoc/src/render/parameter_renderer.dart';
 import 'package:dartdoc/src/render/typedef_renderer.dart';
 import 'package:dartdoc/src/special_elements.dart';
-import 'package:dartdoc/src/tuple.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:test/test.dart';
 
@@ -905,11 +904,11 @@ void main() {
                 '<a href="%%__HTMLBASE_dartdoc_internal__%%reexport_two/BaseReexported/action.html">ExtendedBaseReexported.action</a></p>'));
         var doAwesomeStuffWarnings = packageGraph.packageWarningCounter
                 .countedWarnings[doAwesomeStuff.element] ??
-            [];
+            {};
         expect(
             doAwesomeStuffWarnings,
-            isNot(anyElement((Tuple2<PackageWarning, String> e) =>
-                e.item1 == PackageWarning.ambiguousDocReference)));
+            isNot(doAwesomeStuffWarnings
+                .containsKey(PackageWarning.ambiguousDocReference)));
       });
 
       test('can handle renamed imports', () {


### PR DESCRIPTION
Some minor clean up to the warnings handling and limit external value manipulation.

- `packageWarningsByName` is generated using a map literal, which benchmarked slightly faster
- The use of tuples was removed from `PackageWarningCounter.countedWarnings`, instead just using a nested map. This allows easier access to the relations and is a more natural structure for checking for presence of various pairs.
- External access to `countedWarnings` is now an unmodifiable map view so the caller cannot manipulate the map outside of using the public methods.
- External access to `errorCount` and `warningCount` is now limited to a getter.

**Breaking Change:**
- `PackageWarningCounter.countedWarnings` no longer contains tuples as values but rather Maps from the warning kind to their message.
- Users can no longer set `PackageWarningCounter.errorCount` and `PackageWarningCounter.warningCount`, the values can only be retrieved.