### PR TITLE
Add avoid_dynamic_calls lint rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
+    - avoid_dynamic_calls
     - avoid_single_cascade_in_expression_statements
     - avoid_unused_constructor_parameters
     - annotate_overrides


### PR DESCRIPTION
It appears dartdoc is already clean with this lint 🥳 but I thought it would be nice to enforce it as well.