### PR TITLE
Simplify logic in features rendering.

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -8143,18 +8143,6 @@ class _Renderer_GetterSetterCombo extends RendererBase<GetterSetterCombo> {
                         parent: r);
                   },
                 ),
-                'comboFeatures': Property(
-                  getValue: (CT_ c) => c.comboFeatures,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Set<String>'),
-                  renderIterable:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.comboFeatures.map(
-                        (e) => _render_String(e, ast, r.template, parent: r));
-                  },
-                ),
                 'constantInitializer': Property(
                   getValue: (CT_ c) => c.constantInitializer,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -25,11 +25,10 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
   }
 
   @override
-  Set<String> get features {
-    var _features = super.features;
-    if (isExtended) _features.add('extended');
-    return _features;
-  }
+  Set<String> get features => {
+        ...super.features,
+        if (isExtended) 'extended',
+      };
 
   bool _canonicalEnclosingContainerIsSet = false;
   Container _canonicalEnclosingContainer;

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -12,6 +12,7 @@ import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/warnings.dart';
+import 'package:meta/meta.dart';
 
 /// Mixin for top-level variables and fields (aka properties)
 mixin GetterSetterCombo on ModelElement {
@@ -25,6 +26,7 @@ mixin GetterSetterCombo on ModelElement {
     }
   }
 
+  @protected
   Set<String> get comboFeatures {
     var allFeatures = <String>{};
     if (hasExplicitGetter && hasPublicGetter) {

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -28,13 +28,12 @@ mixin Inheritable on ContainerMember {
   bool get isCovariant;
 
   @override
-  Set<String> get features {
-    var _features = super.features;
-    if (isOverride) _features.add('override');
-    if (isInherited) _features.add('inherited');
-    if (isCovariant) _features.add('covariant');
-    return _features;
-  }
+  Set<String> get features => {
+        ...super.features,
+        if (isOverride) 'override',
+        if (isInherited) 'inherited',
+        if (isCovariant) 'covariant',
+      };
 
   @override
   Library get canonicalLibrary => canonicalEnclosingContainer?.canonicalLibrary;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -1216,20 +1216,21 @@ extension on ElementAnnotation {
   /// Returns this annotation's "real" element, passing through unused,
   /// intermediate elements.
   Element get realElement {
+    Element getDeclaration(Element e) => e is Member ? e.declaration : e;
+
     var element = this.element;
+
     if (element is ConstructorElement) {
       // TODO(srawlins): I think we should actually link to the constructor,
       // which may have details about parameters. For example, given the
       // annotation `@Immutable('text')`, the constructor documents what the
       // parameter is, and the class only references `immutable`. It's a
       // lose-lose cycle of mis-direction.
-      return element.returnType.element;
+      return getDeclaration(element.returnType.element);
     } else if (element is PropertyAccessorElement) {
-      return element.variable;
-    } else if (element is Member) {
-      return element.declaration;
+      return getDeclaration(element.variable);
     } else {
-      return element;
+      return getDeclaration(element);
     }
   }
 }

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -516,16 +516,6 @@ abstract class ModelElement extends Canonicalization
     'deprecated'
   };
 
-  /// Returns whether this has any displayable features.
-  bool get hasFeatures {
-    if (isFinal) return true;
-    if (isLate) return true;
-
-    return element.metadata
-        .where((e) => !_specialFeatures.contains(e.element?.name))
-        .any((e) => _shouldDisplayAnnotation(e.realElement));
-  }
-
   Set<String> get features {
     return {
       ...annotationsFromMetadata(element.metadata

--- a/lib/templates/html/_features.html
+++ b/lib/templates/html/_features.html
@@ -1,1 +1,1 @@
-{{ #featuresAsString.isNotEmpty }}<div class="features">{{{featuresAsString}}}</div>{{ /featuresAsString.isNotEmpty }}
+{{ #hasFeatures }}<div class="features">{{{featuresAsString}}}</div>{{ /hasFeatures }}

--- a/lib/templates/html/_features.html
+++ b/lib/templates/html/_features.html
@@ -1,1 +1,1 @@
-{{ #hasFeatures }}<div class="features">{{{featuresAsString}}}</div>{{ /hasFeatures }}
+{{ #features }}<div class="features">{{{featuresAsString}}}</div>{{ /features }}

--- a/lib/templates/md/_features.md
+++ b/lib/templates/md/_features.md
@@ -1,1 +1,1 @@
-{{ #featuresAsString.isNotEmpty }}_{{{featuresAsString}}}_{{ /featuresAsString.isNotEmpty }}
+{{ #hasFeatures }}_{{{featuresAsString}}}_{{ /hasFeatures }}

--- a/lib/templates/md/_features.md
+++ b/lib/templates/md/_features.md
@@ -1,1 +1,1 @@
-{{ #hasFeatures }}_{{{featuresAsString}}}_{{ /hasFeatures }}
+{{ #features }}_{{{featuresAsString}}}_{{ /features }}


### PR DESCRIPTION
The default template calls `featuresAsString` twice, once to see if it is empty, then again to render the poor String. `featuresAsString` involves:

1. Iterating over all annotations,
2. finding canonical elements,
3. HTML-escaping the source of each one,
4. sorting the results into a list, by a custom sort.

This change switches to just use the `features` getter. Using this in templates avoids creating a List and sorting with a custom sort.

* Additionally, the HtmlEscape is extracted into a static const.
* A `realElement` getter is introduced on ElementAnnotation, which is used in a number of places.
* Annotations are not HTML-escaped unless we definitely want to display them.