### PR TITLE
revert dynamic lint, add todo: ignore, and dartfmt

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,7 @@ include: package:pedantic/analysis_options.1.11.0.yaml
 
 analyzer:
   errors:
+    todo: ignore
     unused_import: warning
     unused_shown_name: warning
   exclude:
@@ -17,7 +18,6 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
-    - avoid_dynamic_calls
     - avoid_single_cascade_in_expression_statements
     - avoid_unused_constructor_parameters
     - annotate_overrides

--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -4,6 +4,7 @@ include: package:pedantic/analysis_options.1.11.0.yaml
 
 analyzer:
   errors:
+    todo: ignore
     unused_import: warning
     unused_shown_name: warning
     ### Extra ignores for presubmit

--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -637,13 +637,13 @@ dartdoc:
           equals(
               'Field dartdoc.fileOptionList from ${path.canonicalize(dartdocOptionsTwo.path)}, set to [existing.dart, thing/that/does/not/exist], resolves to missing path: '
               '"${path.joinAll([
-            path.canonicalize(secondDir.path),
-            'thing',
-            'that',
-            'does',
-            'not',
-            'exist'
-          ])}"'));
+                path.canonicalize(secondDir.path),
+                'thing',
+                'that',
+                'does',
+                'not',
+                'exist'
+              ])}"'));
       // It doesn't matter that this fails.
       expect(dartdocOptionSetFiles['nonCriticalFileOption'].valueAt(firstDir),
           equals(path.joinAll([path.canonicalize(firstDir.path), 'whatever'])));
@@ -663,9 +663,9 @@ dartdoc:
           equals(
               'Field dartdoc.fileOption from ${path.canonicalize(dartdocOptionsTwo.path)}, set to not existing, resolves to missing path: '
               '"${path.joinAll([
-            path.canonicalize(secondDir.path),
-            "not existing"
-          ])}"'));
+                path.canonicalize(secondDir.path),
+                "not existing"
+              ])}"'));
     });
 
     test('DartdocOptionSetFile works for directory options', () {

--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -637,13 +637,13 @@ dartdoc:
           equals(
               'Field dartdoc.fileOptionList from ${path.canonicalize(dartdocOptionsTwo.path)}, set to [existing.dart, thing/that/does/not/exist], resolves to missing path: '
               '"${path.joinAll([
-                path.canonicalize(secondDir.path),
-                'thing',
-                'that',
-                'does',
-                'not',
-                'exist'
-              ])}"'));
+            path.canonicalize(secondDir.path),
+            'thing',
+            'that',
+            'does',
+            'not',
+            'exist'
+          ])}"'));
       // It doesn't matter that this fails.
       expect(dartdocOptionSetFiles['nonCriticalFileOption'].valueAt(firstDir),
           equals(path.joinAll([path.canonicalize(firstDir.path), 'whatever'])));
@@ -663,9 +663,9 @@ dartdoc:
           equals(
               'Field dartdoc.fileOption from ${path.canonicalize(dartdocOptionsTwo.path)}, set to not existing, resolves to missing path: '
               '"${path.joinAll([
-                path.canonicalize(secondDir.path),
-                "not existing"
-              ])}"'));
+            path.canonicalize(secondDir.path),
+            "not existing"
+          ])}"'));
     });
 
     test('DartdocOptionSetFile works for directory options', () {


### PR DESCRIPTION
Reverts #2572 and adds todo: ignore.

It also looks like dartfmt has changed its mind recently about indentation -- fix that too.