### PR TITLE
Update markdown for typedefs for #2649 changes

### DIFF
--- a/lib/templates/md/_typedef.md
+++ b/lib/templates/md/_typedef.md
@@ -1,6 +1,10 @@
 {{#isCallable}}
   {{#asCallable}}
-    {{>callable}}
+    ##### {{{linkedName}}}{{{linkedGenericParameters}}} = {{{modelType.linkedName}}}
+    {{>categorization}}
+
+    {{{ oneLineDoc }}} {{{ extendedDocLink }}}  {{!two spaces intentional}}
+    {{>features}}
   {{/asCallable}}
 {{/isCallable}}
 {{^isCallable}}

--- a/lib/templates/md/_typedef_multiline.md
+++ b/lib/templates/md/_typedef_multiline.md
@@ -1,6 +1,12 @@
 {{#isCallable}}
   {{#asCallable}}
-    {{>callable_multiline}}
+    {{#hasAnnotations}}
+    {{#annotations}}
+    - {{{linkedNameWithParameters}}}
+    {{/annotations}}
+    {{/hasAnnotations}}
+
+    {{{modelType.returnType.linkedName}}} {{name}}{{{linkedGenericParameters}}} = {{{modelType.linkedName}}}
   {{/asCallable}}
 {{/isCallable}}
 {{^isCallable}}


### PR DESCRIPTION
#2649 changed how typedefs are rendered and a couple of the markdown files didn't get caught up.

Tested with `DARTDOC_PARAMS="--format md" grind build-test-experiments-package-docs` and spot checked typedef markdown output.
