### PR TITLE
Do not depend on FunctionType being a subclass of ParameterizedType

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -54,8 +54,13 @@ abstract class ElementType extends Privacy with CommentReferable, Nameable {
       var isGenericTypeAlias = f.aliasElement != null && f is! InterfaceType;
       if (f is FunctionType) {
         assert(f is ParameterizedType);
+        // This is an indication we have an extremely out of date analyzer....
         assert(
             !isGenericTypeAlias, 'should never occur: out of date analyzer?');
+        // And finally, delete this case and its associated class
+        // after https://dart-review.googlesource.com/c/sdk/+/201520
+        // is in all published versions of analyzer this version of dartdoc
+        // is compatible with.
         return CallableElementType(
             f, library, packageGraph, element, returnedFrom);
       } else if (isGenericTypeAlias) {
@@ -158,7 +163,7 @@ class UndefinedElementType extends ElementType {
 /// A FunctionType that does not have an underpinning Element.
 class FunctionTypeElementType extends UndefinedElementType
     with Rendered, Callable {
-  FunctionTypeElementType(DartType f, Library library,
+  FunctionTypeElementType(FunctionType f, Library library,
       PackageGraph packageGraph, ElementType returnedFrom)
       : super(f, library, packageGraph, returnedFrom);
 
@@ -177,9 +182,12 @@ class FunctionTypeElementType extends UndefinedElementType
 
 class AliasedFunctionTypeElementType extends FunctionTypeElementType
     with Aliased {
-  AliasedFunctionTypeElementType(DartType f, Library library,
+  AliasedFunctionTypeElementType(FunctionType f, Library library,
       PackageGraph packageGraph, ElementType returnedFrom)
-      : super(f, library, packageGraph, returnedFrom);
+      : super(f, library, packageGraph, returnedFrom) {
+    assert(type.aliasElement != null);
+    assert(type.aliasArguments != null);
+  }
 
   @override
   ElementTypeRenderer<AliasedFunctionTypeElementType> get _renderer =>

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -124,25 +124,14 @@ class UndefinedElementType extends ElementType {
 
   @override
   String get name {
-    if (isImpliedFuture) return 'Future';
     if (type.isVoid) return 'void';
     assert({'Never', 'void', 'dynamic'}.contains(type.element.name),
         'Unrecognized type for UndefinedElementType: ${type.toString()}');
     return type.element.name;
   }
 
-  /// Returns true if this type is an implied `Future`.
-  bool get isImpliedFuture => (type.isDynamic &&
-      returnedFrom != null &&
-      returnedFrom is DefinedElementType &&
-      (returnedFrom as DefinedElementType).modelElement.isAsynchronous);
-
   @override
   String get nameWithGenerics => '$name$nullabilitySuffix';
-
-  @override
-  String get nullabilitySuffix =>
-      isImpliedFuture && library.isNullSafety ? '?' : super.nullabilitySuffix;
 
   /// Assume that undefined elements don't have useful bounds.
   @override

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -97,7 +97,6 @@ abstract class ElementType extends Privacy with CommentReferable, Nameable {
 
   DartType get instantiatedType;
 
-  /// An unmodifiable list of this element type's parameters.
   Iterable<ElementType> get typeArguments;
 
   bool isBoundSupertypeTo(ElementType t);

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -230,6 +230,10 @@ class AliasedElementType extends ParameterizedElementType with Aliased {
     assert(type.aliasElement != null);
   }
 
+  /// Parameters, if available, for the underlying typedef.
+  List<Parameter> get aliasedParameters =>
+      modelElement.isCallable ? modelElement.parameters : [];
+
   @override
   ElementTypeRenderer<AliasedElementType> get _renderer =>
       packageGraph.rendererFactory.aliasedElementTypeRenderer;
@@ -348,7 +352,8 @@ abstract class DefinedElementType extends ElementType {
       modelElement.referenceParents;
 }
 
-/// Any callable ElementType will mix-in this class, whether anonymous or not.
+/// Any callable ElementType will mix-in this class, whether anonymous or not,
+/// unless it is an alias reference.
 mixin Callable implements ElementType {
   List<Parameter> get parameters => type.parameters
       .map((p) => ModelElement.from(p, library, packageGraph) as Parameter)

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -41,15 +41,15 @@ import 'package:path/path.dart' as path show Context;
 
 const _visibleTypes = {
   Annotation,
-  CallableElementTypeMixin,
+  Callable,
   Category,
   Class,
   Constructor,
-  DefinedElementType,
   Documentable,
   Enum,
   Extension,
   FeatureSet,
+  FunctionTypeElementType,
   LanguageFeature,
   Library,
   LibraryContainer,

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -45,6 +45,7 @@ const _visibleTypes = {
   Category,
   Class,
   Constructor,
+  DefinedElementType,
   Documentable,
   Enum,
   Extension,

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -520,6 +520,26 @@ class _Renderer_CallableElementTypeMixin
                         parent: r);
                   },
                 ),
+                'nameWithGenerics': Property(
+                  getValue: (CT_ c) => c.nameWithGenerics,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.nameWithGenerics == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.nameWithGenerics, ast, r.template,
+                        parent: r);
+                  },
+                ),
                 'returnElement': Property(
                   getValue: (CT_ c) => c.returnElement,
                   renderVariable:
@@ -4039,13 +4059,6 @@ class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isPublic == true,
-                ),
-                'isTypedef': Property(
-                  getValue: (CT_ c) => c.isTypedef,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isTypedef == true,
                 ),
                 'modelElement': Property(
                   getValue: (CT_ c) => c.modelElement,
@@ -10054,7 +10067,7 @@ class _Renderer_ModelFunctionTyped extends RendererBase<ModelFunctionTyped> {
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_DefinedElementType.propertyMap()
+                        _Renderer_CallableElementTypeMixin.propertyMap()
                             .getValue(name);
                     return nextProperty.renderVariable(self.getValue(c),
                         nextProperty, [...remainingNames.skip(1)]);
@@ -10062,7 +10075,7 @@ class _Renderer_ModelFunctionTyped extends RendererBase<ModelFunctionTyped> {
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_DefinedElementType(
+                    return _render_CallableElementTypeMixin(
                         c.modelType, ast, r.template,
                         parent: r);
                   },

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -201,16 +201,14 @@ class _Renderer_Accessor extends RendererBase<Accessor> {
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_CallableElementTypeMixin.propertyMap()
-                            .getValue(name);
+                        _Renderer_Callable.propertyMap().getValue(name);
                     return nextProperty.renderVariable(self.getValue(c),
                         nextProperty, [...remainingNames.skip(1)]);
                   },
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_CallableElementTypeMixin(
-                        c.modelType, ast, r.template,
+                    return _render_Callable(c.modelType, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -484,81 +482,30 @@ class _Renderer_Annotation extends RendererBase<Annotation> {
   }
 }
 
-String _render_CallableElementTypeMixin(CallableElementTypeMixin context,
-    List<MustachioNode> ast, Template template,
+String _render_Callable(
+    Callable context, List<MustachioNode> ast, Template template,
     {RendererBase<Object> parent}) {
-  var renderer = _Renderer_CallableElementTypeMixin(context, parent, template);
+  var renderer = _Renderer_Callable(context, parent, template);
   renderer.renderBlock(ast);
   return renderer.buffer.toString();
 }
 
-class _Renderer_CallableElementTypeMixin
-    extends RendererBase<CallableElementTypeMixin> {
+class _Renderer_Callable extends RendererBase<Callable> {
   static final Map<Type, Object> _propertyMapCache = {};
-  static Map<String, Property<CT_>> propertyMap<
-          CT_ extends CallableElementTypeMixin>() =>
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Callable>() =>
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                'linkedName': Property(
-                  getValue: (CT_ c) => c.linkedName,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.linkedName == null,
-                  renderValue:
+                'parameters': Property(
+                  getValue: (CT_ c) => c.parameters,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'List<Parameter>'),
+                  renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.linkedName, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'nameWithGenerics': Property(
-                  getValue: (CT_ c) => c.nameWithGenerics,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.nameWithGenerics == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.nameWithGenerics, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'returnElement': Property(
-                  getValue: (CT_ c) => c.returnElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ModelElement.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.returnElement == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_ModelElement(
-                        c.returnElement, ast, r.template,
-                        parent: r);
+                    return c.parameters.map((e) =>
+                        _render_Parameter(e, ast, r.template, parent: r));
                   },
                 ),
                 'returnType': Property(
@@ -593,28 +540,16 @@ class _Renderer_CallableElementTypeMixin
                     return renderSimple(c.type, ast, r.template, parent: r);
                   },
                 ),
-                'typeArguments': Property(
-                  getValue: (CT_ c) => c.typeArguments,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ElementType>'),
-                  renderIterable:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.typeArguments.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
-                  },
-                ),
               });
 
-  _Renderer_CallableElementTypeMixin(CallableElementTypeMixin context,
-      RendererBase<Object> parent, Template template)
+  _Renderer_Callable(
+      Callable context, RendererBase<Object> parent, Template template)
       : super(context, parent, template);
 
   @override
-  Property<CallableElementTypeMixin> getProperty(String key) {
-    if (propertyMap<CallableElementTypeMixin>().containsKey(key)) {
-      return propertyMap<CallableElementTypeMixin>()[key];
+  Property<Callable> getProperty(String key) {
+    if (propertyMap<Callable>().containsKey(key)) {
+      return propertyMap<Callable>()[key];
     } else {
       return null;
     }
@@ -1971,9 +1906,8 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.interfaces.map((e) => _render_DefinedElementType(
-                        e, ast, r.template,
-                        parent: r));
+                    return c.interfaces.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'isAbstract': Property(
@@ -2024,30 +1958,20 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.mixedInTypes.map((e) => _render_DefinedElementType(
-                        e, ast, r.template,
-                        parent: r));
+                    return c.mixedInTypes.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'modelType': Property(
                   getValue: (CT_ c) => c.modelType,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_DefinedElementType.propertyMap()
-                            .getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'DefinedElementType'),
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_DefinedElementType(
-                        c.modelType, ast, r.template,
+                    return renderSimple(c.modelType, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -2141,9 +2065,8 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicInterfaces.map((e) =>
-                        _render_DefinedElementType(e, ast, r.template,
-                            parent: r));
+                    return c.publicInterfaces.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'publicMixedInTypes': Property(
@@ -2154,9 +2077,8 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicMixedInTypes.map((e) =>
-                        _render_DefinedElementType(e, ast, r.template,
-                            parent: r));
+                    return c.publicMixedInTypes.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'publicSuperChain': Property(
@@ -2167,9 +2089,8 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicSuperChain.map((e) =>
-                        _render_DefinedElementType(e, ast, r.template,
-                            parent: r));
+                    return c.publicSuperChain.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'publicSuperChainReversed': Property(
@@ -2180,9 +2101,8 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicSuperChainReversed.map((e) =>
-                        _render_DefinedElementType(e, ast, r.template,
-                            parent: r));
+                    return c.publicSuperChainReversed.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'referenceParents': Property(
@@ -2205,30 +2125,20 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.superChain.map((e) => _render_DefinedElementType(
-                        e, ast, r.template,
-                        parent: r));
+                    return c.superChain.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'supertype': Property(
                   getValue: (CT_ c) => c.supertype,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_DefinedElementType.propertyMap()
-                            .getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'DefinedElementType'),
                   isNullValue: (CT_ c) => c.supertype == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_DefinedElementType(
-                        c.supertype, ast, r.template,
+                    return renderSimple(c.supertype, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -2868,16 +2778,14 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_CallableElementTypeMixin.propertyMap()
-                            .getValue(name);
+                        _Renderer_Callable.propertyMap().getValue(name);
                     return nextProperty.renderVariable(self.getValue(c),
                         nextProperty, [...remainingNames.skip(1)]);
                   },
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_CallableElementTypeMixin(
-                        c.modelType, ast, r.template,
+                    return _render_Callable(c.modelType, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -4007,204 +3915,6 @@ class _Renderer_ContainerMember extends RendererBase<ContainerMember> {
   }
 }
 
-String _render_DefinedElementType(
-    DefinedElementType context, List<MustachioNode> ast, Template template,
-    {RendererBase<Object> parent}) {
-  var renderer = _Renderer_DefinedElementType(context, parent, template);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
-  static final Map<Type, Object> _propertyMapCache = {};
-  static Map<String, Property<CT_>> propertyMap<
-          CT_ extends DefinedElementType>() =>
-      _propertyMapCache.putIfAbsent(
-          CT_,
-          () => {
-                ..._Renderer_ElementType.propertyMap<CT_>(),
-                'element': Property(
-                  getValue: (CT_ c) => c.element,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'Element'),
-                  isNullValue: (CT_ c) => c.element == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.element, ast, r.template, parent: r);
-                  },
-                ),
-                'instantiatedType': Property(
-                  getValue: (CT_ c) => c.instantiatedType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'DartType'),
-                  isNullValue: (CT_ c) => c.instantiatedType == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.instantiatedType, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'isParameterType': Property(
-                  getValue: (CT_ c) => c.isParameterType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isParameterType == true,
-                ),
-                'isPublic': Property(
-                  getValue: (CT_ c) => c.isPublic,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isPublic == true,
-                ),
-                'modelElement': Property(
-                  getValue: (CT_ c) => c.modelElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ModelElement.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.modelElement == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_ModelElement(c.modelElement, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'name': Property(
-                  getValue: (CT_ c) => c.name,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.name == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.name, ast, r.template, parent: r);
-                  },
-                ),
-                'parameters': Property(
-                  getValue: (CT_ c) => c.parameters,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'List<Parameter>'),
-                  renderIterable:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.parameters.map((e) =>
-                        _render_Parameter(e, ast, r.template, parent: r));
-                  },
-                ),
-                'referenceChildren': Property(
-                  getValue: (CT_ c) => c.referenceChildren,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Map<String, CommentReferable>'),
-                  isNullValue: (CT_ c) => c.referenceChildren == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.referenceChildren, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'referenceParents': Property(
-                  getValue: (CT_ c) => c.referenceParents,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<CommentReferable>'),
-                  renderIterable:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.referenceParents.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
-                  },
-                ),
-                'returnElement': Property(
-                  getValue: (CT_ c) => c.returnElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ModelElement.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.returnElement == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_ModelElement(
-                        c.returnElement, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'returnType': Property(
-                  getValue: (CT_ c) => c.returnType,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ElementType.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.returnType == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.returnType, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'typeArguments': Property(
-                  getValue: (CT_ c) => c.typeArguments,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ElementType>'),
-                  renderIterable:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.typeArguments.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
-                  },
-                ),
-              });
-
-  _Renderer_DefinedElementType(DefinedElementType context,
-      RendererBase<Object> parent, Template template)
-      : super(context, parent, template);
-
-  @override
-  Property<DefinedElementType> getProperty(String key) {
-    if (propertyMap<DefinedElementType>().containsKey(key)) {
-      return propertyMap<DefinedElementType>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
 String _render_Documentable(
     Documentable context, List<MustachioNode> ast, Template template,
     {RendererBase<Object> parent}) {
@@ -4628,18 +4338,6 @@ class _Renderer_ElementType extends RendererBase<ElementType> {
                         parent: r);
                   },
                 ),
-                'parameters': Property(
-                  getValue: (CT_ c) => c.parameters,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'List<Parameter>'),
-                  renderIterable:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.parameters.map((e) =>
-                        _render_Parameter(e, ast, r.template, parent: r));
-                  },
-                ),
                 'returnedFrom': Property(
                   getValue: (CT_ c) => c.returnedFrom,
                   renderVariable:
@@ -4669,6 +4367,18 @@ class _Renderer_ElementType extends RendererBase<ElementType> {
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
                     return renderSimple(c.type, ast, r.template, parent: r);
+                  },
+                ),
+                'typeArguments': Property(
+                  getValue: (CT_ c) => c.typeArguments,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<ElementType>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.typeArguments.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
               });
@@ -6101,6 +5811,72 @@ class _Renderer_FunctionTemplateData
   }
 }
 
+String _render_FunctionTypeElementType(
+    FunctionTypeElementType context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_FunctionTypeElementType(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_FunctionTypeElementType
+    extends RendererBase<FunctionTypeElementType> {
+  static final Map<Type, Object> _propertyMapCache = {};
+  static Map<String, Property<CT_>> propertyMap<
+          CT_ extends FunctionTypeElementType>() =>
+      _propertyMapCache.putIfAbsent(
+          CT_,
+          () => {
+                ..._Renderer_UndefinedElementType.propertyMap<CT_>(),
+                ..._Renderer_Rendered.propertyMap<CT_>(),
+                ..._Renderer_Callable.propertyMap<CT_>(),
+                'name': Property(
+                  getValue: (CT_ c) => c.name,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.name == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.name, ast, r.template, parent: r);
+                  },
+                ),
+                'typeFormals': Property(
+                  getValue: (CT_ c) => c.typeFormals,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'List<TypeParameter>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.typeFormals.map((e) =>
+                        _render_TypeParameter(e, ast, r.template, parent: r));
+                  },
+                ),
+              });
+
+  _Renderer_FunctionTypeElementType(FunctionTypeElementType context,
+      RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<FunctionTypeElementType> getProperty(String key) {
+    if (propertyMap<FunctionTypeElementType>().containsKey(key)) {
+      return propertyMap<FunctionTypeElementType>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
 String _render_FunctionTypedef(
     FunctionTypedef context, List<MustachioNode> ast, Template template,
     {RendererBase<Object> parent}) {
@@ -6126,7 +5902,7 @@ class _Renderer_FunctionTypedef extends RendererBase<FunctionTypedef> {
                         }
                         var name = remainingNames.first;
                         var nextProperty =
-                            _Renderer_CallableElementTypeMixin.propertyMap()
+                            _Renderer_FunctionTypeElementType.propertyMap()
                                 .getValue(name);
                         return nextProperty.renderVariable(self.getValue(c),
                             nextProperty, [...remainingNames.skip(1)]);
@@ -6134,7 +5910,7 @@ class _Renderer_FunctionTypedef extends RendererBase<FunctionTypedef> {
                       isNullValue: (CT_ c) => c.modelType == null,
                       renderValue: (CT_ c, RendererBase<CT_> r,
                           List<MustachioNode> ast) {
-                        return _render_CallableElementTypeMixin(
+                        return _render_FunctionTypeElementType(
                             c.modelType, ast, r.template,
                             parent: r);
                       },
@@ -8338,16 +8114,14 @@ class _Renderer_Method extends RendererBase<Method> {
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_CallableElementTypeMixin.propertyMap()
-                            .getValue(name);
+                        _Renderer_Callable.propertyMap().getValue(name);
                     return nextProperty.renderVariable(self.getValue(c),
                         nextProperty, [...remainingNames.skip(1)]);
                   },
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_CallableElementTypeMixin(
-                        c.modelType, ast, r.template,
+                    return _render_Callable(c.modelType, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -8769,9 +8543,8 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                           'Iterable<ParameterizedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicSuperclassConstraints.map((e) =>
-                        _render_ParameterizedElementType(e, ast, r.template,
-                            parent: r));
+                    return c.publicSuperclassConstraints.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
                 'superclassConstraints': Property(
@@ -8782,9 +8555,8 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                           'Iterable<ParameterizedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.superclassConstraints.map((e) =>
-                        _render_ParameterizedElementType(e, ast, r.template,
-                            parent: r));
+                    return c.superclassConstraints.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
               });
@@ -10067,16 +9839,14 @@ class _Renderer_ModelFunctionTyped extends RendererBase<ModelFunctionTyped> {
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_CallableElementTypeMixin.propertyMap()
-                            .getValue(name);
+                        _Renderer_Callable.propertyMap().getValue(name);
                     return nextProperty.renderVariable(self.getValue(c),
                         nextProperty, [...remainingNames.skip(1)]);
                   },
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_CallableElementTypeMixin(
-                        c.modelType, ast, r.template,
+                    return _render_Callable(c.modelType, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -11127,7 +10897,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   return _render_PackageTemplateData(context, template.ast, template);
 }
 
@@ -11327,7 +11097,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   return _render_PackageTemplateData(context, template.ast, template);
 }
 
@@ -11603,79 +11373,6 @@ class _Renderer_Parameter extends RendererBase<Parameter> {
   }
 }
 
-String _render_ParameterizedElementType(ParameterizedElementType context,
-    List<MustachioNode> ast, Template template,
-    {RendererBase<Object> parent}) {
-  var renderer = _Renderer_ParameterizedElementType(context, parent, template);
-  renderer.renderBlock(ast);
-  return renderer.buffer.toString();
-}
-
-class _Renderer_ParameterizedElementType
-    extends RendererBase<ParameterizedElementType> {
-  static final Map<Type, Object> _propertyMapCache = {};
-  static Map<String, Property<CT_>> propertyMap<
-          CT_ extends ParameterizedElementType>() =>
-      _propertyMapCache.putIfAbsent(
-          CT_,
-          () => {
-                ..._Renderer_DefinedElementType.propertyMap<CT_>(),
-                'linkedName': Property(
-                  getValue: (CT_ c) => c.linkedName,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.linkedName == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.linkedName, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'nameWithGenerics': Property(
-                  getValue: (CT_ c) => c.nameWithGenerics,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.nameWithGenerics == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.nameWithGenerics, ast, r.template,
-                        parent: r);
-                  },
-                ),
-              });
-
-  _Renderer_ParameterizedElementType(ParameterizedElementType context,
-      RendererBase<Object> parent, Template template)
-      : super(context, parent, template);
-
-  @override
-  Property<ParameterizedElementType> getProperty(String key) {
-    if (propertyMap<ParameterizedElementType>().containsKey(key)) {
-      return propertyMap<ParameterizedElementType>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
 class _Renderer_Privacy extends RendererBase<Privacy> {
   static final Map<Type, Object> _propertyMapCache = {};
   static Map<String, Property<CT_>> propertyMap<CT_ extends Privacy>() =>
@@ -11940,6 +11637,68 @@ class _Renderer_PropertyTemplateData
   Property<PropertyTemplateData> getProperty(String key) {
     if (propertyMap<PropertyTemplateData>().containsKey(key)) {
       return propertyMap<PropertyTemplateData>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+class _Renderer_Rendered extends RendererBase<Rendered> {
+  static final Map<Type, Object> _propertyMapCache = {};
+  static Map<String, Property<CT_>> propertyMap<CT_ extends Rendered>() =>
+      _propertyMapCache.putIfAbsent(
+          CT_,
+          () => {
+                'linkedName': Property(
+                  getValue: (CT_ c) => c.linkedName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.linkedName == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.linkedName, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'nameWithGenerics': Property(
+                  getValue: (CT_ c) => c.nameWithGenerics,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.nameWithGenerics == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.nameWithGenerics, ast, r.template,
+                        parent: r);
+                  },
+                ),
+              });
+
+  _Renderer_Rendered(
+      Rendered context, RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<Rendered> getProperty(String key) {
+    if (propertyMap<Rendered>().containsKey(key)) {
+      return propertyMap<Rendered>()[key];
     } else {
       return null;
     }
@@ -14317,6 +14076,184 @@ class _Renderer_TypedefTemplateData extends RendererBase<TypedefTemplateData> {
   Property<TypedefTemplateData> getProperty(String key) {
     if (propertyMap<TypedefTemplateData>().containsKey(key)) {
       return propertyMap<TypedefTemplateData>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+class _Renderer_UndefinedElementType
+    extends RendererBase<UndefinedElementType> {
+  static final Map<Type, Object> _propertyMapCache = {};
+  static Map<String, Property<CT_>> propertyMap<
+          CT_ extends UndefinedElementType>() =>
+      _propertyMapCache.putIfAbsent(
+          CT_,
+          () => {
+                ..._Renderer_ElementType.propertyMap<CT_>(),
+                'element': Property(
+                  getValue: (CT_ c) => c.element,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'Element'),
+                  isNullValue: (CT_ c) => c.element == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.element, ast, r.template, parent: r);
+                  },
+                ),
+                'instantiatedType': Property(
+                  getValue: (CT_ c) => c.instantiatedType,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'DartType'),
+                  isNullValue: (CT_ c) => c.instantiatedType == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.instantiatedType, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'isImpliedFuture': Property(
+                  getValue: (CT_ c) => c.isImpliedFuture,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isImpliedFuture == true,
+                ),
+                'isPublic': Property(
+                  getValue: (CT_ c) => c.isPublic,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isPublic == true,
+                ),
+                'linkedName': Property(
+                  getValue: (CT_ c) => c.linkedName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.linkedName == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.linkedName, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'name': Property(
+                  getValue: (CT_ c) => c.name,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.name == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.name, ast, r.template, parent: r);
+                  },
+                ),
+                'nameWithGenerics': Property(
+                  getValue: (CT_ c) => c.nameWithGenerics,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.nameWithGenerics == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.nameWithGenerics, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'nullabilitySuffix': Property(
+                  getValue: (CT_ c) => c.nullabilitySuffix,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.nullabilitySuffix == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.nullabilitySuffix, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'referenceChildren': Property(
+                  getValue: (CT_ c) => c.referenceChildren,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Map<String, CommentReferable>'),
+                  isNullValue: (CT_ c) => c.referenceChildren == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.referenceChildren, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'referenceParents': Property(
+                  getValue: (CT_ c) => c.referenceParents,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<CommentReferable>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.referenceParents.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
+                  },
+                ),
+                'typeArguments': Property(
+                  getValue: (CT_ c) => c.typeArguments,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<ElementType>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.typeArguments.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
+                  },
+                ),
+              });
+
+  _Renderer_UndefinedElementType(UndefinedElementType context,
+      RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<UndefinedElementType> getProperty(String key) {
+    if (propertyMap<UndefinedElementType>().containsKey(key)) {
+      return propertyMap<UndefinedElementType>()[key];
     } else {
       return null;
     }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1906,8 +1906,9 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.interfaces.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.interfaces.map((e) => _render_DefinedElementType(
+                        e, ast, r.template,
+                        parent: r));
                   },
                 ),
                 'isAbstract': Property(
@@ -1958,20 +1959,30 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.mixedInTypes.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.mixedInTypes.map((e) => _render_DefinedElementType(
+                        e, ast, r.template,
+                        parent: r));
                   },
                 ),
                 'modelType': Property(
                   getValue: (CT_ c) => c.modelType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'DefinedElementType'),
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_DefinedElementType.propertyMap()
+                            .getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
                   isNullValue: (CT_ c) => c.modelType == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.modelType, ast, r.template,
+                    return _render_DefinedElementType(
+                        c.modelType, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -2065,8 +2076,9 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicInterfaces.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.publicInterfaces.map((e) =>
+                        _render_DefinedElementType(e, ast, r.template,
+                            parent: r));
                   },
                 ),
                 'publicMixedInTypes': Property(
@@ -2077,8 +2089,9 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicMixedInTypes.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.publicMixedInTypes.map((e) =>
+                        _render_DefinedElementType(e, ast, r.template,
+                            parent: r));
                   },
                 ),
                 'publicSuperChain': Property(
@@ -2089,8 +2102,9 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicSuperChain.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.publicSuperChain.map((e) =>
+                        _render_DefinedElementType(e, ast, r.template,
+                            parent: r));
                   },
                 ),
                 'publicSuperChainReversed': Property(
@@ -2101,8 +2115,9 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'Iterable<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicSuperChainReversed.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.publicSuperChainReversed.map((e) =>
+                        _render_DefinedElementType(e, ast, r.template,
+                            parent: r));
                   },
                 ),
                 'referenceParents': Property(
@@ -2125,20 +2140,30 @@ class _Renderer_Class extends RendererBase<Class> {
                           c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.superChain.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.superChain.map((e) => _render_DefinedElementType(
+                        e, ast, r.template,
+                        parent: r));
                   },
                 ),
                 'supertype': Property(
                   getValue: (CT_ c) => c.supertype,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'DefinedElementType'),
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_DefinedElementType.propertyMap()
+                            .getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
                   isNullValue: (CT_ c) => c.supertype == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.supertype, ast, r.template,
+                    return _render_DefinedElementType(
+                        c.supertype, ast, r.template,
                         parent: r);
                   },
                 ),
@@ -3909,6 +3934,151 @@ class _Renderer_ContainerMember extends RendererBase<ContainerMember> {
   Property<ContainerMember> getProperty(String key) {
     if (propertyMap<ContainerMember>().containsKey(key)) {
       return propertyMap<ContainerMember>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_DefinedElementType(
+    DefinedElementType context, List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_DefinedElementType(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
+  static final Map<Type, Object> _propertyMapCache = {};
+  static Map<String, Property<CT_>> propertyMap<
+          CT_ extends DefinedElementType>() =>
+      _propertyMapCache.putIfAbsent(
+          CT_,
+          () => {
+                ..._Renderer_ElementType.propertyMap<CT_>(),
+                'element': Property(
+                  getValue: (CT_ c) => c.element,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'Element'),
+                  isNullValue: (CT_ c) => c.element == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.element, ast, r.template, parent: r);
+                  },
+                ),
+                'instantiatedType': Property(
+                  getValue: (CT_ c) => c.instantiatedType,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'DartType'),
+                  isNullValue: (CT_ c) => c.instantiatedType == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.instantiatedType, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'isParameterType': Property(
+                  getValue: (CT_ c) => c.isParameterType,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isParameterType == true,
+                ),
+                'isPublic': Property(
+                  getValue: (CT_ c) => c.isPublic,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isPublic == true,
+                ),
+                'modelElement': Property(
+                  getValue: (CT_ c) => c.modelElement,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_ModelElement.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.modelElement == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_ModelElement(c.modelElement, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'name': Property(
+                  getValue: (CT_ c) => c.name,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(self.getValue(c),
+                        nextProperty, [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.name == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return _render_String(c.name, ast, r.template, parent: r);
+                  },
+                ),
+                'referenceChildren': Property(
+                  getValue: (CT_ c) => c.referenceChildren,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Map<String, CommentReferable>'),
+                  isNullValue: (CT_ c) => c.referenceChildren == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.referenceChildren, ast, r.template,
+                        parent: r);
+                  },
+                ),
+                'referenceParents': Property(
+                  getValue: (CT_ c) => c.referenceParents,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<CommentReferable>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.referenceParents.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
+                  },
+                ),
+                'typeArguments': Property(
+                  getValue: (CT_ c) => c.typeArguments,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<ElementType>'),
+                  renderIterable:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return c.typeArguments.map(
+                        (e) => renderSimple(e, ast, r.template, parent: r));
+                  },
+                ),
+              });
+
+  _Renderer_DefinedElementType(DefinedElementType context,
+      RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<DefinedElementType> getProperty(String key) {
+    if (propertyMap<DefinedElementType>().containsKey(key)) {
+      return propertyMap<DefinedElementType>()[key];
     } else {
       return null;
     }
@@ -8543,8 +8713,9 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                           'Iterable<ParameterizedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.publicSuperclassConstraints.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.publicSuperclassConstraints.map((e) =>
+                        _render_ParameterizedElementType(e, ast, r.template,
+                            parent: r));
                   },
                 ),
                 'superclassConstraints': Property(
@@ -8555,8 +8726,9 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                           'Iterable<ParameterizedElementType>'),
                   renderIterable:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return c.superclassConstraints.map(
-                        (e) => renderSimple(e, ast, r.template, parent: r));
+                    return c.superclassConstraints.map((e) =>
+                        _render_ParameterizedElementType(e, ast, r.template,
+                            parent: r));
                   },
                 ),
               });
@@ -11367,6 +11539,40 @@ class _Renderer_Parameter extends RendererBase<Parameter> {
   Property<Parameter> getProperty(String key) {
     if (propertyMap<Parameter>().containsKey(key)) {
       return propertyMap<Parameter>()[key];
+    } else {
+      return null;
+    }
+  }
+}
+
+String _render_ParameterizedElementType(ParameterizedElementType context,
+    List<MustachioNode> ast, Template template,
+    {RendererBase<Object> parent}) {
+  var renderer = _Renderer_ParameterizedElementType(context, parent, template);
+  renderer.renderBlock(ast);
+  return renderer.buffer.toString();
+}
+
+class _Renderer_ParameterizedElementType
+    extends RendererBase<ParameterizedElementType> {
+  static final Map<Type, Object> _propertyMapCache = {};
+  static Map<String, Property<CT_>>
+      propertyMap<CT_ extends ParameterizedElementType>() =>
+          _propertyMapCache.putIfAbsent(
+              CT_,
+              () => {
+                    ..._Renderer_DefinedElementType.propertyMap<CT_>(),
+                    ..._Renderer_Rendered.propertyMap<CT_>(),
+                  });
+
+  _Renderer_ParameterizedElementType(ParameterizedElementType context,
+      RendererBase<Object> parent, Template template)
+      : super(context, parent, template);
+
+  @override
+  Property<ParameterizedElementType> getProperty(String key) {
+    if (propertyMap<ParameterizedElementType>().containsKey(key)) {
+      return propertyMap<ParameterizedElementType>()[key];
     } else {
       return null;
     }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -14114,13 +14114,6 @@ class _Renderer_UndefinedElementType
                         parent: r);
                   },
                 ),
-                'isImpliedFuture': Property(
-                  getValue: (CT_ c) => c.isImpliedFuture,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isImpliedFuture == true,
-                ),
                 'isPublic': Property(
                   getValue: (CT_ c) => c.isPublic,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -14184,26 +14177,6 @@ class _Renderer_UndefinedElementType
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
                     return _render_String(c.nameWithGenerics, ast, r.template,
-                        parent: r);
-                  },
-                ),
-                'nullabilitySuffix': Property(
-                  getValue: (CT_ c) => c.nullabilitySuffix,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.nullabilitySuffix == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return _render_String(c.nullabilitySuffix, ast, r.template,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -27,8 +27,8 @@ class Accessor extends ModelElement implements EnclosedElement {
   @override
   ExecutableMember get originalMember => super.originalMember;
 
-  CallableElementTypeMixin _modelType;
-  CallableElementTypeMixin get modelType => _modelType ??=
+  Callable _modelType;
+  Callable get modelType => _modelType ??=
       ElementType.from((originalMember ?? element).type, library, packageGraph);
 
   bool get isSynthetic => element.isSynthetic;

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -79,8 +79,8 @@ class Constructor extends ModelElement
   @override
   String get kind => 'constructor';
 
-  CallableElementTypeMixin _modelType;
-  CallableElementTypeMixin get modelType =>
+  Callable _modelType;
+  Callable get modelType =>
       _modelType ??= ElementType.from(element.type, library, packageGraph);
 
   String _name;

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -97,8 +97,8 @@ class Method extends ModelElement
   @override
   ExecutableMember get originalMember => super.originalMember;
 
-  CallableElementTypeMixin _modelType;
-  CallableElementTypeMixin get modelType => _modelType ??=
+  Callable _modelType;
+  Callable get modelType => _modelType ??=
       ElementType.from((originalMember ?? element).type, library, packageGraph);
 
   @override

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -16,6 +16,7 @@ import 'package:analyzer/src/dart/element/member.dart'
 import 'package:collection/collection.dart';
 import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
+import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/annotation.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/feature.dart';
@@ -945,9 +946,11 @@ abstract class ModelElement extends Canonicalization
         recursedParameters.addAll(newParameters);
         newParameters.clear();
         for (var p in recursedParameters) {
-          var l = p.modelType.parameters
-              .where((pm) => !recursedParameters.contains(pm));
-          newParameters.addAll(l);
+          var parameterModelType = p.modelType;
+          if (parameterModelType is Callable) {
+            newParameters.addAll(parameterModelType.parameters
+                .where((pm) => !recursedParameters.contains(pm)));
+          }
         }
       }
       _allParameters = recursedParameters.toList();

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -942,6 +942,7 @@ abstract class ModelElement extends Canonicalization
       } else {
         if (isCallable) newParameters.addAll(parameters);
       }
+      // TODO(jcollins-g): This part probably belongs in [ElementType].
       while (newParameters.isNotEmpty) {
         recursedParameters.addAll(newParameters);
         newParameters.clear();
@@ -949,6 +950,10 @@ abstract class ModelElement extends Canonicalization
           var parameterModelType = p.modelType;
           if (parameterModelType is Callable) {
             newParameters.addAll(parameterModelType.parameters
+                .where((pm) => !recursedParameters.contains(pm)));
+          }
+          if (parameterModelType is AliasedElementType) {
+            newParameters.addAll(parameterModelType.aliasedParameters
                 .where((pm) => !recursedParameters.contains(pm)));
           }
         }

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -88,7 +88,7 @@ class ModelFunctionTyped extends ModelElement
   @override
   FunctionTypedElement get element => super.element;
 
-  DefinedElementType _modelType;
-  DefinedElementType get modelType =>
+  CallableElementTypeMixin _modelType;
+  CallableElementTypeMixin get modelType =>
       _modelType ??= ElementType.from(element.type, library, packageGraph);
 }

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -88,7 +88,7 @@ class ModelFunctionTyped extends ModelElement
   @override
   FunctionTypedElement get element => super.element;
 
-  CallableElementTypeMixin _modelType;
-  CallableElementTypeMixin get modelType =>
+  Callable _modelType;
+  Callable get modelType =>
       _modelType ??= ElementType.from(element.type, library, packageGraph);
 }

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -89,5 +89,5 @@ class FunctionTypedef extends Typedef {
       : super(element, library, packageGraph);
 
   @override
-  CallableElementTypeMixin get modelType => super.modelType;
+  FunctionTypeElementType get modelType => super.modelType;
 }

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -89,6 +89,41 @@ class ParameterizedElementTypeRendererHtml
   }
 }
 
+class AliasedFunctionTypeElementTypeRendererHtml
+    extends ElementTypeRenderer<AliasedFunctionTypeElementType> {
+  const AliasedFunctionTypeElementTypeRendererHtml();
+
+  @override
+  String renderLinkedName(AliasedFunctionTypeElementType elementType) {
+    var buf = StringBuffer();
+    buf.write(elementType.aliasElement.linkedName);
+    if (elementType.aliasArguments.isNotEmpty &&
+        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
+      buf.write('<span class="signature">');
+      buf.write('&lt;<wbr><span class="type-parameter">');
+      buf.writeAll(elementType.aliasArguments.map((t) => t.linkedName),
+          '</span>, <span class="type-parameter">');
+      buf.write('</span>&gt;');
+      buf.write('</span>');
+    }
+    return wrapNullability(elementType, buf.toString());
+  }
+
+  @override
+  String renderNameWithGenerics(AliasedFunctionTypeElementType elementType) {
+    var buf = StringBuffer();
+    buf.write(elementType.aliasElement.name);
+    if (elementType.aliasArguments.isNotEmpty &&
+        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
+      buf.write('&lt;<wbr><span class="type-parameter">');
+      buf.writeAll(elementType.aliasArguments.map((t) => t.nameWithGenerics),
+          '</span>, <span class="type-parameter">');
+      buf.write('</span>&gt;');
+    }
+    return wrapNullability(elementType, buf.toString());
+  }
+}
+
 class AliasedElementTypeRendererHtml
     extends ElementTypeRenderer<AliasedElementType> {
   const AliasedElementTypeRendererHtml();
@@ -242,6 +277,38 @@ class AliasedElementTypeRendererMd
 
   @override
   String renderNameWithGenerics(AliasedElementType elementType) {
+    var buf = StringBuffer();
+    buf.write(elementType.aliasElement.name);
+    if (elementType.aliasArguments.isNotEmpty &&
+        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
+      buf.write('&lt;');
+      buf.writeAll(
+          elementType.aliasArguments.map((t) => t.nameWithGenerics), ', ');
+      buf.write('>');
+    }
+    return wrapNullability(elementType, buf.toString());
+  }
+}
+
+class AliasedFunctionTypeElementTypeRendererMd
+    extends ElementTypeRenderer<AliasedFunctionTypeElementType> {
+  const AliasedFunctionTypeElementTypeRendererMd();
+
+  @override
+  String renderLinkedName(AliasedFunctionTypeElementType elementType) {
+    var buf = StringBuffer();
+    buf.write(elementType.aliasElement.linkedName);
+    if (elementType.aliasArguments.isNotEmpty &&
+        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
+      buf.write('&lt;');
+      buf.writeAll(elementType.aliasArguments.map((t) => t.linkedName), ', ');
+      buf.write('>');
+    }
+    return wrapNullability(elementType, buf.toString());
+  }
+
+  @override
+  String renderNameWithGenerics(AliasedFunctionTypeElementType elementType) {
     var buf = StringBuffer();
     buf.write(elementType.aliasElement.name);
     if (elementType.aliasArguments.isNotEmpty &&

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -183,7 +183,7 @@ abstract class ParameterRenderer {
     if (param.isCovariant) {
       buf.write(covariant('covariant') + ' ');
     }
-    if (paramModelType is CallableElementTypeMixin) {
+    if (paramModelType is Callable) {
       String returnTypeName;
       if (paramModelType.isTypedef) {
         returnTypeName = paramModelType.linkedName;
@@ -208,10 +208,8 @@ abstract class ParameterRenderer {
       }
       if (!paramModelType.isTypedef && paramModelType.type is FunctionType) {
         buf.write('(');
-        buf.write(renderLinkedParams(
-            (paramModelType as UndefinedElementType).parameters,
-            showMetadata: showMetadata,
-            showNames: showNames));
+        buf.write(renderLinkedParams(paramModelType.parameters,
+            showMetadata: showMetadata, showNames: showNames));
         buf.write(')');
         buf.write(paramModelType.nullabilitySuffix);
       }

--- a/lib/src/render/renderer_factory.dart
+++ b/lib/src/render/renderer_factory.dart
@@ -51,6 +51,9 @@ abstract class RendererFactory {
 
   ElementTypeRenderer<AliasedElementType> get aliasedElementTypeRenderer;
 
+  ElementTypeRenderer<AliasedFunctionTypeElementType>
+      get aliasedFunctionTypeElementTypeRenderer;
+
   ElementTypeRenderer<CallableElementType> get callableElementTypeRenderer;
 
   EnumFieldRenderer get enumFieldRenderer;
@@ -129,6 +132,11 @@ class HtmlRenderFactory extends RendererFactory {
 
   @override
   FeatureRenderer get featureRenderer => const FeatureRendererHtml();
+
+  @override
+  ElementTypeRenderer<AliasedFunctionTypeElementType>
+      get aliasedFunctionTypeElementTypeRenderer =>
+          const AliasedFunctionTypeElementTypeRendererHtml();
 }
 
 class MdRenderFactory extends RendererFactory {
@@ -193,4 +201,9 @@ class MdRenderFactory extends RendererFactory {
 
   @override
   FeatureRenderer get featureRenderer => const FeatureRendererMd();
+
+  @override
+  ElementTypeRenderer<AliasedFunctionTypeElementType>
+      get aliasedFunctionTypeElementTypeRenderer =>
+          const AliasedFunctionTypeElementTypeRendererMd();
 }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -120,7 +120,7 @@ void main() {
           orderedEquals(genericParameters));
     }
 
-    void expectAliasedTypeName(AliasedElementType n, expected) {
+    void expectAliasedTypeName(AliasedElementTypeMixin n, expected) {
       expect(n.aliasElement.name, expected);
     }
 
@@ -212,7 +212,7 @@ void main() {
       expect(anotherOddFunction.modelType.returnType.name, equals('Future'));
       expect(anotherOddFunction.modelType.returnType.nullabilitySuffix,
           equals('?'));
-    });
+    }, skip: 'implied Future detection is broken');
 
     test('isNullSafety is set correctly for libraries', () {
       expect(lateFinalWithoutInitializer.isNullSafety, isTrue);
@@ -2710,7 +2710,7 @@ void main() {
 
     test('async function', () {
       expect(thisIsAsync.isAsynchronous, isTrue);
-      expect(thisIsAsync.modelType.returnType.linkedName, equals('Future'));
+      expect(thisIsAsync.modelType.returnType.linkedName, equals('dynamic'));
       expect(
           thisIsAsync.documentation,
           equals(
@@ -4208,7 +4208,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('async return type', () {
       expect(asyncM.modelType.returnType.linkedName, 'Future');
-    });
+    }, skip: 'async return type is no longer overwritten');
 
     test('param with generics', () {
       var params = ParameterRendererHtml()

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -120,7 +120,7 @@ void main() {
           orderedEquals(genericParameters));
     }
 
-    void expectAliasedTypeName(AliasedElementTypeMixin n, expected) {
+    void expectAliasedTypeName(Aliased n, expected) {
       expect(n.aliasElement.name, expected);
     }
 
@@ -3085,10 +3085,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('parameter is a function', () {
       var functionArgParam = m4.parameters[1];
-      expect(
-          (functionArgParam.modelType as CallableElementTypeMixin)
-              .returnType
-              .linkedName,
+      expect((functionArgParam.modelType as Callable).returnType.linkedName,
           'String');
     });
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -205,14 +205,14 @@ void main() {
           equals('?'));
     });
 
-    test('implied Future types have correct nullability', () {
-      expect(oddAsyncFunction.modelType.returnType.name, equals('Future'));
+    test('old implied Future types have correct nullability', () {
+      expect(oddAsyncFunction.modelType.returnType.name, equals('dynamic'));
       expect(
-          oddAsyncFunction.modelType.returnType.nullabilitySuffix, equals('?'));
-      expect(anotherOddFunction.modelType.returnType.name, equals('Future'));
+          oddAsyncFunction.modelType.returnType.nullabilitySuffix, equals(''));
+      expect(anotherOddFunction.modelType.returnType.name, equals('dynamic'));
       expect(anotherOddFunction.modelType.returnType.nullabilitySuffix,
-          equals('?'));
-    }, skip: 'implied Future detection is broken');
+          equals(''));
+    });
 
     test('isNullSafety is set correctly for libraries', () {
       expect(lateFinalWithoutInitializer.isNullSafety, isTrue);
@@ -4207,8 +4207,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('async return type', () {
-      expect(asyncM.modelType.returnType.linkedName, 'Future');
-    }, skip: 'async return type is no longer overwritten');
+      expect(asyncM.modelType.returnType.linkedName, 'dynamic');
+    });
 
     test('param with generics', () {
       var params = ParameterRendererHtml()

--- a/tool/mustachio/builder.dart
+++ b/tool/mustachio/builder.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/dart/element/member.dart';
 import 'package:build/build.dart';
 import 'package:dartdoc/src/mustachio/annotations.dart';
@@ -131,7 +132,7 @@ class _RendererGatherer {
     if (contextField.isNull) {
       throw StateError('@Renderer context must not be null');
     }
-    var contextFieldType = contextField.type;
+    var contextFieldType = contextField.type as InterfaceType;
     assert(contextFieldType.typeArguments.length == 1);
     var contextType = contextFieldType.typeArguments.single;
 


### PR DESCRIPTION
BREAKING CHANGE:  Changing of `modelType`'s `ElementType` and its subclasses may break custom templates if they depend on certain otherwise unused bits, like `returnElement`.
BREAKING CHANGE:  Implicit futures (the type returned from async functions with no declared return type) will no longer be documented as `Future`, but instead will be documented as `dynamic`, more in line with the language specification but maybe not user expectations.

The upcoming PR, https://dart-review.googlesource.com/c/sdk/+/201520, makes `FunctionType` no longer a subclass of `ParameterizedType` which has a lot of implications in the parallel structure in Dartdoc's `element_type.dart`.   This deals with those issues in a backwards compatible way.

Did some refactoring along the way -- more functionality has been extracted into mixins and the overall structure and usage of types is cleaner with less repetitive code.