### PR TITLE
disable triple-shift and generic-metadata once more

### DIFF
--- a/lib/src/model/operator.dart
+++ b/lib/src/model/operator.dart
@@ -22,6 +22,7 @@ class Operator extends Method {
     '<=': 'less_equal',
     '<<': 'shift_left',
     '>>': 'shift_right',
+    '>>>': 'triple_shift',
     '^': 'bitwise_exclusive_or',
     'unary-': 'unary_minus',
     '|': 'bitwise_or',

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -27,14 +27,10 @@ final Version _platformVersion = Version.parse(_platformVersionString);
 final _testPackageGraphExperimentsMemo = AsyncMemoizer<PackageGraph>();
 Future<PackageGraph> get _testPackageGraphExperiments =>
     _testPackageGraphExperimentsMemo.runOnce(() => utils.bootBasicPackage(
-            'testing/test_package_experiments',
-            pubPackageMetaProvider,
-            PhysicalPackageConfigProvider(),
-            additionalArguments: [
-              '--enable-experiment',
-              'non-nullable,nonfunction-type-aliases',
-              '--no-link-to-remote'
-            ]));
+        'testing/test_package_experiments',
+        pubPackageMetaProvider,
+        PhysicalPackageConfigProvider(),
+        additionalArguments: ['--no-link-to-remote']));
 
 final _testPackageGraphGinormousMemo = AsyncMemoizer<PackageGraph>();
 Future<PackageGraph> get _testPackageGraphGinormous =>
@@ -74,12 +70,16 @@ void main() {
     exit(1);
   }
 
+  // We can not use ExperimentalFeature.releaseVersion or even
+  // ExperimentalFeature.experimentalReleaseVersion as these are set to null
+  // even when partial analyzer implementations are available, and are often
+  // set too high after release.
   final _generalizedTypedefsAllowed =
       VersionRange(min: Version.parse('2.13.0-0'), includeMin: true);
   final _genericMetadataAllowed =
-      VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
+      VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
   final _tripleShiftAllowed =
-      VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
+      VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
 
   // Experimental features not yet enabled by default.  Move tests out of this
   // block when the feature is enabled by default.

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -77,9 +77,9 @@ void main() {
   final _generalizedTypedefsAllowed =
       VersionRange(min: Version.parse('2.13.0-0'), includeMin: true);
   final _genericMetadataAllowed =
-      VersionRange(min: Version.parse('2.13.0-0'), includeMin: true);
+      VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
   final _tripleShiftAllowed =
-      VersionRange(min: Version.parse('2.13.0-0'), includeMin: true);
+      VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
 
   // Experimental features not yet enabled by default.  Move tests out of this
   // block when the feature is enabled by default.

--- a/testing/test_package_experiments/pubspec.yaml
+++ b/testing/test_package_experiments/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_package_experiments
 version: 0.0.1
 environment:
-  sdk: '>=2.13.0-0 <3.0.0'
+  sdk: '>=2.14.0-0 <3.0.0'
 description: Experimental flags are tested here.


### PR DESCRIPTION
Since changes for 2.13 release and 2.14-dev, the triple-shift and generic-metadata experimental features seem to no longer work via the analyzer (even though I have been able to verify they are switched on correctly via the debugger).

So, simply disable them for now.