### PR TITLE
Breaking: Make containerDesc private and final in TemplateData implementations

### DIFF
--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -434,13 +434,12 @@ class PropertyTemplateData extends TemplateData<Field>
   final Container container;
   final Field property;
   final ContainerSidebar _sidebarForContainer;
-  String containerDesc;
+  final String _containerDescription;
 
   PropertyTemplateData(TemplateOptions htmlOptions, PackageGraph packageGraph,
       this.library, this.container, this.property, this._sidebarForContainer)
-      : super(htmlOptions, packageGraph) {
-    containerDesc = container.isClass ? 'class' : 'extension';
-  }
+      : _containerDescription = container.isClass ? 'class' : 'extension',
+        super(htmlOptions, packageGraph);
 
   String get sidebarForContainer => _sidebarForContainer(container, this);
 
@@ -448,8 +447,8 @@ class PropertyTemplateData extends TemplateData<Field>
   Field get self => property;
 
   @override
-  String get title =>
-      '${property.name} ${property.kind} - ${container.name} $containerDesc - '
+  String get title => '${property.name} ${property.kind} - '
+      '${container.name} $_containerDescription - '
       '${library.name} library - Dart API';
   @override
   String get layoutTitle =>
@@ -457,7 +456,8 @@ class PropertyTemplateData extends TemplateData<Field>
   @override
   String get metaDescription =>
       'API docs for the ${property.name} ${property.kind} from the '
-      '${container.name} $containerDesc, for the Dart programming language.';
+      '${container.name} $_containerDescription, '
+      'for the Dart programming language.';
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
   @override

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -393,13 +393,12 @@ class MethodTemplateData extends TemplateData<Method>
   final Container container;
   final ContainerSidebar _sidebarForContainer;
 
-  String containerDesc;
+  final String _containerDescription;
 
   MethodTemplateData(TemplateOptions htmlOptions, PackageGraph packageGraph,
       this.library, this.container, this.method, this._sidebarForContainer)
-      : super(htmlOptions, packageGraph) {
-    containerDesc = container.isClass ? 'class' : 'extension';
-  }
+      : _containerDescription = container.isClass ? 'class' : 'extension',
+        super(htmlOptions, packageGraph);
 
   String get sidebarForContainer => _sidebarForContainer(container, this);
 
@@ -407,7 +406,7 @@ class MethodTemplateData extends TemplateData<Method>
   Method get self => method;
   @override
   String get title =>
-      '${method.name} method - ${container.name} $containerDesc - '
+      '${method.name} method - ${container.name} $_containerDescription - '
       '${library.name} library - Dart API';
   @override
   String get layoutTitle => _layoutTitle(
@@ -415,7 +414,8 @@ class MethodTemplateData extends TemplateData<Method>
   @override
   String get metaDescription =>
       'API docs for the ${method.name} method from the '
-      '${container.name} $containerDesc, for the Dart programming language.';
+      '${container.name} $_containerDescription, '
+      'for the Dart programming language.';
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
   @override

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -8407,26 +8407,6 @@ class _Renderer_MethodTemplateData extends RendererBase<MethodTemplateData> {
                         parent: r);
                   },
                 ),
-                'containerDesc': Property(
-                  getValue: (CT_ c) => c.containerDesc,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.containerDesc == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.containerDesc, ast, r.template,
-                        parent: r);
-                  },
-                ),
                 'htmlBase': Property(
                   getValue: (CT_ c) => c.htmlBase,
                   renderVariable:

--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -11683,26 +11683,6 @@ class _Renderer_PropertyTemplateData
                         parent: r);
                   },
                 ),
-                'containerDesc': Property(
-                  getValue: (CT_ c) => c.containerDesc,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.containerDesc == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.containerDesc, ast, r.template,
-                        parent: r);
-                  },
-                ),
                 'htmlBase': Property(
                   getValue: (CT_ c) => c.htmlBase,
                   renderVariable:


### PR DESCRIPTION
PropertyTemplateData and MethodTemplateData each had a public non-final `containerDesc`. Each one could be made final by assigning in constructor initializers, and each could be made private; neither was ever accessed outside the class.