### PR TITLE
Clean up and add tests for new lookup code parameter handling

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -315,10 +315,6 @@ bool _rejectDefaultAndShadowingConstructors(CommentReferable referable) {
       return false;
     }
   }
-  // Avoid accidentally preferring arguments of the default constructor.
-  if (referable is ModelElement && referable.enclosingElement is Constructor) {
-    return false;
-  }
   return true;
 }
 

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -68,7 +68,7 @@ mixin CommentReferable implements Nameable {
         if (result != null) break;
       }
       if (referenceChildren.containsKey(referenceLookup.lookup)) {
-        result = lookupViaReferenceChildren(referenceLookup, filter);
+        result = _lookupViaReferenceChildren(referenceLookup, filter);
         if (result != null) break;
       }
     }
@@ -107,14 +107,14 @@ mixin CommentReferable implements Nameable {
     return recurseChildrenAndFilter(referenceLookup, result, filter);
   }
 
-  CommentReferable lookupViaReferenceChildren(
+  CommentReferable _lookupViaReferenceChildren(
           ReferenceChildrenLookup referenceLookup,
           bool Function(CommentReferable) filter) =>
       recurseChildrenAndFilter(
           referenceLookup, referenceChildren[referenceLookup.lookup], filter);
 
   /// Given a [result] found in an implementation of [lookupViaScope] or
-  /// [lookupViaReferenceChildren], recurse through children, skipping over
+  /// [_lookupViaReferenceChildren], recurse through children, skipping over
   /// results that do not match the filter.
   CommentReferable recurseChildrenAndFilter(
       ReferenceChildrenLookup referenceLookup,

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -137,6 +137,7 @@ mixin CommentReferable implements Nameable {
   /// A list of lookups that should be attempted on children based on
   /// [reference].  This allows us to deal with libraries that may have
   /// separators in them. [referenceBy] stops at the first one found.
+  // TODO(jcollins-g): Convert to generator after dart-lang/sdk#46419
   Iterable<ReferenceChildrenLookup> childLookups(List<String> reference) {
     var retval = <ReferenceChildrenLookup>[];
     for (var index = 1; index <= reference.length; index++) {

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -68,7 +68,7 @@ mixin CommentReferable implements Nameable {
         if (result != null) break;
       }
       if (referenceChildren.containsKey(referenceLookup.lookup)) {
-        result = _lookupViaReferenceChildren(referenceLookup, filter);
+        result = lookupViaReferenceChildren(referenceLookup, filter);
         if (result != null) break;
       }
     }
@@ -107,14 +107,14 @@ mixin CommentReferable implements Nameable {
     return recurseChildrenAndFilter(referenceLookup, result, filter);
   }
 
-  CommentReferable _lookupViaReferenceChildren(
+  CommentReferable lookupViaReferenceChildren(
           ReferenceChildrenLookup referenceLookup,
           bool Function(CommentReferable) filter) =>
       recurseChildrenAndFilter(
           referenceLookup, referenceChildren[referenceLookup.lookup], filter);
 
   /// Given a [result] found in an implementation of [lookupViaScope] or
-  /// [_lookupViaReferenceChildren], recurse through children, skipping over
+  /// [lookupViaReferenceChildren], recurse through children, skipping over
   /// results that do not match the filter.
   CommentReferable recurseChildrenAndFilter(
       ReferenceChildrenLookup referenceLookup,
@@ -137,11 +137,13 @@ mixin CommentReferable implements Nameable {
   /// A list of lookups that should be attempted on children based on
   /// [reference].  This allows us to deal with libraries that may have
   /// separators in them. [referenceBy] stops at the first one found.
-  Iterable<ReferenceChildrenLookup> childLookups(List<String> reference) sync* {
+  Iterable<ReferenceChildrenLookup> childLookups(List<String> reference) {
+    var retval = <ReferenceChildrenLookup>[];
     for (var index = 1; index <= reference.length; index++) {
-      yield ReferenceChildrenLookup(
-          reference.sublist(0, index).join('.'), reference.sublist(index));
+      retval.add(ReferenceChildrenLookup(
+          reference.sublist(0, index).join('.'), reference.sublist(index)));
     }
+    return retval;
   }
 
   /// Map of name to the elements that are a member of [this], but

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -137,15 +137,7 @@ class Constructor extends ModelElement
               ModelElement.fromElement(paramElement.field, packageGraph);
           _referenceChildren[paramElement.name] = fieldFormal;
         } else {
-          var constructorName = element.name;
-          if (constructorName == '') {
-            constructorName = enclosingElement.name;
-          }
-          if (constructorName == param.name) {
-            // Force users to specify a parameter explicitly in this case.
-            _referenceChildren['$constructorName.${param.name}'] = param;
-          }
-          // Allow fallback handling in [Container] to handle other cases.
+          _referenceChildren[param.name] = param;
         }
       }
       _referenceChildren

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -127,20 +127,10 @@ class Method extends ModelElement
   Map<String, CommentReferable> _referenceChildren;
   @override
   Map<String, CommentReferable> get referenceChildren {
-    if (_referenceChildren == null) {
-      _referenceChildren = {};
-      _referenceChildren
-          .addEntries(typeParameters.map((p) => MapEntry(p.name, p)));
-      _referenceChildren.addEntries(allParameters.expand((p) {
-        if (p.name == name) {
-          // Force explicit references to parameters named the same as
-          // the method.
-          return [MapEntry('$name.${p.name}', p)];
-        }
-        // Allow fallback handling in [Container] to deal with other cases.
-        return [];
-      }));
-    }
+    _referenceChildren ??= Map.fromEntries([
+      ...typeParameters.map((p) => MapEntry(p.name, p)),
+      ...allParameters.map((p) => MapEntry(p.name, p)),
+    ]);
     return _referenceChildren;
   }
 }

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1253,3 +1253,32 @@ abstract class IntermediateAbstract extends Object {
 
 /// This should inherit [==] from [IntermediateAbstract].
 class IntermediateAbstractSubclass extends IntermediateAbstract {}
+
+
+/// Test parameter comment resolution in factory constructors and methods.
+class FactoryConstructorThings {
+  bool aName;
+  int anotherName;
+  String yetAnotherName;
+  final List<String> initViaFieldFormal;
+
+  FactoryConstructorThings(this.initViaFieldFormal);
+
+  factory FactoryConstructorThings.anotherName({
+    bool aName,
+    List<int> anotherName,
+    int anotherDifferentName,
+    String differentName,
+  }) {
+    return null;
+  }
+
+  factory FactoryConstructorThings.anotherConstructor({
+    bool anotherName,
+    bool redHerring,
+  }) {
+    return null;
+  }
+
+  void aMethod(bool yetAnotherName) {}
+}


### PR DESCRIPTION
Some leftovers from before I implemented field formal parameters were causing failures in some cases for Flutter.  Fix that, get rid of another generator that is causing debugging problems, and add tests.

166 flutter unresolved doc references -> 77 with this change.