### PR TITLE
Integrate new parser with new lookup code

### DIFF
--- a/lib/src/generator/templates.renderers.dart
+++ b/lib/src/generator/templates.renderers.dart
@@ -2146,6 +2146,18 @@ class _Renderer_Class extends RendererBase<Class> {
                             parent: r));
                   },
                 ),
+                'referenceParents': Property(
+                  getValue: (CT_ c) => c.referenceParents,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<CommentReferable>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.referenceParents.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
+                  },
+                ),
                 'superChain': Property(
                   getValue: (CT_ c) => c.superChain,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -105,7 +105,6 @@ void startLogging(LoggingContext config) {
         stdout.write('${ansi.backspace} ${ansi.backspace}');
       }
       var message = record.message;
-      assert(message == message.trimRight());
       assert(message.isNotEmpty);
 
       if (record.level < Level.WARNING) {

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -11,6 +11,8 @@ import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:meta/meta.dart';
 
+import 'comment_referable.dart';
+
 /// A [Container] defined with a `class` declaration in Dart.
 ///
 /// Members follow similar naming rules to [Container], with the following
@@ -602,4 +604,10 @@ class Class extends Container
 
   @override
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
+
+  @override
+  Iterable<CommentReferable> get referenceParents => <CommentReferable>[
+        ...super.referenceParents,
+        ...superChain.map((m) => m.modelElement)
+      ];
 }

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -17,13 +17,15 @@ abstract class Base extends Nameable with CommentReferable {
   /// Returns the added (or already existing) [Base].
   Base add(String newName);
 
-  Base lookup(String value) => referenceBy(value.split(_separator));
+  T lookup<T extends CommentReferable>(String value,
+          {bool Function(CommentReferable) filter}) =>
+      referenceBy(value.split(_separator), filter: filter);
 
   @override
   Element get element => throw UnimplementedError();
 }
 
-class Top extends Base {
+class Top extends Base with CommentReferable {
   @override
   final String name;
   final List<TopChild> children;
@@ -124,6 +126,7 @@ void main() {
       referable.add('lib1.class2.member1');
       referable.add('lib2');
       referable.add('lib2.class3');
+      referable.add('lib3.lib3.lib3');
     });
 
     test('Check that basic lookups work', () {
@@ -131,6 +134,12 @@ void main() {
       expect(referable.lookup('lib2').name, equals('lib2'));
       expect(referable.lookup('lib1.class2.member1').name, equals('member1'));
       expect(referable.lookup('lib2.class3').name, equals('class3'));
+    });
+
+    test('Check that filters work', () {
+      expect(referable.lookup('lib3'), isA<TopChild>());
+      expect(referable.lookup('lib3', filter: ((r) => r is GenericChild)),
+          isA<GenericChild>());
     });
   });
 }


### PR DESCRIPTION
This increases the new lookup code compliance to ~91% on the SDK.

```
Documented 18 public libraries in 30.7 seconds
Reference Counts:
total references: 29543
resolved references:  22306 (75.50350336797212%)
resolved references with new lookup:  26590 (90.00440036556884%)
resolved references with old lookup:  22306 (75.50350336797212%)
resolved references with equivalent links:  26844 (90.86416409978675%)
```

Getting close enough now that more direct integration tests involving lookups seem like a good idea -- model_test.dart's comment reference tests are going to need an overhaul to make that possible and will do that in a followup.