### PR TITLE
Fix problems with head analyzer

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -33,6 +33,20 @@ class _Renderer_Accessor extends RendererBase<Accessor> {
           CT_,
           () => {
                 ..._Renderer_ModelElement.propertyMap<CT_>(),
+                'characterLocation': Property(
+                  getValue: (CT_ c) => c.characterLocation,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'CharacterLocation'),
+                  isNullValue: (CT_ c) => c.characterLocation == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.characterLocation, ast, r.template,
+                        parent: r,
+                        getters: _invisibleGetters['CharacterLocation']);
+                  },
+                ),
                 'definingCombo': Property(
                   getValue: (CT_ c) => c.definingCombo,
                   renderVariable:

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -22,6 +22,16 @@ class Accessor extends ModelElement implements EnclosedElement {
       : super(element, library, packageGraph, originalMember);
 
   @override
+  CharacterLocation get characterLocation {
+    if (element.nameOffset < 0) {
+      assert(element.isSynthetic, 'Invalid offset for non-synthetic element');
+      // TODO(jcollins-g): switch to [element.nonSynthetic] after analyzer 1.8
+      return enclosingCombo.characterLocation;
+    }
+    return super.characterLocation;
+  }
+
+  @override
   PropertyAccessorElement get element => super.element;
 
   @override

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -403,8 +403,8 @@ void main() {
           set_literals.constants.firstWhere((v) => v.name == 'specifiedSet');
       untypedMap =
           set_literals.constants.firstWhere((v) => v.name == 'untypedMap');
-      untypedMapWithoutConst =
-          set_literals.constants.firstWhere((v) => v.name == 'untypedMapWithoutConst');
+      untypedMapWithoutConst = set_literals.constants
+          .firstWhere((v) => v.name == 'untypedMapWithoutConst');
       typedSet = set_literals.constants.firstWhere((v) => v.name == 'typedSet');
     });
 
@@ -436,7 +436,8 @@ void main() {
       expect(specifiedSet.constantValue, equals('const {}'));
       // The analyzer is allowed to return a string with or without leading
       // `const` here.
-      expect(untypedMapWithoutConst.constantValue, matches(RegExp('(const )?{}')));
+      expect(
+          untypedMapWithoutConst.constantValue, matches(RegExp('(const )?{}')));
       expect(untypedMap.modelType.name, equals('Map'));
       expect(
           (untypedMap.modelType as ParameterizedElementType)

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -389,6 +389,7 @@ void main() {
         inferredTypeSet,
         specifiedSet,
         untypedMap,
+        untypedMapWithoutConst,
         typedSet;
 
     setUpAll(() async {
@@ -402,6 +403,8 @@ void main() {
           set_literals.constants.firstWhere((v) => v.name == 'specifiedSet');
       untypedMap =
           set_literals.constants.firstWhere((v) => v.name == 'untypedMap');
+      untypedMapWithoutConst =
+          set_literals.constants.firstWhere((v) => v.name == 'untypedMapWithoutConst');
       typedSet = set_literals.constants.firstWhere((v) => v.name == 'typedSet');
     });
 
@@ -431,6 +434,9 @@ void main() {
               .toList(),
           equals(['int']));
       expect(specifiedSet.constantValue, equals('const {}'));
+      // The analyzer is allowed to return a string with or without leading
+      // `const` here.
+      expect(untypedMapWithoutConst.constantValue, matches(RegExp('(const )?{}')));
       expect(untypedMap.modelType.name, equals('Map'));
       expect(
           (untypedMap.modelType as ParameterizedElementType)

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -58,8 +58,8 @@ class aThingToDo {
   const aThingToDo(this.who, this.what);
 }
 
-const ConstantCat MY_CAT = ConstantCat('tabby');
-const List<String> PRETTY_COLORS = <String>[COLOR_GREEN, COLOR_ORANGE, 'blue'];
+const ConstantCat MY_CAT = const ConstantCat('tabby');
+const List<String> PRETTY_COLORS = const <String>[COLOR_GREEN, COLOR_ORANGE, 'blue'];
 @deprecated
 int deprecatedField;
 
@@ -313,7 +313,7 @@ class Dog implements Cat, E {
   static const String aStaticConstField = "A Constant Dog";
 
   /// Verify link substitution in constants (#1535)
-  static const ShortName aName = ExtendedShortName("hello there");
+  static const ShortName aName = const ExtendedShortName("hello there");
 
   @protected
   final int aProtectedFinalField = 84;

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -254,7 +254,7 @@ class AClassWithFancyProperties {
   String aProperty;
 }
 
-const _APrivateConstClass CUSTOM_CLASS_PRIVATE = _APrivateConstClass();
+const _APrivateConstClass CUSTOM_CLASS_PRIVATE = const _APrivateConstClass();
 
 /// Type inference mixing with anonymous functions.
 final importantComputations = {

--- a/testing/test_package/lib/set_literals.dart
+++ b/testing/test_package/lib/set_literals.dart
@@ -1,9 +1,11 @@
 // @dart=2.9
 
-const inferredTypeSet = {1, 3, 5};
-const Set<int> specifiedSet = {};
-const untypedMap = {};
-const typedSet = <String>{};
+const inferredTypeSet = const {1, 3, 5};
+const Set<int> specifiedSet = const {};
+const untypedMap = const {};
+const typedSet = const <String>{};
+const untypedMapWithoutConst = {};
+
 
 class AClassContainingLiterals {
   final int value1;
@@ -12,4 +14,4 @@ class AClassContainingLiterals {
   const AClassContainingLiterals(this.value1, this.value2);
 }
 
-const aComplexSet = {AClassContainingLiterals(3, 5)};
+const aComplexSet = const {const AClassContainingLiterals(3, 5)};


### PR DESCRIPTION
- Allow const to be missing in const value initializers
- Never try to get offsets from synthetic elements even where they used to be available pre 1.8.0