### PR TITLE
Make a text string more generic to pass head analyzer

### DIFF
--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -571,10 +571,8 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var barTemplateFile = getFile('/project/src/bar.mustache');
     expect(
         () async => await Template.parse(barTemplateFile),
-        throwsA(const TypeMatcher<FileSystemException>().having(
-            (e) => e.message,
-            'message',
-            contains('"${barTemplateFile.path}" does not exist.'))));
+        throwsA(const TypeMatcher<FileSystemException>()
+            .having((e) => e.message, 'message', contains('does not exist.'))));
   });
 
   test('Template parser throws when it cannot read a partial', () async {

--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -578,15 +578,19 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
   test('Template parser throws when it cannot read a partial', () async {
     var barTemplateFile = getFile('/project/src/bar.mustache')
       ..writeAsStringSync('Text {{#foo}}{{>missing.mustache}}{{/foo}}');
-    var missingTemplateFile = getFile('/project/src/missing.mustache');
     expect(
         () async => await Template.parse(barTemplateFile),
-        throwsA(const TypeMatcher<MustachioResolutionError>()
-            .having((e) => e.message, 'message', contains('''
-line 1, column 14 of ${barTemplateFile.path}: FileSystemException (File "${missingTemplateFile.path}" does not exist.) when reading partial:
+        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+                contains('''
+line 1, column 14 of ${barTemplateFile.path}: FileSystemException'''),
+                contains('''does not exist.'''),
+                contains('''when reading partial:
   ╷
 1 │ Text {{#foo}}{{>missing.mustache}}{{/foo}}
   │              ^^^^^^^^^^^^^^^^^^^^^
-'''))));
+''')))));
   });
 }


### PR DESCRIPTION
runtime_renderer_render_test is pretty specific with the error message it requires.  I don't think it needs to be, so make it more generic to allow for a new analyzer version.