### PR TITLE
Replace hasDisplayedCategories with hasCategoryNames.

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -8795,13 +8795,6 @@ class _Renderer_Categorization extends RendererBase<Categorization> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.hasCategoryNames == true,
                 ),
-                'hasDisplayedCategories': Property(
-                  getValue: (CT_ c) => c.hasDisplayedCategories,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.hasDisplayedCategories == true,
-                ),
                 'hasImage': Property(
                   getValue: (CT_ c) => c.hasImage,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -117,8 +117,6 @@ abstract class Categorization implements ModelElement {
     return categories.where((c) => c.isDocumented);
   }
 
-  bool get hasDisplayedCategories => displayedCategories.isNotEmpty;
-
   /// True if categories, subcategories, a documentation icon, or samples were
   /// declared.
   bool get hasCategorization {

--- a/lib/templates/md/_categorization.md
+++ b/lib/templates/md/_categorization.md
@@ -1,6 +1,6 @@
-{{#hasDisplayedCategories}}
+{{#hasCategoryNames}}
 Categories:
 {{#displayedCategories}}
 {{{categoryLabel}}}
 {{/displayedCategories}}
-{{/hasDisplayedCategories}}
+{{/hasCategoryNames}}


### PR DESCRIPTION
Sometimes this partial is used for ModelFunctionTyped objects which don't
necessarily mix in Categorization, like ModelFunctionTypedef, so no
`hasDisplayedCategories` method is available.

This was the last usage of this method so I delete it as well.

`_categorization.html` already just used `hasCategoryNames`.