### PR TITLE
Enable experimental feature testing again for 2.14

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: ^1.4.0
+  analyzer: ^1.5.0
   args: ^2.0.0
   charcode: ^1.2.0
   collection: ^1.2.0
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   async: ^2.0.8
   build: ^2.0.0
-  build_runner: ^1.10.0
+  build_runner: ^2.0.1
   build_test: ^2.0.0
   build_version: ^2.0.1
   coverage: ^1.0.2

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -77,9 +77,9 @@ void main() {
   final _generalizedTypedefsAllowed =
       VersionRange(min: Version.parse('2.13.0-0'), includeMin: true);
   final _genericMetadataAllowed =
-      VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
+      VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
   final _tripleShiftAllowed =
-      VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
+      VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
 
   // Experimental features not yet enabled by default.  Move tests out of this
   // block when the feature is enabled by default.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -916,8 +916,8 @@ Future<List<Map>> _buildFlutterDocs(
   );
   // TODO(jcollins-g): flutter's dart SDK pub tries to precompile the universe
   // when using -spath.  Why?
-  await flutterRepo.launcher.runStreamed(
-      'pub', ['global', 'activate', '-spath', '.', '-x', 'dartdoc'],
+  await flutterRepo.launcher.runStreamed(flutterRepo.cachePub,
+      ['global', 'activate', '-spath', '.', '-x', 'dartdoc'],
       workingDirectory: await futureCwd);
   return await flutterRepo.launcher.runStreamed(
     flutterRepo.cacheDart,


### PR DESCRIPTION
Upgrade analyzer version, so we can test triple-shift and generic-metatdata again.