### PR TITLE
Update github workflow to use stable SDK

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [dev, beta]
+        sdk: [dev, stable]
         job: [main, flutter, sdk-analyzer, packages, sdk-docs]
         include:
           - os: macos-latest
@@ -32,9 +32,9 @@ jobs:
             # Do not try to run flutter against the "stable" sdk,
             # it is unlikely to work and produces uninteresting
             # results.
-          - sdk: beta
+          - sdk: stable
             job: flutter
-          - sdk: beta
+          - sdk: stable
             job: sdk-analyzer
 
     steps:


### PR DESCRIPTION
With the release of 2.12 stable, we can now set the github tests to validate against the stable branch rather than beta.