### PR TITLE
Allow embedded type parameters in references

### DIFF
--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -93,7 +93,7 @@ class CommentReferenceParser {
   /// ```text
   ///   <rawCommentReference> ::= <prefix>?<commentReference><suffix>?
   ///
-  ///   <commentReference> ::= (<packageName> '.')? (<libraryName> '.')? <dartdocIdentifier> <typeParameters> ('.' <identifier> <typeParameters>)*
+  ///   <commentReference> ::= (<packageName> '.')? (<libraryName> '.')? <dartdocIdentifier> <typeArguments> ('.' <identifier> <typeArguments>)*
   /// ```
   List<CommentReferenceNode> _parseRawCommentReference() {
     var children = <CommentReferenceNode>[];
@@ -121,16 +121,16 @@ class CommentReferenceParser {
       } else if (identifierResult.type ==
           _IdentifierResultType.parsedIdentifier) {
         children.add(identifierResult.node);
-        var typeParametersResult = _parseTypeParameters();
-        if (typeParametersResult.type == _TypeParametersResultType.endOfFile) {
+        var typeVariablesResult = _parseTypeVariables();
+        if (typeVariablesResult.type == _TypeVariablesResultType.endOfFile) {
           break;
-        } else if (typeParametersResult.type ==
-            _TypeParametersResultType.notTypeParameters) {
+        } else if (typeVariablesResult.type ==
+            _TypeVariablesResultType.notTypeVariables) {
           // Do nothing, _index has not moved.
           ;
-        } else if (typeParametersResult.type ==
-            _TypeParametersResultType.parsedTypeParameters) {
-          children.add(typeParametersResult.node);
+        } else if (typeVariablesResult.type ==
+            _TypeVariablesResultType.parsedTypeVariables) {
+          children.add(typeVariablesResult.node);
         }
       }
       if (_atEnd || _thisChar != $dot) {
@@ -247,20 +247,20 @@ class CommentReferenceParser {
         IdentifierNode(codeRef.substring(startIndex, _index)));
   }
 
-  /// Parse a list of type parameters.
+  /// Parse a list of type variables (arguments or parameters).
   ///
   /// Dartdoc isolates these where present and potentially valid, but we don't
   /// break them down.
-  _TypeParametersParseResult _parseTypeParameters() {
+  _TypeVariablesParseResult _parseTypeVariables() {
     if (_atEnd) {
-      return _TypeParametersParseResult.endOfFile;
+      return _TypeVariablesParseResult.endOfFile;
     }
     var startIndex = _index;
     if (_matchBraces($lt, $gt)) {
-      return _TypeParametersParseResult.ok(
-          TypeParametersNode(codeRef.substring(startIndex + 1, _index - 1)));
+      return _TypeVariablesParseResult.ok(
+          TypeVariablesNode(codeRef.substring(startIndex + 1, _index - 1)));
     }
-    return _TypeParametersParseResult.notIdentifier;
+    return _TypeVariablesParseResult.notIdentifier;
   }
 
   static const _callableHintSuffix = '()';
@@ -421,30 +421,30 @@ class _IdentifierParseResult {
       _IdentifierParseResult._(_IdentifierResultType.notIdentifier, null);
 }
 
-enum _TypeParametersResultType {
+enum _TypeVariablesResultType {
   endOfFile, // Found end of file instead of the beginning of a list of type
-  // parameters.
-  notTypeParameters, // Found something, but it isn't type parameters.
-  parsedTypeParameters, // Found type parameters.
+  // variables.
+  notTypeVariables, // Found something, but it isn't type variables.
+  parsedTypeVariables, // Found type variables.
 }
 
-class _TypeParametersParseResult {
-  final _TypeParametersResultType type;
+class _TypeVariablesParseResult {
+  final _TypeVariablesResultType type;
 
-  final TypeParametersNode node;
+  final TypeVariablesNode node;
 
-  const _TypeParametersParseResult._(this.type, this.node);
+  const _TypeVariablesParseResult._(this.type, this.node);
 
-  factory _TypeParametersParseResult.ok(TypeParametersNode node) =>
-      _TypeParametersParseResult._(
-          _TypeParametersResultType.parsedTypeParameters, node);
+  factory _TypeVariablesParseResult.ok(TypeVariablesNode node) =>
+      _TypeVariablesParseResult._(
+          _TypeVariablesResultType.parsedTypeVariables, node);
 
-  static const _TypeParametersParseResult endOfFile =
-      _TypeParametersParseResult._(_TypeParametersResultType.endOfFile, null);
+  static const _TypeVariablesParseResult endOfFile =
+      _TypeVariablesParseResult._(_TypeVariablesResultType.endOfFile, null);
 
-  static const _TypeParametersParseResult notIdentifier =
-      _TypeParametersParseResult._(
-          _TypeParametersResultType.notTypeParameters, null);
+  static const _TypeVariablesParseResult notIdentifier =
+      _TypeVariablesParseResult._(
+          _TypeVariablesResultType.notTypeVariables, null);
 }
 
 enum _SuffixResultType {
@@ -512,18 +512,18 @@ class IdentifierNode extends CommentReferenceNode {
   String toString() => 'Identifier["$text"]';
 }
 
-/// Represents one or more type parameters, may be
+/// Represents one or more type variables, may be
 /// comma separated.
-class TypeParametersNode extends CommentReferenceNode {
+class TypeVariablesNode extends CommentReferenceNode {
   @override
 
   /// Note that this will contain commas, spaces, and other text, as
-  /// generally type parameters are a form of junk that comment references
+  /// generally type variables are a form of junk that comment references
   /// should ignore.
   final String text;
 
-  TypeParametersNode(this.text);
+  TypeVariablesNode(this.text);
 
   @override
-  String toString() => 'TypeParametersNode["$text"]';
+  String toString() => 'TypeVariablesNode["$text"]';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: ^2.1.0
+  analyzer: ^2.2.0
   args: ^2.0.0
   charcode: ^1.2.0
   collection: ^1.2.0

--- a/test/comment_referable/parser_test.dart
+++ b/test/comment_referable/parser_test.dart
@@ -81,6 +81,16 @@ void main() {
           ['ThisThingy', '[]', 'parameter']);
     });
 
+    test('Check that embedded types within tearoff-like constructs parse', () {
+      expectParseEquivalent('this<stuff>.isValid', ['this', 'isValid']);
+      expectParseEquivalent('this<stuff<that<is, real>, complicated>>.isValid',
+          ['this', 'isValid']);
+      expectParseError('this<stuff.isntValid');
+      expectParseError('this<stuff>, notBeingValid>.isntValid');
+      expectParseError('(AndThisMayBeValidDart.butIt).isntValidInReferences');
+      expectParseError('<NotActually>.valid');
+    });
+
     test('Basic negative tests', () {
       expectParseError(r'.');
       expectParseError(r'');

--- a/test/comment_referable/parser_test.dart
+++ b/test/comment_referable/parser_test.dart
@@ -83,6 +83,8 @@ void main() {
 
     test('Check that embedded types within tearoff-like constructs parse', () {
       expectParseEquivalent('this<stuff>.isValid', ['this', 'isValid']);
+      expectParseEquivalent(
+          'this<stuff, is, also>.isValid', ['this', 'isValid']);
       expectParseEquivalent('this<stuff<that<is, real>, complicated>>.isValid',
           ['this', 'isValid']);
       expectParseError('this<stuff.isntValid');

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -216,8 +216,17 @@ void main() {
       });
 
       test('negative tests', () {
+        // Mixins do not have constructors.
         expect(referenceLookup(constructorTearoffs, 'M.new'),
             equals(MatchingLinkResult(null)));
+        // These things aren't expressions, parentheses are still illegal.
+        expect(referenceLookup(constructorTearoffs, '(C).new'),
+            equals(MatchingLinkResult(null)));
+
+        // A bare new will still not work to reference constructors.
+        // TODO(jcollins-g): reconsider this if we remove "new" as a hint.
+        expect(referenceLookup(A, 'new'), equals(MatchingLinkResult(null)));
+        expect(referenceLookup(At, 'new'), equals(MatchingLinkResult(null)));
       });
     }, skip: !_constructorTearoffsAllowed.allows(utils.platformVersion));
   });

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -203,6 +203,22 @@ void main() {
         expect(referenceLookup(constructorTearoffs, 'Ft.new'),
             equals(MatchingLinkResult(Fnew)));
       });
+
+      test('we can use (ignored) type parameters in references', () {
+        expect(referenceLookup(E, 'D<String>.new'),
+            equals(MatchingLinkResult(Dnew)));
+        expect(referenceLookup(constructorTearoffs, 'F<T>.new'),
+            equals(MatchingLinkResult(Fnew)));
+        expect(
+            referenceLookup(
+                constructorTearoffs, 'F<InvalidThings, DoNotMatterHere>.new'),
+            equals(MatchingLinkResult(Fnew)));
+      });
+
+      test('negative tests', () {
+        expect(referenceLookup(constructorTearoffs, 'M.new'),
+            equals(MatchingLinkResult(null)));
+      });
     }, skip: !_constructorTearoffsAllowed.allows(utils.platformVersion));
   });
 


### PR DESCRIPTION
Continues work for #2655.

Given that type parameters have more interesting uses with tearoffs now, add the capacity to embed (and ignore) type parameters inside comment references.  They are ignored because a single reference can still only point to a single page.  