### PR TITLE
Migrate warnings.dart

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -450,7 +450,7 @@ abstract class DartdocOption<T> {
 
   /// To avoid accessing early, call [add] on the option's parent before
   /// looking up unless this is a [DartdocRootOption].
-  late final DartdocOption parent;
+  late final DartdocOption<dynamic> parent;
 
   /// The [DartdocOptionRoot] containing this object.
   DartdocOptionRoot get root {
@@ -519,6 +519,9 @@ abstract class DartdocOption<T> {
   DartdocOption<dynamic> operator [](String name) {
     return _children[name]!;
   }
+
+  /// Get the immediate child of this node named [name] as a [DartdocOption<U>].
+  DartdocOption<U> getAs<U>(String name) => _children[name] as DartdocOption<U>;
 
   /// Apply the function [visit] to [this] and all children.
   void traverse(void Function(DartdocOption option) visit) {

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -516,7 +516,7 @@ abstract class DartdocOption<T> {
   void addAll(Iterable<DartdocOption> options) => options.forEach(add);
 
   /// Get the immediate child of this node named [name].
-  DartdocOption<dynamic> operator [](String name) {
+  DartdocOption operator [](String name) {
     return _children[name]!;
   }
 

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -100,10 +100,12 @@ class Accessor extends ModelElement implements EnclosedElement {
   }
 
   @override
-  void warn(PackageWarning kind,
-      {String message,
-      Iterable<Locatable> referredFrom,
-      Iterable<String> extendedDebug}) {
+  void warn(
+    PackageWarning kind, {
+    String message,
+    Iterable<Locatable> referredFrom = const [],
+    Iterable<String> extendedDebug = const [],
+  }) {
     enclosingCombo.warn(kind,
         message: message,
         referredFrom: referredFrom,

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -549,12 +549,14 @@ class PackageWarningCounter {
     } else if (warningMode == PackageWarningMode.error) {
       _errorCount += 1;
     }
-    _countedWarnings
-        .putIfAbsent(element.element, () => {})
-        .putIfAbsent(kind, () => {})
-        .add(message);
-    _writeWarning(kind, warningMode, config.verboseWarnings,
-        element.fullyQualifiedName, fullMessage);
+    if (element != null) {
+      _countedWarnings
+          .putIfAbsent(element.element, () => {})
+          .putIfAbsent(kind, () => {})
+          .add(message);
+      _writeWarning(kind, warningMode, config.verboseWarnings,
+          element.fullyQualifiedName, fullMessage);
+    }
   }
 
   @override

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -531,14 +531,15 @@ class PackageWarningCounter {
 
   /// Adds the warning to the counter, and writes out the fullMessage string
   /// if configured to do so.
-  void addWarning(Warnable element, PackageWarning kind, String message,
+  void addWarning(Warnable? element, PackageWarning kind, String message,
       String fullMessage) {
     assert(!hasWarning(element, kind, message));
     // TODO(jcollins-g): Make addWarning not accept nulls for element.
     PackageWarningOptionContext config =
-        element.config ?? packageGraph.defaultPackage.config;
+        element?.config ?? packageGraph.defaultPackage.config;
     PackageWarningMode? warningMode;
-    if (!config.allowNonLocalWarnings && !(element.package.isLocal ?? true)) {
+    var isLocal = element?.package.isLocal ?? true;
+    if (!config.allowNonLocalWarnings && !isLocal) {
       warningMode = PackageWarningMode.ignore;
     } else {
       warningMode = config.packageWarningOptions.getMode(kind);

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:collection';
 
 import 'package:analyzer/dart/element/element.dart';
@@ -14,19 +12,22 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
 
+const _namePlaceholder = '@@name@@';
+
 abstract class PackageWarningOptionContext implements DartdocOptionContextBase {
   bool get allowNonLocalWarnings =>
       optionSet['allowNonLocalWarnings'].valueAt(context);
 
-  // allowWarningsInPackages, ignoreWarningsInPackages, errors, warnings, and ignore
-  // are only used indirectly via the synthetic packageWarningOptions option.
+  // allowWarningsInPackages, ignoreWarningsInPackages, errors, warnings, and
+  // ignore are only used indirectly via the synthetic packageWarningOptions
+  // option.
   PackageWarningOptions get packageWarningOptions =>
       optionSet['packageWarningOptions'].valueAt(context);
 
   bool get verboseWarnings => optionSet['verboseWarnings'].valueAt(context);
 }
 
-Future<List<DartdocOption<Object>>> createPackageWarningOptions(
+Future<List<DartdocOption<Object?>>> createPackageWarningOptions(
   PackageMetaProvider packageMetaProvider,
 ) async {
   var resourceProvider = packageMetaProvider.resourceProvider;
@@ -39,21 +40,21 @@ Future<List<DartdocOption<Object>>> createPackageWarningOptions(
     // for individual packages are command-line only.  This will allow
     // meta-packages like Flutter to control whether warnings are displayed for
     // packages they don't control.
-    DartdocOptionArgOnly<List<String>>(
+    DartdocOptionArgOnly<List<String>?>(
         'allowWarningsInPackages', null, resourceProvider,
         splitCommas: true,
         help:
-            'Package names to display warnings for (ignore all others if set).'),
-    DartdocOptionArgOnly<List<String>>(
+            'Package names to display warnings for (ignore all others if set)'),
+    DartdocOptionArgOnly<List<String>?>(
         'allowErrorsInPackages', null, resourceProvider,
         splitCommas: true,
         help: 'Package names to display errors for (ignore all others if set)'),
-    DartdocOptionArgOnly<List<String>>(
+    DartdocOptionArgOnly<List<String>?>(
         'ignoreWarningsInPackages', null, resourceProvider,
         splitCommas: true,
         help: 'Package names to ignore warnings for.  Takes priority over '
             'allow-warnings-in-packages'),
-    DartdocOptionArgOnly<List<String>>(
+    DartdocOptionArgOnly<List<String>?>(
         'ignoreErrorsInPackages', null, resourceProvider,
         splitCommas: true,
         help: 'Package names to ignore errors for. Takes priority over '
@@ -61,40 +62,24 @@ Future<List<DartdocOption<Object>>> createPackageWarningOptions(
     // Options for globally enabling/disabling warnings and errors across
     // packages.  Loaded from dartdoc_options.yaml, but command line arguments
     // will override.
-    DartdocOptionArgFile<List<String>>('errors', null, resourceProvider,
+    DartdocOptionArgFile<List<String>?>('errors', null, resourceProvider,
         splitCommas: true,
         help: 'Additional warning names to force as errors.  Specify an empty '
-                'list to force defaults (overriding dartdoc_options.yaml)\nDefaults:\n' +
-            (packageWarningDefinitions.values
-                    .where(
-                        (d) => d.defaultWarningMode == PackageWarningMode.error)
-                    .toList()
-                  ..sort())
-                .map((d) => '   ${d.warningName}: ${d.shortHelp}')
-                .join('\n')),
-    DartdocOptionArgFile<List<String>>('ignore', null, resourceProvider,
+                'list to force defaults (overriding '
+                'dartdoc_options.yaml)\nDefaults:\n' +
+            _warningsListHelpText(PackageWarningMode.error)),
+    DartdocOptionArgFile<List<String>?>('ignore', null, resourceProvider,
         splitCommas: true,
         help: 'Additional warning names to ignore.  Specify an empty list to '
-                'force defaults (overriding dartdoc_options.yaml).\nDefaults:\n' +
-            (packageWarningDefinitions.values
-                    .where((d) =>
-                        d.defaultWarningMode == PackageWarningMode.ignore)
-                    .toList()
-                  ..sort())
-                .map((d) => '   ${d.warningName}: ${d.shortHelp}')
-                .join('\n')),
-    DartdocOptionArgFile<List<String>>('warnings', null, resourceProvider,
+                'force defaults (overriding '
+                'dartdoc_options.yaml).\nDefaults:\n' +
+            _warningsListHelpText(PackageWarningMode.ignore)),
+    DartdocOptionArgFile<List<String>?>('warnings', null, resourceProvider,
         splitCommas: true,
         help:
             'Additional warning names to show as warnings (instead of error or '
                     'ignore, if not warning by default).\nDefaults:\n' +
-                (packageWarningDefinitions.values
-                        .where((d) =>
-                            d.defaultWarningMode == PackageWarningMode.warn)
-                        .toList()
-                      ..sort())
-                    .map((d) => '   ${d.warningName}: ${d.shortHelp}')
-                    .join('\n')),
+                _warningsListHelpText(PackageWarningMode.warn)),
     // Synthetic option uses a factory to build a PackageWarningOptions from all the above flags.
     DartdocOptionSyntheticOnly<PackageWarningOptions>(
       'packageWarningOptions',
@@ -105,6 +90,15 @@ Future<List<DartdocOption<Object>>> createPackageWarningOptions(
   ];
 }
 
+String _warningsListHelpText(PackageWarningMode mode) {
+  return (packageWarningDefinitions.values
+          .where((d) => d.defaultWarningMode == mode)
+          .toList()
+        ..sort())
+      .map((d) => '   ${d.warningName}: ${d.shortHelp}')
+      .join('\n');
+}
+
 class PackageWarningDefinition implements Comparable<PackageWarningDefinition> {
   final String warningName;
   final String shortHelp;
@@ -112,10 +106,13 @@ class PackageWarningDefinition implements Comparable<PackageWarningDefinition> {
   final PackageWarning kind;
   final PackageWarningMode defaultWarningMode;
 
-  const PackageWarningDefinition(this.kind, this.warningName, this.shortHelp,
-      {List<String> longHelp, PackageWarningMode defaultWarningMode})
-      : longHelp = longHelp ?? const [],
-        defaultWarningMode = defaultWarningMode ?? PackageWarningMode.warn;
+  const PackageWarningDefinition(
+    this.kind,
+    this.warningName,
+    this.shortHelp, {
+    this.longHelp = const [],
+    this.defaultWarningMode = PackageWarningMode.warn,
+  });
 
   @override
   int compareTo(PackageWarningDefinition other) {
@@ -140,14 +137,16 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
   PackageWarning.ambiguousReexport: PackageWarningDefinition(
       PackageWarning.ambiguousReexport,
       'ambiguous-reexport',
-      'A symbol is exported from private to public in more than one library and dartdoc can not determine which one is canonical',
+      'A symbol is exported from private to public in more than one library '
+          'and dartdoc can not determine which one is canonical',
       longHelp: [
-        "Use {@canonicalFor @@name@@} in the desired library's documentation to resolve",
-        "the ambiguity and/or override dartdoc's decision, or structure your package ",
-        'so the reexport is less ambiguous.  The symbol will still be referenced in ',
-        'all candidates -- this only controls the location where it will be written ',
-        'and which library will be displayed in navigation for the relevant pages.',
-        'The flag --ambiguous-reexport-scorer-min-confidence allows you to set the',
+        "Use {@canonicalFor $_namePlaceholder} in the desired library's",
+        "documentation to resolve the ambiguity and/or override dartdoc's",
+        'decision, or structure your package so the reexport is less',
+        'ambiguous.  The symbol will still be referenced in all candidates --',
+        'this only controls the location where it will be written and which',
+        'library will be displayed in navigation for the relevant pages. The',
+        'flag --ambiguous-reexport-scorer-min-confidence allows you to set the',
         'threshold at which this warning will appear.'
       ]),
   PackageWarning.ignoredCanonicalFor: PackageWarningDefinition(
@@ -176,10 +175,10 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
     'no-documentable-libraries',
     'The package is to be documented but has no Dart libraries to document',
     longHelp: [
-      'Dartdoc could not find any public libraries to document in @@name@@, ',
-      'but documentation was requested.  This might be expected for an ',
-      'asset only package, in which case, disable this warning in your ',
-      'dartdoc_options.yaml file.',
+      'Dartdoc could not find any public libraries to document in',
+      '$_namePlaceholder, but documentation was requested.  This might be',
+      'expected for an asset only package, in which case, disable this',
+      'warning in your dartdoc_options.yaml file.',
     ],
   ),
   PackageWarning.noLibraryLevelDocs: PackageWarningDefinition(
@@ -243,14 +242,15 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
   PackageWarning.duplicateFile: PackageWarningDefinition(
       PackageWarning.duplicateFile,
       'duplicate-file',
-      'Dartdoc is trying to write to a duplicate filename based on the names of Dart symbols.',
+      'Dartdoc is trying to write to a duplicate filename based on the names '
+          'of Dart symbols.',
       longHelp: [
         'Dartdoc generates a path and filename to write to for each symbol.',
-        '@@name@@ conflicts with another symbol in the generated path, and',
-        'therefore can not be written out.  Changing the name, library name, or',
-        'class name (if appropriate) of one of the conflicting items can resolve',
-        "the conflict.   Alternatively, use the @nodoc tag in one symbol's",
-        'documentation comments to hide it.'
+        '$_namePlaceholder conflicts with another symbol in the generated',
+        'path, and therefore can not be written out.  Changing the name,',
+        'library name, or class name (if appropriate) of one of the',
+        'conflicting items can resolve the conflict.   Alternatively, use the',
+        "@nodoc tag in one symbol's documentation comments to hide it."
       ],
       defaultWarningMode: PackageWarningMode.error),
   PackageWarning.missingConstantConstructor: PackageWarningDefinition(
@@ -260,8 +260,8 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
       longHelp: [
         'To resolve a constant into its literal value, Dartdoc relies on the',
         "analyzer to resolve the constructor.  The analyzer didn't provide",
-        'the constructor for @@name@@, which is usually due to an error in the',
-        'code.  Use the analyzer to find missing imports.',
+        'the constructor for $_namePlaceholder, which is usually due to an',
+        'error in the code.  Use the analyzer to find missing imports.',
       ],
       // Defaults to ignore as this doesn't impact the docs severely but is
       // useful for debugging package structure.
@@ -289,10 +289,12 @@ mixin Warnable implements Canonicalization, CommentReferable {
 
   Package get package;
 
-  void warn(PackageWarning kind,
-      {String message,
-      Iterable<Locatable> referredFrom,
-      Iterable<String> extendedDebug}) {
+  void warn(
+    PackageWarning kind, {
+    String? message,
+    Iterable<Locatable> referredFrom = const [],
+    Iterable<String> extendedDebug = const [],
+  }) {
     packageGraph.warnOnElement(this, kind,
         message: message,
         referredFrom: referredFrom,
@@ -354,19 +356,13 @@ class PackageWarningOptions {
     for (var definition in packageWarningDefinitions.values) {
       switch (definition.defaultWarningMode) {
         case PackageWarningMode.warn:
-          {
-            warn(definition.kind);
-          }
+          warn(definition.kind);
           break;
         case PackageWarningMode.error:
-          {
-            error(definition.kind);
-          }
+          error(definition.kind);
           break;
         case PackageWarningMode.ignore:
-          {
-            ignore(definition.kind);
-          }
+          ignore(definition.kind);
           break;
       }
     }
@@ -379,42 +375,55 @@ class PackageWarningOptions {
   ) {
     // First, initialize defaults.
     var newOptions = PackageWarningOptions();
-    var packageMeta = packageMetaProvider.fromDir(dir);
+    var packageMeta = packageMetaProvider.fromDir(dir)!;
 
-    // Interpret errors/warnings/ignore options.  In the event of conflict, warning overrides error and
-    // ignore overrides warning.
-    for (String warningName in option.parent['errors'].valueAt(dir) ?? []) {
-      if (packageWarningsByName[warningName] != null) {
-        newOptions.error(packageWarningsByName[warningName].kind);
+    // Interpret errors/warnings/ignore options.  In the event of conflict,
+    // warning overrides error and ignore overrides warning.
+    var errorsForDir =
+        option.parent.getAs<List<String>?>('errors').valueAt(dir) ?? [];
+    for (var warningName in errorsForDir) {
+      var packageWarnings = packageWarningsByName[warningName];
+      if (packageWarnings != null) {
+        newOptions.error(packageWarnings.kind);
       }
     }
-    for (String warningName in option.parent['warnings'].valueAt(dir) ?? []) {
-      if (packageWarningsByName[warningName] != null) {
-        newOptions.warn(packageWarningsByName[warningName].kind);
+    var warningsForDir =
+        option.parent.getAs<List<String>?>('warnings').valueAt(dir) ?? [];
+    for (var warningName in warningsForDir) {
+      var packageWarnings = packageWarningsByName[warningName];
+      if (packageWarnings != null) {
+        newOptions.warn(packageWarnings.kind);
       }
     }
-    for (String warningName in option.parent['ignore'].valueAt(dir) ?? []) {
-      if (packageWarningsByName[warningName] != null) {
-        newOptions.ignore(packageWarningsByName[warningName].kind);
+    var ignoredForDir =
+        option.parent.getAs<List<String>?>('ignore').valueAt(dir) ?? [];
+    for (var warningName in ignoredForDir) {
+      var packageWarnings = packageWarningsByName[warningName];
+      if (packageWarnings != null) {
+        newOptions.ignore(packageWarnings.kind);
       }
     }
 
     // Check whether warnings are allowed at all in this package.
-    List<String> allowWarningsInPackages =
-        option.parent['allowWarningsInPackages'].valueAt(dir);
-    List<String> allowErrorsInPackages =
-        option.parent['allowErrorsInPackages'].valueAt(dir);
-    List<String> ignoreWarningsInPackages =
-        option.parent['ignoreWarningsInPackages'].valueAt(dir);
-    List<String> ignoreErrorsInPackages =
-        option.parent['ignoreErrorsInPackages'].valueAt(dir);
+    var allowWarningsInPackages = option.parent
+        .getAs<List<String>?>('allowWarningsInPackages')
+        .valueAt(dir);
+    var allowErrorsInPackages = option.parent
+        .getAs<List<String>?>('allowErrorsInPackages')
+        .valueAt(dir);
+    var ignoreWarningsInPackages = option.parent
+        .getAs<List<String>?>('ignoreWarningsInPackages')
+        .valueAt(dir);
+    var ignoreErrorsInPackages = option.parent
+        .getAs<List<String>?>('ignoreErrorsInPackages')
+        .valueAt(dir);
     if (allowWarningsInPackages != null &&
         !allowWarningsInPackages.contains(packageMeta.name)) {
       PackageWarning.values
           .forEach((PackageWarning kind) => newOptions.ignore(kind));
     }
     if (allowErrorsInPackages != null &&
-        !allowWarningsInPackages.contains(packageMeta.name)) {
+        !allowErrorsInPackages.contains(packageMeta.name)) {
       PackageWarning.values
           .forEach((PackageWarning kind) => newOptions.ignore(kind));
     }
@@ -440,7 +449,7 @@ class PackageWarningOptions {
   void error(PackageWarning kind) =>
       warningModes[kind] = PackageWarningMode.error;
 
-  PackageWarningMode getMode(PackageWarning kind) => warningModes[kind];
+  PackageWarningMode? getMode(PackageWarning kind) => warningModes[kind];
 }
 
 class PackageWarningCounter {
@@ -466,13 +475,15 @@ class PackageWarningCounter {
 
   PackageWarningCounter(this.packageGraph);
 
-  /// Actually write out the warning.  Assumes it is already counted with add.
-  void _writeWarning(PackageWarning kind, PackageWarningMode mode,
+  /// Actually write out the warning.
+  ///
+  /// Assumes it is already counted with [addWarning].
+  void _writeWarning(PackageWarning kind, PackageWarningMode? mode,
       bool verboseWarnings, String name, String fullMessage) {
     if (mode == PackageWarningMode.ignore) {
       return;
     }
-    String type;
+    String? type;
     if (mode == PackageWarningMode.error) {
       type = 'error';
     } else if (mode == PackageWarningMode.warn) {
@@ -480,17 +491,16 @@ class PackageWarningCounter {
     }
     if (type != null) {
       var entry = '  $type: $fullMessage';
-      _displayedWarningCounts.putIfAbsent(kind, () => 0);
-      _displayedWarningCounts[kind] += 1;
-      if (_displayedWarningCounts[kind] == 1 &&
+      var displayedWarningCount = _displayedWarningCounts.increment(kind);
+      var packageWarningDefinition = packageWarningDefinitions[kind]!;
+      if (displayedWarningCount == 1 &&
           verboseWarnings &&
-          packageWarningDefinitions[kind].longHelp.isNotEmpty) {
+          packageWarningDefinition.longHelp.isNotEmpty) {
         // First time we've seen this warning.  Give a little extra info.
         final separator = '\n            ';
-        final nameSub = r'@@name@@';
         var verboseOut =
-            '$separator${packageWarningDefinitions[kind].longHelp.join(separator)}'
-                .replaceAll(nameSub, name);
+            '$separator${packageWarningDefinition.longHelp.join(separator)}'
+                .replaceAll(_namePlaceholder, name);
         entry = '$entry$verboseOut';
       }
       assert(entry == entry.trimRight());
@@ -507,8 +517,11 @@ class PackageWarningCounter {
 
   /// Returns `true` if we've already warned for this
   /// combination of [element], [kind], and [message].
-  bool hasWarning(Warnable element, PackageWarning kind, String message) {
-    final warning = _countedWarnings[element?.element];
+  bool hasWarning(Warnable? element, PackageWarning kind, String message) {
+    if (element == null) {
+      return false;
+    }
+    final warning = _countedWarnings[element.element];
     if (warning != null) {
       final messages = warning[kind];
       return messages != null && messages.contains(message);
@@ -523,10 +536,12 @@ class PackageWarningCounter {
     assert(!hasWarning(element, kind, message));
     // TODO(jcollins-g): Make addWarning not accept nulls for element.
     PackageWarningOptionContext config =
-        element?.config ?? packageGraph.defaultPackage.config;
-    var warningMode = config.packageWarningOptions.getMode(kind);
-    if (!config.allowNonLocalWarnings && !(element?.package?.isLocal ?? true)) {
+        element.config ?? packageGraph.defaultPackage.config;
+    PackageWarningMode? warningMode;
+    if (!config.allowNonLocalWarnings && !(element.package.isLocal ?? true)) {
       warningMode = PackageWarningMode.ignore;
+    } else {
+      warningMode = config.packageWarningOptions.getMode(kind);
     }
     if (warningMode == PackageWarningMode.warn) {
       _warningCount += 1;
@@ -534,11 +549,11 @@ class PackageWarningCounter {
       _errorCount += 1;
     }
     _countedWarnings
-        .putIfAbsent(element?.element, () => {})
+        .putIfAbsent(element.element, () => {})
         .putIfAbsent(kind, () => {})
         .add(message);
     _writeWarning(kind, warningMode, config.verboseWarnings,
-        element?.fullyQualifiedName, fullMessage);
+        element.fullyQualifiedName, fullMessage);
   }
 
   @override
@@ -563,8 +578,20 @@ class _JsonWarning extends Jsonable {
   @override
   Map<String, dynamic> toJson() => {
         'type': type,
-        'kind': packageWarningDefinitions[kind].warningName,
+        'kind': packageWarningDefinitions[kind]!.warningName,
         'message': message,
         'text': text
       };
+}
+
+extension on Map<PackageWarning, int> {
+  int increment(PackageWarning kind) {
+    if (this[kind] == null) {
+      this[kind] = 1;
+      return 1;
+    } else {
+      this[kind] = this[kind]! + 1;
+      return this[kind]!;
+    }
+  }
 }


### PR DESCRIPTION
This PR mostly just merges warnings.dart, a straightforward migration.

Additionally:

* Add a `getAs` method to DartdocOption for easy casting.
* Wrap help text to 80 chars.
* Wrap comments to 80 chars.
* Extract the `_namePlaceholder` in help text.