### PR TITLE
Put late before final in feature sorting

### DIFF
--- a/lib/src/model/feature.dart
+++ b/lib/src/model/feature.dart
@@ -47,6 +47,7 @@ class Feature implements Privacy {
   // TODO(jcollins-g): consider [Comparable]?
   final int sortGroup;
 
+  static const lateFeature = Feature('late', 1);
   static const readOnly = Feature('read-only', 1);
   static const finalFeature = Feature('final', 2);
   static const writeOnly = Feature('write-only', 2);
@@ -56,7 +57,6 @@ class Feature implements Privacy {
   static const inherited = Feature('inherited', 3);
   static const inheritedGetter = Feature('inherited-getter', 3);
   static const inheritedSetter = Feature('inherited-setter', 3);
-  static const lateFeature = Feature('late', 3);
   static const overrideFeature = Feature('override', 3);
   static const overrideGetter = Feature('override-getter', 3);
   static const overrideSetter = Feature('override-setter', 3);

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -42,7 +42,7 @@ mixin GetterSetterCombo on ModelElement {
         if (hasExplicitSetter && hasPublicSetter) ...setter.features,
         if (readOnly && !isFinal && !isConst) Feature.readOnly,
         if (writeOnly) Feature.writeOnly,
-        if (readWrite) Feature.readWrite,
+        if (readWrite && !isLate) Feature.readWrite,
       };
 
   @override

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -219,18 +219,22 @@ void main() {
       expect(a.modelType.name, equals('dynamic'));
       expect(a.isLate, isTrue);
       expect(a.features, contains(Feature.lateFeature));
+      expect(a.features, isNot(contains(Feature.readWrite)));
 
       expect(b.modelType.name, equals('int'));
       expect(b.isLate, isTrue);
       expect(b.features, contains(Feature.lateFeature));
+      expect(b.features, isNot(contains(Feature.readWrite)));
 
       expect(cField.modelType.name, equals('dynamic'));
       expect(cField.isLate, isTrue);
       expect(cField.features, contains(Feature.lateFeature));
+      expect(cField.features, isNot(contains(Feature.readWrite)));
 
       expect(dField.modelType.name, equals('double'));
       expect(dField.isLate, isTrue);
       expect(dField.features, contains(Feature.lateFeature));
+      expect(dField.features, isNot(contains(Feature.readWrite)));
     });
 
     test('Late final top level variables', () {
@@ -239,6 +243,7 @@ void main() {
       expect(initializeMe.modelType.name, equals('String'));
       expect(initializeMe.isLate, isTrue);
       expect(initializeMe.features, contains(Feature.lateFeature));
+      expect(initializeMe.features, isNot(contains(Feature.readWrite)));
     });
 
     test('Opt out of Null safety', () {


### PR DESCRIPTION
Also, do not mark late fields/variables as "read-write".  While that's technically true depending on your point of view, the word "late" encapsulates the behavior more accurately.

before:

![Screen Shot 2021-04-07 at 12 19 55 PM](https://user-images.githubusercontent.com/14116827/113924654-ec4c9180-979e-11eb-9076-54cd3086c686.png)

after: 

![Screen Shot 2021-04-07 at 12 19 42 PM](https://user-images.githubusercontent.com/14116827/113924670-f1a9dc00-979e-11eb-8e5d-1aafcd00b5c7.png)
