### PR TITLE
Refactor MultiFutureTracker to not be generic

### DIFF
--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -117,12 +117,11 @@ final RegExp partOfRegexp = RegExp('part of ');
     'as Dartdoc 1.0.0')
 final RegExp newLinePartOfRegexp = RegExp('\npart of ');
 
-/// Best used with Future<void>.
-class MultiFutureTracker<T> {
+class MultiFutureTracker {
   /// Approximate maximum number of simultaneous active Futures.
   final int parallel;
 
-  final Set<Future<T>> _trackedFutures = {};
+  final Set<Future<void>> _trackedFutures = {};
 
   MultiFutureTracker(this.parallel);
 
@@ -139,9 +138,9 @@ class MultiFutureTracker<T> {
   ///
   /// If the closure does not handle its own exceptions, other calls to
   /// [addFutureFromClosure] or [wait] may trigger an exception.
-  Future<void> addFutureFromClosure(Future<T> Function() closure) async {
+  Future<void> addFutureFromClosure(Future<void> Function() closure) async {
     await _waitUntil(parallel - 1);
-    Future<void> future = closure();
+    var future = closure();
     _trackedFutures.add(future);
     // ignore: unawaited_futures
     future.then((f) {

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -19,7 +19,7 @@ typedef FakeResultCallback = String Function(String tool,
 
 /// Set a ceiling on how many tool instances can be in progress at once,
 /// limiting both parallelization and the number of open temporary files.
-final MultiFutureTracker<void> _toolTracker = MultiFutureTracker(4);
+final MultiFutureTracker _toolTracker = MultiFutureTracker(4);
 
 class ToolTempFileTracker {
   final ResourceProvider resourceProvider;


### PR DESCRIPTION
The generic is never used; the Futures are always `Future<void>`.