### PR TITLE
Escape variable renders in runtime renderer

### DIFF
--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -6,6 +6,7 @@
 // documentation.
 
 import 'dart:collection';
+import 'dart:convert' show htmlEscape;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:meta/meta.dart';
@@ -216,7 +217,11 @@ abstract class RendererBase<T> {
         write(node.content);
       } else if (node is Variable) {
         var content = getFields(node);
-        write(content);
+        if (node.escape) {
+          write(htmlEscape.convert(content));
+        } else {
+          write(content);
+        }
       } else if (node is Section) {
         section(node);
       } else if (node is Partial) {

--- a/test/mustachio/aot_compiler_render_test.dart
+++ b/test/mustachio/aot_compiler_render_test.dart
@@ -158,11 +158,18 @@ void main() {
     s1: hello    b1? no    l1:item: 1item: 2item: 3    baz:baz is null</div>'''));
   });
 
-  test('Renderer renders a non-bool variable node', () async {
+  test('Renderer renders a non-bool variable node, escaped', () async {
     var output = await renderFoo({
       'foo|lib/templates/html/foo.html': 'Text {{s1}}',
-    }, '_i1.Foo()..s1 = "hello"');
-    expect(output, equals('Text hello'));
+    }, '_i1.Foo()..s1 = "<p>hello</p>"');
+    expect(output, equals('Text &lt;p&gt;hello&lt;&#47;p&gt;'));
+  });
+
+  test('Renderer renders a non-bool variable node, not escaped', () async {
+    var output = await renderFoo({
+      'foo|lib/templates/html/foo.html': 'Text {{{s1}}}',
+    }, '_i1.Foo()..s1 = "<p>hello</p>"');
+    expect(output, equals('Text <p>hello</p>'));
   });
 
   test('Renderer renders a bool variable node', () async {

--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -96,12 +96,21 @@ void main() {
     expect(propertyMap['b1'].getBool(foo), isFalse);
   });
 
-  test('Renderer renders a non-bool variable node', () async {
+  test('Renderer renders a non-bool variable node, escaped', () async {
     var fooTemplateFile = getFile('/project/foo.mustache')
       ..writeAsStringSync('Text {{s1}}');
     var fooTemplate = await Template.parse(fooTemplateFile);
-    var foo = Foo()..s1 = 'hello';
-    expect(renderFoo(foo, fooTemplate), equals('Text hello'));
+    var foo = Foo()..s1 = '<p>hello</p>';
+    expect(renderFoo(foo, fooTemplate),
+        equals('Text &lt;p&gt;hello&lt;&#47;p&gt;'));
+  });
+
+  test('Renderer renders a non-bool variable node, not escaped', () async {
+    var fooTemplateFile = getFile('/project/foo.mustache')
+      ..writeAsStringSync('Text {{{s1}}}');
+    var fooTemplate = await Template.parse(fooTemplateFile);
+    var foo = Foo()..s1 = '<p>hello</p>';
+    expect(renderFoo(foo, fooTemplate), equals('Text <p>hello</p>'));
   });
 
   test('Renderer renders a bool variable node', () async {
@@ -379,7 +388,7 @@ void main() {
     expect(
         renderBar(bar, barTemplate),
         equals('Line 1 Partial Section 1Section 2Section 3\n'
-            'Line 2 Partial Section Instance of \'Bar\''));
+            'Line 2 Partial Section Instance of &#39;Bar&#39;'));
   });
 
   test('Renderer renders a partial using a custom partial renderer', () async {


### PR DESCRIPTION
A bit shocking that this bug slipped through, but this corrects escaping behavior for the runtime renderers.