### PR TITLE
Add PrefixElement linkage to analyzer scope lookups

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -309,6 +309,12 @@ MatchingLinkResult _getMatchingLinkElementCommentReferable(
   var lookupResult =
       warnable.referenceBy(commentReference.referenceBy, filter: filter);
 
+  // TODO(jcollins-g): Referring to packages or other non-[ModelElement]s
+  // might be needed here.  Determine if that's the case.
+  if (!(lookupResult is ModelElement)) {
+    lookupResult = null;
+  }
+
   // TODO(jcollins-g): Consider prioritizing analyzer resolution before custom.
   return MatchingLinkResult(lookupResult);
 }

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -79,17 +79,12 @@ mixin CommentReferable implements Nameable {
   /// Looks up references by [scope], skipping over results that do not match
   /// the given filter.
   ///
-  /// Override if [Scope.lookup] may return a [PrefixElement] or other elements
-  /// not corresponding to a [CommentReferable], but you still want to have
-  /// an implementation of [scope].
+  /// Override if [Scope.lookup] may return elements not corresponding to a
+  /// [CommentReferable], but you still want to have an implementation of
+  /// [scope].
   CommentReferable lookupViaScope(ReferenceChildrenLookup referenceLookup,
       bool Function(CommentReferable) filter) {
     var resultElement = scope.lookupPreferGetter(referenceLookup.lookup);
-    if (resultElement is PrefixElement) {
-      assert(false,
-          'PrefixElement detected, override [lookupViaScope] in subclass');
-      return null;
-    }
     if (resultElement == null) return null;
     var result = ModelElement.fromElement(resultElement, packageGraph);
     if (result is Accessor) {

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -22,6 +22,7 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/feature_set.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model/prefix.dart';
 import 'package:dartdoc/src/model_utils.dart' as utils;
 import 'package:dartdoc/src/render/model_element_renderer.dart';
 import 'package:dartdoc/src/render/parameter_renderer.dart';
@@ -285,6 +286,9 @@ abstract class ModelElement extends Canonicalization
     assert(e is! MultiplyDefinedElement);
     if (e is LibraryElement) {
       return Library(e, packageGraph);
+    }
+    if (e is PrefixElement) {
+      return Prefix(e, library, packageGraph);
     }
     if (e is ClassElement) {
       if (e.isMixin) {

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -31,7 +31,7 @@ class Parameter extends ModelElement implements EnclosedElement {
 
   @override
   String get filePath {
-    throw StateError('filePath not implemented for parameters');
+    throw UnimplementedError('Parameters have no generated files in dartdoc');
   }
 
   @override

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -11,15 +9,13 @@ import 'package:dartdoc/src/model/library.dart';
 
 import '../../dartdoc.dart';
 
-
 /// Represents a [PrefixElement] for dartdoc.
 ///
 /// Like [Parameter], it doesn't have doc pages, but participates in lookups.
 class Prefix extends ModelElement implements EnclosedElement {
   /// [library] is the library the prefix is defined in, not the [Library]
   /// referred to by the [PrefixElement].
-  Prefix(
-      PrefixElement element, Library library, PackageGraph packageGraph)
+  Prefix(PrefixElement element, Library library, PackageGraph packageGraph)
       : super(element, library, packageGraph);
 
   @override
@@ -36,7 +32,8 @@ class Prefix extends ModelElement implements EnclosedElement {
   ModelElement get enclosingElement => library;
 
   @override
-  String get filePath => throw UnimplementedError('prefixes have no generated files in dartdoc');
+  String get filePath =>
+      throw UnimplementedError('prefixes have no generated files in dartdoc');
 
   @override
   String get href => null;

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/scope.dart';
+import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/library.dart';
+
+import '../../dartdoc.dart';
+
+
+/// Represents a [PrefixElement] for dartdoc.
+///
+/// Like [Parameter], it doesn't have doc pages, but participates in lookups.
+class Prefix extends ModelElement implements EnclosedElement {
+  /// [library] is the library the prefix is defined in, not the [Library]
+  /// referred to by the [PrefixElement].
+  Prefix(
+      PrefixElement element, Library library, PackageGraph packageGraph)
+      : super(element, library, packageGraph);
+
+  @override
+  // TODO(jcollins-g): consider allowing bare prefixes to link to a library doc?
+  bool get isCanonical => false;
+
+  @override
+  Scope get scope => element.scope;
+
+  @override
+  PrefixElement get element => super.element;
+
+  @override
+  ModelElement get enclosingElement => library;
+
+  @override
+  String get filePath => throw UnimplementedError('prefixes have no generated files in dartdoc');
+
+  @override
+  String get href => null;
+
+  @override
+  String get kind => 'prefix';
+
+  @override
+  Map<String, CommentReferable> get referenceChildren => {};
+
+  @override
+  Iterable<CommentReferable> get referenceParents => [library];
+}

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2264,8 +2264,7 @@ void main() {
           equals(MatchingLinkResult(incorrectDocReferenceFromEx)));
 
       // A prefixed constant in another library.
-      // TODO(jcollins-g): prefixed namespace lookups are not yet implemented with new lookup code.
-      expect(originalLookup(doAwesomeStuff, 'css.theOnlyThingInTheLibrary'),
+      expect(bothLookup(doAwesomeStuff, 'css.theOnlyThingInTheLibrary'),
           equals(MatchingLinkResult(theOnlyThingInTheLibrary)));
 
       // A name that exists in this package but is not imported.


### PR DESCRIPTION
This adds scoped lookups via the new lookup code for import prefixes.

Also, patches over an issue with a TODO so we can run Flutter to completion.

Current stats for flutter:

```
Documented 116 public libraries in 219.2 seconds
Reference Counts:
total references: 181952
resolved references:  162688 (89.41259233204362%)
resolved references with new lookup:  131981 (72.53616338374957%)
resolved references with old lookup:  137558 (75.60125747449877%)
resolved references with equivalent links:  131085 (72.0437258177981%)
```