### PR TITLE
Increase timeout to avoid occasional timeout exceeded on MacOS bots

### DIFF
--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -222,7 +222,7 @@ import 'package:mustachio/annotations.dart';
     expect(renderersLibrary.getTopLevelFunction('renderBar'), isNotNull);
     expect(renderersLibrary.getType('_Renderer_Foo'), isNotNull);
     expect(renderersLibrary.getType('_Renderer_Bar'), isNotNull);
-  });
+  }, timeout: Timeout.factor(2));
 
   group('builds a renderer class for a generic type', () {
     String generatedContent;


### PR DESCRIPTION
Getting some timeouts on the bots occasionally with this test, so increasing the default timeout.