### PR TITLE
Improve scoping interaction with canonicalization, inheritance, and reexports

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -160,7 +160,7 @@ class UndefinedElementType extends ElementType {
   Iterable<CommentReferable> get referenceParents => [];
 
   @override
-  Iterable<Iterable<CommentReferable>> get referenceGrandparentOverrides => null;
+  Iterable<CommentReferable> get referenceGrandparentOverrides => null;
 }
 
 /// A FunctionType that does not have an underpinning Element.
@@ -363,7 +363,7 @@ abstract class DefinedElementType extends ElementType {
       modelElement.referenceParents;
 
   @override
-  Iterable<Iterable<CommentReferable>> get referenceGrandparentOverrides =>
+  Iterable<CommentReferable> get referenceGrandparentOverrides =>
       modelElement.referenceGrandparentOverrides;
 }
 

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -158,6 +158,9 @@ class UndefinedElementType extends ElementType {
 
   @override
   Iterable<CommentReferable> get referenceParents => [];
+
+  @override
+  Iterable<Iterable<CommentReferable>> get referenceGrandparentOverrides => null;
 }
 
 /// A FunctionType that does not have an underpinning Element.
@@ -358,6 +361,10 @@ abstract class DefinedElementType extends ElementType {
   @override
   Iterable<CommentReferable> get referenceParents =>
       modelElement.referenceParents;
+
+  @override
+  Iterable<Iterable<CommentReferable>> get referenceGrandparentOverrides =>
+      modelElement.referenceGrandparentOverrides;
 }
 
 /// Any callable ElementType will mix-in this class, whether anonymous or not,

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -47,6 +47,7 @@ class GeneratorFrontEnd implements Generator {
       }
 
       for (var lib in filterNonDocumented(package.libraries)) {
+        if (lib.name != 'painting') continue;
         logInfo('Generating docs for library ${lib.name} from '
             '${lib.element.source.uri}...');
         if (!lib.isAnonymous && !lib.hasDocumentation) {

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -46,7 +46,6 @@ class GeneratorFrontEnd implements Generator {
       }
 
       for (var lib in filterNonDocumented(package.libraries)) {
-        if (lib.name != 'services') continue;
         logInfo('Generating docs for library ${lib.name} from '
             '${lib.element.source.uri}...');
         if (!lib.isAnonymous && !lib.hasDocumentation) {

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -46,6 +46,7 @@ class GeneratorFrontEnd implements Generator {
       }
 
       for (var lib in filterNonDocumented(package.libraries)) {
+        if (lib.name != 'services') continue;
         logInfo('Generating docs for library ${lib.name} from '
             '${lib.element.source.uri}...');
         if (!lib.isAnonymous && !lib.hasDocumentation) {

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -47,7 +47,6 @@ class GeneratorFrontEnd implements Generator {
       }
 
       for (var lib in filterNonDocumented(package.libraries)) {
-        if (lib.name != 'painting') continue;
         logInfo('Generating docs for library ${lib.name} from '
             '${lib.element.source.uri}...');
         if (!lib.isAnonymous && !lib.hasDocumentation) {

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1740,6 +1740,19 @@ class _Renderer_Class extends RendererBase<Class> {
                         parent: r);
                   },
                 ),
+                'extraReferenceChildren': Property(
+                  getValue: (CT_ c) => c.extraReferenceChildren,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames,
+                          'Iterable<MapEntry<String, CommentReferable>>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.extraReferenceChildren.map((e) => renderSimple(
+                        e, ast, r.template, sink,
+                        parent: r, getters: _invisibleGetters['MapEntry']));
+                  },
+                ),
                 'fileName': Property(
                   getValue: (CT_ c) => c.fileName,
                   renderVariable:
@@ -2173,33 +2186,6 @@ class _Renderer_Class extends RendererBase<Class> {
                     return c.publicSuperChainReversed.map((e) =>
                         _render_DefinedElementType(e, ast, r.template, sink,
                             parent: r));
-                  },
-                ),
-                'referenceChildren': Property(
-                  getValue: (CT_ c) => c.referenceChildren,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Map<String, CommentReferable>'),
-                  isNullValue: (CT_ c) => c.referenceChildren == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.referenceChildren, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Map']);
-                  },
-                ),
-                'referenceParents': Property(
-                  getValue: (CT_ c) => c.referenceParents,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<CommentReferable>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.referenceParents.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']));
                   },
                 ),
                 'superChain': Property(
@@ -2641,6 +2627,20 @@ class _Renderer_CommentReferable extends RendererBase<CommentReferable> {
                         parent: r, getters: _invisibleGetters['Map']);
                   },
                 ),
+                'referenceGrandparentOverrides': Property(
+                  getValue: (CT_ c) => c.referenceGrandparentOverrides,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<CommentReferable>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.referenceGrandparentOverrides.map((e) =>
+                        renderSimple(e, ast, r.template, sink,
+                            parent: r,
+                            getters: _invisibleGetters['CommentReferable']));
+                  },
+                ),
                 'referenceParents': Property(
                   getValue: (CT_ c) => c.referenceParents,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -2698,6 +2698,7 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
           () => {
                 ..._Renderer_ModelElement.propertyMap<CT_>(),
                 ..._Renderer_TypeParameters.propertyMap<CT_>(),
+                ..._Renderer_ContainerMember.propertyMap<CT_>(),
                 'characterLocation': Property(
                   getValue: (CT_ c) => c.characterLocation,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -2943,20 +2944,6 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
                       List<MustachioNode> ast, StringSink sink) {
                     renderSimple(c.referenceChildren, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['Map']);
-                  },
-                ),
-                'referenceParents': Property(
-                  getValue: (CT_ c) => c.referenceParents,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<CommentReferable>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.referenceParents.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']));
                   },
                 ),
                 'shortName': Property(
@@ -3392,6 +3379,19 @@ class _Renderer_Container extends RendererBase<Container> {
                     _render_ModelElement(
                         c.enclosingElement, ast, r.template, sink,
                         parent: r);
+                  },
+                ),
+                'extraReferenceChildren': Property(
+                  getValue: (CT_ c) => c.extraReferenceChildren,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames,
+                          'Iterable<MapEntry<String, CommentReferable>>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.extraReferenceChildren.map((e) => renderSimple(
+                        e, ast, r.template, sink,
+                        parent: r, getters: _invisibleGetters['MapEntry']));
                   },
                 ),
                 'hasInstanceFields': Property(
@@ -4031,6 +4031,30 @@ class _Renderer_ContainerMember extends RendererBase<ContainerMember> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isExtended == true,
                 ),
+                'referenceGrandparentOverrides': Property(
+                  getValue: (CT_ c) => c.referenceGrandparentOverrides,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<Library>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.referenceGrandparentOverrides.map((e) =>
+                        _render_Library(e, ast, r.template, sink, parent: r));
+                  },
+                ),
+                'referenceParents': Property(
+                  getValue: (CT_ c) => c.referenceParents,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<Container>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.referenceParents.map((e) =>
+                        _render_Container(e, ast, r.template, sink, parent: r));
+                  },
+                ),
               });
 
   _Renderer_ContainerMember(ContainerMember context,
@@ -4150,6 +4174,20 @@ class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
                       List<MustachioNode> ast, StringSink sink) {
                     renderSimple(c.referenceChildren, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['Map']);
+                  },
+                ),
+                'referenceGrandparentOverrides': Property(
+                  getValue: (CT_ c) => c.referenceGrandparentOverrides,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<CommentReferable>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.referenceGrandparentOverrides.map((e) =>
+                        renderSimple(e, ast, r.template, sink,
+                            parent: r,
+                            getters: _invisibleGetters['CommentReferable']));
                   },
                 ),
                 'referenceParents': Property(
@@ -6585,20 +6623,6 @@ class _Renderer_GetterSetterCombo extends RendererBase<GetterSetterCombo> {
                         parent: r, getters: _invisibleGetters['Map']);
                   },
                 ),
-                'referenceParents': Property(
-                  getValue: (CT_ c) => c.referenceParents,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<CommentReferable>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.referenceParents.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']));
-                  },
-                ),
                 'setter': Property(
                   getValue: (CT_ c) => c.setter,
                   renderVariable:
@@ -8440,20 +8464,6 @@ class _Renderer_Method extends RendererBase<Method> {
                       List<MustachioNode> ast, StringSink sink) {
                     renderSimple(c.referenceChildren, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['Map']);
-                  },
-                ),
-                'referenceParents': Property(
-                  getValue: (CT_ c) => c.referenceParents,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<CommentReferable>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.referenceParents.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']));
                   },
                 ),
                 'typeParameters': Property(
@@ -13584,6 +13594,20 @@ class _Renderer_TopLevelVariable extends RendererBase<TopLevelVariable> {
                     _render_String(c.kind, ast, r.template, sink, parent: r);
                   },
                 ),
+                'referenceParents': Property(
+                  getValue: (CT_ c) => c.referenceParents,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<CommentReferable>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.referenceParents.map((e) => renderSimple(
+                        e, ast, r.template, sink,
+                        parent: r,
+                        getters: _invisibleGetters['CommentReferable']));
+                  },
+                ),
                 'setter': Property(
                   getValue: (CT_ c) => c.setter,
                   renderVariable:
@@ -14570,6 +14594,7 @@ const _invisibleGetters = {
     'scope',
     'referenceChildren',
     'referenceParents',
+    'referenceGrandparentOverrides',
     'library',
     'element',
     'packageGraph'
@@ -14896,7 +14921,6 @@ const _invisibleGetters = {
     'readWrite',
     'writeOnly',
     'referenceChildren',
-    'referenceParents',
     'enclosingElement'
   },
   'HashMap': {'hashCode', 'runtimeType'},
@@ -14961,6 +14985,7 @@ const _invisibleGetters = {
     'isEmpty',
     'isNotEmpty'
   },
+  'MapEntry': {'hashCode', 'runtimeType', 'key', 'value'},
   'Member': {
     'hashCode',
     'runtimeType',

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -296,10 +296,16 @@ ModelElement _getPreferredClass(ModelElement modelElement) {
 }
 
 /// Return false if the passed [referable] is a default [Constructor].
-bool _rejectDefaultConstructors(CommentReferable referable) {
-  if (referable is Constructor &&
-      referable.name == referable.enclosingElement.name) {
-    return false;
+bool _rejectDefaultAndShadowingConstructors(CommentReferable referable) {
+  if (referable is Constructor) {
+    if (referable.name == referable.enclosingElement.name) {
+      return false;
+    }
+    if (referable.enclosingElement.referenceChildren[referable.name
+        .split('.')
+        .last] is! Constructor) {
+      return false;
+    }
   }
   // Avoid accidentally preferring arguments of the default constructor.
   if (referable is ModelElement && referable.enclosingElement is Constructor) {
@@ -342,7 +348,7 @@ MatchingLinkResult _getMatchingLinkElementCommentReferable(
   } else {
     // Without hints, reject default constructors to force resolution to the
     // class.
-    filter = _rejectDefaultConstructors;
+    filter = _rejectDefaultAndShadowingConstructors;
   }
 
   var lookupResult =

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -295,7 +295,8 @@ ModelElement _getPreferredClass(ModelElement modelElement) {
   return null;
 }
 
-/// Return false if the passed [referable] is a default [Constructor].
+/// Return false if the passed [referable] is a default [Constructor],
+/// or if it is shadowing another type of element.
 bool _rejectDefaultAndShadowingConstructors(CommentReferable referable) {
   if (referable is Constructor) {
     if (referable.name == referable.enclosingElement.name) {

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -226,7 +226,7 @@ class MatchingLinkResult {
 
   @override
   String toString() {
-    return 'element: ${modelElement?.fullyQualifiedName} warn: $warn';
+    return 'element: [${modelElement is Constructor ? 'new ' : ''}${modelElement?.fullyQualifiedName}] warn: $warn';
   }
 }
 
@@ -316,6 +316,7 @@ bool _requireCallable(CommentReferable referable) =>
 /// Return false unless the passed [referable] represents a constructor.
 bool _requireConstructor(CommentReferable referable) =>
     referable is Constructor;
+
 
 /// Implements _getMatchingLinkElement via [CommentReferable.referenceBy].
 MatchingLinkResult _getMatchingLinkElementCommentReferable(

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -317,7 +317,6 @@ bool _requireCallable(CommentReferable referable) =>
 bool _requireConstructor(CommentReferable referable) =>
     referable is Constructor;
 
-
 /// Implements _getMatchingLinkElement via [CommentReferable.referenceBy].
 MatchingLinkResult _getMatchingLinkElementCommentReferable(
     String codeRef, Warnable warnable) {

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -301,9 +301,8 @@ bool _rejectDefaultAndShadowingConstructors(CommentReferable referable) {
     if (referable.name == referable.enclosingElement.name) {
       return false;
     }
-    if (referable.enclosingElement.referenceChildren[referable.name
-        .split('.')
-        .last] is! Constructor) {
+    if (referable.enclosingElement
+        .referenceChildren[referable.name.split('.').last] is! Constructor) {
       return false;
     }
   }

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -608,14 +608,16 @@ class Class extends Container
   @override
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
 
-  static Iterable<MapEntry<String, CommentReferable>> _constructorGenerator(Iterable<Constructor> source) sync* {
+  static Iterable<MapEntry<String, CommentReferable>> _constructorGenerator(
+      Iterable<Constructor> source) sync* {
     for (var constructor in source) {
       var constructorName = constructor.element.name;
       if (constructorName == '') {
         constructorName = constructor.enclosingElement.name;
       }
       yield MapEntry(constructorName, constructor);
-      yield MapEntry('${constructor.enclosingElement.name}.$constructorName', constructor);
+      yield MapEntry(
+          '${constructor.enclosingElement.name}.$constructorName', constructor);
     }
   }
 

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -622,6 +622,28 @@ class Class extends Container
   }
 
   @override
+  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren {
+    for (var modelElement in _constructors)
+      // Populate default constructor names so they make sense for the
+      // new lookup code.
+      var constructorName = modelElement.element.name;
+    if (constructorName == '') {
+      constructorName = name;
+    }
+    // TODO(jcollins-g): Create an unambiguous way to refer to
+    // fields/methods with the same name as a constructor.  Until then,
+    // assume that we're not referring to the constructor unless
+    // there is a hint.
+    if (!_referenceChildren.containsKey(constructorName)) {
+      _referenceChildren[constructorName] = modelElement;
+    }
+    _referenceChildren['$name.$constructorName'] = modelElement;
+    continue;
+  }
+}
+
+
+  @override
   Iterable<CommentReferable> get referenceParents => <CommentReferable>[
         ...super.referenceParents,
         ...superChain.expand((m) => m.modelElement.referenceParents)

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -47,10 +47,10 @@ class Class extends Container
 
   Class(ClassElement element, Library library, PackageGraph packageGraph)
       : _mixedInTypes = element.mixins
-            .map<DefinedElementType>(
-                (f) => ElementType.from(f, library, packageGraph))
-            .where((mixin) => mixin != null)
-            .toList(growable: false),
+      .map<DefinedElementType>(
+          (f) => ElementType.from(f, library, packageGraph))
+      .where((mixin) => mixin != null)
+      .toList(growable: false),
         _supertype = element.supertype?.element?.supertype == null
             ? null
             : ElementType.from(element.supertype, library, packageGraph),
@@ -72,7 +72,7 @@ class Class extends Container
 
   @Deprecated(
       'Renamed to `unnamedConstructor`; this getter with the old name will be '
-      'removed as early as Dartdoc 1.0.0')
+          'removed as early as Dartdoc 1.0.0')
   Constructor get defaultConstructor => unnamedConstructor;
 
   @override
@@ -112,8 +112,10 @@ class Class extends Container
         allModelElements.where((e) => e.isCanonical).toList());
   }
 
-  Iterable<Constructor> get constructors => element.constructors
-      .map((e) => ModelElement.from(e, library, packageGraph) as Constructor);
+  Iterable<Constructor> get constructors =>
+      element.constructors
+          .map((e) =>
+      ModelElement.from(e, library, packageGraph) as Constructor);
 
   @override
   bool get hasPublicConstructors => publicConstructors.isNotEmpty;
@@ -126,7 +128,8 @@ class Class extends Container
 
   @override
   Iterable<Constructor> get publicConstructorsSorted =>
-      _publicConstructorsSorted ??= publicConstructors.toList()..sort(byName);
+      _publicConstructorsSorted ??= publicConstructors.toList()
+        ..sort(byName);
 
   /// Returns the library that encloses this element.
   @override
@@ -155,11 +158,11 @@ class Class extends Container
   @override
   bool get hasModifiers =>
       hasPublicMixedInTypes ||
-      hasAnnotations ||
-      hasPublicInterfaces ||
-      hasPublicSuperChainReversed ||
-      hasPublicImplementors ||
-      hasPotentiallyApplicableExtensions;
+          hasAnnotations ||
+          hasPublicInterfaces ||
+          hasPublicSuperChainReversed ||
+          hasPublicImplementors ||
+          hasPotentiallyApplicableExtensions;
 
   bool get hasPublicSuperChainReversed => publicSuperChainReversed.isNotEmpty;
 
@@ -206,10 +209,13 @@ class Class extends Container
   }
 
   List<Class> _publicImplementorsSorted;
-  Iterable<Class> get publicImplementorsSorted =>
-      _publicImplementorsSorted ??= publicImplementors.toList()..sort(byName);
 
-  /*lazy final*/ List<Method> _inheritedMethods;
+  Iterable<Class> get publicImplementorsSorted =>
+      _publicImplementorsSorted ??= publicImplementors.toList()
+        ..sort(byName);
+
+  /*lazy final*/
+  List<Method> _inheritedMethods;
 
   Iterable<Method> get inheritedMethods {
     if (_inheritedMethods == null) {
@@ -237,7 +243,8 @@ class Class extends Container
 
   bool get hasPublicInheritedMethods => publicInheritedMethods.isNotEmpty;
 
-  /*lazy final*/ List<Operator> _inheritedOperators;
+  /*lazy final*/
+  List<Operator> _inheritedOperators;
 
   Iterable<Operator> get inheritedOperators {
     if (_inheritedOperators == null) {
@@ -294,8 +301,8 @@ class Class extends Container
         yield* hiddenClass.publicInterfaces;
       } else {
         assert(
-            false,
-            'Can not handle intermediate non-public interfaces '
+        false,
+        'Can not handle intermediate non-public interfaces '
             'created by ModelElements that are not classes or mixins:  '
             '$fullyQualifiedName contains an interface {$i}, '
             'defined by ${i.modelElement}');
@@ -327,7 +334,7 @@ class Class extends Container
 
   @Deprecated(
       'Public method intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
+          'Dartdoc 1.0.0')
   bool isInheritingFrom(Class other) => _isInheritingFrom(other);
 
   @override
@@ -356,7 +363,7 @@ class Class extends Container
 
       /// Caching should make this recursion a little less painful.
       for (var c
-          in mixedInTypes.reversed.map((e) => (e.modelElement as Class))) {
+      in mixedInTypes.reversed.map((e) => (e.modelElement as Class))) {
         _inheritanceChain.addAll(c.inheritanceChain);
       }
 
@@ -397,7 +404,9 @@ class Class extends Container
       model_utils.filterNonPublic(superChain);
 
   Iterable<DefinedElementType> get publicSuperChainReversed =>
-      publicSuperChain.toList().reversed;
+      publicSuperChain
+          .toList()
+          .reversed;
 
   List<ExecutableElement> __inheritedElements;
 
@@ -437,7 +446,7 @@ class Class extends Container
           bool _isDartCoreObject(ClassElement e) =>
               e.name == 'Object' && e.library.name == 'dart.core';
           assert(inheritanceChainElements
-                  .contains(imap[nameObj].enclosingElement) ||
+              .contains(imap[nameObj].enclosingElement) ||
               _isDartCoreObject(imap[nameObj].enclosingElement));
 
           // If the concrete object from [InheritanceManager3.getInheritedConcreteMap2]
@@ -446,7 +455,7 @@ class Class extends Container
           // correctly accounts for intermediate abstract classes that have
           // method/field implementations.
           if (inheritanceChainElements
-                  .indexOf(combinedMap[nameObj.name].enclosingElement) <
+              .indexOf(combinedMap[nameObj.name].enclosingElement) <
               inheritanceChainElements
                   .indexOf(imap[nameObj].enclosingElement)) {
             combinedMap[nameObj.name] = imap[nameObj];
@@ -501,9 +510,9 @@ class Class extends Container
       for (var fieldName in accessorMap.keys) {
         var elements = accessorMap[fieldName].toList();
         var getterElement =
-            elements.firstWhere((e) => e.isGetter, orElse: () => null);
+        elements.firstWhere((e) => e.isGetter, orElse: () => null);
         var setterElement =
-            elements.firstWhere((e) => e.isSetter, orElse: () => null);
+        elements.firstWhere((e) => e.isSetter, orElse: () => null);
         _addSingleField(
             getterElement, setterElement, inheritedAccessorElements);
       }
@@ -519,15 +528,14 @@ class Class extends Container
   /// If [f] is not specified, pick the FieldElement from the PropertyAccessorElement
   /// whose enclosing class inherits from the other (defaulting to the getter)
   /// and construct a Field using that.
-  void _addSingleField(
-      PropertyAccessorElement getterElement,
+  void _addSingleField(PropertyAccessorElement getterElement,
       PropertyAccessorElement setterElement,
       Set<PropertyAccessorElement> inheritedAccessors,
       [FieldElement f]) {
     var getter =
-        ContainerAccessor.from(getterElement, inheritedAccessors, this);
+    ContainerAccessor.from(getterElement, inheritedAccessors, this);
     var setter =
-        ContainerAccessor.from(setterElement, inheritedAccessors, this);
+    ContainerAccessor.from(setterElement, inheritedAccessors, this);
     // Rebind getterElement/setterElement as ModelElement.from can resolve
     // MultiplyInheritedExecutableElements or resolve Members.
     getterElement = getter?.element;
@@ -606,7 +614,8 @@ class Class extends Container
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
 
   @override
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren sync* {
+  Iterable<
+      MapEntry<String, CommentReferable>> get extraReferenceChildren sync* {
     for (var modelElement in constructors) {
       // Populate default constructor names so they make sense for the
       // new lookup code.
@@ -617,11 +626,17 @@ class Class extends Container
       yield MapEntry(constructorName, modelElement);
       yield MapEntry('$name.$constructorName', modelElement);
     }
-  }
-
-  @override
-  Iterable<CommentReferable> get referenceParents sync* {
-    yield* super.referenceParents;
-    yield* superChain.expand((m) => m.modelElement.referenceParents);
+    // TODO(jcollins-g): wean important users off of relying on static method
+    // inheritance (dart-lang/dartdoc#2698)
+    for (var container in publicSuperChain.map((t) => t.modelElement).whereType<
+        Container>()) {
+      for (var modelElement in [
+        ...container.staticFields,
+        ...container.staticAccessors,
+        ...container.staticMethods
+      ]) {
+        yield MapEntry(modelElement.name, modelElement);
+      }
+    }
   }
 }

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -47,10 +47,10 @@ class Class extends Container
 
   Class(ClassElement element, Library library, PackageGraph packageGraph)
       : _mixedInTypes = element.mixins
-      .map<DefinedElementType>(
-          (f) => ElementType.from(f, library, packageGraph))
-      .where((mixin) => mixin != null)
-      .toList(growable: false),
+            .map<DefinedElementType>(
+                (f) => ElementType.from(f, library, packageGraph))
+            .where((mixin) => mixin != null)
+            .toList(growable: false),
         _supertype = element.supertype?.element?.supertype == null
             ? null
             : ElementType.from(element.supertype, library, packageGraph),
@@ -72,7 +72,7 @@ class Class extends Container
 
   @Deprecated(
       'Renamed to `unnamedConstructor`; this getter with the old name will be '
-          'removed as early as Dartdoc 1.0.0')
+      'removed as early as Dartdoc 1.0.0')
   Constructor get defaultConstructor => unnamedConstructor;
 
   @override
@@ -112,10 +112,8 @@ class Class extends Container
         allModelElements.where((e) => e.isCanonical).toList());
   }
 
-  Iterable<Constructor> get constructors =>
-      element.constructors
-          .map((e) =>
-      ModelElement.from(e, library, packageGraph) as Constructor);
+  Iterable<Constructor> get constructors => element.constructors
+      .map((e) => ModelElement.from(e, library, packageGraph) as Constructor);
 
   @override
   bool get hasPublicConstructors => publicConstructors.isNotEmpty;
@@ -128,8 +126,7 @@ class Class extends Container
 
   @override
   Iterable<Constructor> get publicConstructorsSorted =>
-      _publicConstructorsSorted ??= publicConstructors.toList()
-        ..sort(byName);
+      _publicConstructorsSorted ??= publicConstructors.toList()..sort(byName);
 
   /// Returns the library that encloses this element.
   @override
@@ -158,11 +155,11 @@ class Class extends Container
   @override
   bool get hasModifiers =>
       hasPublicMixedInTypes ||
-          hasAnnotations ||
-          hasPublicInterfaces ||
-          hasPublicSuperChainReversed ||
-          hasPublicImplementors ||
-          hasPotentiallyApplicableExtensions;
+      hasAnnotations ||
+      hasPublicInterfaces ||
+      hasPublicSuperChainReversed ||
+      hasPublicImplementors ||
+      hasPotentiallyApplicableExtensions;
 
   bool get hasPublicSuperChainReversed => publicSuperChainReversed.isNotEmpty;
 
@@ -211,8 +208,7 @@ class Class extends Container
   List<Class> _publicImplementorsSorted;
 
   Iterable<Class> get publicImplementorsSorted =>
-      _publicImplementorsSorted ??= publicImplementors.toList()
-        ..sort(byName);
+      _publicImplementorsSorted ??= publicImplementors.toList()..sort(byName);
 
   /*lazy final*/
   List<Method> _inheritedMethods;
@@ -301,8 +297,8 @@ class Class extends Container
         yield* hiddenClass.publicInterfaces;
       } else {
         assert(
-        false,
-        'Can not handle intermediate non-public interfaces '
+            false,
+            'Can not handle intermediate non-public interfaces '
             'created by ModelElements that are not classes or mixins:  '
             '$fullyQualifiedName contains an interface {$i}, '
             'defined by ${i.modelElement}');
@@ -334,7 +330,7 @@ class Class extends Container
 
   @Deprecated(
       'Public method intended to be private; will be removed as early as '
-          'Dartdoc 1.0.0')
+      'Dartdoc 1.0.0')
   bool isInheritingFrom(Class other) => _isInheritingFrom(other);
 
   @override
@@ -363,7 +359,7 @@ class Class extends Container
 
       /// Caching should make this recursion a little less painful.
       for (var c
-      in mixedInTypes.reversed.map((e) => (e.modelElement as Class))) {
+          in mixedInTypes.reversed.map((e) => (e.modelElement as Class))) {
         _inheritanceChain.addAll(c.inheritanceChain);
       }
 
@@ -404,9 +400,7 @@ class Class extends Container
       model_utils.filterNonPublic(superChain);
 
   Iterable<DefinedElementType> get publicSuperChainReversed =>
-      publicSuperChain
-          .toList()
-          .reversed;
+      publicSuperChain.toList().reversed;
 
   List<ExecutableElement> __inheritedElements;
 
@@ -446,7 +440,7 @@ class Class extends Container
           bool _isDartCoreObject(ClassElement e) =>
               e.name == 'Object' && e.library.name == 'dart.core';
           assert(inheritanceChainElements
-              .contains(imap[nameObj].enclosingElement) ||
+                  .contains(imap[nameObj].enclosingElement) ||
               _isDartCoreObject(imap[nameObj].enclosingElement));
 
           // If the concrete object from [InheritanceManager3.getInheritedConcreteMap2]
@@ -455,7 +449,7 @@ class Class extends Container
           // correctly accounts for intermediate abstract classes that have
           // method/field implementations.
           if (inheritanceChainElements
-              .indexOf(combinedMap[nameObj.name].enclosingElement) <
+                  .indexOf(combinedMap[nameObj.name].enclosingElement) <
               inheritanceChainElements
                   .indexOf(imap[nameObj].enclosingElement)) {
             combinedMap[nameObj.name] = imap[nameObj];
@@ -510,9 +504,9 @@ class Class extends Container
       for (var fieldName in accessorMap.keys) {
         var elements = accessorMap[fieldName].toList();
         var getterElement =
-        elements.firstWhere((e) => e.isGetter, orElse: () => null);
+            elements.firstWhere((e) => e.isGetter, orElse: () => null);
         var setterElement =
-        elements.firstWhere((e) => e.isSetter, orElse: () => null);
+            elements.firstWhere((e) => e.isSetter, orElse: () => null);
         _addSingleField(
             getterElement, setterElement, inheritedAccessorElements);
       }
@@ -528,14 +522,15 @@ class Class extends Container
   /// If [f] is not specified, pick the FieldElement from the PropertyAccessorElement
   /// whose enclosing class inherits from the other (defaulting to the getter)
   /// and construct a Field using that.
-  void _addSingleField(PropertyAccessorElement getterElement,
+  void _addSingleField(
+      PropertyAccessorElement getterElement,
       PropertyAccessorElement setterElement,
       Set<PropertyAccessorElement> inheritedAccessors,
       [FieldElement f]) {
     var getter =
-    ContainerAccessor.from(getterElement, inheritedAccessors, this);
+        ContainerAccessor.from(getterElement, inheritedAccessors, this);
     var setter =
-    ContainerAccessor.from(setterElement, inheritedAccessors, this);
+        ContainerAccessor.from(setterElement, inheritedAccessors, this);
     // Rebind getterElement/setterElement as ModelElement.from can resolve
     // MultiplyInheritedExecutableElements or resolve Members.
     getterElement = getter?.element;
@@ -614,8 +609,8 @@ class Class extends Container
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
 
   @override
-  Iterable<
-      MapEntry<String, CommentReferable>> get extraReferenceChildren sync* {
+  Iterable<MapEntry<String, CommentReferable>>
+      get extraReferenceChildren sync* {
     for (var modelElement in constructors) {
       // Populate default constructor names so they make sense for the
       // new lookup code.
@@ -628,8 +623,8 @@ class Class extends Container
     }
     // TODO(jcollins-g): wean important users off of relying on static method
     // inheritance (dart-lang/dartdoc#2698)
-    for (var container in publicSuperChain.map((t) => t.modelElement).whereType<
-        Container>()) {
+    for (var container
+        in publicSuperChain.map((t) => t.modelElement).whereType<Container>()) {
       for (var modelElement in [
         ...container.staticFields,
         ...container.staticAccessors,

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -624,6 +624,6 @@ class Class extends Container
   @override
   Iterable<CommentReferable> get referenceParents => <CommentReferable>[
         ...super.referenceParents,
-        ...superChain.map((m) => m.modelElement)
+        ...superChain.expand((m) => m.modelElement.referenceParents)
       ];
 }

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -21,7 +21,7 @@ class ReferenceChildrenLookup {
   ReferenceChildrenLookup(this.lookup, this.remaining);
 
   @override
-  String toString() => '$lookup.${remaining.join(".")}';
+  String toString() => '$lookup ($lookup${remaining.isNotEmpty ? "." + remaining.join(".") : ''})';
 }
 
 extension on Scope {

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -72,7 +72,7 @@ mixin CommentReferable implements Nameable {
     // If we can't find it in children, try searching parents if allowed.
     if (result == null && tryParents) {
       for (var parent in parentOverrides) {
-        result = parent.referenceBy(reference, parentOverrides: referenceGrandparentOverrides, filter: filter);
+        result = parent.referenceBy(reference, tryParents: true, parentOverrides: referenceGrandparentOverrides, filter: filter);
         if (result != null) break;
       }
     }

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -32,7 +32,6 @@ extension on Scope {
   }
 }
 
-
 /// Support comment reference lookups on a Nameable object.
 mixin CommentReferable implements Nameable {
   PackageGraph packageGraph;
@@ -48,8 +47,9 @@ mixin CommentReferable implements Nameable {
   /// searching.
   @nonVirtual
   CommentReferable referenceBy(List<String> reference,
-      {bool tryParents = true, bool Function(CommentReferable) filter,
-       Iterable<CommentReferable> parentOverrides}) {
+      {bool tryParents = true,
+      bool Function(CommentReferable) filter,
+      Iterable<CommentReferable> parentOverrides}) {
     filter ??= (r) => true;
     parentOverrides ??= referenceParents;
     if (reference.isEmpty) {
@@ -72,13 +72,15 @@ mixin CommentReferable implements Nameable {
     // If we can't find it in children, try searching parents if allowed.
     if (result == null && tryParents) {
       for (var parent in parentOverrides) {
-        result = parent.referenceBy(reference, tryParents: true, parentOverrides: referenceGrandparentOverrides, filter: filter);
+        result = parent.referenceBy(reference,
+            tryParents: true,
+            parentOverrides: referenceGrandparentOverrides,
+            filter: filter);
         if (result != null) break;
       }
     }
     return result;
   }
-
 
   /// Looks up references by [scope], skipping over results that do not match
   /// the given filter.
@@ -134,7 +136,8 @@ mixin CommentReferable implements Nameable {
   /// separators in them. [referenceBy] stops at the first one found.
   Iterable<ReferenceChildrenLookup> childLookups(List<String> reference) sync* {
     for (var index = 1; index <= reference.length; index++) {
-      yield ReferenceChildrenLookup(reference.sublist(0, index).join('.'), reference.sublist(index));
+      yield ReferenceChildrenLookup(
+          reference.sublist(0, index).join('.'), reference.sublist(index));
     }
   }
 

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -135,10 +135,11 @@ mixin CommentReferable implements Nameable {
   /// A list of lookups that should be attempted on children based on
   /// [reference].  This allows us to deal with libraries that may have
   /// separators in them. [referenceBy] stops at the first one found.
-  List<ReferenceChildrenLookup> childLookups(List<String> reference) => [
-        ReferenceChildrenLookup(
-            reference.first, reference.length > 1 ? reference.sublist(1) : [])
-      ];
+  Iterable<ReferenceChildrenLookup> childLookups(List<String> reference) sync* {
+    for (var index = 1; index <= reference.length; index++) {
+      yield ReferenceChildrenLookup(reference.sublist(0, index).join('.'), reference.sublist(index));
+    }
+  }
 
   /// Map of name to the elements that are a member of [this], but
   /// not this model element itself.  Can be cached.
@@ -156,10 +157,10 @@ mixin CommentReferable implements Nameable {
   // making the iterable make sense here.
   Iterable<CommentReferable> get referenceParents;
 
-  /// Replace the parents of parents.  For each parent in
-  /// [referenceParents], an iterable containing overrides must exist here
-  /// (or return null for the getter to indicate no overrides).
-  Iterable<Iterable<CommentReferable>> get referenceGrandparentOverrides => null;
+  /// Replace the parents of parents.  [referenceBy] ignores whatever might
+  /// otherwise be implied by the [referenceParents] of [referenceParents],
+  /// replacing them with this.
+  Iterable<CommentReferable> get referenceGrandparentOverrides => null;
 
   // TODO(jcollins-g): Eliminate need for this in markdown_processor.
   Library get library => null;

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -21,7 +21,8 @@ class ReferenceChildrenLookup {
   ReferenceChildrenLookup(this.lookup, this.remaining);
 
   @override
-  String toString() => '$lookup ($lookup${remaining.isNotEmpty ? "." + remaining.join(".") : ''})';
+  String toString() =>
+      '$lookup ($lookup${remaining.isNotEmpty ? "." + remaining.join(".") : ''})';
 }
 
 extension on Scope {

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -49,7 +49,7 @@ mixin CommentReferable implements Nameable {
   @nonVirtual
   CommentReferable referenceBy(List<String> reference,
       {bool tryParents = true, bool Function(CommentReferable) filter,
-       List<CommentReferable> parentOverrides}) {
+       Iterable<CommentReferable> parentOverrides}) {
     filter ??= (r) => true;
     parentOverrides ??= referenceParents;
     if (reference.isEmpty) {
@@ -71,11 +71,8 @@ mixin CommentReferable implements Nameable {
     }
     // If we can't find it in children, try searching parents if allowed.
     if (result == null && tryParents) {
-      var overrideIterator = (referenceGrandparentOverrides ?? []).iterator;
       for (var parent in parentOverrides) {
-        overrideIterator.moveNext();
-        var grandparentOverride = overrideIterator.current;
-        result = parent.referenceBy(reference, parentOverrides: grandparentOverride, filter: filter);
+        result = parent.referenceBy(reference, parentOverrides: referenceGrandparentOverrides, filter: filter);
         if (result != null) break;
       }
     }

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -88,6 +88,9 @@ class Constructor extends ModelElement
   @override
   String get name {
     if (_name == null) {
+      // TODO(jcollins-g): After the old lookup code is retired, rationalize
+      // [name] around the conventions used in referenceChildren and replace
+      // code there and elsewhere with simple references to the name.
       var constructorName = element.name;
       if (constructorName.isEmpty) {
         _name = enclosingElement.name;
@@ -134,7 +137,15 @@ class Constructor extends ModelElement
               ModelElement.fromElement(paramElement.field, packageGraph);
           _referenceChildren[paramElement.name] = fieldFormal;
         } else {
-          _referenceChildren[param.name] = param;
+          var constructorName = element.name;
+          if (constructorName == '') {
+            constructorName = enclosingElement.name;
+          }
+          if (constructorName == param.name) {
+            // Force users to specify a parameter explicitly in this case.
+            _referenceChildren['$constructorName.${param.name}'] = param;
+          }
+          // Allow fallback handling in [Container] to handle other cases.
         }
       }
       _referenceChildren

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -9,7 +9,7 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Constructor extends ModelElement
-    with TypeParameters
+    with TypeParameters, ContainerMember
     implements EnclosedElement {
   Constructor(
       ConstructorElement element, Library library, PackageGraph packageGraph)
@@ -142,7 +142,4 @@ class Constructor extends ModelElement
     }
     return _referenceChildren;
   }
-
-  @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
 }

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -271,7 +271,14 @@ abstract class Container extends ModelElement with TypeParameters {
           if (constructorName == '') {
             constructorName = name;
           }
-          _referenceChildren[constructorName] = modelElement;
+          // TODO(jcollins-g): Create an unambiguous way to refer to
+          // fields/methods with the same name as a constructor.  Until then,
+          // assume that we're not referring to the constructor unless
+          // there is a hint.
+          if (!_referenceChildren.containsKey(constructorName)) {
+            _referenceChildren[constructorName] = modelElement;
+          }
+          _referenceChildren['$name.$constructorName'] = modelElement;
           continue;
         }
         if (modelElement is Operator) {
@@ -302,5 +309,5 @@ abstract class Container extends ModelElement with TypeParameters {
   }
 
   @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
+  Iterable<CommentReferable> get referenceParents => [definingLibrary];
 }

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -62,16 +62,22 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
   @nonVirtual
   Iterable<Container> get referenceParents sync* {
     yield enclosingElement;
+    // TODO(jcollins-g): Wean users off of depending on canonical library
+    // resolution. dart-lang/dartdoc#2696
+    if (enclosingElement != canonicalEnclosingContainer && canonicalEnclosingContainer != null) yield canonicalEnclosingContainer;
     if (enclosingElement != definingEnclosingContainer) yield definingEnclosingContainer;
   }
 
 
   @override
-  Iterable<Library> get referenceGrandparentOverrides {
+  Iterable<Library> get referenceGrandparentOverrides sync* {
     // TODO(jcollins-g): split Field documentation up between accessors
     // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
     //assert(documentationFrom.length == 1);
     // Until then, just pretend we're handling this correctly.
-    return [documentationFrom.first.definingLibrary];
+    yield documentationFrom.first.definingLibrary;
+    // TODO(jcollins-g): Wean users off of depending on canonical library
+    // resolution. dart-lang/dartdoc#2696
+    if (canonicalLibrary != null) yield canonicalLibrary;
   }
 }

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -60,7 +60,11 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
 
   @override
   @nonVirtual
-  Iterable<Container> get referenceParents => [enclosingElement];
+  Iterable<Container> get referenceParents sync* {
+    yield enclosingElement;
+    if (enclosingElement != definingEnclosingContainer) yield definingEnclosingContainer;
+  }
+
 
   @override
   Iterable<Iterable<Library>> get referenceGrandparentOverrides {

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -67,11 +67,11 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
 
 
   @override
-  Iterable<Iterable<Library>> get referenceGrandparentOverrides {
+  Iterable<Library> get referenceGrandparentOverrides {
     // TODO(jcollins-g): split Field documentation up between accessors
-    // and resolve the pieces with different scopes.
+    // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
     //assert(documentationFrom.length == 1);
     // Until then, just pretend we're handling this correctly.
-    return [[documentationFrom.first.definingLibrary]];
+    return [documentationFrom.first.definingLibrary];
   }
 }

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -4,6 +4,7 @@
 
 import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:meta/meta.dart';
 
 /// A [ModelElement] that is a [Container] member.
 mixin ContainerMember on ModelElement implements EnclosedElement {
@@ -55,5 +56,18 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
           .findCanonicalModelElementFor(element.enclosingElement);
     }
     return null;
+  }
+
+  @override
+  @nonVirtual
+  Iterable<Container> get referenceParents => [enclosingElement];
+
+  @override
+  Iterable<Iterable<Library>> get referenceGrandparentOverrides {
+    // TODO(jcollins-g): split Field documentation up between accessors
+    // and resolve the pieces with different scopes.
+    //assert(documentationFrom.length == 1);
+    // Until then, just pretend we're handling this correctly.
+    return [[documentationFrom.first.definingLibrary]];
   }
 }

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -60,14 +60,7 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
 
   @override
   @nonVirtual
-  Iterable<Container> get referenceParents sync* {
-    yield enclosingElement;
-    // TODO(jcollins-g): Wean users off of depending on canonical library
-    // resolution. dart-lang/dartdoc#2696
-    if (enclosingElement != canonicalEnclosingContainer && canonicalEnclosingContainer != null) yield canonicalEnclosingContainer;
-    if (enclosingElement != definingEnclosingContainer) yield definingEnclosingContainer;
-  }
-
+  Iterable<Container> get referenceParents => [enclosingElement];
 
   @override
   Iterable<Library> get referenceGrandparentOverrides sync* {

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -66,7 +66,6 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
   Iterable<Library> get referenceGrandparentOverrides sync* {
     // TODO(jcollins-g): split Field documentation up between accessors
     // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
-    //assert(documentationFrom.length == 1);
     // Until then, just pretend we're handling this correctly.
     yield documentationFrom.first.definingLibrary;
     // TODO(jcollins-g): Wean users off of depending on canonical library

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -68,7 +68,7 @@ class Documentation {
     if (text == null || text.isEmpty) {
       return DocumentationParseResult.empty;
     }
-    showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
+    //showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
     var document = MarkdownDocument.withElementLinkResolver(_element);
     return document.parseMarkdownText(text, processFullDocs);
   }

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -68,7 +68,7 @@ class Documentation {
     if (text == null || text.isEmpty) {
       return DocumentationParseResult.empty;
     }
-    //showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
+    showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
     var document = MarkdownDocument.withElementLinkResolver(_element);
     return document.parseMarkdownText(text, processFullDocs);
   }

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -243,9 +243,7 @@ mixin GetterSetterCombo on ModelElement {
   Map<String, CommentReferable> get referenceChildren {
     if (_referenceChildren == null) {
       _referenceChildren = {};
-      _referenceChildren
-          .addEntries(allParameters.expand((p)
-      {
+      _referenceChildren.addEntries(allParameters.expand((p) {
         if (p.name == name) {
           // Force explicit references to parameters named the same as
           // the method.

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -244,11 +244,17 @@ mixin GetterSetterCombo on ModelElement {
     if (_referenceChildren == null) {
       _referenceChildren = {};
       _referenceChildren
-          .addEntries(allParameters.map((p) => MapEntry(p.name, p)));
+          .addEntries(allParameters.expand((p)
+      {
+        if (p.name == name) {
+          // Force explicit references to parameters named the same as
+          // the method.
+          return [MapEntry('$name.${p.name}', p)];
+        }
+        // Allow fallback handling in [Container] to deal with other cases.
+        return [];
+      }));
     }
     return _referenceChildren;
   }
-
-  @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
 }

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -664,8 +664,14 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   Map<String, CommentReferable> get referenceChildren {
     if (_referenceChildren == null) {
       _referenceChildren = Map.fromEntries(
-          element.exportNamespace.definedNames.entries.map((entry) => MapEntry(
-              entry.key, ModelElement.fromElement(entry.value, packageGraph))));
+          element.exportNamespace.definedNames.entries.expand((entry) sync* {
+            var modelElement = ModelElement.fromElement(entry.value, packageGraph);
+            if (modelElement is! Accessor) {
+              yield MapEntry(
+                  entry.key,
+                  ModelElement.fromElement(entry.value, packageGraph));
+            }
+          }));
       // TODO(jcollins-g): warn and get rid of this case where it shows up.
       // If a user is hiding parts of a prefix import, the user should not
       // refer to hidden members via the prefix, because that can be

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -665,13 +665,12 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     if (_referenceChildren == null) {
       _referenceChildren = Map.fromEntries(
           element.exportNamespace.definedNames.entries.expand((entry) sync* {
-            var modelElement = ModelElement.fromElement(entry.value, packageGraph);
-            if (modelElement is! Accessor) {
-              yield MapEntry(
-                  entry.key,
-                  ModelElement.fromElement(entry.value, packageGraph));
-            }
-          }));
+        var modelElement = ModelElement.fromElement(entry.value, packageGraph);
+        if (modelElement is! Accessor) {
+          yield MapEntry(
+              entry.key, ModelElement.fromElement(entry.value, packageGraph));
+        }
+      }));
       // TODO(jcollins-g): warn and get rid of this case where it shows up.
       // If a user is hiding parts of a prefix import, the user should not
       // refer to hidden members via the prefix, because that can be

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -136,7 +136,4 @@ class Method extends ModelElement
     }
     return _referenceChildren;
   }
-
-  @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
 }

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -131,9 +131,7 @@ class Method extends ModelElement
       _referenceChildren = {};
       _referenceChildren
           .addEntries(typeParameters.map((p) => MapEntry(p.name, p)));
-      _referenceChildren
-          .addEntries(allParameters.expand((p)
-      {
+      _referenceChildren.addEntries(allParameters.expand((p) {
         if (p.name == name) {
           // Force explicit references to parameters named the same as
           // the method.

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -132,7 +132,16 @@ class Method extends ModelElement
       _referenceChildren
           .addEntries(typeParameters.map((p) => MapEntry(p.name, p)));
       _referenceChildren
-          .addEntries(allParameters.map((p) => MapEntry(p.name, p)));
+          .addEntries(allParameters.expand((p)
+      {
+        if (p.name == name) {
+          // Force explicit references to parameters named the same as
+          // the method.
+          return [MapEntry('$name.${p.name}', p)];
+        }
+        // Allow fallback handling in [Container] to deal with other cases.
+        return [];
+      }));
     }
     return _referenceChildren;
   }

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -83,7 +83,7 @@ class ModelFunctionTyped extends ModelElement
   }
 
   @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
+  Iterable<CommentReferable> get referenceParents => [definingLibrary];
 
   @override
   FunctionTypedElement get element => super.element;

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -45,5 +45,5 @@ class Prefix extends ModelElement implements EnclosedElement {
   Map<String, CommentReferable> get referenceChildren => {};
 
   @override
-  Iterable<CommentReferable> get referenceParents => [library];
+  Iterable<CommentReferable> get referenceParents => [definingLibrary];
 }

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/model.dart';
 
@@ -87,4 +88,7 @@ class TopLevelVariable extends ModelElement
   String get fileName => '${isConst ? '$name-constant' : name}.$fileType';
 
   TopLevelVariableElement get _variable => (element as TopLevelVariableElement);
+
+  @override
+  Iterable<CommentReferable> get referenceParents => [definingLibrary];
 }

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -79,7 +79,7 @@ class Typedef extends ModelElement
   }
 
   @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
+  Iterable<CommentReferable> get referenceParents => [definingLibrary];
 }
 
 /// A typedef referring to a function type.

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -162,10 +162,12 @@ void main() {
       referable.add('lib4');
       var i1 = referable.add('lib4.intermediate1');
       var i1target = referable.add('lib4.intermediate1.target');
+      referable.add('lib4.intermediate2');
       var i2target = referable.add('lib4.intermediate2.target');
+      var i2other = referable.add('lib4.intermediate2.other');
       var i2notFromHere = referable.add('lib4.intermediate2.notFromHere');
-      var overrider = GrandparentOverrider('fromHere', [], i2target, [[i1]]);
-      i2target.children.add(overrider);
+      var overrider = GrandparentOverrider('fromHere', [], i2other, [[i1]]);
+      i2other.children.add(overrider);
       expect(i2notFromHere.lookup('target'), i2target);
       // Ordinarily, since overrider's parent is i2target, we would expect this
       // to work the same.  But it has an override.

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -27,7 +27,7 @@ abstract class Base extends Nameable with CommentReferable {
   Element get element => throw UnimplementedError();
 
   @override
-  Iterable<Iterable<CommentReferable>> get referenceGrandparentOverrides => null;
+  Iterable<CommentReferable> get referenceGrandparentOverrides => null;
 }
 
 class Top extends Base {
@@ -122,7 +122,7 @@ class GenericChild extends Child {
 
 class GrandparentOverrider extends GenericChild {
   @override
-  final Iterable<Iterable<Base>> referenceGrandparentOverrides;
+  final Iterable<Base> referenceGrandparentOverrides;
 
   GrandparentOverrider(String name, List<GenericChild> children, Base parent, this.referenceGrandparentOverrides) : super(name, children, parent);
 }
@@ -166,7 +166,7 @@ void main() {
       var i2target = referable.add('lib4.intermediate2.target');
       var i2other = referable.add('lib4.intermediate2.other');
       var i2notFromHere = referable.add('lib4.intermediate2.notFromHere');
-      var overrider = GrandparentOverrider('fromHere', [], i2other, [[i1]]);
+      var overrider = GrandparentOverrider('fromHere', [], i2other, [i1]);
       i2other.children.add(overrider);
       expect(i2notFromHere.lookup('target'), i2target);
       // Ordinarily, since overrider's parent is i2target, we would expect this

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -117,16 +117,16 @@ class GenericChild extends Child {
 
   @override
   Iterable<CommentReferable> get referenceParents => [parent];
-
 }
 
 class GrandparentOverrider extends GenericChild {
   @override
   final Iterable<Base> referenceGrandparentOverrides;
 
-  GrandparentOverrider(String name, List<GenericChild> children, Base parent, this.referenceGrandparentOverrides) : super(name, children, parent);
+  GrandparentOverrider(String name, List<GenericChild> children, Base parent,
+      this.referenceGrandparentOverrides)
+      : super(name, children, parent);
 }
-
 
 void main() {
   group('Basic comment reference lookups', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2123,8 +2123,6 @@ void main() {
   // Put linkage tests here; rendering tests should go to the appropriate
   // [Class], [Extension], etc groups.
   group('Comment References link tests', () {
-
-
     /// For comparison purposes, return an equivalent [MatchingLinkResult]
     /// for the defining element returned.  May return [originalResult].
     /// We do this to eliminate canonicalization effects from comparison,
@@ -2158,66 +2156,96 @@ void main() {
       Library base, extending, local_scope, two_exports;
       Class BaseWithMembers, ExtendingAgain;
       Field aField, anotherField, aStaticField;
-      TopLevelVariable aNotReexportedVariable, anotherNotReexportedVariable, aSymbolOnlyAvailableInExportContext, someConflictingNameSymbolTwoExports, someConflictingNameSymbol;
+      TopLevelVariable aNotReexportedVariable,
+          anotherNotReexportedVariable,
+          aSymbolOnlyAvailableInExportContext,
+          someConflictingNameSymbolTwoExports,
+          someConflictingNameSymbol;
       Method aStaticMethod;
       Constructor aConstructor;
 
       setUp(() {
-        base = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports.src.base');
-        extending = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports.src.extending');
-        local_scope = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports.src.local_scope');
-        two_exports = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports');
+        base = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'two_exports.src.base');
+        extending = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'two_exports.src.extending');
+        local_scope = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'two_exports.src.local_scope');
+        two_exports = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'two_exports');
 
-        BaseWithMembers = base.classes.firstWhere((c) => c.name == 'BaseWithMembers');
-        aStaticField = BaseWithMembers.staticFields.firstWhere((f) => f.name == 'aStaticField');
-        aStaticMethod = BaseWithMembers.staticMethods.firstWhere((m) => m.name == 'aStaticMethod');
-        aConstructor = BaseWithMembers.constructors.firstWhere((c) => c.name == 'BaseWithMembers.aConstructor');
+        BaseWithMembers =
+            base.classes.firstWhere((c) => c.name == 'BaseWithMembers');
+        aStaticField = BaseWithMembers.staticFields
+            .firstWhere((f) => f.name == 'aStaticField');
+        aStaticMethod = BaseWithMembers.staticMethods
+            .firstWhere((m) => m.name == 'aStaticMethod');
+        aConstructor = BaseWithMembers.constructors
+            .firstWhere((c) => c.name == 'BaseWithMembers.aConstructor');
 
-        someConflictingNameSymbol = extending.properties.firstWhere((p) => p.name == 'someConflictingNameSymbol');
+        someConflictingNameSymbol = extending.properties
+            .firstWhere((p) => p.name == 'someConflictingNameSymbol');
 
         // This group tests lookups from the perspective of the reexported
         // elements, to verify that various fallbacks work correctly.
-        ExtendingAgain = two_exports.classes.firstWhere((c) => c.name == 'ExtendingAgain');
+        ExtendingAgain =
+            two_exports.classes.firstWhere((c) => c.name == 'ExtendingAgain');
         aField = ExtendingAgain.allFields.firstWhere((f) => f.name == 'aField');
-        anotherField = ExtendingAgain.allFields.firstWhere((f) => f.name == 'anotherField');
+        anotherField = ExtendingAgain.allFields
+            .firstWhere((f) => f.name == 'anotherField');
 
-        aNotReexportedVariable = local_scope.properties.firstWhere((p) => p.name == 'aNotReexportedVariable');
-        anotherNotReexportedVariable = local_scope.properties.firstWhere((p) => p.name == 'anotherNotReexportedVariable');
-        aSymbolOnlyAvailableInExportContext = two_exports.properties.firstWhere((p) => p.name == 'aSymbolOnlyAvailableInExportContext');
-        someConflictingNameSymbolTwoExports = two_exports.properties.firstWhere((p) => p.name == 'someConflictingNameSymbol');
+        aNotReexportedVariable = local_scope.properties
+            .firstWhere((p) => p.name == 'aNotReexportedVariable');
+        anotherNotReexportedVariable = local_scope.properties
+            .firstWhere((p) => p.name == 'anotherNotReexportedVariable');
+        aSymbolOnlyAvailableInExportContext = two_exports.properties
+            .firstWhere((p) => p.name == 'aSymbolOnlyAvailableInExportContext');
+        someConflictingNameSymbolTwoExports = two_exports.properties
+            .firstWhere((p) => p.name == 'someConflictingNameSymbol');
       });
 
       test('Grandparent override in container members', () {
         // Original lookup fails unless the variable is reexported via other
         // means, but to do that would not be testing the same case on both.
-        expect(newLookup(aField, 'aNotReexportedVariable'), equals(MatchingLinkResult(aNotReexportedVariable)));
+        expect(newLookup(aField, 'aNotReexportedVariable'),
+            equals(MatchingLinkResult(aNotReexportedVariable)));
 
         // Verify that documentationFrom cases work.  Just having the doc
         // in the base class is enough to trigger [documentationFrom] and this
         // feature.
-        expect(bothLookup(anotherField, 'aNotReexportedVariable'), equals(MatchingLinkResult(aNotReexportedVariable)));
+        expect(bothLookup(anotherField, 'aNotReexportedVariable'),
+            equals(MatchingLinkResult(aNotReexportedVariable)));
       });
 
       // TODO(jcollins-g): dart-lang/dartdoc#2698
       test('Linking for static/constructor inheritance across libraries', () {
-        expect(bothLookup(ExtendingAgain, 'aStaticField'), equals(MatchingLinkResult(aStaticField)));
-        expect(bothLookup(ExtendingAgain, 'aStaticMethod'), equals(MatchingLinkResult(aStaticMethod)));
-        expect(bothLookup(ExtendingAgain, 'aConstructor'), equals(MatchingLinkResult(aConstructor)));
+        expect(bothLookup(ExtendingAgain, 'aStaticField'),
+            equals(MatchingLinkResult(aStaticField)));
+        expect(bothLookup(ExtendingAgain, 'aStaticMethod'),
+            equals(MatchingLinkResult(aStaticMethod)));
+        expect(bothLookup(ExtendingAgain, 'aConstructor'),
+            equals(MatchingLinkResult(aConstructor)));
       });
 
       test('Linking for inherited field from reexport context', () {
-        expect(bothLookup(aField, 'anotherNotReexportedVariable'), equals(MatchingLinkResult(anotherNotReexportedVariable)));
+        expect(bothLookup(aField, 'anotherNotReexportedVariable'),
+            equals(MatchingLinkResult(anotherNotReexportedVariable)));
       });
 
       // TODO(jcollins-g): dart-lang/dartdoc#2696
       test('Allow non-explicit export namespace linking', () {
-        expect(bothLookup(BaseWithMembers, 'aSymbolOnlyAvailableInExportContext'), equals(MatchingLinkResult(aSymbolOnlyAvailableInExportContext)));
+        expect(
+            bothLookup(BaseWithMembers, 'aSymbolOnlyAvailableInExportContext'),
+            equals(MatchingLinkResult(aSymbolOnlyAvailableInExportContext)));
       });
 
-      test('Link to definingLibrary for class rather than its export context', () {
+      test('Link to definingLibrary for class rather than its export context',
+          () {
         // This is an improvement over the original.
-        expect(newLookup(ExtendingAgain, 'someConflictingNameSymbol'), equals(MatchingLinkResult(someConflictingNameSymbol)));
-        expect(newLookup(two_exports, 'someConflictingNameSymbol'), equals(MatchingLinkResult(someConflictingNameSymbolTwoExports)));
+        expect(newLookup(ExtendingAgain, 'someConflictingNameSymbol'),
+            equals(MatchingLinkResult(someConflictingNameSymbol)));
+        expect(newLookup(two_exports, 'someConflictingNameSymbol'),
+            equals(MatchingLinkResult(someConflictingNameSymbolTwoExports)));
       });
     });
 
@@ -2228,7 +2256,9 @@ void main() {
           nameWithTwoUnderscores,
           nameWithSingleUnderscore,
           theOnlyThingInTheLibrary;
-      Constructor aNonDefaultConstructor, defaultConstructor, aConstructorShadowed;
+      Constructor aNonDefaultConstructor,
+          defaultConstructor,
+          aConstructorShadowed;
       Class Apple,
           BaseClass,
           baseForDocComments,
@@ -2239,7 +2269,11 @@ void main() {
       // ignore: unused_local_variable
       Operator bracketOperator, bracketOperatorOtherClass;
       Parameter doAwesomeStuffParam;
-      Field forInheriting, action, initializeMe, somethingShadowy, aConstructorShadowedField;
+      Field forInheriting,
+          action,
+          initializeMe,
+          somethingShadowy,
+          aConstructorShadowedField;
 
       setUpAll(() async {
         nameWithTwoUnderscores = fakeLibrary.constants
@@ -2254,10 +2288,10 @@ void main() {
             .firstWhere((e) => e.name == 'meta')
             .allClasses
             .firstWhere((c) => c.name == 'UseResult');
-        baseForDocComments =
-            fakeLibrary.classes.firstWhere((c) => c.name == 'BaseForDocComments');
+        baseForDocComments = fakeLibrary.classes
+            .firstWhere((c) => c.name == 'BaseForDocComments');
         aNonDefaultConstructor = baseForDocComments.constructors.firstWhere(
-                (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
+            (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
         defaultConstructor = baseForDocComments.constructors
             .firstWhere((c) => c.name == 'BaseForDocComments');
         initializeMe = baseForDocComments.allFields
@@ -2269,9 +2303,10 @@ void main() {
         anotherMethod = baseForDocComments.instanceMethods
             .firstWhere((m) => m.name == 'anotherMethod');
         doAwesomeStuffParam = doAwesomeStuff.parameters.first;
-        topLevelFunction =
-            fakeLibrary.functions.firstWhere((f) => f.name == 'topLevelFunction');
-        function1 = exLibrary.functions.firstWhere((f) => f.name == 'function1');
+        topLevelFunction = fakeLibrary.functions
+            .firstWhere((f) => f.name == 'topLevelFunction');
+        function1 =
+            exLibrary.functions.firstWhere((f) => f.name == 'function1');
         Apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
         incorrectDocReference = fakeLibrary.constants
             .firstWhere((v) => v.name == 'incorrectDocReference');
@@ -2307,8 +2342,10 @@ void main() {
             .firstWhere((c) => c.name == 'BaseReexported')
             .allFields
             .firstWhere((f) => f.name == 'action');
-        aConstructorShadowed = baseForDocComments.constructors.firstWhere((c) => c.name == 'BaseForDocComments.aConstructorShadowed');
-        aConstructorShadowedField = baseForDocComments.allFields.firstWhere((f) => f.name == 'aConstructorShadowed');
+        aConstructorShadowed = baseForDocComments.constructors.firstWhere(
+            (c) => c.name == 'BaseForDocComments.aConstructorShadowed');
+        aConstructorShadowedField = baseForDocComments.allFields
+            .firstWhere((f) => f.name == 'aConstructorShadowed');
       });
 
       test('Verify basic linking inside a constructor', () {
@@ -2324,10 +2361,19 @@ void main() {
             equals(MatchingLinkResult(aNonDefaultConstructor)));
       });
 
-      test('Verify that constructors do not override member fields unless explicitly specified', () {
-        expect(bothLookup(baseForDocComments, 'aConstructorShadowed'), equals(MatchingLinkResult(aConstructorShadowedField)));
-        expect(bothLookup(baseForDocComments, 'BaseForDocComments.aConstructorShadowed'), equals(MatchingLinkResult(aConstructorShadowedField)));
-        expect(bothLookup(baseForDocComments, 'new BaseForDocComments.aConstructorShadowed'), equals(MatchingLinkResult(aConstructorShadowed)));
+      test(
+          'Verify that constructors do not override member fields unless explicitly specified',
+          () {
+        expect(bothLookup(baseForDocComments, 'aConstructorShadowed'),
+            equals(MatchingLinkResult(aConstructorShadowedField)));
+        expect(
+            bothLookup(
+                baseForDocComments, 'BaseForDocComments.aConstructorShadowed'),
+            equals(MatchingLinkResult(aConstructorShadowedField)));
+        expect(
+            bothLookup(baseForDocComments,
+                'new BaseForDocComments.aConstructorShadowed'),
+            equals(MatchingLinkResult(aConstructorShadowed)));
       });
 
       test('Deprecated lookup styles still function', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2123,92 +2123,7 @@ void main() {
   // Put linkage tests here; rendering tests should go to the appropriate
   // [Class], [Extension], etc groups.
   group('Comment References link tests', () {
-    ModelFunction doesStuff, function1, topLevelFunction;
-    TopLevelVariable incorrectDocReference,
-        incorrectDocReferenceFromEx,
-        nameWithTwoUnderscores,
-        nameWithSingleUnderscore,
-        theOnlyThingInTheLibrary;
-    Constructor aNonDefaultConstructor, defaultConstructor;
-    Class Apple,
-        BaseClass,
-        baseForDocComments,
-        ExtraSpecialList,
-        string,
-        metaUseResult;
-    Method doAwesomeStuff, anotherMethod;
-    // ignore: unused_local_variable
-    Operator bracketOperator, bracketOperatorOtherClass;
-    Parameter doAwesomeStuffParam;
-    Field forInheriting, action, initializeMe, somethingShadowy;
 
-    setUpAll(() async {
-      nameWithTwoUnderscores = fakeLibrary.constants
-          .firstWhere((v) => v.name == 'NAME_WITH_TWO_UNDERSCORES');
-      nameWithSingleUnderscore = fakeLibrary.constants
-          .firstWhere((v) => v.name == 'NAME_SINGLEUNDERSCORE');
-      string = packageGraph.allLibraries.values
-          .firstWhere((e) => e.name == 'dart:core')
-          .allClasses
-          .firstWhere((c) => c.name == 'String');
-      metaUseResult = packageGraph.allLibraries.values
-          .firstWhere((e) => e.name == 'meta')
-          .allClasses
-          .firstWhere((c) => c.name == 'UseResult');
-      baseForDocComments =
-          fakeLibrary.classes.firstWhere((c) => c.name == 'BaseForDocComments');
-      aNonDefaultConstructor = baseForDocComments.constructors.firstWhere(
-          (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
-      defaultConstructor = baseForDocComments.constructors
-          .firstWhere((c) => c.name == 'BaseForDocComments');
-      initializeMe = baseForDocComments.allFields
-          .firstWhere((f) => f.name == 'initializeMe');
-      somethingShadowy = baseForDocComments.allFields
-          .firstWhere((f) => f.name == 'somethingShadowy');
-      doAwesomeStuff = baseForDocComments.instanceMethods
-          .firstWhere((m) => m.name == 'doAwesomeStuff');
-      anotherMethod = baseForDocComments.instanceMethods
-          .firstWhere((m) => m.name == 'anotherMethod');
-      doAwesomeStuffParam = doAwesomeStuff.parameters.first;
-      topLevelFunction =
-          fakeLibrary.functions.firstWhere((f) => f.name == 'topLevelFunction');
-      function1 = exLibrary.functions.firstWhere((f) => f.name == 'function1');
-      Apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
-      incorrectDocReference = fakeLibrary.constants
-          .firstWhere((v) => v.name == 'incorrectDocReference');
-      incorrectDocReferenceFromEx = exLibrary.constants
-          .firstWhere((v) => v.name == 'incorrectDocReferenceFromEx');
-      theOnlyThingInTheLibrary = packageGraph.libraries
-          .firstWhere((l) => l.name == 'csspub')
-          .properties
-          .firstWhere((v) => v.name == 'theOnlyThingInTheLibrary');
-      doesStuff = packageGraph.allLibraries.values
-          .firstWhere((l) => l.name == 'anonymous_library')
-          .functions
-          .firstWhere((f) => f.name == 'doesStuff');
-      BaseClass = packageGraph.allLibraries.values
-          .firstWhere((l) => l.name == 'two_exports.src.base')
-          .classes
-          .firstWhere((c) => c.name == 'BaseClass');
-      bracketOperator = baseForDocComments.instanceOperators
-          .firstWhere((o) => o.name == 'operator []');
-      bracketOperatorOtherClass = fakeLibrary.classes
-          .firstWhere((c) => c.name == 'SpecialList')
-          .instanceOperators
-          .firstWhere((o) => o.name == 'operator []');
-      ExtraSpecialList =
-          fakeLibrary.classes.firstWhere((c) => c.name == 'ExtraSpecialList');
-      forInheriting = fakeLibrary.classes
-          .firstWhere((c) => c.name == 'ImplicitProperties')
-          .allFields
-          .firstWhere((n) => n.name == 'forInheriting');
-      action = packageGraph.allLibraries.values
-          .firstWhere((l) => l.name == 'reexport.somelib')
-          .classes
-          .firstWhere((c) => c.name == 'BaseReexported')
-          .allFields
-          .firstWhere((f) => f.name == 'action');
-    });
 
     /// For comparison purposes, return an equivalent [MatchingLinkResult]
     /// for the defining element returned.  May return [originalResult].
@@ -2239,122 +2154,287 @@ void main() {
       return newLookupResult;
     }
 
-    test('Verify basic linking inside a constructor', () {
-      // Field formal parameters worked sometimes by accident in the old code,
-      // but should work reliably now.
-      expect(newLookup(aNonDefaultConstructor, 'initializeMe'),
-          equals(MatchingLinkResult(initializeMe)));
-      expect(newLookup(aNonDefaultConstructor, 'aNonDefaultConstructor'),
-          equals(MatchingLinkResult(aNonDefaultConstructor)));
-      expect(
-          bothLookup(aNonDefaultConstructor,
-              'BaseForDocComments.aNonDefaultConstructor'),
-          equals(MatchingLinkResult(aNonDefaultConstructor)));
+    group('Linking for complex inheritance and reexport cases', () {
+      Library base, extending, local_scope, two_exports;
+      Class BaseWithMembers, ExtendingAgain;
+      Field aField, anotherField, aStaticField;
+      TopLevelVariable aNotReexportedVariable, anotherNotReexportedVariable, aSymbolOnlyAvailableInExportContext, someConflictingNameSymbolTwoExports, someConflictingNameSymbol;
+      Method aStaticMethod;
+      Constructor aConstructor;
+
+      setUp(() {
+        base = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports.src.base');
+        extending = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports.src.extending');
+        local_scope = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports.src.local_scope');
+        two_exports = packageGraph.allLibraries.values.firstWhere((l) => l.name == 'two_exports');
+
+        BaseWithMembers = base.classes.firstWhere((c) => c.name == 'BaseWithMembers');
+        aStaticField = BaseWithMembers.staticFields.firstWhere((f) => f.name == 'aStaticField');
+        aStaticMethod = BaseWithMembers.staticMethods.firstWhere((m) => m.name == 'aStaticMethod');
+        aConstructor = BaseWithMembers.constructors.firstWhere((c) => c.name == 'BaseWithMembers.aConstructor');
+
+        someConflictingNameSymbol = extending.properties.firstWhere((p) => p.name == 'someConflictingNameSymbol');
+
+        // This group tests lookups from the perspective of the reexported
+        // elements, to verify that various fallbacks work correctly.
+        ExtendingAgain = two_exports.classes.firstWhere((c) => c.name == 'ExtendingAgain');
+        aField = ExtendingAgain.allFields.firstWhere((f) => f.name == 'aField');
+        anotherField = ExtendingAgain.allFields.firstWhere((f) => f.name == 'anotherField');
+
+        aNotReexportedVariable = local_scope.properties.firstWhere((p) => p.name == 'aNotReexportedVariable');
+        anotherNotReexportedVariable = local_scope.properties.firstWhere((p) => p.name == 'anotherNotReexportedVariable');
+        aSymbolOnlyAvailableInExportContext = two_exports.properties.firstWhere((p) => p.name == 'aSymbolOnlyAvailableInExportContext');
+        someConflictingNameSymbolTwoExports = two_exports.properties.firstWhere((p) => p.name == 'someConflictingNameSymbol');
+      });
+
+      test('Grandparent override in container members', () {
+        // Original lookup fails unless the variable is reexported via other
+        // means, but to do that would not be testing the same case on both.
+        expect(newLookup(aField, 'aNotReexportedVariable'), equals(MatchingLinkResult(aNotReexportedVariable)));
+
+        // Verify that documentationFrom cases work.  Just having the doc
+        // in the base class is enough to trigger [documentationFrom] and this
+        // feature.
+        expect(bothLookup(anotherField, 'aNotReexportedVariable'), equals(MatchingLinkResult(aNotReexportedVariable)));
+      });
+
+      // TODO(jcollins-g): dart-lang/dartdoc#2698
+      test('Linking for static/constructor inheritance across libraries', () {
+        expect(bothLookup(ExtendingAgain, 'aStaticField'), equals(MatchingLinkResult(aStaticField)));
+        expect(bothLookup(ExtendingAgain, 'aStaticMethod'), equals(MatchingLinkResult(aStaticMethod)));
+        expect(bothLookup(ExtendingAgain, 'aConstructor'), equals(MatchingLinkResult(aConstructor)));
+      });
+
+      test('Linking for inherited field from reexport context', () {
+        expect(bothLookup(aField, 'anotherNotReexportedVariable'), equals(MatchingLinkResult(anotherNotReexportedVariable)));
+      });
+
+      // TODO(jcollins-g): dart-lang/dartdoc#2696
+      test('Allow non-explicit export namespace linking', () {
+        expect(bothLookup(BaseWithMembers, 'aSymbolOnlyAvailableInExportContext'), equals(MatchingLinkResult(aSymbolOnlyAvailableInExportContext)));
+      });
+
+      test('Link to definingLibrary for class rather than its export context', () {
+        // This is an improvement over the original.
+        expect(newLookup(ExtendingAgain, 'someConflictingNameSymbol'), equals(MatchingLinkResult(someConflictingNameSymbol)));
+        expect(newLookup(two_exports, 'someConflictingNameSymbol'), equals(MatchingLinkResult(someConflictingNameSymbolTwoExports)));
+      });
     });
 
-    test('Deprecated lookup styles still function', () {
-      // dart-lang/dartdoc#2683
-      expect(bothLookup(baseForDocComments, 'aPrefix.UseResult'),
-          equals(MatchingLinkResult(metaUseResult)));
-    });
+    group('Ordinary namespace cases', () {
+      ModelFunction doesStuff, function1, topLevelFunction;
+      TopLevelVariable incorrectDocReference,
+          incorrectDocReferenceFromEx,
+          nameWithTwoUnderscores,
+          nameWithSingleUnderscore,
+          theOnlyThingInTheLibrary;
+      Constructor aNonDefaultConstructor, defaultConstructor, aConstructorShadowed;
+      Class Apple,
+          BaseClass,
+          baseForDocComments,
+          ExtraSpecialList,
+          string,
+          metaUseResult;
+      Method doAwesomeStuff, anotherMethod;
+      // ignore: unused_local_variable
+      Operator bracketOperator, bracketOperatorOtherClass;
+      Parameter doAwesomeStuffParam;
+      Field forInheriting, action, initializeMe, somethingShadowy, aConstructorShadowedField;
 
-    test('Verify basic linking inside class', () {
-      expect(
-          bothLookup(
-              baseForDocComments, 'BaseForDocComments.BaseForDocComments'),
-          equals(MatchingLinkResult(defaultConstructor)));
+      setUpAll(() async {
+        nameWithTwoUnderscores = fakeLibrary.constants
+            .firstWhere((v) => v.name == 'NAME_WITH_TWO_UNDERSCORES');
+        nameWithSingleUnderscore = fakeLibrary.constants
+            .firstWhere((v) => v.name == 'NAME_SINGLEUNDERSCORE');
+        string = packageGraph.allLibraries.values
+            .firstWhere((e) => e.name == 'dart:core')
+            .allClasses
+            .firstWhere((c) => c.name == 'String');
+        metaUseResult = packageGraph.allLibraries.values
+            .firstWhere((e) => e.name == 'meta')
+            .allClasses
+            .firstWhere((c) => c.name == 'UseResult');
+        baseForDocComments =
+            fakeLibrary.classes.firstWhere((c) => c.name == 'BaseForDocComments');
+        aNonDefaultConstructor = baseForDocComments.constructors.firstWhere(
+                (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
+        defaultConstructor = baseForDocComments.constructors
+            .firstWhere((c) => c.name == 'BaseForDocComments');
+        initializeMe = baseForDocComments.allFields
+            .firstWhere((f) => f.name == 'initializeMe');
+        somethingShadowy = baseForDocComments.allFields
+            .firstWhere((f) => f.name == 'somethingShadowy');
+        doAwesomeStuff = baseForDocComments.instanceMethods
+            .firstWhere((m) => m.name == 'doAwesomeStuff');
+        anotherMethod = baseForDocComments.instanceMethods
+            .firstWhere((m) => m.name == 'anotherMethod');
+        doAwesomeStuffParam = doAwesomeStuff.parameters.first;
+        topLevelFunction =
+            fakeLibrary.functions.firstWhere((f) => f.name == 'topLevelFunction');
+        function1 = exLibrary.functions.firstWhere((f) => f.name == 'function1');
+        Apple = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
+        incorrectDocReference = fakeLibrary.constants
+            .firstWhere((v) => v.name == 'incorrectDocReference');
+        incorrectDocReferenceFromEx = exLibrary.constants
+            .firstWhere((v) => v.name == 'incorrectDocReferenceFromEx');
+        theOnlyThingInTheLibrary = packageGraph.libraries
+            .firstWhere((l) => l.name == 'csspub')
+            .properties
+            .firstWhere((v) => v.name == 'theOnlyThingInTheLibrary');
+        doesStuff = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'anonymous_library')
+            .functions
+            .firstWhere((f) => f.name == 'doesStuff');
+        BaseClass = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'two_exports.src.base')
+            .classes
+            .firstWhere((c) => c.name == 'BaseClass');
+        bracketOperator = baseForDocComments.instanceOperators
+            .firstWhere((o) => o.name == 'operator []');
+        bracketOperatorOtherClass = fakeLibrary.classes
+            .firstWhere((c) => c.name == 'SpecialList')
+            .instanceOperators
+            .firstWhere((o) => o.name == 'operator []');
+        ExtraSpecialList =
+            fakeLibrary.classes.firstWhere((c) => c.name == 'ExtraSpecialList');
+        forInheriting = fakeLibrary.classes
+            .firstWhere((c) => c.name == 'ImplicitProperties')
+            .allFields
+            .firstWhere((n) => n.name == 'forInheriting');
+        action = packageGraph.allLibraries.values
+            .firstWhere((l) => l.name == 'reexport.somelib')
+            .classes
+            .firstWhere((c) => c.name == 'BaseReexported')
+            .allFields
+            .firstWhere((f) => f.name == 'action');
+        aConstructorShadowed = baseForDocComments.constructors.firstWhere((c) => c.name == 'BaseForDocComments.aConstructorShadowed');
+        aConstructorShadowedField = baseForDocComments.allFields.firstWhere((f) => f.name == 'aConstructorShadowed');
+      });
 
-      // We don't want the parameter on the default constructor, here.
-      expect(
-          bothLookup(baseForDocComments, 'BaseForDocComments.somethingShadowy'),
-          equals(MatchingLinkResult(somethingShadowy)));
+      test('Verify basic linking inside a constructor', () {
+        // Field formal parameters worked sometimes by accident in the old code,
+        // but should work reliably now.
+        expect(newLookup(aNonDefaultConstructor, 'initializeMe'),
+            equals(MatchingLinkResult(initializeMe)));
+        expect(newLookup(aNonDefaultConstructor, 'aNonDefaultConstructor'),
+            equals(MatchingLinkResult(aNonDefaultConstructor)));
+        expect(
+            bothLookup(aNonDefaultConstructor,
+                'BaseForDocComments.aNonDefaultConstructor'),
+            equals(MatchingLinkResult(aNonDefaultConstructor)));
+      });
 
-      expect(bothLookup(doAwesomeStuff, 'aNonDefaultConstructor'),
-          equals(MatchingLinkResult(aNonDefaultConstructor)));
+      test('Verify that constructors do not override member fields unless explicitly specified', () {
+        expect(bothLookup(baseForDocComments, 'aConstructorShadowed'), equals(MatchingLinkResult(aConstructorShadowedField)));
+        expect(bothLookup(baseForDocComments, 'BaseForDocComments.aConstructorShadowed'), equals(MatchingLinkResult(aConstructorShadowedField)));
+        expect(bothLookup(baseForDocComments, 'new BaseForDocComments.aConstructorShadowed'), equals(MatchingLinkResult(aConstructorShadowed)));
+      });
 
-      expect(
-          bothLookup(
-              doAwesomeStuff, 'BaseForDocComments.aNonDefaultConstructor'),
-          equals(MatchingLinkResult(aNonDefaultConstructor)));
+      test('Deprecated lookup styles still function', () {
+        // dart-lang/dartdoc#2683
+        expect(bothLookup(baseForDocComments, 'aPrefix.UseResult'),
+            equals(MatchingLinkResult(metaUseResult)));
+      });
 
-      expect(bothLookup(doAwesomeStuff, 'this'),
-          equals(MatchingLinkResult(baseForDocComments)));
+      test('Verify basic linking inside class', () {
+        expect(
+            bothLookup(
+                baseForDocComments, 'BaseForDocComments.BaseForDocComments'),
+            equals(MatchingLinkResult(defaultConstructor)));
 
-      expect(bothLookup(doAwesomeStuff, 'value'),
-          equals(MatchingLinkResult(doAwesomeStuffParam)));
+        // We don't want the parameter on the default constructor, here.
+        expect(
+            bothLookup(
+                baseForDocComments, 'BaseForDocComments.somethingShadowy'),
+            equals(MatchingLinkResult(somethingShadowy)));
 
-      // Parent class of [doAwesomeStuff].
-      expect(bothLookup(doAwesomeStuff, 'BaseForDocComments'),
-          equals(MatchingLinkResult(baseForDocComments)));
+        expect(bothLookup(doAwesomeStuff, 'aNonDefaultConstructor'),
+            equals(MatchingLinkResult(aNonDefaultConstructor)));
 
-      // Top level constants in the same library as [doAwesomeStuff].
-      expect(bothLookup(doAwesomeStuff, 'NAME_WITH_TWO_UNDERSCORES'),
-          equals(MatchingLinkResult(nameWithTwoUnderscores)));
-      expect(bothLookup(doAwesomeStuff, 'NAME_SINGLEUNDERSCORE'),
-          equals(MatchingLinkResult(nameWithSingleUnderscore)));
+        expect(
+            bothLookup(
+                doAwesomeStuff, 'BaseForDocComments.aNonDefaultConstructor'),
+            equals(MatchingLinkResult(aNonDefaultConstructor)));
 
-      // Top level class from [dart:core].
-      expect(bothLookup(doAwesomeStuff, 'String'),
-          equals(MatchingLinkResult(string)));
+        expect(bothLookup(doAwesomeStuff, 'this'),
+            equals(MatchingLinkResult(baseForDocComments)));
 
-      // Another method in the same class.
-      expect(bothLookup(doAwesomeStuff, 'anotherMethod'),
-          equals(MatchingLinkResult(anotherMethod)));
+        expect(bothLookup(doAwesomeStuff, 'value'),
+            equals(MatchingLinkResult(doAwesomeStuffParam)));
 
-      // A top level function in this library.
-      expect(bothLookup(doAwesomeStuff, 'topLevelFunction'),
-          equals(MatchingLinkResult(topLevelFunction)));
+        // Parent class of [doAwesomeStuff].
+        expect(bothLookup(doAwesomeStuff, 'BaseForDocComments'),
+            equals(MatchingLinkResult(baseForDocComments)));
 
-      // A top level function in another library imported into this library.
-      expect(bothLookup(doAwesomeStuff, 'function1'),
-          equals(MatchingLinkResult(function1)));
+        // Top level constants in the same library as [doAwesomeStuff].
+        expect(bothLookup(doAwesomeStuff, 'NAME_WITH_TWO_UNDERSCORES'),
+            equals(MatchingLinkResult(nameWithTwoUnderscores)));
+        expect(bothLookup(doAwesomeStuff, 'NAME_SINGLEUNDERSCORE'),
+            equals(MatchingLinkResult(nameWithSingleUnderscore)));
 
-      // A class in another library imported into this library.
-      expect(bothLookup(doAwesomeStuff, 'Apple'),
-          equals(MatchingLinkResult(Apple)));
+        // Top level class from [dart:core].
+        expect(bothLookup(doAwesomeStuff, 'String'),
+            equals(MatchingLinkResult(string)));
 
-      // A top level constant in this library sharing the same name as a name in another library.
-      expect(bothLookup(doAwesomeStuff, 'incorrectDocReference'),
-          equals(MatchingLinkResult(incorrectDocReference)));
+        // Another method in the same class.
+        expect(bothLookup(doAwesomeStuff, 'anotherMethod'),
+            equals(MatchingLinkResult(anotherMethod)));
 
-      // A top level constant in another library.
-      expect(bothLookup(doAwesomeStuff, 'incorrectDocReferenceFromEx'),
-          equals(MatchingLinkResult(incorrectDocReferenceFromEx)));
+        // A top level function in this library.
+        expect(bothLookup(doAwesomeStuff, 'topLevelFunction'),
+            equals(MatchingLinkResult(topLevelFunction)));
 
-      // A prefixed constant in another library.
-      expect(bothLookup(doAwesomeStuff, 'css.theOnlyThingInTheLibrary'),
-          equals(MatchingLinkResult(theOnlyThingInTheLibrary)));
+        // A top level function in another library imported into this library.
+        expect(bothLookup(doAwesomeStuff, 'function1'),
+            equals(MatchingLinkResult(function1)));
 
-      // A name that exists in this package but is not imported.
-      expect(bothLookup(doAwesomeStuff, 'doesStuff'),
-          equals(MatchingLinkResult(doesStuff)));
+        // A class in another library imported into this library.
+        expect(bothLookup(doAwesomeStuff, 'Apple'),
+            equals(MatchingLinkResult(Apple)));
 
-      // A name of a class from an import of a library that exported that name.
-      expect(bothLookup(doAwesomeStuff, 'BaseClass'),
-          equals(MatchingLinkResult(BaseClass)));
+        // A top level constant in this library sharing the same name as a name in another library.
+        expect(bothLookup(doAwesomeStuff, 'incorrectDocReference'),
+            equals(MatchingLinkResult(incorrectDocReference)));
 
-      // A bracket operator within this class.
-      expect(bothLookup(doAwesomeStuff, 'operator []'),
-          equals(MatchingLinkResult(bracketOperator)));
+        // A top level constant in another library.
+        expect(bothLookup(doAwesomeStuff, 'incorrectDocReferenceFromEx'),
+            equals(MatchingLinkResult(incorrectDocReferenceFromEx)));
 
-      // A bracket operator in another class.
-      // Doesn't work in older lookup code.
-      expect(newLookup(doAwesomeStuff, 'SpecialList.operator []'),
-          equals(MatchingLinkResult(bracketOperatorOtherClass)));
+        // A prefixed constant in another library.
+        expect(bothLookup(doAwesomeStuff, 'css.theOnlyThingInTheLibrary'),
+            equals(MatchingLinkResult(theOnlyThingInTheLibrary)));
 
-      // Reference containing a type parameter.
-      expect(bothLookup(doAwesomeStuff, 'ExtraSpecialList<Object>'),
-          equals(MatchingLinkResult(ExtraSpecialList)));
+        // A name that exists in this package but is not imported.
+        expect(bothLookup(doAwesomeStuff, 'doesStuff'),
+            equals(MatchingLinkResult(doesStuff)));
 
-      // Reference to an inherited member.
-      expect(
-          bothLookup(
-              doAwesomeStuff, 'ClassWithUnusualProperties.forInheriting'),
-          equals(MatchingLinkResult(forInheriting)));
+        // A name of a class from an import of a library that exported that name.
+        expect(bothLookup(doAwesomeStuff, 'BaseClass'),
+            equals(MatchingLinkResult(BaseClass)));
 
-      // Reference to an inherited member in another library via class name.
-      expect(bothLookup(doAwesomeStuff, 'ExtendedBaseReexported.action'),
-          equals(MatchingLinkResult(action)));
+        // A bracket operator within this class.
+        expect(bothLookup(doAwesomeStuff, 'operator []'),
+            equals(MatchingLinkResult(bracketOperator)));
+
+        // A bracket operator in another class.
+        // Doesn't work in older lookup code.
+        expect(newLookup(doAwesomeStuff, 'SpecialList.operator []'),
+            equals(MatchingLinkResult(bracketOperatorOtherClass)));
+
+        // Reference containing a type parameter.
+        expect(bothLookup(doAwesomeStuff, 'ExtraSpecialList<Object>'),
+            equals(MatchingLinkResult(ExtraSpecialList)));
+
+        // Reference to an inherited member.
+        expect(
+            bothLookup(
+                doAwesomeStuff, 'ClassWithUnusualProperties.forInheriting'),
+            equals(MatchingLinkResult(forInheriting)));
+
+        // Reference to an inherited member in another library via class name.
+        expect(bothLookup(doAwesomeStuff, 'ExtendedBaseReexported.action'),
+            equals(MatchingLinkResult(action)));
+      });
     });
   });
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -965,9 +965,14 @@ class BaseForDocComments {
 
   int somethingShadowy;
 
+  /// I'm not really a constructor, but I'm allowed to exist anyway.
+  int aConstructorShadowed;
+
   BaseForDocComments(this.initializeMe, [bool somethingShadowy]);
 
   BaseForDocComments.aNonDefaultConstructor(this.initializeMe);
+
+  BaseForDocComments.aConstructorShadowed(this.initializeMe);
 
   factory BaseForDocComments.aFactoryFunction() => null;
 }

--- a/testing/test_package/lib/src/base.dart
+++ b/testing/test_package/lib/src/base.dart
@@ -4,4 +4,24 @@ library two_exports.src.base;
 
 import '../fake.dart';
 
+import 'local_scope.dart';
+
 class BaseClass extends WithGetterAndSetter {}
+
+
+
+class BaseWithMembers {
+  int aField;
+
+  /// Here is some documentation that links to [aNotReexportedVariable]
+  /// for documentationFrom processing.
+  bool anotherField;
+
+  static aStaticMethod() {}
+
+  static String aStaticField;
+
+  BaseWithMembers() {}
+
+  BaseWithMembers.aConstructor() {}
+}

--- a/testing/test_package/lib/src/extending.dart
+++ b/testing/test_package/lib/src/extending.dart
@@ -6,9 +6,18 @@ import 'base.dart';
 
 int topLevelVariable = 1;
 
+bool someConflictingNameSymbol;
+
 /// Extending class extends [BaseClass].
 ///
 /// Also check out [topLevelVariable].
 ///
 /// Linking over to [Apple] should work.
 class ExtendingClass extends BaseClass {}
+
+
+
+class ExtendingAgain extends BaseWithMembers {
+  @override
+  bool anotherField;
+}

--- a/testing/test_package/lib/src/local_scope.dart
+++ b/testing/test_package/lib/src/local_scope.dart
@@ -4,6 +4,6 @@
 library two_exports.src.local_scope;
 
 
-final String aNotReexportedVariable;
+String aNotReexportedVariable;
 
-final bool anotherNotReexportedVariable;
+bool anotherNotReexportedVariable;

--- a/testing/test_package/lib/src/local_scope.dart
+++ b/testing/test_package/lib/src/local_scope.dart
@@ -1,0 +1,9 @@
+// @dart=2.9
+
+/// Imported by a library but not reexported.
+library two_exports.src.local_scope;
+
+
+final String aNotReexportedVariable;
+
+final bool anotherNotReexportedVariable;

--- a/testing/test_package/lib/two_exports.dart
+++ b/testing/test_package/lib/two_exports.dart
@@ -6,4 +6,9 @@
 library two_exports;
 
 export 'src/base.dart';
-export 'src/extending.dart';
+export 'src/extending.dart' hide someConflictingNameSymbol;
+
+
+int aSymbolOnlyAvailableInExportContext;
+
+bool someConflictingNameSymbol;


### PR DESCRIPTION
This is a set of related changes around handling inheritance and export namespaces to make the new lookup code conform more to what the old code used to do.  A number of bugs are referenced, including #2698, #2696, and #2693 as we're now treating these quirks of the old code as bugs, but trying to remain compatible for now.