### PR TITLE
Fix runtime renderers rendering of certain sections

### DIFF
--- a/lib/src/mustachio/parser.dart
+++ b/lib/src/mustachio/parser.dart
@@ -255,7 +255,6 @@ class MustachioParser {
           keySpanEndOffset - lastName.length, keySpanEndOffset);
       var section = Section([lastName], children,
           invert: invert, span: span, keySpan: lastNameSpan);
-      //for (var sectionKey in parsedKey.names.reversed.skip(1)) {
       for (var i = parsedKey.names.length - 2; i >= 0; i--) {
         var sectionKey = parsedKey.names[i];
         // To find the start offset of the ith name, take the length of all of

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -145,6 +145,8 @@ abstract class RendererBase<T> {
   Template _template;
 
   /// The output buffer into which [context] is rendered, using a template.
+  // TODO(srawlins): Pass around a single [StringBuffer], and make this field
+  // `final`.
   StringBuffer buffer = StringBuffer();
 
   final Set<String> _invisibleGetters;

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -145,7 +145,7 @@ abstract class RendererBase<T> {
   Template _template;
 
   /// The output buffer into which [context] is rendered, using a template.
-  final buffer = StringBuffer();
+  StringBuffer buffer = StringBuffer();
 
   final Set<String> _invisibleGetters;
 
@@ -234,7 +234,7 @@ abstract class RendererBase<T> {
             "Failed to resolve '$key' as a property on any types in the "
             'current context'));
       } else {
-        return parent.section(node);
+        return parent.withBuffer(buffer, () => parent.section(node));
       }
     }
 
@@ -278,6 +278,16 @@ abstract class RendererBase<T> {
     _template = partialTemplate;
     renderBlock(partialTemplate.ast);
     _template = outerTemplate;
+  }
+
+  /// Executes [fn] after replacing [buffer] with [newBuffer].
+  ///
+  /// Replaces the previous buffer as [buffer].
+  void withBuffer(StringBuffer newBuffer, void Function() fn) {
+    var previousBuffer = buffer;
+    buffer = newBuffer;
+    fn();
+    buffer = previousBuffer;
   }
 }
 

--- a/test/mustachio/aot_compiler_render_test.dart
+++ b/test/mustachio/aot_compiler_render_test.dart
@@ -259,6 +259,15 @@ void main() {
     expect(output, equals('Text Foo: hello'));
   });
 
+  test('Renderer renders a value section node keyed lower in the stack',
+      () async {
+    var output = await renderBar({
+      'foo|lib/templates/html/bar.html':
+          'Text {{#foo}}One {{#s2}}Two{{/s2}}{{/foo}}',
+    }, '_i1.Bar()..foo = _i1.Foo()..s2 = "hello"');
+    expect(output, equals('Text One Two'));
+  });
+
   test('Renderer renders a null value section node as blank', () async {
     var output = await renderFoo({
       'foo|lib/templates/html/foo.html':

--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -202,6 +202,17 @@ void main() {
     expect(renderBar(bar, barTemplate), equals('Text Foo: hello'));
   });
 
+  test('Renderer renders a value section node keyed lower in the stack',
+      () async {
+    var barTemplateFile = getFile('/project/bar.mustache')
+      ..writeAsStringSync('Text {{#foo}}One {{#s2}}Two{{/s2}}{{/foo}}');
+    var barTemplate = await Template.parse(barTemplateFile);
+    var bar = Bar()
+      ..foo = (Foo()..s1 = 'goodbye')
+      ..s2 = 'hello';
+    expect(renderBar(bar, barTemplate), equals('Text One Two'));
+  });
+
   test('Renderer renders a null value section node as blank', () async {
     var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{#s1}}"{{.}}" ({{length}}){{/s1}}');

--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -208,7 +208,7 @@ void main() {
       ..writeAsStringSync('Text {{#foo}}One {{#s2}}Two{{/s2}}{{/foo}}');
     var barTemplate = await Template.parse(barTemplateFile);
     var bar = Bar()
-      ..foo = (Foo()..s1 = 'goodbye')
+      ..foo = Foo()
       ..s2 = 'hello';
     expect(renderBar(bar, barTemplate), equals('Text One Two'));
   });


### PR DESCRIPTION
If a section is found which is  keyed on a context variable other than the _top_ of the stack, then the wrong buffer will be written to.

Before this fix, the test added in this PR renders "Text TwoOne ". Yikes!

It looks like `section()` is the only node to refer to `parent` in this way. (`getProperties()` does not touch its own `buffer`; it only returns a result directly.)