### PR TITLE
Remove a foreach that seems to trigger the debugger

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -1089,7 +1089,7 @@ final RegExp allAfterLastNewline = RegExp(r'\n.*$', multiLine: true);
 // https://github.com/dart-lang/dartdoc/issues/1250#issuecomment-269257942
 void showWarningsForGenericsOutsideSquareBracketsBlocks(
     String text, Warnable element) {
-  findFreeHangingGenericsPositions(text).forEach((int position) {
+  for (var position in findFreeHangingGenericsPositions(text)) {
     var priorContext =
         '${text.substring(max(position - maxPriorContext, 0), position)}';
     var postContext =
@@ -1099,7 +1099,7 @@ void showWarningsForGenericsOutsideSquareBracketsBlocks(
     var errorMessage = '$priorContext$postContext';
     // TODO(jcollins-g):  allow for more specific error location inside comments
     element.warn(PackageWarning.typeAsHtml, message: errorMessage);
-  });
+  }
 }
 
 Iterable<int> findFreeHangingGenericsPositions(String string) sync* {


### PR DESCRIPTION
Will file a SDK bug, but this forEach call seems to trigger on each iteration of the loop in the debugger now when debugging markdown_processor.dart.  So, remove it to make debugging dartdoc less frustrating.