### PR TITLE
Fix handling of allowErrorsInPackages

### DIFF
--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -405,7 +405,7 @@ class PackageWarningOptions {
           .forEach((PackageWarning kind) => newOptions.ignore(kind));
     }
     if (allowErrorsInPackages != null &&
-        !allowWarningsInPackages.contains(packageMeta.name)) {
+        !allowErrorsInPackages.contains(packageMeta.name)) {
       PackageWarning.values
           .forEach((PackageWarning kind) => newOptions.ignore(kind));
     }


### PR DESCRIPTION
Presumably there should be a test that fails because of the previous behavior... haven't looked into that.