### PR TITLE
Temporarily ignore fenced code block warning by default for release

### DIFF
--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -265,7 +265,8 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
         'Dartdoc requires code blocks to specify the language used after',
         'the initial declaration.  As an example, to specify Dart you would',
         'specify ```dart or ~~~dart.'
-      ]),
+      ],
+      defaultWarningMode: PackageWarningMode.ignore),
 };
 
 /// Something that package warnings can be called on.  Optionally associated


### PR DESCRIPTION
Before the next release, I gave it some more thought and I think we should ignore this warning by default for now. Gives users an indication to start identifying code blocks and they can enable it if desired. Perhaps we can specify in the changelog that this warning is added and users should start specifying language identifiers. In a later release, we can investigate enabling it by default again.

I planned to do some downstream cleanup for popular packages, libraries, and frameworks but didn't have as much time as I would have liked yet. I should have time to finalize that work soon.

@jcollins-g 