### PR TITLE
Enhance browser search experience

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -77,6 +77,7 @@ main {
 
 .sidebar-offcanvas-left {
   flex: 0 1 230px;
+  order: 1;
   overflow-y: scroll;
   padding: 20px 0 15px 30px;
   margin: 5px 20px 0 0;
@@ -93,6 +94,7 @@ main {
 
 .main-content {
   flex: 1;
+  order: 2;
   overflow-y: scroll;
   padding: 10px 20px 0 20px;
   visibility: hidden; /* shown by Javascript after scroll position restore */
@@ -100,6 +102,7 @@ main {
 
 .sidebar-offcanvas-right {
   flex: 0 1 12em;
+  order: 3;
   overflow-y: scroll;
   padding: 20px 15px 15px 15px;
   margin-top: 5px;

--- a/lib/templates/html/404error.html
+++ b/lib/templates/html/404error.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
-    {{>packages}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     <h1>404: Something's gone wrong :-(</h1>
 
@@ -20,6 +14,12 @@
 
     </section>
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
+    {{>packages}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div>

--- a/lib/templates/html/category.html
+++ b/lib/templates/html/category.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-  {{>search_sidebar}}
-  <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
-  {{>packages}}
-</div>
-
 <div id="dartdoc-main-content" class="main-content">
   {{#self}}
   <h1><span class="kind-category">{{name}}</span> {{kind}}</h1>
@@ -121,6 +115,13 @@
   {{/self}}
 
 </div> <!-- /.main-content -->
+
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  {{>search_sidebar}}
+  <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
+  {{>packages}}
+</div>
+
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   <h5>{{self.name}} {{self.kind}}</h5>
   {{>sidebar_for_category}}

--- a/lib/templates/html/class.html
+++ b/lib/templates/html/class.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-class">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -172,6 +166,12 @@
     {{/clazz}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{{sidebarForContainer}}}

--- a/lib/templates/html/constructor.html
+++ b/lib/templates/html/constructor.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForContainer}}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-constructor">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}}</h1></div>
@@ -32,6 +26,12 @@
 
     {{/constructor}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForContainer}}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/lib/templates/html/enum.html
+++ b/lib/templates/html/enum.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-enum">{{{name}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -162,6 +156,12 @@
     {{/hasPublicStaticMethods}}
     {{/eNum}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{{sidebarForContainer}}}

--- a/lib/templates/html/extension.html
+++ b/lib/templates/html/extension.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-</div>
-
 <div id="dartdoc-main-content" class="main-content">
     {{#self}}
     <div>{{>source_link}}<h1><span class="kind-class">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -97,6 +91,12 @@
     {{/extension}}
 
 </div> <!-- /.main-content -->
+
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+</div>
 
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{{sidebarForContainer}}}

--- a/lib/templates/html/function.html
+++ b/lib/templates/html/function.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-function">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -21,6 +15,12 @@
 
     {{/function}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/lib/templates/html/index.html
+++ b/lib/templates/html/index.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5 class="hidden-xs"><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
-    {{>packages}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#defaultPackage}}
       {{>documentation}}
@@ -34,6 +28,12 @@
     {{/localPackages}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5 class="hidden-xs"><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
+    {{>packages}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div>

--- a/lib/templates/html/library.html
+++ b/lib/templates/html/library.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
-    {{>packages}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-library">{{{name}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -124,6 +118,12 @@
     {{/library.hasPublicExceptions}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
+    {{>packages}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     <h5>{{self.name}} {{self.kind}}</h5>

--- a/lib/templates/html/method.html
+++ b/lib/templates/html/method.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForContainer}}}
-  </div><!--/.sidebar-offcanvas-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-method">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}}</h1></div>
@@ -22,6 +16,12 @@
 
     {{/method}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForContainer}}}
+  </div><!--/.sidebar-offcanvas-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/lib/templates/html/mixin.html
+++ b/lib/templates/html/mixin.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-mixin">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -171,6 +165,12 @@
     {{/hasPublicConstantFields}}
     {{/mixin}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{{sidebarForContainer}}}

--- a/lib/templates/html/property.html
+++ b/lib/templates/html/property.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForContainer}}}
-  </div><!--/.sidebar-offcanvas-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-property">{{name}}</span> {{kind}} {{>feature_set}}</h1></div>
@@ -33,6 +27,12 @@
       {{/hasGetterOrSetter}}
     {{/self}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForContainer}}}
+  </div><!--/.sidebar-offcanvas-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/lib/templates/html/top_level_property.html
+++ b/lib/templates/html/top_level_property.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-top-level-property">{{{name}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -29,6 +23,12 @@
       {{/hasExplicitSetter}}
     {{/self}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/lib/templates/html/typedef.html
+++ b/lib/templates/html/typedef.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-typedef">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
@@ -23,6 +17,12 @@
     {{/typeDef}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{{sidebarForLibrary}}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/404error.html
+++ b/testing/test_package_custom_templates/templates/404error.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
-    {{>packages}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     <h1>404: Something's gone wrong :-(</h1>
 
@@ -20,6 +14,12 @@
 
     </section>
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
+    {{>packages}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div>

--- a/testing/test_package_custom_templates/templates/category.html
+++ b/testing/test_package_custom_templates/templates/category.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
-    {{>packages}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <h1><span class="kind-category">{{name}}</span> {{kind}}</h1>
@@ -121,6 +115,13 @@
     {{/self}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
+    {{>packages}}
+  </div>
+
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     <h5>{{self.name}} {{self.kind}}</h5>
     {{>sidebar_for_category}}

--- a/testing/test_package_custom_templates/templates/class.html
+++ b/testing/test_package_custom_templates/templates/class.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-class">{{{nameWithGenerics}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -172,6 +166,12 @@
     {{/clazz}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{>sidebar_for_class}}

--- a/testing/test_package_custom_templates/templates/constant.html
+++ b/testing/test_package_custom_templates/templates/constant.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_container}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-constant">{{{name}}}</span> {{kind}}</h1></div>
@@ -26,6 +20,12 @@
     {{/property}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_container}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/constructor.html
+++ b/testing/test_package_custom_templates/templates/constructor.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_class}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-constructor">{{{nameWithGenerics}}}</span> {{kind}}</h1></div>
@@ -32,6 +26,12 @@
 
     {{/constructor}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_class}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/enum.html
+++ b/testing/test_package_custom_templates/templates/enum.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-enum">{{{name}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -162,6 +156,12 @@
     {{/hasPublicStaticMethods}}
     {{/eNum}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{>sidebar_for_enum}}

--- a/testing/test_package_custom_templates/templates/extension.html
+++ b/testing/test_package_custom_templates/templates/extension.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-</div>
-
 <div id="dartdoc-main-content" class="main-content">
     {{#self}}
     <div>{{>source_link}}<h1><span class="kind-class">{{{nameWithGenerics}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -97,6 +91,12 @@
     {{/extension}}
 
 </div> <!-- /.main-content -->
+
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+</div>
 
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{>sidebar_for_extension}}

--- a/testing/test_package_custom_templates/templates/function.html
+++ b/testing/test_package_custom_templates/templates/function.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-function">{{{nameWithGenerics}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -21,6 +15,12 @@
 
     {{/function}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/index.html
+++ b/testing/test_package_custom_templates/templates/index.html
@@ -1,10 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5 class="hidden-xs"><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
-    {{>packages}}
-  </div>
 
 Welcome my friends to a custom template
 
@@ -37,6 +32,12 @@ Welcome my friends to a custom template
     {{/localPackages}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5 class="hidden-xs"><span class="package-name">{{self.name}}</span> <span class="package-kind">{{self.kind}}</span></h5>
+    {{>packages}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div>

--- a/testing/test_package_custom_templates/templates/library.html
+++ b/testing/test_package_custom_templates/templates/library.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
-    {{>packages}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-library">{{{name}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -124,6 +118,12 @@
     {{/library.hasPublicExceptions}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
+    {{>packages}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     <h5>{{self.name}} {{self.kind}}</h5>

--- a/testing/test_package_custom_templates/templates/method.html
+++ b/testing/test_package_custom_templates/templates/method.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_container}}
-  </div><!--/.sidebar-offcanvas-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-method">{{{nameWithGenerics}}}</span> {{kind}}</h1></div>
@@ -22,6 +16,12 @@
 
     {{/method}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_container}}
+  </div><!--/.sidebar-offcanvas-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/mixin.html
+++ b/testing/test_package_custom_templates/templates/mixin.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div>
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-mixin">{{{nameWithGenerics}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -171,6 +165,12 @@
     {{/hasPublicConstantFields}}
     {{/mixin}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
     {{>sidebar_for_class}}

--- a/testing/test_package_custom_templates/templates/property.html
+++ b/testing/test_package_custom_templates/templates/property.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_container}}
-  </div><!--/.sidebar-offcanvas-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-property">{{name}}</span> {{kind}}</h1></div>
@@ -33,6 +27,12 @@
       {{/hasGetterOrSetter}}
     {{/self}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_container}}
+  </div><!--/.sidebar-offcanvas-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/top_level_constant.html
+++ b/testing/test_package_custom_templates/templates/top_level_constant.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-top-level-constant">{{{name}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -21,6 +15,12 @@
     {{/self}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/top_level_property.html
+++ b/testing/test_package_custom_templates/templates/top_level_property.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-top-level-property">{{{name}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -29,6 +23,12 @@
       {{/hasExplicitSetter}}
     {{/self}}
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->

--- a/testing/test_package_custom_templates/templates/typedef.html
+++ b/testing/test_package_custom_templates/templates/typedef.html
@@ -1,11 +1,5 @@
 {{>head}}
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{>sidebar_for_library}}
-  </div><!--/.sidebar-offcanvas-left-->
-
   <div id="dartdoc-main-content" class="main-content">
     {{#self}}
       <div>{{>source_link}}<h1><span class="kind-typedef">{{{nameWithGenerics}}}</span> {{kind}} {{>categorization}}</h1></div>
@@ -25,6 +19,12 @@
     {{/typeDef}}
 
   </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+    {{>search_sidebar}}
+    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{>sidebar_for_library}}
+  </div><!--/.sidebar-offcanvas-left-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->


### PR DESCRIPTION
The primary cause of the unpleasant browser search experience was the order in which sidebars were placed in the DOM, which would make results from the left sidebar to precede those from the main content while using any browser's search functionality.

It is fixed by reordering the sidebars in the DOM while preserving the visual order using [flex order](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items) as suggested by @mleonhard in https://github.com/dart-lang/dartdoc/issues/2131#issuecomment-824390149.

As a bonus this also fixes an a11y issue where screen readers would first read out contents of the sidebar instead of the main content as they also rely on the DOM order.

**Related Issues:**

Fixes #2131
Fixes flutter/flutter#80849