### PR TITLE
Fix implied Future and isBottom check for types

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -124,15 +124,16 @@ class UndefinedElementType extends ElementType {
 
   /// Returns true if this type is an implied `Future`.
   bool get isImpliedFuture => (type.isDynamic &&
-    returnedFrom != null &&
-          returnedFrom is DefinedElementType &&
-              (returnedFrom as DefinedElementType).element.isAsynchronous);
+      returnedFrom != null &&
+      returnedFrom is DefinedElementType &&
+      (returnedFrom as DefinedElementType).element.isAsynchronous);
 
   @override
   String get nameWithGenerics => '$name$nullabilitySuffix';
 
   @override
-  String get nullabilitySuffix => isImpliedFuture && library.isNullSafety ? '?' : super.nullabilitySuffix;
+  String get nullabilitySuffix =>
+      isImpliedFuture && library.isNullSafety ? '?' : super.nullabilitySuffix;
 
   /// Assume that undefined elements don't have useful bounds.
   @override

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -115,24 +115,24 @@ class UndefinedElementType extends ElementType {
 
   @override
   String get name {
-    if (type.isDynamic) {
-      if (returnedFrom != null &&
-          (returnedFrom is DefinedElementType &&
-              (returnedFrom as DefinedElementType).element.isAsynchronous)) {
-        return 'Future';
-      } else {
-        return 'dynamic';
-      }
-    }
+    if (isImpliedFuture) return 'Future';
     if (type.isVoid) return 'void';
-    if (type.isBottom) return 'Never';
-    assert(false,
+    assert({'Never', 'void', 'dynamic'}.contains(type.element.name),
         'Unrecognized type for UndefinedElementType: ${type.toString()}');
-    return '';
+    return type.element.name;
   }
+
+  /// Returns true if this type is an implied `Future`.
+  bool get isImpliedFuture => (type.isDynamic &&
+    returnedFrom != null &&
+          returnedFrom is DefinedElementType &&
+              (returnedFrom as DefinedElementType).element.isAsynchronous);
 
   @override
   String get nameWithGenerics => '$name$nullabilitySuffix';
+
+  @override
+  String get nullabilitySuffix => isImpliedFuture && library.isNullSafety ? '?' : super.nullabilitySuffix;
 
   /// Assume that undefined elements don't have useful bounds.
   @override

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -111,24 +111,31 @@ void main() {
           .firstWhere((c) => c.name == 'B');
       c = nullSafetyClassMemberDeclarations.allClasses
           .firstWhere((c) => c.name == 'C');
-      oddAsyncFunction = nullableElements.publicFunctions.firstWhere((f) => f.name == 'oddAsyncFunction');
-      anotherOddFunction = nullableElements.publicFunctions.firstWhere((f) => f.name == 'oddAsyncFunction');
-      neverReturns = nullableElements.publicFunctions.firstWhere((f) => f.name == 'neverReturns');
-      almostNeverReturns = nullableElements.publicFunctions.firstWhere((f) => f.name == 'almostNeverReturns');
+      oddAsyncFunction = nullableElements.publicFunctions
+          .firstWhere((f) => f.name == 'oddAsyncFunction');
+      anotherOddFunction = nullableElements.publicFunctions
+          .firstWhere((f) => f.name == 'oddAsyncFunction');
+      neverReturns = nullableElements.publicFunctions
+          .firstWhere((f) => f.name == 'neverReturns');
+      almostNeverReturns = nullableElements.publicFunctions
+          .firstWhere((f) => f.name == 'almostNeverReturns');
     });
 
     test('Never types are allowed to have nullability markers', () {
       expect(neverReturns.modelType.returnType.name, equals('Never'));
       expect(neverReturns.modelType.returnType.nullabilitySuffix, equals(''));
       expect(almostNeverReturns.modelType.returnType.name, equals('Never'));
-      expect(almostNeverReturns.modelType.returnType.nullabilitySuffix, equals('?'));
+      expect(almostNeverReturns.modelType.returnType.nullabilitySuffix,
+          equals('?'));
     });
 
     test('implied Future types have correct nullability', () {
       expect(oddAsyncFunction.modelType.returnType.name, equals('Future'));
-      expect(oddAsyncFunction.modelType.returnType.nullabilitySuffix, equals('?'));
+      expect(
+          oddAsyncFunction.modelType.returnType.nullabilitySuffix, equals('?'));
       expect(anotherOddFunction.modelType.returnType.name, equals('Future'));
-      expect(anotherOddFunction.modelType.returnType.nullabilitySuffix, equals('?'));
+      expect(anotherOddFunction.modelType.returnType.nullabilitySuffix,
+          equals('?'));
     });
 
     test('isNullSafety is set correctly for libraries', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -95,6 +95,8 @@ void main() {
         nullableElements;
     Class b;
     Class c;
+    ModelFunction oddAsyncFunction, anotherOddFunction;
+    ModelFunction neverReturns, almostNeverReturns;
 
     setUpAll(() async {
       lateFinalWithoutInitializer = packageGraph.libraries
@@ -109,6 +111,24 @@ void main() {
           .firstWhere((c) => c.name == 'B');
       c = nullSafetyClassMemberDeclarations.allClasses
           .firstWhere((c) => c.name == 'C');
+      oddAsyncFunction = nullableElements.publicFunctions.firstWhere((f) => f.name == 'oddAsyncFunction');
+      anotherOddFunction = nullableElements.publicFunctions.firstWhere((f) => f.name == 'oddAsyncFunction');
+      neverReturns = nullableElements.publicFunctions.firstWhere((f) => f.name == 'neverReturns');
+      almostNeverReturns = nullableElements.publicFunctions.firstWhere((f) => f.name == 'almostNeverReturns');
+    });
+
+    test('Never types are allowed to have nullability markers', () {
+      expect(neverReturns.modelType.returnType.name, equals('Never'));
+      expect(neverReturns.modelType.returnType.nullabilitySuffix, equals(''));
+      expect(almostNeverReturns.modelType.returnType.name, equals('Never'));
+      expect(almostNeverReturns.modelType.returnType.nullabilitySuffix, equals('?'));
+    });
+
+    test('implied Future types have correct nullability', () {
+      expect(oddAsyncFunction.modelType.returnType.name, equals('Future'));
+      expect(oddAsyncFunction.modelType.returnType.nullabilitySuffix, equals('?'));
+      expect(anotherOddFunction.modelType.returnType.name, equals('Future'));
+      expect(anotherOddFunction.modelType.returnType.nullabilitySuffix, equals('?'));
     });
 
     test('isNullSafety is set correctly for libraries', () {

--- a/testing/test_package/lib/features/nnbd_class_member_declarations.dart
+++ b/testing/test_package/lib/features/nnbd_class_member_declarations.dart
@@ -30,5 +30,5 @@ class C {
 
   List<Map<String, num?>>? method1() => null;
 
-  void m3(void listen(int t)?, {void onDone()?});
+  void m3(void listen(int t)?, {void onDone()?}) {}
 }

--- a/testing/test_package/lib/features/nullable_elements.dart
+++ b/testing/test_package/lib/features/nullable_elements.dart
@@ -14,6 +14,14 @@ void set nullableSetter(String? value) {
   _nullableSetter = _nullableSetter ??= value;
 }
 
+/// This should have return type of `Future?`.
+dynamic? oddAsyncFunction() async {}
+/// This should also have return type of `Future?`.
+dynamic anotherOddFunction() async {}
+
+Never neverReturns() {}
+Never? almostNeverReturns() {}
+
 void some(int? nullable, String? parameters) {}
 
 class NullableMembers {

--- a/testing/test_package/lib/features/nullable_elements.dart
+++ b/testing/test_package/lib/features/nullable_elements.dart
@@ -20,7 +20,10 @@ dynamic? oddAsyncFunction() async {}
 /// This should also have return type of `Future?`.
 dynamic anotherOddFunction() async {}
 
-Never neverReturns() {throw Exception();}
+Never neverReturns() {
+  throw Exception();
+}
+
 Never? almostNeverReturns() {}
 
 void some(int? nullable, String? parameters) {}

--- a/testing/test_package/lib/features/nullable_elements.dart
+++ b/testing/test_package/lib/features/nullable_elements.dart
@@ -16,10 +16,11 @@ void set nullableSetter(String? value) {
 
 /// This should have return type of `Future?`.
 dynamic? oddAsyncFunction() async {}
+
 /// This should also have return type of `Future?`.
 dynamic anotherOddFunction() async {}
 
-Never neverReturns() {}
+Never neverReturns() {throw Exception();}
 Never? almostNeverReturns() {}
 
 void some(int? nullable, String? parameters) {}


### PR DESCRIPTION
This cleans up the implied Future support for asynchronous functions returning dynamic and removes the assumption that Never types can never be nullable (`isBottom` is not equivalent to `this is NeverType`).  This was discovered using the language tests in language/nonfunction-type-aliases, but applies to more than that.