### PR TITLE
Always run markdown rendering against the experiments package

### DIFF
--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -14,9 +14,13 @@ import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../src/utils.dart';
+
+final _experimentPackageAllowed =
+    VersionRange(min: Version.parse('2.14.0-0'), includeMin: true);
 
 final _resourceProvider = pubPackageMetaProvider.resourceProvider;
 final _pathContext = _resourceProvider.pathContext;
@@ -371,7 +375,7 @@ void main() {
       var dartdoc = await buildDartdoc(
           ['--format', 'md'], _testPackageExperiments, tempDir);
       await dartdoc.generateDocsBase();
-    });
+    }, skip: !_experimentPackageAllowed.allows(platformVersion));
 
     test('rel canonical prefix does not include base href', () async {
       final prefix = 'foo.bar/baz';

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -33,8 +33,10 @@ final Folder _testPackageIncludeExclude =
 final Folder _testPackageImportExportError =
     _getFolder('testing/test_package_import_export_error');
 final Folder _testPackageOptions = _getFolder('testing/test_package_options');
-final _testPackageCustomTemplates =
+final Folder _testPackageCustomTemplates =
     _getFolder('testing/test_package_custom_templates');
+final Folder _testPackageExperiments =
+    _getFolder('testing/test_package_experiments');
 
 /// Convenience factory to build a [DartdocGeneratorOptionContext] and associate
 /// it with a [DartdocOptionSet] based on the current working directory and/or
@@ -361,6 +363,13 @@ void main() {
     test('generating markdown docs does not crash', () async {
       var dartdoc =
           await buildDartdoc(['--format', 'md'], _testPackageDir, tempDir);
+      await dartdoc.generateDocsBase();
+    });
+
+    test('generating markdown docs for experimental features does not crash',
+        () async {
+      var dartdoc = await buildDartdoc(
+          ['--format', 'md'], _testPackageExperiments, tempDir);
       await dartdoc.generateDocsBase();
     });
 

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -20,9 +20,6 @@ import 'package:test/test.dart';
 
 import '../src/utils.dart' as utils;
 
-final String _platformVersionString = Platform.version.split(' ').first;
-final Version _platformVersion = Version.parse(_platformVersionString);
-
 final _testPackageGraphExperimentsMemo = AsyncMemoizer<PackageGraph>();
 Future<PackageGraph> get _testPackageGraphExperiments =>
     _testPackageGraphExperimentsMemo.runOnce(() => utils.bootBasicPackage(
@@ -127,7 +124,7 @@ void main() {
         expect(tripleShiftF.isInherited, isFalse);
         expect(tripleShiftF.modelType.returnType.name, equals('F'));
       });
-    }, skip: !_tripleShiftAllowed.allows(_platformVersion));
+    }, skip: !_tripleShiftAllowed.allows(utils.platformVersion));
 
     group('generic metadata', () {
       Library genericMetadata;
@@ -185,7 +182,7 @@ void main() {
                 .map((p) => p.features.map((f) => f.linkedNameWithParameters)),
             everyElement(contains(ab0)));
       });
-    }, skip: !_genericMetadataAllowed.allows(_platformVersion));
+    }, skip: !_genericMetadataAllowed.allows(utils.platformVersion));
   });
 
   group('HTML Injection when allowed', () {

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -4,6 +4,8 @@
 
 library test_utils;
 
+import 'dart:io';
+
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
@@ -12,6 +14,7 @@ import 'package:dartdoc/src/model/package_builder.dart';
 import 'package:dartdoc/src/model/package_graph.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 /// The number of public libraries in testing/test_package, minus 2 for
 /// the excluded libraries listed in the initializers for _testPackageGraphMemo
@@ -20,6 +23,9 @@ const int kTestPackagePublicLibraries = 23;
 
 final _resourceProvider = pubPackageMetaProvider.resourceProvider;
 final _pathContext = _resourceProvider.pathContext;
+
+final String platformVersionString = Platform.version.split(' ').first;
+final Version platformVersion = Version.parse(platformVersionString);
 
 final Folder testPackageToolError = _resourceProvider.getFolder(_pathContext
     .absolute(_pathContext.normalize('testing/test_package_tool_error')));


### PR DESCRIPTION
Fixes #2652.  Be sure we run markdown rendering for new language features.