### PR TITLE
Frame for merging scoped lookups

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -16,6 +16,7 @@ import 'package:dartdoc/src/render/element_type_renderer.dart';
 /// may link to a [ModelElement].
 abstract class ElementType extends Privacy with CommentReferable, Nameable {
   final DartType _type;
+  @override
   final PackageGraph packageGraph;
   final ElementType returnedFrom;
   @override

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2586,6 +2586,19 @@ class _Renderer_CommentReferable extends RendererBase<CommentReferable> {
                         parent: r);
                   },
                 ),
+                'packageGraph': Property(
+                  getValue: (CT_ c) => c.packageGraph,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'PackageGraph'),
+                  isNullValue: (CT_ c) => c.packageGraph == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.packageGraph, ast, r.template,
+                        parent: r);
+                  },
+                ),
                 'referenceChildren': Property(
                   getValue: (CT_ c) => c.referenceChildren,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -2609,6 +2622,17 @@ class _Renderer_CommentReferable extends RendererBase<CommentReferable> {
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
                     return c.referenceParents.map(
                         (e) => renderSimple(e, ast, r.template, parent: r));
+                  },
+                ),
+                'scope': Property(
+                  getValue: (CT_ c) => c.scope,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'Scope'),
+                  isNullValue: (CT_ c) => c.scope == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.scope, ast, r.template, parent: r);
                   },
                 ),
               });

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -100,7 +100,8 @@ mixin CommentReferable implements Nameable {
       recurseChildrenAndFilter(
           referenceLookup, referenceChildren[referenceLookup.lookup], filter);
 
-  /// Assuming we found a [result], recurse through children, skipping over
+  /// Given a [result] found in an implementation of [lookupViaScope] or
+  /// [_lookupViaReferenceChildren], recurse through children, skipping over
   /// results that do not match the filter.
   CommentReferable recurseChildrenAndFilter(
       ReferenceChildrenLookup referenceLookup,
@@ -108,10 +109,10 @@ mixin CommentReferable implements Nameable {
       bool Function(CommentReferable) filter) {
     assert(result != null);
     if (referenceLookup.remaining.isNotEmpty) {
-      result = result?.referenceBy(referenceLookup.remaining,
+      result = result.referenceBy(referenceLookup.remaining,
           tryParents: false, filter: filter);
     } else if (!filter(result)) {
-      result = result?.referenceBy([referenceLookup.lookup],
+      result = result.referenceBy([referenceLookup.lookup],
           tryParents: false, filter: filter);
     }
     if (!filter(result)) {

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -267,6 +267,7 @@ class PackageGraph with CommentReferable, Nameable {
 
   bool get hasFooterVersion => !config.excludeFooterVersion;
 
+  @override
   PackageGraph get packageGraph => this;
 
   /// Map of package name to Package.

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -25,7 +25,7 @@ abstract class Base extends Nameable with CommentReferable {
   Element get element => throw UnimplementedError();
 }
 
-class Top extends Base with CommentReferable {
+class Top extends Base {
   @override
   final String name;
   final List<TopChild> children;


### PR DESCRIPTION
Making the maximum use of the analyzer's code for looking up symbols will require using the analyzer's `Scope` and `lookup` code.  Since we don't preserve the AST, construct them ourselves on demand and prioritize the analyzer's lookup, when available, with dartdoc's customizations isolated and added on.
