### PR TITLE
Fix duplicate field on static const extension method

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -147,7 +147,8 @@ class GeneratorFrontEnd implements Generator {
                 writer, packageGraph, lib, extension, property);
           }
 
-          for (var staticField in filterNonDocumented(extension.variableStaticFields)) {
+          for (var staticField
+              in filterNonDocumented(extension.variableStaticFields)) {
             indexAccumulator.add(staticField);
             _generatorBackend.generateProperty(
                 writer, packageGraph, lib, extension, staticField);

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -147,7 +147,7 @@ class GeneratorFrontEnd implements Generator {
                 writer, packageGraph, lib, extension, property);
           }
 
-          for (var staticField in filterNonDocumented(extension.staticFields)) {
+          for (var staticField in filterNonDocumented(extension.variableStaticFields)) {
             indexAccumulator.add(staticField);
             _generatorBackend.generateProperty(
                 writer, packageGraph, lib, extension, staticField);

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -136,7 +136,7 @@ void main() {
         expectAliasedTypeName(a.modelType, equals('T0'));
         expectAliasedTypeName(b.modelType, equals('T0'));
         expectAliasedTypeName(f.modelType, equals('T0'));
-      }, skip: 'dart-lang/sdk#45921');
+      }, skip: 'dart-lang/sdk#45291');
 
       test('basic non-function typedefs work', () {
         expectTypedefs(T0, 'void', []);

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -211,6 +211,9 @@ extension AppleExtension on Apple {
   void s() {
     print('Extension on Apple');
   }
+
+  /// Do not crash on static const extensions.
+  static const int f = 3;
 }
 
 class WithGeneric<T> {

--- a/testing/test_package/pubspec.yaml
+++ b/testing/test_package/pubspec.yaml
@@ -8,4 +8,4 @@ dependencies:
   test_package_imported:
     path: "../test_package_imported"
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'

--- a/testing/test_package_experiments/lib/generalized_typedefs.dart
+++ b/testing/test_package_experiments/lib/generalized_typedefs.dart
@@ -21,13 +21,13 @@ T0 a;
 
 class C2 {
   T0 b;
-  T1 c;
-  T2 d(T3 e, T4 f);
+  T1? c;
+  T2? d(T3 e, T4 f) {}
 }
 
 class C1<T extends T3> {
-  T2 a;
-  T0 b(T1 c, T d);
+  T2? a;
+  T0 b(T1 c, T d) {}
 }
 
 typedef T8 = C1;

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -238,9 +238,15 @@ void analyze() async {
   );
 
   for (var testPackagePath in [testPackageExperiments.path, testPackage.path]) {
-    await SubprocessLauncher('analyze-test-package').runStreamed(
+    await SubprocessLauncher('pub-get').runStreamed(
       sdkBin('dart'),
-      ['analyze', '--no-fatal-warnings', testPackagePath],
+      ['pub', 'get'],
+      workingDirectory: testPackagePath,
+    );
+    await SubprocessLauncher('analyze-test-package').runStreamed(
+      sdkBin('dartanalyzer'),
+      ['.'],
+      workingDirectory: testPackagePath,
     );
   }
 }
@@ -291,10 +297,10 @@ void dartfmt() async {
 @Task('Run quick presubmit checks.')
 @Depends(
   analyze,
-  checkBuild,
-  smokeTest,
   dartfmt,
+  checkBuild,
   tryPublish,
+  smokeTest,
 )
 void presubmit() => null;
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -236,8 +236,11 @@ void analyze() async {
     sdkBin('dartanalyzer'),
     ['--fatal-infos', '--options', 'analysis_options_presubmit.yaml', '.'],
   );
-
-  for (var testPackagePath in [testPackageExperiments.path, testPackage.path]) {
+  var testPackagePaths = [testPackage.path];
+  if (Platform.version.contains('dev')) {
+    testPackagePaths.add(testPackageExperiments.path);
+  }
+  for (var testPackagePath in testPackagePaths) {
     await SubprocessLauncher('pub-get').runStreamed(
       sdkBin('dart'),
       ['pub', 'get'],

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -236,6 +236,13 @@ void analyze() async {
     sdkBin('dartanalyzer'),
     ['--fatal-infos', '--options', 'analysis_options_presubmit.yaml', '.'],
   );
+
+  for (var testPackagePath in [testPackageExperiments.path, testPackage.path]) {
+    await SubprocessLauncher('analyze-test-package').runStreamed(
+      sdkBin('dart'),
+      ['analyze', '--no-fatal-warnings', testPackagePath],
+    );
+  }
 }
 
 @Task('Check for dartfmt cleanliness')


### PR DESCRIPTION
This fixes a bug where dartdoc will throw trying to write a duplicate file for a `static const` declaration inside an extension.  Also, corrects some analysis issues and adds enforcement of no analysis errors (yet, allowing warnings) within the two main test packages.