### PR TITLE
Migrate various util and small libraries

### DIFF
--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 /// Make it possible to load resources from the dartdoc code repository.
 library dartdoc.resource_loader;
 

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 typedef ContainerSidebar = String Function(
@@ -234,7 +235,7 @@ abstract class InheritingContainerTemplateData<T extends InheritingContainer>
 
   @override
   T get self => clazz;
-  String get linkedObjectType => objectType.linkedName;
+  String get linkedObjectType => objectType?.linkedName ?? 'Object';
   @override
   String get title =>
       '${clazz.name} ${clazz.kind} - ${library.name} library - Dart API';
@@ -251,15 +252,15 @@ abstract class InheritingContainerTemplateData<T extends InheritingContainer>
   @override
   String get htmlBase => '../';
 
-  Class get objectType {
+  Class? get objectType {
     if (_objectType != null) {
       return _objectType!;
     }
 
     var dc = _packageGraph.libraries
-        .firstWhere((it) => it.name == 'dart:core', orElse: () => null);
+        .firstWhereOrNull((it) => it.name == 'dart:core');
 
-    return _objectType = dc.getClassByName('Object');
+    return _objectType = dc?.getClassByName('Object');
   }
 }
 

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:dartdoc/src/model/model.dart';
 
 typedef ContainerSidebar = String Function(
@@ -31,7 +29,7 @@ abstract class TemplateData<T extends Documentable> {
 
   List<Documentable> get navLinks;
   List<Container> get navLinksWithGenerics => [];
-  Documentable get parent {
+  Documentable? get parent {
     if (navLinksWithGenerics.isEmpty) {
       return navLinks.isNotEmpty ? navLinks.last : null;
     }
@@ -42,7 +40,7 @@ abstract class TemplateData<T extends Documentable> {
 
   bool get hasHomepage => false;
 
-  String get homepage => null;
+  String? get homepage => null;
 
   String get htmlBase;
   T get self;
@@ -212,10 +210,10 @@ class ClassTemplateData extends InheritingContainerTemplateData<Class> {
 abstract class InheritingContainerTemplateData<T extends InheritingContainer>
     extends TemplateData<T>
     implements TemplateDataWithLibrary<T>, TemplateDataWithContainer<T> {
-  final InheritingContainer clazz;
+  final T clazz;
   @override
   final Library library;
-  Class _objectType;
+  Class? _objectType;
   final LibrarySidebar _sidebarForLibrary;
   final ContainerSidebar _sidebarForContainer;
 
@@ -236,8 +234,7 @@ abstract class InheritingContainerTemplateData<T extends InheritingContainer>
 
   @override
   T get self => clazz;
-  String get linkedObjectType =>
-      objectType == null ? 'Object' : objectType.linkedName;
+  String get linkedObjectType => objectType.linkedName;
   @override
   String get title =>
       '${clazz.name} ${clazz.kind} - ${library.name} library - Dart API';
@@ -256,13 +253,13 @@ abstract class InheritingContainerTemplateData<T extends InheritingContainer>
 
   Class get objectType {
     if (_objectType != null) {
-      return _objectType;
+      return _objectType!;
     }
 
     var dc = _packageGraph.libraries
         .firstWhere((it) => it.name == 'dart:core', orElse: () => null);
 
-    return _objectType = dc?.getClassByName('Object');
+    return _objectType = dc.getClassByName('Object');
   }
 }
 

--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';
@@ -14,12 +12,12 @@ import 'package:package_config/package_config.dart' as package_config;
 /// This provides an abstraction around package_config, which can only work
 /// with the physical file system.
 abstract class PackageConfigProvider {
-  Future<package_config.PackageConfig> findPackageConfig(Folder dir);
+  Future<package_config.PackageConfig?> findPackageConfig(Folder dir);
 }
 
 class PhysicalPackageConfigProvider implements PackageConfigProvider {
   @override
-  Future<package_config.PackageConfig> findPackageConfig(Folder dir) =>
+  Future<package_config.PackageConfig?> findPackageConfig(Folder dir) =>
       package_config.findPackageConfig(io.Directory(dir.path));
 }
 
@@ -35,8 +33,9 @@ class FakePackageConfigProvider implements PackageConfigProvider {
 
   @override
   Future<package_config.PackageConfig> findPackageConfig(Folder dir) async {
-    assert(_packageConfigData[dir.path] != null,
+    var packageConfig = _packageConfigData[dir.path];
+    assert(packageConfig != null,
         'Package config data at ${dir.path} should not be null');
-    return package_config.PackageConfig(_packageConfigData[dir.path]);
+    return package_config.PackageConfig(packageConfig!);
   }
 }

--- a/lib/src/quiver.dart
+++ b/lib/src/quiver.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 /// Methods in-lined from package:quiver.
 
 // From lib/iterables.dart:

--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -1,7 +1,5 @@
 // Copied from source at github.com/kseo/tuple/blob/470ed3aeb/lib/src/tuple.dart
 
-// @dart=2.9
-
 // Original copyright:
 // Copyright (c) 2014, the tuple project authors. Please see the AUTHORS
 // file for details. All rights reserved. Use of this source code is governed


### PR DESCRIPTION
These are basically all of the unmigrated files, not including tests or generated stuff, which is not _in_ model/ and which does not import model/.

Very straightforward migration.