### PR TITLE
Add a message for the package not found case to help users

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
+import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -63,6 +64,10 @@ class PackageGraph with CommentReferable, Nameable {
     var libraryElement = resolvedLibrary.element;
     var packageMeta =
         packageMetaProvider.fromElement(libraryElement, config.sdkDir);
+    if (packageMeta == null) {
+      throw DartdocFailure(packageMetaProvider.getMessageForMissingPackageMeta(
+          libraryElement, config));
+    }
     var lib = Library.fromLibraryResult(
         resolvedLibrary, this, Package.fromPackageMeta(packageMeta, this));
     packageMap[packageMeta.name].libraries.add(lib);

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
-import 'package:dartdoc/dartdoc.dart';
+import 'package:dartdoc/dartdoc.dart' show DartdocFailure;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -44,13 +44,14 @@ void main() {
       sdkFolder = utils.writeMockSdkFiles(mockSdk);
 
       packageMetaProvider = PackageMetaProvider(
-        PubPackageMeta.fromElement,
-        PubPackageMeta.fromFilename,
-        PubPackageMeta.fromDir,
-        resourceProvider,
-        sdkFolder,
-        defaultSdk: mockSdk,
-      );
+          PubPackageMeta.fromElement,
+          PubPackageMeta.fromFilename,
+          PubPackageMeta.fromDir,
+          resourceProvider,
+          sdkFolder,
+          defaultSdk: mockSdk,
+          messageForMissingPackageMeta:
+              PubPackageMeta.messageForMissingPackageMeta);
       var optionSet = await DartdocOptionSet.fromOptionGenerators(
           'dartdoc', [createDartdocOptions], packageMetaProvider);
       optionSet.parseArguments([]);

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -93,6 +93,16 @@ void main() {
         packageGraph.libraries.firstWhere((lib) => lib.name == 'base_class');
   });
 
+  group('PackageMeta and PackageGraph integration', () {
+    test('PackageMeta error messages generate correctly', () {
+      var message = packageGraph.packageMetaProvider
+          .getMessageForMissingPackageMeta(
+              fakeLibrary.element, packageGraph.config);
+      expect(message, contains('fake.dart'));
+      expect(message, contains('pub global activate dartdoc'));
+    });
+  });
+
   group('triple-shift', () {
     Library tripleShift;
     Class C, E, F;

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -93,6 +93,7 @@ PackageMetaProvider get testPackageMetaProvider {
     resourceProvider,
     sdkFolder,
     defaultSdk: mockSdk,
+    messageForMissingPackageMeta: PubPackageMeta.messageForMissingPackageMeta,
   );
 }
 


### PR DESCRIPTION
Fixes #2778.

This doesn't correct whatever the underlying issue is (probably some sort of problem where the pub installation of dartdoc gets corrupted after a flutter upgrade in some cases?).  However, it does suggest to the user a way to correct the situation.