### PR TITLE
Fix constructors and type parameters in the new lookup code

### DIFF
--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -133,7 +133,7 @@ class CommentReferenceParser {
     if (suffixResult.type == _SuffixResultType.notSuffix) {
       // Invalid trailing junk; reject the reference.
       return [];
-    } else if (suffixResult.type == _SuffixResultType.parsedConstructorHint) {
+    } else if (suffixResult.type == _SuffixResultType.parsedCallableHint) {
       children.add(suffixResult.node);
     }
 
@@ -234,10 +234,10 @@ class CommentReferenceParser {
         IdentifierNode(codeRef.substring(startIndex, _index)));
   }
 
-  static const _constructorHintSuffix = '()';
+  static const _callableHintSuffix = '()';
 
   /// ```text
-  /// <suffix> ::= <constructorPostfixHint>
+  /// <suffix> ::= <callableHintSuffix>
   ///   | <trailingJunk>
   ///
   /// <trailingJunk> ::= '<'<CHARACTER>*'>'
@@ -246,7 +246,7 @@ class CommentReferenceParser {
   ///   | '?'
   ///   | '!'
   ///
-  /// <constructorPostfixHint> ::= '()'
+  /// <callableHintSuffix> ::= '()'
   /// ```
   _SuffixParseResult _parseSuffix() {
     var startIndex = _index;
@@ -254,10 +254,10 @@ class CommentReferenceParser {
     if (_atEnd) {
       return _SuffixParseResult.missing;
     }
-    if (_tryMatchLiteral(_constructorHintSuffix)) {
+    if (_tryMatchLiteral(_callableHintSuffix)) {
       if (_atEnd) {
         return _SuffixParseResult.ok(
-            ConstructorHintEndNode(codeRef.substring(startIndex, _index)));
+            CallableHintEndNode(codeRef.substring(startIndex, _index)));
       }
       return _SuffixParseResult.notSuffix;
     }
@@ -386,10 +386,10 @@ enum _SuffixResultType {
   junk, // Found known types of junk it is OK to ignore.
   missing, // There is no suffix here.  Same as EOF as this is a suffix.
   notSuffix, // Found something, but not a valid suffix.
-  parsedConstructorHint, // Parsed a [ConstructorHintEndNode].
+  parsedCallableHint, // Parsed a [CallableHintEndNode].
 }
 
-/// The result of attempting to parse a prefix to a comment reference.
+/// The result of attempting to parse a suffix to a comment reference.
 class _SuffixParseResult {
   final _SuffixResultType type;
 
@@ -398,7 +398,7 @@ class _SuffixParseResult {
   const _SuffixParseResult._(this.type, this.node);
 
   factory _SuffixParseResult.ok(CommentReferenceNode node) =>
-      _SuffixParseResult._(_SuffixResultType.parsedConstructorHint, node);
+      _SuffixParseResult._(_SuffixResultType.parsedCallableHint, node);
 
   static const _SuffixParseResult junk =
       _SuffixParseResult._(_SuffixResultType.junk, null);
@@ -426,14 +426,14 @@ class ConstructorHintStartNode extends CommentReferenceNode {
   String toString() => 'ConstructorHintStartNode["$text"]';
 }
 
-class ConstructorHintEndNode extends CommentReferenceNode {
+class CallableHintEndNode extends CommentReferenceNode {
   @override
   final String text;
 
-  ConstructorHintEndNode(this.text);
+  CallableHintEndNode(this.text);
 
   @override
-  String toString() => 'ConstructorHintEndNode["$text"]';
+  String toString() => 'CallableHintEndNode["$text"]';
 }
 
 /// Represents an identifier.

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2162,9 +2162,9 @@ class _Renderer_Class extends RendererBase<Class> {
                       self.renderSimpleVariable(
                           c, remainingNames, 'Map<String, CommentReferable>'),
                   isNullValue: (CT_ c) => c.referenceChildren == null,
-                  renderValue:
-                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
-                    return renderSimple(c.referenceChildren, ast, r.template,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    renderSimple(c.referenceChildren, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['Map']);
                   },
                 ),

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2153,6 +2153,19 @@ class _Renderer_Class extends RendererBase<Class> {
                             parent: r));
                   },
                 ),
+                'referenceChildren': Property(
+                  getValue: (CT_ c) => c.referenceChildren,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Map<String, CommentReferable>'),
+                  isNullValue: (CT_ c) => c.referenceChildren == null,
+                  renderValue:
+                      (CT_ c, RendererBase<CT_> r, List<MustachioNode> ast) {
+                    return renderSimple(c.referenceChildren, ast, r.template,
+                        parent: r, getters: _invisibleGetters['Map']);
+                  },
+                ),
                 'referenceParents': Property(
                   getValue: (CT_ c) => c.referenceParents,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -605,6 +605,22 @@ class Class extends Container
   @override
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
 
+  Map<String, CommentReferable> _referenceChildren;
+  @override
+  Map<String, CommentReferable> get referenceChildren {
+    if (_referenceChildren == null) {
+      _referenceChildren = super.referenceChildren;
+      for (var constructor in constructors) {
+        // For default constructors this is a no-op, but other constructors
+        // sometimes have a prefix attached to them in their "real name".
+        // TODO(jcollins-g): consider disallowing that, and only using
+        // the element name as here?
+        _referenceChildren[constructor.element.name] = constructor;
+      }
+    }
+    return _referenceChildren;
+  }
+
   @override
   Iterable<CommentReferable> get referenceParents => <CommentReferable>[
         ...super.referenceParents,

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -127,8 +127,16 @@ class Constructor extends ModelElement
   Map<String, CommentReferable> get referenceChildren {
     if (_referenceChildren == null) {
       _referenceChildren = {};
-      _referenceChildren
-          .addEntries(allParameters.map((p) => MapEntry(p.name, p)));
+      for (var param in allParameters) {
+        var paramElement = param.element;
+        if (paramElement is FieldFormalParameterElement) {
+          var fieldFormal =
+              ModelElement.fromElement(paramElement.field, packageGraph);
+          _referenceChildren[paramElement.name] = fieldFormal;
+        } else {
+          _referenceChildren[param.name] = param;
+        }
+      }
       _referenceChildren
           .addEntries(typeParameters.map((p) => MapEntry(p.name, p)));
     }

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -262,7 +262,18 @@ abstract class Container extends ModelElement with TypeParameters {
     if (_referenceChildren == null) {
       _referenceChildren = {};
       for (var modelElement in allModelElements) {
+        // Never directly look up accessors.
         if (modelElement is Accessor) continue;
+        if (modelElement is Constructor) {
+          // Populate default constructor names so they make sense for the
+          // new lookup code.
+          var constructorName = modelElement.element.name;
+          if (constructorName == '') {
+            constructorName = name;
+          }
+          _referenceChildren[constructorName] = modelElement;
+          continue;
+        }
         if (modelElement is Operator) {
           // TODO(jcollins-g): once todo in [Operator.name] is fixed, remove
           // this special case.
@@ -270,6 +281,10 @@ abstract class Container extends ModelElement with TypeParameters {
         } else {
           _referenceChildren[modelElement.name] = modelElement;
         }
+      }
+      // Process unscoped parameters last to make sure they don't override
+      // other options.
+      for (var modelElement in allModelElements) {
         // Don't complain about references to parameter names, but prefer
         // referring to anything else.
         // TODO(jcollins-g): Figure out something good to do in the ecosystem

--- a/test/comment_referable/parser_test.dart
+++ b/test/comment_referable/parser_test.dart
@@ -11,7 +11,7 @@ void main() {
     var result = CommentReferenceParser(codeRef).parse();
     var hasHint = result.isNotEmpty &&
         (result.first is ConstructorHintStartNode ||
-            result.last is ConstructorHintEndNode);
+            result.last is CallableHintEndNode);
     var stringParts = result.whereType<IdentifierNode>().map((i) => i.text);
     expect(stringParts, equals(parts));
     expect(hasHint, equals(constructorHint));

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2148,7 +2148,8 @@ void main() {
           .firstWhere((c) => c.name == 'String');
       baseForDocComments =
           fakeLibrary.classes.firstWhere((c) => c.name == 'BaseForDocComments');
-      aNonDefaultConstructor = baseForDocComments.constructors.firstWhere((c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
+      aNonDefaultConstructor = baseForDocComments.constructors.firstWhere(
+          (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
       doAwesomeStuff = baseForDocComments.instanceMethods
           .firstWhere((m) => m.name == 'doAwesomeStuff');
       anotherMethod = baseForDocComments.instanceMethods
@@ -2227,7 +2228,9 @@ void main() {
       expect(bothLookup(doAwesomeStuff, 'aNonDefaultConstructor'),
           equals(MatchingLinkResult(aNonDefaultConstructor)));
 
-      expect(bothLookup(doAwesomeStuff, 'BaseForDocComments.aNonDefaultConstructor'),
+      expect(
+          bothLookup(
+              doAwesomeStuff, 'BaseForDocComments.aNonDefaultConstructor'),
           equals(MatchingLinkResult(aNonDefaultConstructor)));
 
       expect(bothLookup(doAwesomeStuff, 'this'),

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2136,13 +2136,13 @@ void main() {
         nameWithTwoUnderscores,
         nameWithSingleUnderscore,
         theOnlyThingInTheLibrary;
-    Constructor aNonDefaultConstructor;
+    Constructor aNonDefaultConstructor, defaultConstructor;
     Class Apple, BaseClass, baseForDocComments, ExtraSpecialList, string;
     Method doAwesomeStuff, anotherMethod;
     // ignore: unused_local_variable
     Operator bracketOperator, bracketOperatorOtherClass;
     Parameter doAwesomeStuffParam;
-    Field forInheriting, action;
+    Field forInheriting, action, initializeMe;
 
     setUpAll(() async {
       nameWithTwoUnderscores = fakeLibrary.constants
@@ -2157,6 +2157,10 @@ void main() {
           fakeLibrary.classes.firstWhere((c) => c.name == 'BaseForDocComments');
       aNonDefaultConstructor = baseForDocComments.constructors.firstWhere(
           (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
+      defaultConstructor = baseForDocComments.constructors
+          .firstWhere((c) => c.name == 'BaseForDocComments');
+      initializeMe = baseForDocComments.allFields
+          .firstWhere((f) => f.name == 'initializeMe');
       doAwesomeStuff = baseForDocComments.instanceMethods
           .firstWhere((m) => m.name == 'doAwesomeStuff');
       anotherMethod = baseForDocComments.instanceMethods
@@ -2231,7 +2235,25 @@ void main() {
       return newLookupResult;
     }
 
+    test('Verify basic linking inside a constructor', () {
+      // Field formal parameters worked sometimes by accident in the old code,
+      // but should work reliably now.
+      expect(newLookup(aNonDefaultConstructor, 'initializeMe'),
+          equals(MatchingLinkResult(initializeMe)));
+      expect(newLookup(aNonDefaultConstructor, 'aNonDefaultConstructor'),
+          equals(MatchingLinkResult(aNonDefaultConstructor)));
+      expect(
+          bothLookup(aNonDefaultConstructor,
+              'BaseForDocComments.aNonDefaultConstructor'),
+          equals(MatchingLinkResult(aNonDefaultConstructor)));
+    });
+
     test('Verify basic linking inside class', () {
+      expect(
+          bothLookup(
+              baseForDocComments, 'BaseForDocComments.BaseForDocComments'),
+          equals(MatchingLinkResult(defaultConstructor)));
+
       expect(bothLookup(doAwesomeStuff, 'aNonDefaultConstructor'),
           equals(MatchingLinkResult(aNonDefaultConstructor)));
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2129,6 +2129,7 @@ void main() {
         nameWithTwoUnderscores,
         nameWithSingleUnderscore,
         theOnlyThingInTheLibrary;
+    Constructor aNonDefaultConstructor;
     Class Apple, BaseClass, baseForDocComments, ExtraSpecialList, string;
     Method doAwesomeStuff, anotherMethod;
     // ignore: unused_local_variable
@@ -2147,6 +2148,7 @@ void main() {
           .firstWhere((c) => c.name == 'String');
       baseForDocComments =
           fakeLibrary.classes.firstWhere((c) => c.name == 'BaseForDocComments');
+      aNonDefaultConstructor = baseForDocComments.constructors.firstWhere((c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
       doAwesomeStuff = baseForDocComments.instanceMethods
           .firstWhere((m) => m.name == 'doAwesomeStuff');
       anotherMethod = baseForDocComments.instanceMethods
@@ -2222,6 +2224,12 @@ void main() {
     }
 
     test('Verify basic linking inside class', () {
+      expect(bothLookup(doAwesomeStuff, 'aNonDefaultConstructor'),
+          equals(MatchingLinkResult(aNonDefaultConstructor)));
+
+      expect(bothLookup(doAwesomeStuff, 'BaseForDocComments.aNonDefaultConstructor'),
+          equals(MatchingLinkResult(aNonDefaultConstructor)));
+
       expect(bothLookup(doAwesomeStuff, 'this'),
           equals(MatchingLinkResult(baseForDocComments)));
 
@@ -2280,7 +2288,6 @@ void main() {
           equals(MatchingLinkResult(BaseClass)));
 
       // A bracket operator within this class.
-      // TODO(jcollins-g): operator lookups not yet implemented with the new lookup code.
       expect(bothLookup(doAwesomeStuff, 'operator []'),
           equals(MatchingLinkResult(bracketOperator)));
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -985,6 +985,8 @@ enum MacrosFromAccessors {
 /// Testing if docs for inherited method are correct.
 /// {@category NotSoExcellent}
 class SubForDocComments extends BaseForDocComments {
+  SubForDocComments(bool thing) : super(thing);
+  
   /// Reference to [foo] and [bar]
   void localMethod(String foo, bar) {}
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -960,9 +960,11 @@ class BaseForDocComments {
 
   String operator [](String key) => "${key}'s value";
 
+  final bool initializeMe;
 
-  BaseForDocComments();
-  BaseForDocComments.aNonDefaultConstructor();
+  BaseForDocComments(this.initializeMe);
+
+  BaseForDocComments.aNonDefaultConstructor(this.initializeMe);
 
   factory BaseForDocComments.aFactoryFunction() => null;
 }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -962,6 +962,8 @@ class BaseForDocComments {
 
 
   BaseForDocComments();
+  BaseForDocComments.aNonDefaultConstructor();
+
   factory BaseForDocComments.aFactoryFunction() => null;
 }
 


### PR DESCRIPTION
This is a batch of small changes and accompanying tests that correct the following issues in the new lookup code:

- Finding TypeParameters was inappropriately logged as a non-equivalent result.  Since they don't actually link to anything, it's not important that we found one when we didn't in the old code.
- The `allowDefaultConstructors` boolean was not set correctly now that we actually have parse nodes, this is now fixed.
- Ambiguity between requiring a callable and requiring a constructor is fixed in the new code; it works better than the old one did now.
- Consistently look up field formal parameters instead of doing so accidentally.
- All constructor lookups have been overhauled, with names appropriate for the new lookup system inserted in the `referenceChildren` tables.