### PR TITLE
Split FileWriter.writeBytes out from FileWriter.write

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -53,43 +53,58 @@ class DartdocFileWriter implements FileWriter {
   DartdocFileWriter(this.outputDir, this.resourceProvider);
 
   @override
-  void write(String filePath, Object content,
-      {bool allowOverwrite, Warnable element}) {
+  void writeBytes(
+    String filePath,
+    List<int> content, {
+    bool allowOverwrite = false,
+  }) {
     // Replace '/' separators with proper separators for the platform.
     var outFile = path.joinAll(filePath.split('/'));
 
-    allowOverwrite ??= false;
     if (!allowOverwrite) {
-      if (_fileElementMap.containsKey(outFile)) {
-        assert(element != null,
-            'Attempted overwrite of $outFile without corresponding element');
-        var originalElement = _fileElementMap[outFile];
-        Iterable<Warnable> referredFrom =
-            originalElement != null ? [originalElement] : null;
-        element?.warn(PackageWarning.duplicateFile,
-            message: outFile, referredFrom: referredFrom);
-      }
+      _warnAboutOverwrite(outFile, null);
     }
-    _fileElementMap[outFile] = element;
 
+    var file = _getFile(outFile);
+    file.writeAsBytesSync(content);
+    writtenFiles.add(outFile);
+    logProgress(outFile);
+  }
+
+  @override
+  void write(String filePath, String content, {Warnable element}) {
+    // Replace '/' separators with proper separators for the platform.
+    var outFile = path.joinAll(filePath.split('/'));
+
+    _warnAboutOverwrite(outFile, element);
+
+    var file = _getFile(outFile);
+    file.writeAsStringSync(content);
+    writtenFiles.add(outFile);
+    logProgress(outFile);
+  }
+
+  void _warnAboutOverwrite(String outFile, Warnable element) {
+    if (_fileElementMap.containsKey(outFile)) {
+      assert(element != null,
+          'Attempted overwrite of $outFile without corresponding element');
+      var originalElement = _fileElementMap[outFile];
+      var referredFrom = originalElement != null ? [originalElement] : null;
+      element?.warn(PackageWarning.duplicateFile,
+          message: outFile, referredFrom: referredFrom);
+    }
+  }
+
+  /// Returns the file at [outFile] relative to [outputDir], creating the parent
+  /// directory if necessary.
+  File _getFile(String outFile) {
     var file = resourceProvider
         .getFile(resourceProvider.pathContext.join(outputDir, outFile));
     var parent = file.parent2;
     if (!parent.exists) {
       parent.create();
     }
-
-    if (content is String) {
-      file.writeAsStringSync(content);
-    } else if (content is List<int>) {
-      file.writeAsBytesSync(content);
-    } else {
-      throw ArgumentError.value(
-          content, 'content', '`content` must be `String` or `List<int>`.');
-    }
-
-    writtenFiles.add(outFile);
-    logProgress(outFile);
+    return file;
   }
 }
 

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -64,6 +64,7 @@ class DartdocFileWriter implements FileWriter {
     if (!allowOverwrite) {
       _warnAboutOverwrite(outFile, null);
     }
+    _fileElementMap[outFile] = null;
 
     var file = _getFile(outFile);
     file.writeAsBytesSync(content);
@@ -77,6 +78,7 @@ class DartdocFileWriter implements FileWriter {
     var outFile = path.joinAll(filePath.split('/'));
 
     _warnAboutOverwrite(outFile, element);
+    _fileElementMap[outFile] = element;
 
     var file = _getFile(outFile);
     file.writeAsStringSync(content);

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -17,9 +17,20 @@ abstract class FileWriter {
   /// All filenames written by this generator.
   Set<String> get writtenFiles;
 
-  /// Write [content] to a file at [filePath].
-  void write(String filePath, Object content,
-      {bool allowOverwrite, Warnable element});
+  /// Writes [content] to a file at [filePath].
+  ///
+  /// If a file is to be overwritten, a warning will be reported on [element].
+  void write(String filePath, String content, {Warnable element});
+
+  /// Writes [content] to a file at [filePath].
+  ///
+  /// If a file is to be overwritten, a warning will be reported, unless
+  /// [allowOverwrite] is `true`.
+  void writeBytes(
+    String filePath,
+    List<int> content, {
+    bool allowOverwrite = false,
+  });
 }
 
 /// An abstract class that defines a generator that generates documentation for

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -48,12 +48,12 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
     if (options.favicon != null) {
       // Allow overwrite of favicon.
       var bytes =
-          graph.resourceProvider.getFile(options.favicon).readAsBytesSync();
-      writer.write(
-          graph.resourceProvider.pathContext
-              .join('static-assets', 'favicon.png'),
-          bytes,
-          allowOverwrite: true);
+          writer.resourceProvider.getFile(options.favicon).readAsBytesSync();
+      writer.writeBytes(
+        graph.resourceProvider.pathContext.join('static-assets', 'favicon.png'),
+        bytes,
+        allowOverwrite: true,
+      );
     }
   }
 
@@ -66,7 +66,7 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
       var destFileName = resourcePath.substring(_dartdocResourcePrefix.length);
       var destFilePath = writer.resourceProvider.pathContext
           .join('static-assets', destFileName);
-      writer.write(destFilePath,
+      writer.writeBytes(destFilePath,
           await writer.resourceProvider.loadResourceAsBytes(resourcePath));
     }
   }


### PR DESCRIPTION
The 5 callers of this method have a rather split set of arguments. `writeBytes` is the only method which needs `allowOverwrite` and `write` is the only method that needs `element`. The primary benefit here is to properly type `content` so that errors are known statically vs at runtime.