### PR TITLE
Revert "Pin the sdk analyzer to work around dart-lang/sdk#46475 (#2708)"

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -478,7 +478,6 @@ Future<String> createSdkDartdoc() async {
   var dartdocSdk = Directory.systemTemp.createTempSync('dartdoc-sdk');
   await launcher
       .runStreamed('git', ['clone', Directory.current.path, dartdocSdk.path]);
-  // TODO(jcollins-g): remove pin after dart-lang/sdk#46475 is resolved.
   await launcher.runStreamed('git', ['checkout'],
       workingDirectory: dartdocSdk.path);
 
@@ -487,16 +486,11 @@ Future<String> createSdkDartdoc() async {
     'clone',
     '--branch',
     'master',
-    // TODO(jcollins-g): remove after removing pin, below.
-    //'--depth',
-    //'1',
+    '--depth',
+    '1',
     'https://dart.googlesource.com/sdk.git',
     sdkClone.path
   ]);
-  // TODO(jcollins-g): remove pin after dart-lang/sdk#46475 is resolved.
-  await launcher.runStreamed(
-      'git', ['checkout', '253764ebbb67669773f3e239f8c6211ebc74e19d'],
-      workingDirectory: sdkClone.path);
   var dartdocPubspec = File(path.join(dartdocSdk.path, 'pubspec.yaml'));
   var pubspecLines = await dartdocPubspec.readAsLines();
   var pubspecLinesFiltered = <String>[];


### PR DESCRIPTION
Since the issue dart-lang/sdk#46475 was resolved at head, we no longer need the pin introduced by #2708.