### PR TITLE
Mustachio: avoid calling Iterable getter multiple times

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -89,14 +89,10 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(
                       c, remainingNames, 'List<Documentable>'),
-          isEmptyIterable: (CT_ c) => c.navLinks?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.navLinks) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.navLinks
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'package': Property(
@@ -175,14 +171,10 @@ class _Renderer_Package extends RendererBase<Package> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'Set<Library>'),
-          isEmptyIterable: (CT_ c) => c.allLibraries?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.allLibraries) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.allLibraries
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'baseHref': Property(
@@ -210,14 +202,10 @@ class _Renderer_Package extends RendererBase<Package> {
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'List<Category>'),
-          isEmptyIterable: (CT_ c) => c.categories?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.categories) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.categories
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'categoriesWithPublicLibraries': Property(
@@ -226,16 +214,10 @@ class _Renderer_Package extends RendererBase<Package> {
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(
                       c, remainingNames, 'Iterable<LibraryContainer>'),
-          isEmptyIterable: (CT_ c) =>
-              c.categoriesWithPublicLibraries?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.categoriesWithPublicLibraries) {
-              buffer.write(
-                  _render_LibraryContainer(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.categoriesWithPublicLibraries.map(
+                (e) => _render_LibraryContainer(e, ast, r.template, parent: r));
           },
         ),
         'config': Property(
@@ -254,14 +236,10 @@ class _Renderer_Package extends RendererBase<Package> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'List<String>'),
-          isEmptyIterable: (CT_ c) => c.containerOrder?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.containerOrder) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.containerOrder
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'defaultCategory': Property(
@@ -318,14 +296,10 @@ class _Renderer_Package extends RendererBase<Package> {
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'List<Locatable>'),
-          isEmptyIterable: (CT_ c) => c.documentationFrom?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentationFrom) {
-              buffer.write(_render_Locatable(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.documentationFrom
+                .map((e) => _render_Locatable(e, ast, r.template, parent: r));
           },
         ),
         'documentedCategories': Property(
@@ -334,14 +308,10 @@ class _Renderer_Package extends RendererBase<Package> {
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(
                       c, remainingNames, 'Iterable<Category>'),
-          isEmptyIterable: (CT_ c) => c.documentedCategories?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentedCategories) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.documentedCategories
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'documentedCategoriesSorted': Property(
@@ -350,15 +320,10 @@ class _Renderer_Package extends RendererBase<Package> {
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(
                       c, remainingNames, 'Iterable<Category>'),
-          isEmptyIterable: (CT_ c) =>
-              c.documentedCategoriesSorted?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentedCategoriesSorted) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.documentedCategoriesSorted
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'documentedWhere': Property(
@@ -567,14 +532,10 @@ class _Renderer_Package extends RendererBase<Package> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
-          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.locationPieces) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.locationPieces
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'name': Property(
@@ -658,14 +619,10 @@ class _Renderer_Package extends RendererBase<Package> {
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'Iterable<Library>'),
-          isEmptyIterable: (CT_ c) => c.publicLibraries?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibraries) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.publicLibraries
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'toolInvocationIndex': Property(
@@ -733,14 +690,10 @@ class _Renderer_Locatable extends RendererBase<Locatable> {
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'List<Locatable>'),
-          isEmptyIterable: (CT_ c) => c.documentationFrom?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.documentationFrom) {
-              buffer.write(_render_Locatable(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.documentationFrom
+                .map((e) => _render_Locatable(e, ast, r.template, parent: r));
           },
         ),
         'documentationIsLocal': Property(
@@ -815,14 +768,10 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'List<String>'),
-          isEmptyIterable: (CT_ c) => c.containerOrder?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.containerOrder) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.containerOrder
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'enclosingName': Property(
@@ -854,14 +803,10 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'List<Library>'),
-          isEmptyIterable: (CT_ c) => c.libraries?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.libraries) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.libraries
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'packageGraph': Property(
@@ -879,14 +824,10 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'Iterable<Library>'),
-          isEmptyIterable: (CT_ c) => c.publicLibraries?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibraries) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.publicLibraries
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'publicLibrariesSorted': Property(
@@ -894,14 +835,10 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'Iterable<Library>'),
-          isEmptyIterable: (CT_ c) => c.publicLibrariesSorted?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.publicLibrariesSorted) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.publicLibrariesSorted
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'sortKey': Property(
@@ -1044,14 +981,10 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
-          isEmptyIterable: (CT_ c) => c.namePieces?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.namePieces) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.namePieces
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
       };
@@ -1099,14 +1032,10 @@ class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(
                       c, remainingNames, 'List<ModelCommentReference>'),
-          isEmptyIterable: (CT_ c) => c.commentRefs?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.commentRefs) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.commentRefs
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'isCanonical': Property(
@@ -1121,14 +1050,10 @@ class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'Set<String>'),
-          isEmptyIterable: (CT_ c) => c.locationPieces?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.locationPieces) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.locationPieces
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
       };
@@ -1299,14 +1224,10 @@ class _Renderer_TemplateData<T extends Documentable>
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'List<Package>'),
-          isEmptyIterable: (CT_ c) => c.localPackages?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.localPackages) {
-              buffer.write(_render_Package(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.localPackages
+                .map((e) => _render_Package(e, ast, r.template, parent: r));
           },
         ),
         'metaDescription': Property(
@@ -1325,14 +1246,10 @@ class _Renderer_TemplateData<T extends Documentable>
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(
                       c, remainingNames, 'List<Documentable>'),
-          isEmptyIterable: (CT_ c) => c.navLinks?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.navLinks) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.navLinks
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'navLinksWithGenerics': Property(
@@ -1340,14 +1257,10 @@ class _Renderer_TemplateData<T extends Documentable>
           renderVariable: (CT_ c, Property<CT_> self,
                   List<String> remainingNames) =>
               self.renderSimpleVariable(c, remainingNames, 'List<Container>'),
-          isEmptyIterable: (CT_ c) => c.navLinksWithGenerics?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.navLinksWithGenerics) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.navLinksWithGenerics
+                .map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'parent': Property(

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -236,10 +236,7 @@ abstract class RendererBase<T> {
         // An inverted section is rendered with the current context.
         renderBlock(node.children);
       } else if (!node.invert && renderedIterable.isNotEmpty) {
-        var buffer = StringBuffer();
-        for (var renderedElement in renderedIterable) {
-          buffer.write(renderedElement);
-        }
+        var buffer = StringBuffer()..writeAll(renderedIterable);
         write(buffer.toString());
       }
       // Otherwise, render nothing.

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -230,13 +230,20 @@ abstract class RendererBase<T> {
     }
 
     if (property.renderIterable != null) {
-      // An inverted section is rendered with the current context.
-      if (node.invert && property.isEmptyIterable(context)) {
+      var renderedIterable =
+          property.renderIterable(context, this, node.children);
+      if (node.invert && renderedIterable.isEmpty) {
+        // An inverted section is rendered with the current context.
         renderBlock(node.children);
+      } else if (!node.invert && renderedIterable.isNotEmpty) {
+        var buffer = StringBuffer();
+        for (var renderedElement in renderedIterable) {
+          buffer.write(renderedElement);
+        }
+        write(buffer.toString());
       }
-      if (!node.invert && !property.isEmptyIterable(context)) {
-        write(property.renderIterable(context, this, node.children));
-      }
+      // Otherwise, render nothing.
+
       return;
     }
 
@@ -302,9 +309,7 @@ class Property<T> {
   /// object [context].
   final bool /*!*/ Function(T context) /*?*/ getBool;
 
-  final bool /*!*/ Function(T) /*?*/ isEmptyIterable;
-
-  final String /*!*/ Function(
+  final Iterable<String> /*!*/ Function(
           T, RendererBase<T>, List<MustachioNode> /*!*/) /*?*/
       renderIterable;
 
@@ -317,7 +322,6 @@ class Property<T> {
       {@required this.getValue,
       this.renderVariable,
       this.getBool,
-      this.isEmptyIterable,
       this.renderIterable,
       this.isNullValue,
       this.renderValue});

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -176,14 +176,9 @@ class Baz {}
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'List<int>'),
-          isEmptyIterable: (CT_ c) => c.l1?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.l1) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.l1.map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
 '''));

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -53,14 +53,9 @@ class Renderer_Foo extends RendererBase<Foo> {
           renderVariable:
               (CT_ c, Property<CT_> self, List<String> remainingNames) =>
                   self.renderSimpleVariable(c, remainingNames, 'List<int>'),
-          isEmptyIterable: (CT_ c) => c.l1?.isEmpty ?? true,
           renderIterable:
               (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-            var buffer = StringBuffer();
-            for (var e in c.l1) {
-              buffer.write(renderSimple(e, ast, r.template, parent: r));
-            }
-            return buffer.toString();
+            return c.l1.map((e) => renderSimple(e, ast, r.template, parent: r));
           },
         ),
         'p1': Property(

--- a/test/mustachio/renderer_test.dart
+++ b/test/mustachio/renderer_test.dart
@@ -36,7 +36,6 @@ void main() {
     expect(propertyMap['b1'].getValue, isNotNull);
     expect(propertyMap['b1'].renderVariable, isNotNull);
     expect(propertyMap['b1'].getBool, isNotNull);
-    expect(propertyMap['b1'].isEmptyIterable, isNull);
     expect(propertyMap['b1'].renderIterable, isNull);
     expect(propertyMap['b1'].isNullValue, isNull);
     expect(propertyMap['b1'].renderValue, isNull);
@@ -47,7 +46,6 @@ void main() {
     expect(propertyMap['l1'].getValue, isNotNull);
     expect(propertyMap['l1'].renderVariable, isNotNull);
     expect(propertyMap['l1'].getBool, isNull);
-    expect(propertyMap['l1'].isEmptyIterable, isNotNull);
     expect(propertyMap['l1'].renderIterable, isNotNull);
     expect(propertyMap['l1'].isNullValue, isNull);
     expect(propertyMap['l1'].renderValue, isNull);
@@ -58,7 +56,6 @@ void main() {
     expect(propertyMap['s1'].getValue, isNotNull);
     expect(propertyMap['s1'].renderVariable, isNotNull);
     expect(propertyMap['s1'].getBool, isNull);
-    expect(propertyMap['s1'].isEmptyIterable, isNull);
     expect(propertyMap['s1'].renderIterable, isNull);
     expect(propertyMap['s1'].isNullValue, isNotNull);
     expect(propertyMap['s1'].renderValue, isNotNull);
@@ -74,24 +71,6 @@ void main() {
     var propertyMap = Renderer_Foo.propertyMap();
     var foo = Foo()..b1 = true;
     expect(propertyMap['b1'].getBool(foo), isTrue);
-  });
-
-  test('isEmptyIterable returns true when an Iterable value is empty', () {
-    var propertyMap = Renderer_Foo.propertyMap();
-    var foo = Foo()..l1 = [];
-    expect(propertyMap['l1'].isEmptyIterable(foo), isTrue);
-  });
-
-  test('isEmptyIterable returns false when an Iterable value is not empty', () {
-    var propertyMap = Renderer_Foo.propertyMap();
-    var foo = Foo()..l1 = [1, 2, 3];
-    expect(propertyMap['l1'].isEmptyIterable(foo), isFalse);
-  });
-
-  test('isEmptyIterable returns true when an Iterable value is null', () {
-    var propertyMap = Renderer_Foo.propertyMap();
-    var foo = Foo()..l1 = null;
-    expect(propertyMap['l1'].isEmptyIterable(foo), isTrue);
   });
 
   test('isNullValue returns true when a value is null', () {

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -456,15 +456,9 @@ renderVariable:
           var rendererName =
               _typeToRenderFunctionName[innerType.element] ?? 'renderSimple';
           _buffer.writeln('''
-isEmptyIterable: ($_contextTypeVariable c) => c.$getterName?.isEmpty ?? true,
-
 renderIterable:
     ($_contextTypeVariable c, RendererBase<$_contextTypeVariable> r, List<MustachioNode> ast) {
-  var buffer = StringBuffer();
-  for (var e in c.$getterName) {
-    buffer.write($rendererName(e, ast, r.template, parent: r));
-  }
-  return buffer.toString();
+  return c.$getterName.map((e) => $rendererName(e, ast, r.template, parent: r));
 },
 ''');
         }


### PR DESCRIPTION
Take this template, where `widgets` is an Iterable property:

    Text {{#widgets}} {{name}} {{/widgets}}.

A mustache renderer should assume that the `widgets` getter may have side
effects and may be expensive to compute, and it should only be called one
time. Currently, Mustachio will call this getter 2 or 3 times, as the behavior
differs if the section is inverted, and if the Iterable is empty.

This change is actually quite readable, and simplifies the code. The magic
sauce is in the lazy Iterable returned by `renderIterable`. If Mustachio does
not wish to render the elements, then the lazy map will not be evaluated.