### PR TITLE
Add a blurb to the README about requiring analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Run `pub global activate dartdoc` to install the latest version of dartdoc compa
 
 ## Generating docs
 
-Run `dartdoc` from the root directory of a package.  Here is an example of dartdoc documenting itself:
+Run `dartdoc` from the root directory of a package.  Your package must analyze without errors
+with `dart analyze` or `flutter analyze` as appropriate.  Here is an example of dartdoc documenting
+itself:
 
 ```
 $ dartdoc


### PR DESCRIPTION
Per #2722, add a blurb to the README indicating that we require a package to analyze without errors before generating documentation.