### PR TITLE
Add scoped lookup to Libraries

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -7514,7 +7514,8 @@ class _Renderer_Library extends RendererBase<Library> {
                   isNullValue: (CT_ c) => c.scope == null,
                   renderValue:
                       (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.scope, ast, r.template, parent: r);
+                    return renderSimple(c.scope, ast, r.template,
+                        parent: r, getters: _invisibleGetters['Scope']);
                   },
                 ),
                 'sdkLib': Property(
@@ -11172,7 +11173,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   return _render_PackageTemplateData(context, template.ast, template);
 }
 
@@ -11372,7 +11373,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   return _render_PackageTemplateData(context, template.ast, template);
 }
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -7443,6 +7443,17 @@ class _Renderer_Library extends RendererBase<Library> {
                         (e) => renderSimple(e, ast, r.template, parent: r));
                   },
                 ),
+                'scope': Property(
+                  getValue: (CT_ c) => c.scope,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'Scope'),
+                  isNullValue: (CT_ c) => c.scope == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.scope, ast, r.template, parent: r);
+                  },
+                ),
                 'sdkLib': Property(
                   getValue: (CT_ c) => c.sdkLib,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -90,8 +90,17 @@ mixin CommentReferable implements Nameable {
           'PrefixElement detected, override [lookupViaScope] in subclass');
       return null;
     }
-    return recurseChildrenAndFilter(referenceLookup,
-        ModelElement.fromElement(resultElement, packageGraph), filter);
+    if (resultElement == null) return null;
+    var result = ModelElement.fromElement(resultElement, packageGraph);
+    if (result is Accessor) {
+      result = (result as Accessor).enclosingCombo;
+    }
+    if (result?.enclosingElement is Container) {
+      assert(false,
+          '[Container] member detected, override in subclass and handle inheritance');
+      return null;
+    }
+    return recurseChildrenAndFilter(referenceLookup, result, filter);
   }
 
   CommentReferable _lookupViaReferenceChildren(

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -81,9 +81,7 @@ mixin MarkdownFileDocumentation implements Documentable, Canonicalization {
   File get documentationFile;
 
   @override
-  String get location => packageGraph.resourceProvider.pathContext
-      .toUri(documentationFile.path)
-      .toString();
+  String get location => '(${documentationFile.path})';
 
   @override
   Set<String> get locationPieces => <String>{location};

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -20,7 +20,7 @@ class Dynamic extends ModelElement {
   ModelElement get canonicalModelElement => null;
 
   @override
-  ModelElement get enclosingElement => throw UnsupportedError('');
+  ModelElement get enclosingElement => null;
 
   /// And similarly, even if someone references it directly it can have
   /// no hyperlink.

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -119,9 +119,8 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
           CompilationUnitElement compilationUnit) =>
       _getDefinedElements(compilationUnit);
 
-  @override
-
   /// Allow scope for Libraries.
+  @override
   Scope get scope => element.scope;
 
   List<String> __allOriginalModelElementNames;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -494,12 +494,7 @@ class PackageGraph with CommentReferable, Nameable {
     if (config.verboseWarnings && extendedDebug != null) {
       messageParts.addAll(extendedDebug.map((s) => '    $s'));
     }
-    String fullMessage;
-    if (messageParts.length <= 2) {
-      fullMessage = messageParts.join(', ');
-    } else {
-      fullMessage = messageParts.join('\n    ');
-    }
+    var fullMessage = messageParts.join('\n    ');
 
     packageWarningCounter.addWarning(warnable, kind, message, fullMessage);
   }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2222,11 +2222,7 @@ void main() {
     }
 
     test('Verify basic linking inside class', () {
-      // parameter of [doAwesomeStuff]
-      // Parameter lookups are discarded with the original lookup code
-      expect(originalLookup(doAwesomeStuff, 'value'),
-          equals(MatchingLinkResult(null, warn: false)));
-      expect(newLookup(doAwesomeStuff, 'value'),
+      expect(bothLookup(doAwesomeStuff, 'value'),
           equals(MatchingLinkResult(doAwesomeStuffParam)));
 
       // Parent class of [doAwesomeStuff].
@@ -2240,7 +2236,6 @@ void main() {
           equals(MatchingLinkResult(nameWithSingleUnderscore)));
 
       // Top level class from [dart:core].
-      // TODO(jcollins-g): dart:core not recognized yet with new lookup code.
       expect(bothLookup(doAwesomeStuff, 'String'),
           equals(MatchingLinkResult(string)));
 
@@ -2249,28 +2244,23 @@ void main() {
           equals(MatchingLinkResult(anotherMethod)));
 
       // A top level function in this library.
-      // TODO(jcollins-g): top level functions not recognized yet with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'topLevelFunction'),
+      expect(bothLookup(doAwesomeStuff, 'topLevelFunction'),
           equals(MatchingLinkResult(topLevelFunction)));
 
       // A top level function in another library imported into this library.
-      // TODO(jcollins-g): namespace lookups are not yet implemented with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'function1'),
+      expect(bothLookup(doAwesomeStuff, 'function1'),
           equals(MatchingLinkResult(function1)));
 
       // A class in another library imported into this library.
-      // TODO(jcollins-g): namespace lookups are not yet implemented with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'Apple'),
+      expect(bothLookup(doAwesomeStuff, 'Apple'),
           equals(MatchingLinkResult(Apple)));
 
       // A top level constant in this library sharing the same name as a name in another library.
-      // TODO(jcollins-g): namespace lookups are not yet implemented with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'incorrectDocReference'),
+      expect(bothLookup(doAwesomeStuff, 'incorrectDocReference'),
           equals(MatchingLinkResult(incorrectDocReference)));
 
       // A top level constant in another library.
-      // TODO(jcollins-g): namespace lookups are not yet implemented with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'incorrectDocReferenceFromEx'),
+      expect(bothLookup(doAwesomeStuff, 'incorrectDocReferenceFromEx'),
           equals(MatchingLinkResult(incorrectDocReferenceFromEx)));
 
       // A prefixed constant in another library.
@@ -2284,7 +2274,7 @@ void main() {
           equals(MatchingLinkResult(doesStuff)));
 
       // A name of a class from an import of a library that exported that name.
-      expect(originalLookup(doAwesomeStuff, 'BaseClass'),
+      expect(bothLookup(doAwesomeStuff, 'BaseClass'),
           equals(MatchingLinkResult(BaseClass)));
 
       // A bracket operator within this class.

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2217,7 +2217,7 @@ void main() {
     MatchingLinkResult bothLookup(Warnable element, String codeRef) {
       var originalLookupResult = originalLookup(element, codeRef);
       var newLookupResult = newLookup(element, codeRef);
-      expect(newLookupResult, equals(originalLookupResult));
+      expect(newLookupResult.isEquivalentTo(originalLookupResult), isTrue);
       return newLookupResult;
     }
 
@@ -2241,7 +2241,7 @@ void main() {
 
       // Top level class from [dart:core].
       // TODO(jcollins-g): dart:core not recognized yet with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'String'),
+      expect(bothLookup(doAwesomeStuff, 'String'),
           equals(MatchingLinkResult(string)));
 
       // Another method in the same class.


### PR DESCRIPTION
This adds a `scope` implementation for `Library` which allows us to use the analyzer scope for imported and defined objects, reducing the custom implementation to allowing export lookups.  Since we prioritize analyzer resolution, edge cases will now favor imports over exports where it can make a difference.

Also did some small cosmetic changes to make warning links show up more consistently in IntelliJ terminal output. 

Comparison of sdk docs using  `dart --enable-asserts dartdoc.dart --sdk-docs --warnings reference-lookup-found-with-new,reference-lookup-missing-with-new,reference-lookup-not-found-with-new --show-stats`:

this PR:
```
total references: 29582
resolved references:  22262 (75.25522277060375%)
resolved references with new lookup:  28738 (97.14691366371441%)
resolved references with old lookup:  22262 (75.25522277060375%)
resolved references with equivalent links:  28996 (98.0190656480292%)
```

Head:
```
total references: 29582
resolved references:  22262 (75.25522277060375%)
resolved references with new lookup:  26672 (90.16293692110067%)
resolved references with old lookup:  22262 (75.25522277060375%)
resolved references with equivalent links:  26945 (91.08579541613143%)
```