### PR TITLE
Enable coverage once more.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,8 +52,7 @@ jobs:
         run: ./tool/travis.sh
         env:
           DARTDOC_BOT: ${{ matrix.job }}
-          # TODO(jcollins-g): uncomment after #2590 is fixed
-          #COVERAGE_TOKEN: true # this needs to be set to enable coverage
+          COVERAGE_TOKEN: true # this needs to be set to enable coverage
       - name: ${{ matrix.job }}
         if: runner.os == 'Windows' && matrix.job == 'main'
         run: pub run grinder buildbot

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,14 +59,13 @@ jobs:
         run: pub run grinder buildbot
         env:
           DARTDOC_BOT: ${{ matrix.job }}
-      # TODO(jcollins-g): uncomment after #2590 is fixed
-      #- id: coverage
-      #  name: Upload coverage
-      #  if: runner.os == 'Linux' && matrix.job == 'main' && matrix.sdk == 'dev'
-      #  uses: coverallsapp/github-action@v1.1.2
-      #  with:
-      #    github-token: ${{ secrets.GITHUB_TOKEN }}
-      #    path-to-lcov: lcov.info
-      #- name: Echo coveralls api result
-      #  if: runner.os == 'Linux' && matrix.job == 'main' && matrix.sdk == 'dev'
-      #  run: echo ${{ steps.coverage.outputs['coveralls-api-result'] }}
+      - id: coverage
+        name: Upload coverage
+        if: runner.os == 'Linux' && matrix.job == 'main' && matrix.sdk == 'dev'
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info
+      - name: Echo coveralls api result
+        if: runner.os == 'Linux' && matrix.job == 'main' && matrix.sdk == 'dev'
+        run: echo ${{ steps.coverage.outputs['coveralls-api-result'] }}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: ^1.3.0
+  analyzer: ^1.4.0
   args: ^2.0.0
   charcode: ^1.2.0
   collection: ^1.2.0

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -91,15 +91,20 @@ void main() {
     test('invalid parameters return non-zero and print a fatal-error',
         () async {
       var outputLines = <String>[];
-      await expectLater(
-          () => subprocessLauncher.runStreamed(
-              Platform.resolvedExecutable,
-              [
-                dartdocPath,
-                '--nonexisting',
-              ],
-              perLine: outputLines.add),
-          throwsA(const TypeMatcher<ProcessException>()));
+      var threwException = false;
+      // consider [expectLater] when it works reliably with coverage again.
+      try {
+        await subprocessLauncher.runStreamed(
+            Platform.resolvedExecutable,
+            [
+              dartdocPath,
+              '--nonexisting',
+            ],
+            perLine: outputLines.add);
+      } on ProcessException {
+        threwException = true;
+      }
+      expect(threwException, isTrue);
       expect(
           outputLines.firstWhere((l) => l.startsWith(' fatal')),
           equals(
@@ -109,20 +114,21 @@ void main() {
     test('missing a required file path prints a fatal-error', () async {
       var outputLines = <String>[];
       var impossiblePath = path.join(dartdocPath, 'impossible');
+      var threwException = false;
+      // consider [expectLater] when it works with coverage again.
       try {
-        await expectLater(
-            () => subprocessLauncher.runStreamed(
-                Platform.resolvedExecutable,
-                [
-                  dartdocPath,
-                  '--input',
-                  impossiblePath,
-                ],
-                perLine: outputLines.add),
-            throwsA(const TypeMatcher<ProcessException>()));
-      } catch (e) {
-        print('How did we get here, should be impossible right?\n$e');
+        await subprocessLauncher.runStreamed(
+            Platform.resolvedExecutable,
+            [
+              dartdocPath,
+              '--input',
+              impossiblePath,
+            ],
+            perLine: outputLines.add);
+      } on ProcessException {
+        threwException = true;
       }
+      expect(threwException, isTrue);
       expect(
           outputLines.firstWhere((l) => l.startsWith(' fatal')),
           startsWith(

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -136,14 +136,19 @@ void main() {
     });
 
     test('errors cause non-zero exit when warnings are off', () async {
-      expect(
-          () => subprocessLauncher.runStreamed(Platform.resolvedExecutable, [
-                dartdocPath,
-                '--allow-tools',
-                '--input=${testPackageToolError.path}',
-                '--output=${path.join(tempDir.absolute.path, 'test_package_tool_error')}'
-              ]),
-          throwsA(const TypeMatcher<ProcessException>()));
+      // consider [expectLater] when it works with coverage.
+      var exceptionThrown = false;
+      try {
+        await subprocessLauncher.runStreamed(Platform.resolvedExecutable, [
+          dartdocPath,
+          '--allow-tools',
+          '--input=${testPackageToolError.path}',
+          '--output=${path.join(tempDir.absolute.path, 'test_package_tool_error')}'
+        ]);
+      } on ProcessException {
+        exceptionThrown = true;
+      }
+      expect(exceptionThrown, isTrue);
     });
 
     test('help prints command line args', () async {
@@ -166,19 +171,20 @@ void main() {
       var dartTool =
           Directory(path.join(_testPackageFlutterPluginPath, '.dart_tool'));
       if (dartTool.existsSync()) dartTool.deleteSync(recursive: true);
-      Future run = subprocessLauncher.runStreamed(
-          Platform.resolvedExecutable, args,
-          environment: Map.from(Platform.environment)..remove('FLUTTER_ROOT'),
-          includeParentEnvironment: false,
-          workingDirectory: _testPackageFlutterPluginPath, perLine: (s) {
-        output.writeln(s);
-      });
-      // Asynchronous exception, but we still need the output, too.
-      expect(run, throwsA(TypeMatcher<ProcessException>()));
+      var exceptionThrown = false;
+      // consider [expectLater] when this works with coverage
       try {
-        await run;
-      } on ProcessException catch (_) {}
-
+        await subprocessLauncher.runStreamed(Platform.resolvedExecutable, args,
+            environment: Map.from(Platform.environment)..remove('FLUTTER_ROOT'),
+            includeParentEnvironment: false,
+            workingDirectory: _testPackageFlutterPluginPath, perLine: (s) {
+          output.writeln(s);
+        });
+      } on ProcessException {
+        exceptionThrown = true;
+      }
+      // Asynchronous exception, but we still need the output, too.
+      expect(exceptionThrown, isTrue);
       expect(
           output.toString(),
           contains(RegExp(

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -109,16 +109,20 @@ void main() {
     test('missing a required file path prints a fatal-error', () async {
       var outputLines = <String>[];
       var impossiblePath = path.join(dartdocPath, 'impossible');
-      await expectLater(
-          () => subprocessLauncher.runStreamed(
-              Platform.resolvedExecutable,
-              [
-                dartdocPath,
-                '--input',
-                impossiblePath,
-              ],
-              perLine: outputLines.add),
-          throwsA(const TypeMatcher<ProcessException>()));
+      try {
+        await expectLater(
+            () => subprocessLauncher.runStreamed(
+                Platform.resolvedExecutable,
+                [
+                  dartdocPath,
+                  '--input',
+                  impossiblePath,
+                ],
+                perLine: outputLines.add),
+            throwsA(const TypeMatcher<ProcessException>()));
+      } catch (e) {
+        print('How did we get here, should be impossible right?\n$e');
+      }
       expect(
           outputLines.firstWhere((l) => l.startsWith(' fatal')),
           startsWith(


### PR DESCRIPTION
Fixes #2590. 

Something about the timing of how the exceptions are raised (synchronous vs. asynchronous?) when coverage runs under GitHub actions (but not, frustratingly, locally) results in the exceptions not being caught _sometimes_ using the variety of patterns present in the tests.  Often only one of these cases will fail in a single run of coverage and it changes from run to run which is impacted.   Fix this by removing `await expectLater` and similar constructs, in favor of a try block surrounding a more simple await.

I _think_ this may be either a bug in the test package or the VM, but I am not sure what behavior I should be expecting so can't really say.  Insight on what we may have been doing wrong (or, indeed, if this is still wrong!) would be appreciated.