### PR TITLE
Fix tests for new flutter tooling change and Dart cmd line change

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -230,9 +230,9 @@ class ToolConfiguration {
         return isDartCommand;
       }
 
-      var executableRelatvePath = command.removeAt(0);
+      var executableRelativePath = command.removeAt(0);
       var executable = pathContext.canonicalize(
-          pathContext.join(canonicalYamlPath, executableRelatvePath));
+          pathContext.join(canonicalYamlPath, executableRelativePath));
       validateExecutable(executable);
       if (setupCommand != null) {
         var setupExecutableRelativePath = setupCommand.removeAt(0);

--- a/test/tool_runner_test.dart
+++ b/test/tool_runner_test.dart
@@ -15,6 +15,7 @@ import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
 final Directory _testPackageDir = Directory('testing/test_package');
+final Directory _toolExecutableDir = Directory('testing/tool_executables');
 
 void main() {
   ToolConfiguration toolMap;
@@ -50,10 +51,9 @@ void main() {
     }
     expect(result?.exitCode, equals(0));
     setupFile = File(path.join(tempDir.path, 'setup.stamp'));
-    // We use the Dart executable for our "non-dart" tool
-    // test, because it's the only executable that we know the
-    // exact location of that works on all platforms.
-    var nonDartExecutable = Platform.resolvedExecutable;
+    var nonDartName = Platform.isWindows ? 'non_dart.bat' : 'non_dart.sh';
+    var nonDartExecutable =
+        path.join(_toolExecutableDir.absolute.path, nonDartName);
     // Have to replace backslashes on Windows with double-backslashes, to
     // escape them for YAML parser.
     var yamlMap = '''
@@ -153,7 +153,7 @@ echo:
         toolErrorCallback: errorCallback,
       );
       expect(errors, isEmpty);
-      expect(result, isEmpty); // Output is on stderr.
+      expect(result, startsWith('this is not dart'));
     });
     test('can invoke a pre-snapshotted tool', () async {
       var result = await runner.run(

--- a/testing/tool_executables/non_dart.bat
+++ b/testing/tool_executables/non_dart.bat
@@ -1,0 +1,1 @@
+echo this is not dart

--- a/testing/tool_executables/non_dart.bat
+++ b/testing/tool_executables/non_dart.bat
@@ -1,1 +1,1 @@
-echo this is not dart
+@echo this is not dart

--- a/testing/tool_executables/non_dart.sh
+++ b/testing/tool_executables/non_dart.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo this is not dart

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -914,11 +914,6 @@ Future<List<Map>> _buildFlutterDocs(
     ['get'],
     workingDirectory: path.join(flutterPath, 'dev', 'tools'),
   );
-  await flutterRepo.launcher.runStreamed(
-    flutterRepo.cachePub,
-    ['get'],
-    workingDirectory: path.join(flutterPath, 'dev', 'snippets'),
-  );
   // TODO(jcollins-g): flutter's dart SDK pub tries to precompile the universe
   // when using -spath.  Why?
   await flutterRepo.launcher.runStreamed(flutterRepo.cachePub,

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -914,6 +914,10 @@ Future<List<Map>> _buildFlutterDocs(
     ['get'],
     workingDirectory: path.join(flutterPath, 'dev', 'tools'),
   );
+  await flutterRepo.launcher.runStreamed(
+    flutterRepo.cachePub,
+    ['global', 'activate', 'snippets'],
+  );
   // TODO(jcollins-g): flutter's dart SDK pub tries to precompile the universe
   // when using -spath.  Why?
   await flutterRepo.launcher.runStreamed(flutterRepo.cachePub,


### PR DESCRIPTION
This fixes some problems blocking tests at head.  Some underlying change in the dart command line tool means we no longer can fake a "non-dart" execution run in the same way, and snippets have moved to a published package in Flutter.