### PR TITLE
write out static methods on extensions

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -370,7 +370,8 @@ class Dartdoc {
     found.add(indexPath);
     for (Map<String, dynamic> entry in jsonData) {
       if (entry.containsKey('href')) {
-        var entryPath = path.joinAll([origin, entry['href']]);
+        var entryPath =
+            path.joinAll([origin, ...path.posix.split(entry['href'])]);
         if (!visited.contains(entryPath)) {
           _warn(packageGraph, PackageWarning.brokenLink, entryPath,
               path.normalize(origin),

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -153,6 +153,14 @@ class GeneratorFrontEnd implements Generator {
             _generatorBackend.generateProperty(
                 writer, packageGraph, lib, extension, staticField);
           }
+
+          for (var method in filterNonDocumented(extension.staticMethods)) {
+            if (!method.isCanonical) continue;
+
+            indexAccumulator.add(method);
+            _generatorBackend.generateMethod(
+                writer, packageGraph, lib, extension, method);
+          }
         }
 
         for (var mixin in filterNonDocumented(lib.mixins)) {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1332,12 +1332,6 @@ void main() {
             contains('<code>ThisIsNotHereNoWay&lt;MyType&gt;</code>'));
       });
 
-      test('leaves relative href resulting in a broken link', () {
-        // Dartdoc does emit a brokenLink warning for this.
-        expect(docsAsHtml,
-            contains('<a href="SubForDocComments/localMethod.html">link</a>'));
-      });
-
       test('leaves relative href resulting in a working link', () {
         // Ideally doc comments should not make assumptions about Dartdoc output
         // files, but unfortunately some do...

--- a/testing/test_package/dartdoc_options.yaml
+++ b/testing/test_package/dartdoc_options.yaml
@@ -20,6 +20,8 @@ dartdoc:
       linux: ['/bin/sh', '-c', 'echo']
       windows: ['C:\\Windows\\System32\\cmd.exe', '/c', 'echo']
       description: 'Works on everything'
+  errors:
+    - broken-link
   linkToSource:
     root: '.'
     uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/master/testing/test_package/%f%#L%l%'

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -950,8 +950,6 @@ class BaseForDocComments {
   ///
   /// Reference to an inherited member in another library via class name: [ExtendedBaseReexported.action]
   ///
-  /// Link to a nonexistent file (erroneously expects base href): [link](SubForDocComments/localMethod.html)
-  ///
   /// Link to an existing file: [link](../SubForDocComments/localMethod.html)
   String doAwesomeStuff(int value) => null;
 


### PR DESCRIPTION
Fixes #2588.   Drops a test that verified we wrote the wrong broken link if someone wrote out a wrong broken link, which isn't something we really need, in favor of enabling link validation on the test package.