### PR TITLE
Minor typedef renderer cleanup

### DIFF
--- a/lib/src/render/renderer_factory.dart
+++ b/lib/src/render/renderer_factory.dart
@@ -101,7 +101,7 @@ class HtmlRenderFactory extends RendererFactory {
       TypeParametersRendererHtml();
 
   @override
-  TypedefRenderer get typedefRenderer => TypedefRendererHtml();
+  TypedefRenderer get typedefRenderer => const TypedefRendererHtml();
 
   @override
   FeatureRenderer get featureRenderer => FeatureRendererHtml();
@@ -154,7 +154,7 @@ class MdRenderFactory extends RendererFactory {
       TypeParametersRendererMd();
 
   @override
-  TypedefRenderer get typedefRenderer => TypedefRendererMd();
+  TypedefRenderer get typedefRenderer => const TypedefRendererMd();
 
   @override
   FeatureRenderer get featureRenderer => FeatureRendererMd();

--- a/lib/src/render/typedef_renderer.dart
+++ b/lib/src/render/typedef_renderer.dart
@@ -4,30 +4,49 @@
 
 import 'package:dartdoc/src/model/typedef.dart';
 
+/// A renderer for a [Typedef].
 abstract class TypedefRenderer {
+  const TypedefRenderer();
+
+  /// Render the the generic type parameters of the specified [typedef].
   String renderGenericParameters(Typedef typedef);
 }
 
+/// A HTML renderer for a [Typedef].
 class TypedefRendererHtml extends TypedefRenderer {
+  const TypedefRendererHtml();
+
   @override
   String renderGenericParameters(Typedef typedef) {
-    if (typedef.genericTypeParameters.isEmpty) {
+    final genericTypeParameters = typedef.genericTypeParameters;
+    if (genericTypeParameters.isEmpty) {
       return '';
     }
-    var joined = typedef.genericTypeParameters
-        .map((t) => t.name)
-        .join('</span>, <span class="type-parameter">');
-    return '&lt;<wbr><span class="type-parameter">${joined}</span>&gt;';
+
+    final buffer = StringBuffer('&lt;<wbr><span class="type-parameter">');
+    buffer.writeAll(genericTypeParameters.map((t) => t.name),
+        '</span>, <span class="type-parameter">');
+    buffer.write('</span>&gt;');
+
+    return buffer.toString();
   }
 }
 
+/// A markdown renderer for a [Typedef].
 class TypedefRendererMd extends TypedefRenderer {
+  const TypedefRendererMd();
+
   @override
   String renderGenericParameters(Typedef typedef) {
-    if (typedef.genericTypeParameters.isEmpty) {
+    final genericTypeParameters = typedef.genericTypeParameters;
+    if (genericTypeParameters.isEmpty) {
       return '';
     }
-    var joined = typedef.genericTypeParameters.map((t) => t.name).join(', ');
-    return '&lt;{$joined}>';
+
+    final buffer = StringBuffer('&lt;{');
+    buffer.writeAll(genericTypeParameters.map((t) => t.name), ', ');
+    buffer.write('}>');
+
+    return buffer.toString();
   }
 }


### PR DESCRIPTION
Cleans up the typedef renderer a bit:

- Adds some very basic dartdocs
- Switches to const constructors
- Cache type parameters as a local variable to avoid running checks from its getter twice
- Switch rendering to use `StringBuffer`. Some minor performance benefits here since this logic is hit more often.