### PR TITLE
Fix public mixins template text in category sidebar

### DIFF
--- a/lib/templates/html/_sidebar_for_category.html
+++ b/lib/templates/html/_sidebar_for_category.html
@@ -7,7 +7,7 @@
   {{/self.hasPublicLibraries}}
 
   {{#self.hasPublicMixins}}
-  <li class="section-title"><a href="{{{library.href}}}#mixins">Mixins</a></li>
+  <li class="section-title"><a href="{{{self.href}}}#mixins">Mixins</a></li>
   {{#self.publicMixinsSorted}}
   <li>{{{ linkedName }}}</li>
   {{/self.publicMixinsSorted}}


### PR DESCRIPTION
As neither Category nor CategoryTemplateData have a member called `library`, I'm pretty sure this code is a runtime error waiting to happen.

It must have never been reported yet because no one (including flutter) has a `@category` with public mixins? I'm honestly not sure.