### PR TITLE
Cleanup language feature usage and renderer

### DIFF
--- a/lib/src/model/language_feature.dart
+++ b/lib/src/model/language_feature.dart
@@ -15,10 +15,17 @@ const Map<String, String> _featureUrls = {
 /// An abstraction for a language feature; used to render tags to notify
 /// the user that the documentation should be specially interpreted.
 class LanguageFeature {
+  /// The description of this language feature.
   String get featureDescription => _featureDescriptions[name];
-  String get featureUrl => _featureUrls[name];
+
+  /// A URL containing more information about this feature or `null` if there
+  /// is none.
+  String /*?*/ get featureUrl => _featureUrls[name];
+
+  /// The rendered label for this language feature.
   String get featureLabel => _featureRenderer.renderFeatureLabel(this);
 
+  /// The name of this language feature.
   final String name;
 
   final FeatureRenderer _featureRenderer;

--- a/lib/src/render/feature_renderer.dart
+++ b/lib/src/render/feature_renderer.dart
@@ -4,49 +4,59 @@
 
 import 'package:dartdoc/src/model/language_feature.dart';
 
+/// A renderer for a [LanguageFeature].
 abstract class FeatureRenderer {
+  const FeatureRenderer();
+
+  /// Render the label of this [feature].
   String renderFeatureLabel(LanguageFeature feature);
 }
 
+/// A HTML renderer for a [LanguageFeature].
 class FeatureRendererHtml extends FeatureRenderer {
-  static final FeatureRendererHtml _instance = FeatureRendererHtml._();
-
-  factory FeatureRendererHtml() {
-    return _instance;
-  }
-
-  FeatureRendererHtml._();
+  const FeatureRendererHtml();
 
   @override
   String renderFeatureLabel(LanguageFeature feature) {
-    final classesText = [
-      'feature',
-      'feature-${feature.name.split(' ').join('-').toLowerCase()}'
-    ].join(' ');
+    final buffer = StringBuffer();
+    final url = feature.featureUrl;
 
-    if (feature.featureUrl != null) {
-      return '<a href="${feature.featureUrl}" class="${classesText}"'
-          ' title="${feature.featureDescription}">${feature.name}</a>';
+    if (url != null) {
+      buffer.write('<a href="');
+      buffer.write(url);
+      buffer.write('"');
+    } else {
+      buffer.write('<span');
     }
 
-    return '<span class="${classesText}" '
-        'title="${feature.featureDescription}">${feature.name}</span>';
+    final name = feature.name;
+
+    buffer.write(' class="feature feature-');
+    buffer.writeAll(name.toLowerCase().split(' '), '-');
+    buffer.write('" title="');
+    buffer.write(feature.featureDescription);
+    buffer.write('">');
+    buffer.write(name);
+
+    if (url != null) {
+      buffer.write('</a>');
+    } else {
+      buffer.write('</span>');
+    }
+
+    return buffer.toString();
   }
 }
 
+/// A markdown renderer for a [LanguageFeature].
 class FeatureRendererMd extends FeatureRenderer {
-  static final FeatureRendererMd _instance = FeatureRendererMd._();
-
-  factory FeatureRendererMd() {
-    return _instance;
-  }
-
-  FeatureRendererMd._();
+  const FeatureRendererMd();
 
   @override
   String renderFeatureLabel(LanguageFeature feature) {
-    if (feature.featureUrl != null) {
-      return '*[\<${feature.name}\>](${feature.featureUrl})*';
+    final featureUrl = feature.featureUrl;
+    if (featureUrl != null) {
+      return '*[\<${feature.name}\>]($featureUrl)*';
     }
     return '*\<${feature.name}\>*';
   }

--- a/lib/src/render/renderer_factory.dart
+++ b/lib/src/render/renderer_factory.dart
@@ -104,7 +104,7 @@ class HtmlRenderFactory extends RendererFactory {
   TypedefRenderer get typedefRenderer => TypedefRendererHtml();
 
   @override
-  FeatureRenderer get featureRenderer => FeatureRendererHtml();
+  FeatureRenderer get featureRenderer => const FeatureRendererHtml();
 
   @override
   SourceCodeRenderer get sourceCodeRenderer => SourceCodeRendererHtml();
@@ -157,7 +157,7 @@ class MdRenderFactory extends RendererFactory {
   TypedefRenderer get typedefRenderer => TypedefRendererMd();
 
   @override
-  FeatureRenderer get featureRenderer => FeatureRendererMd();
+  FeatureRenderer get featureRenderer => const FeatureRendererMd();
 
   @override
   SourceCodeRenderer get sourceCodeRenderer => SourceCodeRendererNoop();


### PR DESCRIPTION
Cleans up the `LanguageFeature` class and renderer a bit:

- Adds some very basic dartdocs
- Switches to const constructors
- Switch HTML rendering to `StringBuffer` for more consistency and slightly improved performance since this logic is hit more often.
- Pulls out usage of `feature.featureUrl` to a local variable to enable non-null type inference in the future