### PR TITLE
Prepare for dartdoc 3.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.1.0
+* This version supports the Dart language feature constructor tearoffs,
+  pending completion by other tools.
+* Allow embedded type parameters in comment references. (#2772)
+* Add testing for constructor tearoff constant rendering.  (#2780)
+* Do not crash on package not found, instead provide a more useful
+  explanation for users. (#2781, #2778)
+* `--allow-warnings-in-packages` no longer also applies to errors.
+  The `--allow-errors-in-packages` flag should now work as intended.
+  (#2785)
+* Some additional deprecations preparing for NNBD. (#2784)
+
 ## 3.0.0
 * BREAKING CHANGE: Refactor of Class, Enum, and Mixin types result in some
   deleted interfaces in templates and a change in class hierarchy. (#2770)

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v3.0.0/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v3.1.0/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.0.0';
+const packageVersion = '3.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,42 +1,42 @@
 name: dartdoc
 # Run `grind build` after updating.
-version: 3.0.0
+version: 3.1.0
 description: A non-interactive HTML documentation generator for Dart source code.
 homepage: https://github.com/dart-lang/dartdoc
 environment:
   sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: ^2.2.0
-  args: ^2.0.0
-  charcode: ^1.2.0
-  collection: ^1.2.0
-  cli_util: ^0.3.0
-  crypto: ^3.0.0
-  glob: ^2.0.0
+  analyzer: ^2.3.0
+  args: ^2.3.0
+  charcode: ^1.3.1
+  collection: ^1.15.0
+  cli_util: ^0.3.3
+  crypto: ^3.0.1
+  glob: ^2.0.1
   html: ^0.15.0
-  logging: ^1.0.0
+  logging: ^1.0.2
   markdown: ^4.0.0
   meta: ^1.7.0
-  package_config: ^2.0.0
-  path: ^1.3.0
-  pub_semver: ^2.0.0
-  source_span: ^1.5.2
-  yaml: ^3.0.0
+  package_config: ^2.0.2
+  path: ^1.8.0
+  pub_semver: ^2.1.0
+  source_span: ^1.8.1
+  yaml: ^3.1.0
 
 dev_dependencies:
-  async: ^2.0.8
-  build: ^2.0.0
-  build_runner: ^2.0.1
-  build_test: ^2.0.0
-  build_version: ^2.0.1
-  code_builder: ^4.0.0
-  coverage: ^1.0.2
-  dart_style: ^2.0.0
-  grinder: ^0.9.0-nullsafety.0
-  http: ^0.13.0
-  pedantic: ^1.11.0
-  test: ^1.3.0
+  async: ^2.8.2
+  build: ^2.1.0
+  build_runner: ^2.1.2
+  build_test: ^2.1.3
+  build_version: ^2.1.0
+  code_builder: ^4.1.0
+  coverage: ^1.0.3
+  dart_style: ^2.1.0
+  grinder: ^0.9.0
+  http: ^0.13.3
+  pedantic: ^1.11.1
+  test: ^1.17.12
 
 executables:
   dartdoc: null


### PR DESCRIPTION
Update changelog and pubspec for dartdoc 3.1.0.

It has been a while since versions were updated for dartdoc's dependencies; also taking the time to do that now.