### PR TITLE
Print version information when an exception is encountered

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -10,7 +10,7 @@ library dartdoc;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show exitCode, stderr;
+import 'dart:io' show Platform, exitCode, stderr;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/options.dart';
@@ -483,10 +483,10 @@ class Dartdoc {
       },
       (e, chain) {
         if (e is DartdocFailure) {
-          stderr.writeln('\ndartdoc failed: $e.');
+          stderr.writeln('\n$_dartdocFailedMessage: $e.');
           exitCode = 1;
         } else {
-          stderr.writeln('\ndartdoc failed: $e\n$chain');
+          stderr.writeln('\n$_dartdocFailedMessage: $e\n$chain');
           exitCode = 255;
         }
       },
@@ -516,3 +516,5 @@ class DartdocResults {
 
   DartdocResults(this.packageMeta, this.packageGraph, this.outDir);
 }
+
+String get _dartdocFailedMessage => 'dartdoc $packageVersion (${Platform.script.path}) failed';

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -517,4 +517,5 @@ class DartdocResults {
   DartdocResults(this.packageMeta, this.packageGraph, this.outDir);
 }
 
-String get _dartdocFailedMessage => 'dartdoc $packageVersion (${Platform.script.path}) failed';
+String get _dartdocFailedMessage =>
+    'dartdoc $packageVersion (${Platform.script.path}) failed';


### PR DESCRIPTION
Fixes #2594 by making sure it is extremely clear what version of dartdoc is reporting the error.  Given that there are multiple ways to access the package for now, this should reduce confusion.

example (with a hand-added exception):

```
jcollins-macbookpro2:dartdoc jcollins$ dart bin/dartdoc.dart
Documenting dartdoc...
-
dartdoc 0.42.0 (/Users/jcollins/dart/dartdoc/bin/dartdoc.dart) failed: Exception
#0      PackageGraph.addLibraryToGraph (package:dartdoc/src/model/package_graph.dart:56:5)
#1      PubPackageBuilder._parseLibraries (package:dartdoc/src/model/package_builder.dart:224:23)
<asynchronous suspension>
#2      PubPackageBuilder.getLibraries (package:dartdoc/src/model/package_builder.dart:403:5)
<asynchronous suspension>
#3      PubPackageBuilder.buildPackageGraph (package:dartdoc/src/model/package_builder.dart:71:5)
<asynchronous suspension>
#4      Dartdoc.generateDocsBase (package:dartdoc/dartdoc.dart:176:20)
<asynchronous suspension>
#5      Dartdoc.generateDocs (package:dartdoc/dartdoc.dart:217:28)
<asynchronous suspension>
#6      Dartdoc.executeGuarded.<anonymous closure> (package:dartdoc/dartdoc.dart:481:9)
<asynchronous suspension>
```