### PR TITLE
Fix directives sort ordering

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -8,12 +8,12 @@
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/src/model/annotation.dart';
-import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
+import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/feature_set.dart';
 import 'package:dartdoc/src/model/language_feature.dart';
-import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:dartdoc/src/mustachio/parser.dart';
+import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'templates.dart';
 

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
-import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/context/builder.dart';
+import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/src/dart/sdk/sdk.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/java_io.dart';
@@ -19,10 +19,10 @@ import 'package:analyzer/src/generated/source_io.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart' hide Package;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart'
     show PackageMeta, PackageMetaProvider;
+import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:dartdoc/src/render/renderer_factory.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -20,7 +20,6 @@ import 'package:dartdoc/src/render/renderer_factory.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:dartdoc/src/tuple.dart';
 import 'package:dartdoc/src/warnings.dart';
-import 'package:dartdoc/src/model_utils.dart' show matchGlobs;
 
 class PackageGraph {
   PackageGraph.uninitialized(
@@ -976,7 +975,7 @@ class PackageGraph {
       // for nodoc's semantics.  Looking up the defining element just to pull
       // a context is again, slow.
       List<String> globs = config.optionSet['nodoc'].valueAt(file.parent2);
-      _configSetsNodocFor[fullName] = matchGlobs(globs, fullName);
+      _configSetsNodocFor[fullName] = utils.matchGlobs(globs, fullName);
     }
     return _configSetsNodocFor[fullName];
   }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -13,8 +13,8 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/dart/ast/utilities.dart';
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:path/path.dart' as path;
 import 'package:glob/glob.dart';
+import 'package:path/path.dart' as path;
 
 final _driveLetterMatcher = RegExp(r'^\w:\\');
 

--- a/test/mustachio/foo.renderers.dart
+++ b/test/mustachio/foo.renderers.dart
@@ -8,12 +8,12 @@
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/src/model/annotation.dart';
-import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
+import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/feature_set.dart';
 import 'package:dartdoc/src/model/language_feature.dart';
-import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:dartdoc/src/mustachio/parser.dart';
+import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'foo.dart';
 

--- a/test/quiver_test.dart
+++ b/test/quiver_test.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 import 'package:dartdoc/src/quiver.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('concat', () {

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -90,12 +90,12 @@ class RuntimeRenderersBuilder {
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/src/model/annotation.dart';
-import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
+import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/feature_set.dart';
 import 'package:dartdoc/src/model/language_feature.dart';
-import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:dartdoc/src/mustachio/parser.dart';
+import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:dartdoc/src/warnings.dart';
 import '${p.basename(_sourceUri.path)}';
 ''');


### PR DESCRIPTION
I think a recent fix in linter changed how directives_ordering works; found new bugs.