### PR TITLE
Warn about a failed snapshot

### DIFF
--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -191,7 +191,9 @@ class ToolRunner {
           toolName, toolDefinition, envWithInput, toolErrorCallback);
     }
 
-    var toolStateForArgs = await toolDefinition.toolStateForArgs(argsWithInput);
+    var toolStateForArgs = await toolDefinition.toolStateForArgs(
+        toolName, argsWithInput,
+        toolErrorCallback: toolErrorCallback);
     var commandPath = toolStateForArgs.commandPath;
     argsWithInput = toolStateForArgs.args;
     var callCompleter = toolStateForArgs.onProcessComplete;


### PR DESCRIPTION
Previously, if a snapshot was attempted and failed, the failure was swallowed silently. This pushes `toolErrorCallback` through the chain so it can be used in this failure case.