### PR TITLE
Allow comment references on generic typedefs

### DIFF
--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -71,8 +71,12 @@ class Typedef extends ModelElement
   Map<String, CommentReferable> get referenceChildren {
     if (_referenceChildren == null) {
       _referenceChildren = {};
-      _referenceChildren
-          .addEntriesIfAbsent(parameters.explicitOnCollisionWith(this));
+
+      // Only consider parameters if this is a function typedef.
+      if (isCallable) {
+        _referenceChildren
+            .addEntriesIfAbsent(parameters.explicitOnCollisionWith(this));
+      }
       _referenceChildren
           .addEntriesIfAbsent(typeParameters.explicitOnCollisionWith(this));
     }

--- a/testing/test_package/lib/features/generalized_typedefs.dart
+++ b/testing/test_package/lib/features/generalized_typedefs.dart
@@ -10,6 +10,8 @@ library generalized_typedefs;
 
 typedef T0 = void;
 typedef T1 = Function;
+
+/// [List], [String]
 typedef T2<X> = List<X>;
 typedef T3<X, Y> = Map<X, Y>;
 typedef T4 = void Function();


### PR DESCRIPTION
This fixes #2755.