### PR TITLE
Extend builder timeouts

### DIFF
--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 @Timeout.factor(2)
 import 'dart:convert';

--- a/test/mustachio/builder_test.dart
+++ b/test/mustachio/builder_test.dart
@@ -1,3 +1,5 @@
+
+@Timeout.factor(2)
 import 'dart:convert';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
@@ -219,7 +221,7 @@ import 'package:mustachio/annotations.dart';
     expect(renderersLibrary.getTopLevelFunction('renderBar'), isNotNull);
     expect(renderersLibrary.getType('_Renderer_Foo'), isNotNull);
     expect(renderersLibrary.getType('_Renderer_Bar'), isNotNull);
-  }, timeout: Timeout.factor(2));
+  });
 
   group('builds a renderer class for a generic type', () {
     String generatedContent;


### PR DESCRIPTION
Other tests in builder_test.dart seem to hit timeouts occasionally besides the one I recently extended -- just extend timeouts for all of them.