### PR TITLE
Fix StringTrie so it handles partial matches better

### DIFF
--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -36,15 +36,22 @@ class StringTrie {
   /// Does [this] node represent a valid entry in the trie?
   bool valid = false;
 
-  /// Greedily match on the string trie.  Returns the index of the first
-  /// non-operator character if valid, otherwise -1.
-  int match(String toMatch, [int index = 0]) {
-    if (index < 0 || index >= toMatch.length) return valid ? index : 1;
+  /// Greedily match on the string trie starting at the given index.  Returns
+  /// the index of the first non-operator character if a match is valid,
+  /// otherwise -1.
+  int match(String toMatch, [int index = 0, int lastValid = -1]) {
+    if (index < 0 || index > toMatch.length) {
+      return lastValid;
+    }
+    if (index == toMatch.length) {
+      return valid ? index : lastValid;
+    }
     var matchChar = toMatch.codeUnitAt(index);
     if (children.containsKey(matchChar)) {
-      return children[matchChar].match(toMatch, index + 1);
+      lastValid = valid ? index : lastValid;
+      return children[matchChar].match(toMatch, index + 1, lastValid);
     }
-    return valid ? index : -1;
+    return valid ? index : lastValid;
   }
 
   void addWord(String toAdd) {

--- a/test/comment_referable/parser_test.dart
+++ b/test/comment_referable/parser_test.dart
@@ -27,8 +27,30 @@ void main() {
         isEmpty);
   }
 
+  group('StringTrie tests', () {
+    test('test partials', () {
+      var trie = StringTrie()..addWord('longerString');
+      expect(trie.match('l'), equals(-1));
+      expect(trie.match('longerStringWithExtras'), equals(12));
+      expect(trie.match('longerString'), equals(12));
+      expect(trie.match('prefix-longerString'), equals(-1));
+    });
+
+    test('substrings', () {
+      var trie = StringTrie();
+      trie.addWord('aString');
+      trie.addWord('aStr');
+      trie.addWord('a');
+      expect(trie.match('a'), equals(1));
+      expect(trie.match('aS'), equals(1));
+      expect(trie.match('aStr'), equals(4));
+      expect(trie.match('aStringTwo'), equals(7));
+    });
+  });
+
   group('Basic comment reference parsing', () {
     test('Check that basic references parse', () {
+      expectParseEquivalent('Funvas.u', ['Funvas', 'u']);
       expectParseEquivalent('valid', ['valid']);
       expectParseEquivalent('new valid', ['valid'], constructorHint: true);
       expectParseEquivalent('valid()', ['valid'], callableHint: true);


### PR DESCRIPTION
Fixes #2808.  A silly bug where the StringTrie used for operator matching wasn't handling some boundary conditions very well.  Fix and add tests.