### PR TITLE
Parameterized type hierarchy change

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -235,13 +235,7 @@ mixin Aliased implements ElementType {
           .map((f) => ElementType.from(f, library, packageGraph))
           .toList(growable: false);
 
-  Iterable<ElementType> _typeArguments;
-  @override
-  Iterable<ElementType> get typeArguments =>
-      _typeArguments ??= (type as ParameterizedType)
-          .typeArguments
-          .map((f) => ElementType.from(f, library, packageGraph))
-          .toList(growable: false);
+
 }
 
 class AliasedElementType extends ParameterizedElementType with Aliased {
@@ -251,6 +245,9 @@ class AliasedElementType extends ParameterizedElementType with Aliased {
     assert(type.aliasElement != null);
   }
 
+  @override
+  ParameterizedType get type;
+
   /// Parameters, if available, for the underlying typedef.
   List<Parameter> get aliasedParameters =>
       modelElement.isCallable ? modelElement.parameters : [];
@@ -258,6 +255,13 @@ class AliasedElementType extends ParameterizedElementType with Aliased {
   @override
   ElementTypeRenderer<AliasedElementType> get _renderer =>
       packageGraph.rendererFactory.aliasedElementTypeRenderer;
+
+  Iterable<ElementType> _typeArguments;
+  @override
+  Iterable<ElementType> get typeArguments =>
+      _typeArguments ??= type.typeArguments
+      .map((f) => ElementType.from(f, library, packageGraph))
+      .toList(growable: false);
 }
 
 class TypeParameterElementType extends DefinedElementType {

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -253,13 +253,6 @@ class AliasedElementType extends ParameterizedElementType with Aliased {
   @override
   ElementTypeRenderer<AliasedElementType> get _renderer =>
       packageGraph.rendererFactory.aliasedElementTypeRenderer;
-
-  Iterable<ElementType> _typeArguments;
-  @override
-  Iterable<ElementType> get typeArguments =>
-      _typeArguments ??= type.typeArguments
-          .map((f) => ElementType.from(f, library, packageGraph))
-          .toList(growable: false);
 }
 
 class TypeParameterElementType extends DefinedElementType {

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -234,8 +234,6 @@ mixin Aliased implements ElementType {
       _aliasArguments ??= type.aliasArguments
           .map((f) => ElementType.from(f, library, packageGraph))
           .toList(growable: false);
-
-
 }
 
 class AliasedElementType extends ParameterizedElementType with Aliased {
@@ -260,8 +258,8 @@ class AliasedElementType extends ParameterizedElementType with Aliased {
   @override
   Iterable<ElementType> get typeArguments =>
       _typeArguments ??= type.typeArguments
-      .map((f) => ElementType.from(f, library, packageGraph))
-      .toList(growable: false);
+          .map((f) => ElementType.from(f, library, packageGraph))
+          .toList(growable: false);
 }
 
 class TypeParameterElementType extends DefinedElementType {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4554,9 +4554,9 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           oldgeneric.modelType.linkedName,
           isIn([
+            'T Function<span class="signature">(<span class="parameter" id="GenericTypedef-param-input"><span class="type-annotation">T</span> <span class="parameter-name">input</span></span>)</span>',
+            // Remove following after analyzer 2.0.0
             'T Function<span class="signature">(<span class="parameter" id="param-input"><span class="type-annotation">T</span> <span class="parameter-name">input</span></span>)</span>',
-            // Remove below option after analyzer 1.6.0.
-            'Function(<span class=\"parameter\" id=\"GenericTypedef-param-input\"><span class=\"type-annotation\">T</span></span>) → T'
           ]));
       expect(
           generic.modelType.linkedName,

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4068,6 +4068,7 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     TopLevelVariable nodocGetter, nodocSetter;
     TopLevelVariable complicatedReturn;
     TopLevelVariable meaningOfLife, importantComputations;
+    TopLevelVariable genericTypedefCombo;
 
     setUpAll(() {
       v = exLibrary.properties.firstWhere((p) => p.name == 'number');
@@ -4090,6 +4091,19 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
           fakeLibrary.properties.firstWhere((p) => p.name == 'setAndGet');
       mapWithDynamicKeys = fakeLibrary.properties
           .firstWhere((p) => p.name == 'mapWithDynamicKeys');
+      genericTypedefCombo = fakeLibrary.properties
+          .firstWhere((p) => p.name == 'genericTypedefCombo');
+    });
+
+    test(
+        'Verify that combos with a generic typedef modelType can render correctly',
+        () {
+      // TODO(jcollins-g): After analyzer 2.0.0, this can be `isEmpty`.
+      expect(genericTypedefCombo.modelType.typeArguments, isNotNull);
+      expect(
+          genericTypedefCombo.modelType.linkedName,
+          equals(
+              '<a href=\"%%__HTMLBASE_dartdoc_internal__%%fake/NewGenericTypedef.html\">NewGenericTypedef</a>'));
     });
 
     test('Verify that final and late show up (or not) appropriately', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -301,6 +301,9 @@ typedef T GenericTypedef<T>(T input);
 /// A typedef with the new style generic function syntax.
 typedef NewGenericTypedef<T> = List<S> Function<S>(T, int, bool);
 
+/// A top level variable with a generic typedef type.
+NewGenericTypedef genericTypedefCombo;
+
 /// A complicated type parameter to ATypeTakingClass.
 ATypeTakingClass<String Function(int)> get complicatedReturn => null;
 


### PR DESCRIPTION
This fixes an issue blocking https://dart-review.googlesource.com/c/sdk/+/185903.  Dartdoc was still trying to cast a type where it shouldn't.  Also add some test coverage as besides building the SDK this case was uncovered.