### PR TITLE
VM is less forgiving for invalid vm-service option

### DIFF
--- a/testing/flutter_packages/test_package_flutter_plugin/analysis_options.yaml
+++ b/testing/flutter_packages/test_package_flutter_plugin/analysis_options.yaml
@@ -1,3 +1,0 @@
-analyzer:
-  exclude:
-    - '**'

--- a/tool/subprocess_launcher.dart
+++ b/tool/subprocess_launcher.dart
@@ -100,7 +100,7 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
       coverageResults.add(coverageResult.future);
       arguments = [
         '--disable-service-auth-codes',
-        '--enable-vm-service:0',
+        '--enable-vm-service=0',
         '--pause-isolates-on-exit',
         ...arguments
       ];


### PR DESCRIPTION
Somehow, the `--enable-vm-service:0` option managed to work before but doesn't now.  Also, the analyzer bugfixes WRT
exclude handling mean yet another old workaround must be eliminated.