### PR TITLE
Add option for setting arguments for tool compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ dartdoc:
       command: ["bin/drill.dart"]
       setup_command: ["bin/setup.dart"]
       description: "Puts holes in things."
-      compile_args: ["-no-sound-null-safety"]
+      compile_args: ["--no-sound-null-safety"]
     echo:
       macos: ['/bin/sh', '-c', 'echo']
       setup_macos: ['/bin/sh', '-c', 'setup.sh']

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ dartdoc:
       command: ["bin/drill.dart"]
       setup_command: ["bin/setup.dart"]
       description: "Puts holes in things."
+      compile_args: ["-no-sound-null-safety"]
     echo:
       macos: ['/bin/sh', '-c', 'echo']
       setup_macos: ['/bin/sh', '-c', 'setup.sh']
@@ -327,6 +328,9 @@ The `description` is just a short description of the tool for use as help text.
 
 Only tools which are configured in the `dartdoc_options.yaml` file are able to
 be invoked.
+
+The `compile_args` tag is used to pass options to the dart compiler when the
+first run of the tool is being snapshotted.
 
 To use the tools in comment documentation, use the `{@tool <name> [<options>
 ...] [$INPUT]}` directive to invoke the tool:

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -39,6 +39,8 @@ const int _kIntVal = 0;
 const double _kDoubleVal = 0.0;
 const bool _kBoolVal = true;
 
+const String _kCompileArgsTagName = 'compile_args';
+
 int get _usageLineLength => stdout.hasTerminal ? stdout.terminalColumns : null;
 
 typedef ConvertYamlToType<T> = T Function(YamlMap, String, ResourceProvider);
@@ -160,7 +162,7 @@ class ToolDefinition {
       if (compileArgs != null && compileArgs.isNotEmpty) {
         throw DartdocOptionError(
             'Compile arguments may only be specified for Dart tools, but '
-            'compile-args of $compileArgs were specified for '
+            '$_kCompileArgsTagName of $compileArgs were specified for '
             '$command.');
       }
       return ToolDefinition(command, setupCommand, description);
@@ -393,19 +395,18 @@ class ToolConfiguration {
         setupCommand = findCommand('setup_');
 
         List<String> findArgs() {
-          const tagName = 'compile-args';
           List<String> args;
-          if (toolMap.containsKey(tagName)) {
-            var compileArgs = toolMap[tagName];
+          if (toolMap.containsKey(_kCompileArgsTagName)) {
+            var compileArgs = toolMap[_kCompileArgsTagName];
             if (compileArgs is String) {
-              args = [toolMap[tagName].toString()];
+              args = [toolMap[_kCompileArgsTagName].toString()];
             } else if (compileArgs is YamlList) {
               args =
                   compileArgs.map<String>((node) => node.toString()).toList();
             } else {
               throw DartdocOptionError(
                   'Tool compile arguments must be a list of strings. The tool '
-                  '$name has a $tagName entry that is a '
+                  '$name has a $_kCompileArgsTagName entry that is a '
                   '${compileArgs.runtimeType}');
             }
           }

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -191,11 +191,15 @@ mixin DocumentationComment
   /// ```yaml
   /// dartdoc:
   ///   tools:
-  ///     # Prefixes the given input with "## "
-  ///     # Path is relative to project root.
-  ///     prefix: "bin/prefix.dart"
-  ///     # Prints the date
-  ///     date: "/bin/date"
+  ///     prefix:
+  ///       # Path is relative to project root.
+  ///       command: ["bin/prefix.dart"]
+  ///       description: "Prefixes the given input with '##'"
+  ///       # If false, adds --no-sound-null-safety when compiling.
+  ///       sound-null-safety: false
+  ///     date:
+  ///       command: ["/bin/date"]
+  ///       description: "Prints the date"
   /// ```
   ///
   /// In code:

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -195,7 +195,7 @@ mixin DocumentationComment
   ///       # Path is relative to project root.
   ///       command: ["bin/prefix.dart"]
   ///       description: "Prefixes the given input with '##'."
-  ///       compile-args: ["--no-sound-null-safety"]
+  ///       compile_args: ["--no-sound-null-safety"]
   ///     date:
   ///       command: ["/bin/date"]
   ///       description: "Prints the date"

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -194,9 +194,8 @@ mixin DocumentationComment
   ///     prefix:
   ///       # Path is relative to project root.
   ///       command: ["bin/prefix.dart"]
-  ///       description: "Prefixes the given input with '##'"
-  ///       # If false, adds --no-sound-null-safety when compiling.
-  ///       sound-null-safety: false
+  ///       description: "Prefixes the given input with '##'."
+  ///       compile-args: ["--no-sound-null-safety"]
   ///     date:
   ///       command: ["/bin/date"]
   ///       description: "Prints the date"

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -59,6 +59,7 @@ void main() {
 drill:
   command: ["bin/drill.dart"]
   description: "Puts holes in things."
+  compile-args: ["--no-sound-null-safety"]
 snapshot_drill:
   command: ["${snapshotFile.replaceAll(r'\', r'\\')}"]
   description: "Puts holes in things, but faster."
@@ -104,6 +105,10 @@ echo:
     });
     // This test must come first, to verify that the first run creates
     // a snapshot.
+    test('Tool definition includes compile arguments.', () async {
+      DartToolDefinition definition = runner.toolConfiguration.tools['drill'];
+      expect(definition.compileArgs, equals(['--no-sound-null-safety']));
+    });
     test('can invoke a Dart tool, and second run is a snapshot.', () async {
       var result = await runner.run(
         ['drill', r'--file=$INPUT'],
@@ -114,6 +119,8 @@ echo:
       expect(result, contains('--file=<INPUT_FILE>'));
       expect(result, contains('## `TEST INPUT`'));
       expect(result, contains('Script location is in dartdoc tree.'));
+      // This shouldn't be in the args passed to the tool.
+      expect(result, isNot(contains('--no-sound-null-safety')));
       expect(setupFile.existsSync(), isFalse);
       result = await runner.run(
         ['drill', r'--file=$INPUT'],

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -59,7 +59,7 @@ void main() {
 drill:
   command: ["bin/drill.dart"]
   description: "Puts holes in things."
-  compile-args: ["--no-sound-null-safety"]
+  compile_args: ["--no-sound-null-safety"]
 snapshot_drill:
   command: ["${snapshotFile.replaceAll(r'\', r'\\')}"]
   description: "Puts holes in things, but faster."
@@ -119,7 +119,7 @@ echo:
       expect(result, contains('--file=<INPUT_FILE>'));
       expect(result, contains('## `TEST INPUT`'));
       expect(result, contains('Script location is in dartdoc tree.'));
-      // This shouldn't be in the args passed to the tool.
+      // Compile args shouldn't be in the args passed to the tool.
       expect(result, isNot(contains('--no-sound-null-safety')));
       expect(setupFile.existsSync(), isFalse);
       result = await runner.run(


### PR DESCRIPTION
I started to convert a tool to null safety that had non-null-safe dependencies, and I realized that dartdoc will try and compile without the `--no-strong-null-safety` flag, and there was no way to specify it.

This PR adds a mechanism for adding compile arguments to Dart-based tools, so that they can specify arguments like `--no-strong-null-safety` (or any other args).

