### PR TITLE
Add testing for constructor tearoffs constant rendering.

### DIFF
--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -228,6 +228,52 @@ void main() {
         expect(referenceLookup(A, 'new'), equals(MatchingLinkResult(null)));
         expect(referenceLookup(At, 'new'), equals(MatchingLinkResult(null)));
       });
+
+      test('constant rendering', () {
+        TopLevelVariable aFunc,
+            aFuncParams,
+            aTearOffDefaultConstructor,
+            aTearOffNonDefaultConstructor,
+            aTearOffNonDefaultConstructorInt,
+            aTearOffDefaultConstructorArgs;
+        TopLevelVariable aTearOffDefaultConstructorTypedef,
+            aTearOffDefaultConstructorArgsTypedef;
+        aFunc =
+            constructorTearoffs.constants.firstWhere((c) => c.name == 'aFunc');
+        aFuncParams = constructorTearoffs.constants
+            .firstWhere((c) => c.name == 'aFuncParams');
+        aTearOffDefaultConstructor = constructorTearoffs.constants
+            .firstWhere((c) => c.name == 'aTearOffDefaultConstructor');
+        aTearOffNonDefaultConstructor = constructorTearoffs.constants
+            .firstWhere((c) => c.name == 'aTearOffNonDefaultConstructor');
+        aTearOffNonDefaultConstructorInt = constructorTearoffs.constants
+            .firstWhere((c) => c.name == 'aTearOffNonDefaultConstructorInt');
+        aTearOffDefaultConstructorArgs = constructorTearoffs.constants
+            .firstWhere((c) => c.name == 'aTearOffDefaultConstructorArgs');
+        aTearOffDefaultConstructorTypedef = constructorTearoffs.constants
+            .firstWhere((c) => c.name == 'aTearOffDefaultConstructorTypedef');
+        aTearOffDefaultConstructorArgsTypedef = constructorTearoffs.constants
+            .firstWhere(
+                (c) => c.name == 'aTearOffDefaultConstructorArgsTypedef');
+
+        expect(aFunc.constantValue, equals('func'));
+        expect(aFuncParams.constantValue, equals('funcTypeParams'));
+        // Does not work @ analyzer 2.2
+        //expect(aFuncWithArgs.constantValue, equals('funcTypeParams&lt;String, int&gt;'));
+
+        expect(aTearOffDefaultConstructor.constantValue, equals('F.new'));
+        expect(aTearOffNonDefaultConstructor.constantValue,
+            equals('F.alternative'));
+        expect(aTearOffNonDefaultConstructorInt.constantValue,
+            equals('F&lt;int&gt;.alternative'));
+        expect(aTearOffDefaultConstructorArgs.constantValue,
+            equals('F&lt;String&gt;.new'));
+
+        expect(aTearOffDefaultConstructorTypedef.constantValue,
+            equals('Fstring.new'));
+        expect(aTearOffDefaultConstructorArgsTypedef.constantValue,
+            equals('Ft&lt;String&gt;.new'));
+      });
     }, skip: !_constructorTearoffsAllowed.allows(utils.platformVersion));
   });
 

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -236,8 +236,7 @@ void main() {
             aTearOffNonDefaultConstructor,
             aTearOffNonDefaultConstructorInt,
             aTearOffDefaultConstructorArgs;
-        TopLevelVariable aTearOffDefaultConstructorTypedef,
-            aTearOffDefaultConstructorArgsTypedef;
+        TopLevelVariable aTearOffDefaultConstructorTypedef;
         aFunc =
             constructorTearoffs.constants.firstWhere((c) => c.name == 'aFunc');
         aFuncParams = constructorTearoffs.constants
@@ -252,9 +251,6 @@ void main() {
             .firstWhere((c) => c.name == 'aTearOffDefaultConstructorArgs');
         aTearOffDefaultConstructorTypedef = constructorTearoffs.constants
             .firstWhere((c) => c.name == 'aTearOffDefaultConstructorTypedef');
-        aTearOffDefaultConstructorArgsTypedef = constructorTearoffs.constants
-            .firstWhere(
-                (c) => c.name == 'aTearOffDefaultConstructorArgsTypedef');
 
         expect(aFunc.constantValue, equals('func'));
         expect(aFuncParams.constantValue, equals('funcTypeParams'));
@@ -271,8 +267,9 @@ void main() {
 
         expect(aTearOffDefaultConstructorTypedef.constantValue,
             equals('Fstring.new'));
-        expect(aTearOffDefaultConstructorArgsTypedef.constantValue,
-            equals('Ft&lt;String&gt;.new'));
+        // Does not work @ analyzer 2.2
+        //expect(aTearOffDefaultConstructorArgsTypedef.constantValue,
+        //    equals('Ft&lt;String&gt;.new'));
       });
     }, skip: !_constructorTearoffsAllowed.allows(utils.platformVersion));
   });

--- a/testing/test_package_experiments/lib/constructor_tearoffs.dart
+++ b/testing/test_package_experiments/lib/constructor_tearoffs.dart
@@ -46,6 +46,8 @@ class F<T> {
   F() {
     print('I too am a valid constructor invocation with this feature.');
   }
+
+  F.alternative() {}
 }
 
 typedef Ft = F;
@@ -59,3 +61,19 @@ typedef NotAClass = Function;
 /// Mixins don't have constructors either, so disallow `M.new`.
 mixin M<T> on C {
 }
+
+void func() {}
+void funcTypeParams<T extends String, U extends num>(T something, U different) {}
+
+const aFunc = func;
+const aFuncParams = funcTypeParams;
+// TODO(jcollins-g): does not work @ analyzer 2.2
+//const aFuncWithArgs = funcTypeParams<String, int>;
+
+const aTearOffDefaultConstructor = F.new;
+const aTearOffNonDefaultConstructor = F.alternative;
+const aTearOffNonDefaultConstructorInt = F<int>.alternative;
+const aTearOffDefaultConstructorArgs = F<String>.new;
+
+const aTearOffDefaultConstructorTypedef = Fstring.new;
+const aTearOffDefaultConstructorArgsTypedef = Ft<String>.new;

--- a/testing/test_package_experiments/lib/constructor_tearoffs.dart
+++ b/testing/test_package_experiments/lib/constructor_tearoffs.dart
@@ -76,4 +76,6 @@ const aTearOffNonDefaultConstructorInt = F<int>.alternative;
 const aTearOffDefaultConstructorArgs = F<String>.new;
 
 const aTearOffDefaultConstructorTypedef = Fstring.new;
-const aTearOffDefaultConstructorArgsTypedef = Ft<String>.new;
+
+// TODO(jcollins-g): does not work @ analyzer 2.2
+//const aTearOffDefaultConstructorArgsTypedef = Ft<String>.new;


### PR DESCRIPTION
Fixes #2655.

It looks like constant rendering is at least of similar quality to other features as-is for constructor tearoffs.  There is one aspect of passing arguments that does not work yet but may work soon with a newer analyzer.

This is the last bit of planned work for constructor tearoffs for dartdoc, so marking it as fixing the issue.   We will have to maintain this feature as the analyzer implementation changes.   We also may yet discover more work and will reopen if need be.