### PR TITLE
Prepare for dartdoc 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.45.0
+* BREAKING CHANGE:  Custom templates using some obscure
+  getters of modelType may no longer function (returnElement
+  and others not used in standard templates).  (#2665)
+* BREAKING CHANGE:  Implicit `Future` detection, where an
+  asynchronous function without a declared return type had
+  its return type listed as `Future`, is no more.  Those
+  functions now show a `dynamic` return type. (#2665)
+* Fix a problem with enum field location calculations.
+  (#2660, #2659)
+* Support for AOT compilation of templates added to Mustachio,
+  but not yet enabled. (#2664, #2651)
+* Some additional new lookup code implementation and testing.
+
 ## 0.44.0
 * BREAKING CHANGE:  Add support for generic metadata rendering in
   typedefs. (#2649,  #2654).  This changes how typedefs are rendered

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.44.0/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v0.45.0/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.44.0';
+const packageVersion = '0.45.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 0.44.0
+version: 0.45.0
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:


### PR DESCRIPTION
This will also unblock https://dart-review.googlesource.com/c/sdk/+/201520 when it lands in the SDK.
