### PR TITLE
Add grinder to test the language directories

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -759,8 +759,9 @@ $analyzerOptions
     ..createSync();
   var languageTestDir =
       Directory(path.context.resolveTildePath(languageTestPath));
-  if (!languageTestDir.existsSync())
+  if (!languageTestDir.existsSync()) {
     fail('language test dir does not exist:  $languageTestDir');
+  }
 
   for (var entry in languageTestDir.listSync(recursive: true)) {
     if (entry is File &&

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -719,7 +719,7 @@ Future<void> serveFlutterDocs() async {
 @Task('Serve language test directory docs on port 8004')
 @Depends(buildLanguageTestDocs)
 Future<void> serveLanguageTestDocs() async {
-  log('launching dhttpd on port 8004 for Flutter');
+  log('launching dhttpd on port 8004 for language tests');
   var launcher = SubprocessLauncher('serve-language-test-docs');
   await launcher.runStreamed(sdkBin('pub'), ['get']);
   await launcher.runStreamed(sdkBin('pub'), [

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -36,6 +36,13 @@ void expectFileContains(String path, List<Pattern> items) {
   }
 }
 
+/// Path to the base directory for language tests.
+final String languageTestPath = Platform.environment['LANGUAGE_TESTS'];
+
+/// Enable the following experiments for language tests.
+final List<String> languageExperiments =
+    (Platform.environment['LANGUAGE_EXPERIMENTS'] ?? '').split(RegExp(r'\s+'));
+
 /// The pub cache inherited by grinder.
 final String defaultPubCache = Platform.environment['PUB_CACHE'] ??
     path.context.resolveTildePath('~/.pub-cache');
@@ -113,6 +120,10 @@ Directory cleanFlutterDir = Directory(path.join(
 Directory _flutterDir;
 
 Directory get flutterDir => _flutterDir ??= createTempSync('flutter');
+
+Directory _languageTestPackageDir;
+Directory get languageTestPackageDir =>
+    _languageTestPackageDir ??= createTempSync('languageTestPackageDir');
 
 Directory get testPackage =>
     Directory(path.joinAll(['testing', 'test_package']));
@@ -703,6 +714,82 @@ Future<void> serveFlutterDocs() async {
     '--path',
     path.join(flutterDir.path, 'dev', 'docs', 'doc'),
   ]);
+}
+
+@Task('Serve language test directory docs on port 8004')
+@Depends(buildLanguageTestDocs)
+Future<void> serveLanguageTestDocs() async {
+  log('launching dhttpd on port 8004 for Flutter');
+  var launcher = SubprocessLauncher('serve-language-test-docs');
+  await launcher.runStreamed(sdkBin('pub'), ['get']);
+  await launcher.runStreamed(sdkBin('pub'), [
+    'global',
+    'run',
+    'dhttpd',
+    '--port',
+    '8004',
+    '--path',
+    path.join(languageTestPackageDir.path, 'doc', 'api'),
+  ]);
+}
+
+@Task('Build docs for a language test directory in the SDK')
+Future<void> buildLanguageTestDocs() async {
+  var launcher = SubprocessLauncher('build-language-test-docs');
+  if (languageTestPath == null) {
+    fail('LANGUAGE_TESTS must be set to the directory to build language tests');
+  }
+  var pubspecFile =
+      File(path.join(languageTestPackageDir.path, 'pubspec.yaml'));
+  pubspecFile.writeAsStringSync('''name: _language_test_package
+version: 0.0.1
+environment:
+  sdk: '>=${Platform.version.split(' ').first}'
+''');
+
+  var analyzerOptionsFile =
+      File(path.join(languageTestPackageDir.path, 'analysis_options.yaml'));
+  var analyzerOptions = languageExperiments.map((e) => '    - $e').join('\n');
+  analyzerOptionsFile.writeAsStringSync('''analyzer:
+   enable-experiment:
+$analyzerOptions
+ ''');
+
+  var libDir = Directory(path.join(languageTestPackageDir.path, 'lib'))
+    ..createSync();
+  var languageTestDir =
+      Directory(path.context.resolveTildePath(languageTestPath));
+  if (!languageTestDir.existsSync())
+    fail('language test dir does not exist:  $languageTestDir');
+
+  for (var entry in languageTestDir.listSync(recursive: true)) {
+    if (entry is File &&
+        entry.existsSync() &&
+        !entry.path.endsWith('_error_test.dart')) {
+      var destDir = Directory(path.join(
+          libDir.path,
+          path.dirname(entry.absolute.path.replaceFirst(
+              languageTestDir.absolute.path + path.separator, ''))));
+      if (!destDir.existsSync()) destDir.createSync(recursive: true);
+      copy(entry, destDir);
+    }
+  }
+
+  await launcher.runStreamed('pub', ['get'],
+      workingDirectory: languageTestPackageDir.absolute.path);
+  await launcher.runStreamed(
+      Platform.resolvedExecutable,
+      [
+        '--enable-asserts',
+        path.join(Directory.current.absolute.path, 'bin', 'dartdoc.dart'),
+        '--json',
+        '--link-to-remote',
+        '--show-progress',
+        '--enable-experiment',
+        '${languageExperiments.join(",")}',
+        ...extraDartdocParameters,
+      ],
+      workingDirectory: languageTestPackageDir.absolute.path);
 }
 
 @Task('Validate flutter docs')

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -737,7 +737,8 @@ Future<void> serveLanguageTestDocs() async {
 Future<void> buildLanguageTestDocs() async {
   var launcher = SubprocessLauncher('build-language-test-docs');
   if (languageTestPath == null) {
-    fail('LANGUAGE_TESTS must be set to the directory to build language tests');
+    fail(
+        'LANGUAGE_TESTS must be set to the SDK language test directory from which to copy tests');
   }
   var pubspecFile =
       File(path.join(languageTestPackageDir.path, 'pubspec.yaml'));
@@ -766,7 +767,8 @@ $analyzerOptions
   for (var entry in languageTestDir.listSync(recursive: true)) {
     if (entry is File &&
         entry.existsSync() &&
-        !entry.path.endsWith('_error_test.dart')) {
+        !entry.path.endsWith('_error_test.dart') &&
+        !entry.path.endsWith('_error_lib.dart')) {
       var destDir = Directory(path.join(
           libDir.path,
           path.dirname(entry.absolute.path.replaceFirst(


### PR DESCRIPTION
A quick and dirty grinder to automatically build pub-like packages out of Dart SDK language test directories and run dartdoc against them.  Already found one stack overflow with it.

usage example:

```
jcollins-macbookpro2:dartdoc jcollins$ LANGUAGE_TESTS=~/dart/sdk/sdk/tests/language/type LANGUAGE_EXPERIMENTS=nonfunction-type-aliases grind serve-language-test-docs
grinder running build-language-test-docs serve-language-test-docs

build-language-test-docs
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/constants_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/intersection_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/conversion_ssa_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/alias_equality_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/guard_conversion_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/checks_in_factory_method_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/check_const_function_typedef2_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/hoisting_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/check_const_function_typedef_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/error_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/checks_in_factory_method_runtime_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
  copying /Users/jcollins/dart/sdk/sdk/tests/language/type/check_test.dart to /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/lib/.
build-language-test-docs: + (cd "/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm" &&  pub get)
build-language-test-docs: Resolving dependencies...
build-language-test-docs: Got dependencies!
build-language-test-docs: + (cd "/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm" &&  /Users/jcollins/dart/all_sdks/2.13.0-117.0.dev/bin/dart --enable-asserts /Users/jcollins/dart/dartdoc/bin/dartdoc.dart --json --link-to-remote --show-progress --enable-experiment nonfunction-type-aliases)
build-language-test-docs: Documenting _language_test_package...
build-language-test-docs: Initialized dartdoc with 49 libraries in 17.2 seconds
build-language-test-docs: Generating docs for library constants_test from package:_language_test_package/constants_test.dart...
build-language-test-docs: Generating docs for library intersection_test from package:_language_test_package/intersection_test.dart...
build-language-test-docs: Generating docs for library conversion_ssa_test from package:_language_test_package/conversion_ssa_test.dart...
build-language-test-docs: Generating docs for library alias_equality_test from package:_language_test_package/alias_equality_test.dart...
build-language-test-docs: Generating docs for library guard_conversion_test from package:_language_test_package/guard_conversion_test.dart...
build-language-test-docs: Generating docs for library checks_in_factory_method_test from package:_language_test_package/checks_in_factory_method_test.dart...
build-language-test-docs: Generating docs for library check_const_function_typedef2_test from package:_language_test_package/check_const_function_typedef2_test.dart...
build-language-test-docs: Generating docs for library hoisting_test from package:_language_test_package/hoisting_test.dart...
build-language-test-docs: Generating docs for library check_const_function_typedef_test from package:_language_test_package/check_const_function_typedef_test.dart...
build-language-test-docs: Generating docs for library error_test from package:_language_test_package/error_test.dart...
build-language-test-docs: Generating docs for library checks_in_factory_method_runtime_test from package:_language_test_package/checks_in_factory_method_runtime_test.dart...
build-language-test-docs: Generating docs for library check_test from package:_language_test_package/check_test.dart...
build-language-test-docs: Validating docs...
build-language-test-docs: no issues found
build-language-test-docs: Documented 12 public libraries in 1.8 seconds
build-language-test-docs: Success! Docs generated into /private/var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/doc/api

serve-language-test-docs
  launching dhttpd on port 8004 for language tests
serve-language-test-docs: +  /Users/jcollins/dart/all_sdks/2.13.0-117.0.dev/bin/pub get
serve-language-test-docs: Resolving dependencies...
serve-language-test-docs:   checked_yaml 1.0.4 (2.0.1 available)
serve-language-test-docs:   coverage 0.15.2 (1.0.1 available)
serve-language-test-docs:   graphs 0.2.0 (1.0.0 available)
serve-language-test-docs:   http_multi_server 2.2.0 (3.0.0 available)
serve-language-test-docs:   io 0.3.5 (1.0.0 available)
serve-language-test-docs:   node_preamble 1.4.13 (2.0.0 available)
serve-language-test-docs:   pubspec_parse 0.1.8 (1.0.0 available)
serve-language-test-docs:   shelf_web_socket 0.2.4+1 (1.0.0 available)
serve-language-test-docs:   web_socket_channel 1.2.0 (2.0.0 available)
serve-language-test-docs: Got dependencies!
serve-language-test-docs: +  /Users/jcollins/dart/all_sdks/2.13.0-117.0.dev/bin/pub global run dhttpd --port 8004 --path /var/folders/b8/jg3_spkj02d51bcz3fsb5jjc000b33/T/languageTestPackageDirREirmm/doc/api
serve-language-test-docs: Server started on port 8004
```

<img width="1070" alt="Screen Shot 2021-03-08 at 3 49 05 PM" src="https://user-images.githubusercontent.com/14116827/110396990-dde74a80-8025-11eb-96b2-956c20b0a288.png">

