### PR TITLE
Remove overlapping imports; bleeding edge SDK warns on these now

### DIFF
--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:dartdoc/src/model/inheriting_container.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 import 'comment_referable.dart';

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dartdoc/src/model/feature.dart';
-import 'package:dartdoc/src/model/inheriting_container.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/special_elements.dart';
 

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
-import 'package:dartdoc/src/model/class.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
-import 'package:dartdoc/src/model/inheriting_container.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:dartdoc/src/special_elements.dart';

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
-import 'package:dartdoc/src/model/library.dart';
 
 import '../../dartdoc.dart';
 

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -12,7 +12,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/dart/ast/utilities.dart';
 import 'package:dartdoc/dartdoc.dart' show DartdocFailure;
-import 'package:dartdoc/src/model/inheriting_container.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;


### PR DESCRIPTION
Without this change, the unused-imports lint is going to start causing dartdoc bot failures.