### PR TITLE
Fix invalid json on an empty categories list

### DIFF
--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -86,7 +86,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   @override
   void generateCategoryJson(
       FileWriter writer, List<Categorization> categories) {
-    var json = '';
+    var json = '[]';
     if (categories.isNotEmpty) {
       json = generator_util.generateCategoryJson(
           categories, options.prettyIndexJson);


### PR DESCRIPTION
Fix a bug introduced in #2534 that's blocking a downstream roll.   After that PR if there are no categories defined, dartdoc will write only `\n` which is not valid JSON.
