### PR TITLE
Remove all deprecated bits in preparation for next release

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -141,20 +141,6 @@ class Dartdoc {
   // ignore: unnecessary_getters_setters
   set generator(Generator newGenerator) => _generator = newGenerator;
 
-  /// An asynchronous factory method that builds Dartdoc's file writers
-  /// and returns a Dartdoc object with them.
-  @Deprecated('Prefer fromContext() instead')
-  static Future<Dartdoc> withDefaultGenerators(
-    DartdocGeneratorOptionContext config,
-    PackageBuilder packageBuilder,
-  ) async {
-    return Dartdoc._(
-      config,
-      await initHtmlGenerator(config),
-      packageBuilder,
-    );
-  }
-
   /// Asynchronous factory method that builds Dartdoc with an empty generator.
   static Future<Dartdoc> withEmptyGenerator(
     DartdocOptionContext config,
@@ -193,15 +179,10 @@ class Dartdoc {
 
   Stream<String> get onCheckProgress => _onCheckProgress.stream;
 
-  @Deprecated('Will be removed in 4.0.0. '
-      'Use the return value from generateDocsBase instead.')
-  PackageGraph packageGraph;
-
   @visibleForTesting
   Future<DartdocResults> generateDocsBase() async {
     var stopwatch = Stopwatch()..start();
     var packageGraph = await packageBuilder.buildPackageGraph();
-    this.packageGraph = packageGraph;
     var seconds = stopwatch.elapsedMilliseconds / 1000.0;
     var libs = packageGraph.libraries.length;
     logInfo("Initialized dartdoc with $libs librar${libs == 1 ? 'y' : 'ies'} "

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1138,26 +1138,6 @@ class _Renderer_Category extends RendererBase<Category> {
                         parent: r);
                   },
                 ),
-                'fileType': Property(
-                  getValue: (CT_ c) => c.fileType,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(self.getValue(c),
-                        nextProperty, [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.fileType == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.fileType, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'fullyQualifiedName': Property(
                   getValue: (CT_ c) => c.fullyQualifiedName,
                   renderVariable:
@@ -7373,18 +7353,6 @@ class _Renderer_Library extends RendererBase<Library> {
                         parent: r));
                   },
                 ),
-                'allOriginalModelElementNames': Property(
-                  getValue: (CT_ c) => c.allOriginalModelElementNames,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<String>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.allOriginalModelElementNames.map((e) =>
-                        _render_String(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'canonicalFor': Property(
                   getValue: (CT_ c) => c.canonicalFor,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -11196,13 +11164,6 @@ class _Renderer_Package extends RendererBase<Package> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.hasDocumentation == true,
                 ),
-                'hasDocumentationFile': Property(
-                  getValue: (CT_ c) => c.hasDocumentationFile,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.hasDocumentationFile == true,
-                ),
                 'hasDocumentedCategories': Property(
                   getValue: (CT_ c) => c.hasDocumentedCategories,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -11594,7 +11555,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -11796,7 +11757,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -108,17 +108,6 @@ String getFileNameFor(String name) =>
     '${name.replaceAll(_libraryNameRegExp, '-')}.html';
 
 final _libraryNameRegExp = RegExp('[.:]');
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-RegExp get libraryNameRegexp => _libraryNameRegExp;
-
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-final RegExp partOfRegexp = RegExp('part of ');
-
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-final RegExp newLinePartOfRegexp = RegExp('\npart of ');
 
 typedef TaskQueueClosure<T> = Future<T> Function();
 

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -26,7 +26,7 @@ abstract class Canonicalization implements Locatable, Documentable {
   }
 
   ScoredCandidate _scoreElementWithLibrary(Library lib) {
-    var scoredCandidate = ScoredCandidate(this, lib);
+    var scoredCandidate = ScoredCandidate(lib);
     Iterable<String> resplit(Set<String> items) sync* {
       for (var item in items) {
         for (var subItem in item.split('_')) {
@@ -70,12 +70,6 @@ abstract class Canonicalization implements Locatable, Documentable {
         scoreBoost, 'element location parts start with parts of name');
     return scoredCandidate;
   }
-
-  @Deprecated(
-      'Public method intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  ScoredCandidate scoreElementWithLibrary(Library lib) =>
-      _scoreElementWithLibrary(lib);
 }
 
 /// This class represents the score for a particular element; how likely
@@ -83,31 +77,13 @@ abstract class Canonicalization implements Locatable, Documentable {
 class ScoredCandidate implements Comparable<ScoredCandidate> {
   final List<String> _reasons = [];
 
-  @Deprecated(
-      'Public field intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  List<String> get reasons => _reasons;
-
-  @Deprecated(
-      'Public field intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  set reasons(List<String> value) => reasons = value;
-
-  /// The canonicalization element being scored.
-  final Canonicalization _element;
-
-  @Deprecated(
-      'Public getter intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  Canonicalization get element => _element;
-
   final Library library;
 
   /// The score accumulated so far.  Higher means it is more likely that this
   /// is the intended canonical Library.
   double score = 0.0;
 
-  ScoredCandidate(this._element, this.library);
+  ScoredCandidate(this.library);
 
   void _alterScore(double scoreDelta, String reason) {
     score += scoreDelta;
@@ -116,12 +92,6 @@ class ScoredCandidate implements Comparable<ScoredCandidate> {
           "$reason (${scoreDelta >= 0 ? '+' : ''}${scoreDelta.toStringAsPrecision(4)})");
     }
   }
-
-  @Deprecated(
-      'Public method intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  void alterScore(double scoreDelta, String reason) =>
-      _alterScore(scoreDelta, reason);
 
   @override
   int compareTo(ScoredCandidate other) {

--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -8,10 +8,6 @@ final RegExp _categoryRegExp = RegExp(
     r'[ ]*{@(api|category|subCategory|image|samples) (.+?)}[ ]*\n?',
     multiLine: true);
 
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-RegExp get categoryRegexp => _categoryRegExp;
-
 /// Mixin implementing dartdoc categorization for ModelElements.
 abstract class Categorization implements ModelElement {
   @override

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -32,10 +32,6 @@ class Category extends Nameable
   @override
   Package get package => _package;
 
-  @Deprecated('Field intended to be final; setter will be removed as early as '
-      'Dartdoc 1.0.0')
-  set package(Package value) => _package = value;
-
   final String _name;
 
   // TODO(srawlins): To make final, remove public getter, setter, rename to be
@@ -44,10 +40,6 @@ class Category extends Nameable
 
   @override
   DartdocOptionContext get config => _config;
-
-  @Deprecated('Field intended to be final; setter will be removed as early as '
-      'Dartdoc 1.0.0')
-  set config(DartdocOptionContext value) => _config = value;
 
   final Set<Categorization> _allItems = {};
 
@@ -139,11 +131,6 @@ class Category extends Nameable
   String get fullyQualifiedName => name;
 
   String get _fileType => package.fileType;
-
-  @Deprecated(
-      'Public field intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  String get fileType => _fileType;
 
   String get filePath => 'topics/$name-topic.$_fileType';
 

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -25,18 +25,14 @@ class Category extends Nameable
         Indexable
     implements Documentable {
   /// All libraries in [libraries] must come from [package].
-  // TODO(srawlins): To make final, remove public getter, setter, rename to be
-  // public, and add `final` modifier.
-  Package _package;
+  final Package _package;
 
   @override
   Package get package => _package;
 
   final String _name;
 
-  // TODO(srawlins): To make final, remove public getter, setter, rename to be
-  // public, and add `final` modifier.
-  DartdocOptionContext _config;
+  final DartdocOptionContext _config;
 
   @override
   DartdocOptionContext get config => _config;

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -359,11 +359,6 @@ abstract class InheritingContainer extends Container
       .map((et) => (et.modelElement as InheritingContainer))
       .contains(other);
 
-  @Deprecated(
-      'Public method intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  bool isInheritingFrom(InheritingContainer other) => _isInheritingFrom(other);
-
   DefinedElementType _modelType;
 
   @override

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -112,13 +112,6 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     ]);
   }
 
-  @Deprecated(
-      'Public method intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  static Iterable<Element> getDefinedElements(
-          CompilationUnitElement compilationUnit) =>
-      _getDefinedElements(compilationUnit);
-
   /// Allow scope for Libraries.
   @override
   Scope get scope => element.scope;
@@ -170,12 +163,6 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     }).toList();
     return __allOriginalModelElementNames;
   }
-
-  @Deprecated(
-      'Public getter intended to be private; will be removed as early as '
-      'Dartdoc 1.0.0')
-  Iterable<String> get allOriginalModelElementNames =>
-      _allOriginalModelElementNames;
 
   @override
   CharacterLocation get characterLocation {

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -15,10 +15,6 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path show Context;
 import 'package:pub_semver/pub_semver.dart';
 
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-RegExp get substituteNameVersion => Package._substituteNameVersion;
-
 // All hrefs are emitted as relative paths from the output root. We are unable
 // to compute them from the page we are generating, and many properties computed
 // using hrefs are memoized anyway. To build complete relative hrefs, we emit
@@ -30,11 +26,6 @@ RegExp get substituteNameVersion => Package._substituteNameVersion;
 // might reasonably exist normally.
 @internal
 const String htmlBasePlaceholder = '\%\%__HTMLBASE_dartdoc_internal__\%\%';
-
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-// ignore: non_constant_identifier_names
-const String HTMLBASE_PLACEHOLDER = htmlBasePlaceholder;
 
 /// A [LibraryContainer] that contains [Library] objects related to a particular
 /// package.
@@ -141,10 +132,6 @@ class Package extends LibraryContainer
   bool get hasExtendedDocumentation => hasDocumentation;
 
   File /*?*/ _documentationFile;
-
-  @Deprecated(
-      'Instead use [documentationFile] which will be `null` if this package does not have one.')
-  bool get hasDocumentationFile => documentationFile != null;
 
   File /*?*/ get documentationFile =>
       _documentationFile ??= packageMeta.getReadmeContents();

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -53,17 +53,6 @@ class PackageGraph with CommentReferable, Nameable {
   @override
   Element get element => null;
 
-  @Deprecated('Use with [PackageGraph.uninitialized] instead')
-  // ignore: non_constant_identifier_names
-  factory PackageGraph.UninitializedPackageGraph(
-          DartdocOptionContext config,
-          DartSdk sdk,
-          bool hasEmbedderSdk,
-          RendererFactory rendererFactory,
-          PackageMetaProvider packageMetaProvider) =>
-      PackageGraph.uninitialized(
-          config, sdk, hasEmbedderSdk, rendererFactory, packageMetaProvider);
-
   /// Call during initialization to add a library to this [PackageGraph].
   ///
   /// Libraries added in this manner are assumed to be part of documented

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -12,9 +12,6 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 final _uriTemplateRegExp = RegExp(r'(%[frl]%)');
-@Deprecated('Public variable intended to be private; will be removed as early '
-    'as Dartdoc 1.0.0')
-RegExp get uriTemplateRegexp => _uriTemplateRegExp;
 
 abstract class SourceLinkerOptionContext implements DartdocOptionContextBase {
   List<String> get linkToSourceExcludes =>

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -257,8 +257,6 @@ void main() {
         var packageGraph = results.packageGraph;
         var p = packageGraph.defaultPackage;
         expect(p.name, 'test_package');
-        // ignore: deprecated_member_use_from_same_package
-        expect(p.hasDocumentationFile, isTrue);
         expect(p.documentationFile, isNotNull);
         // Total number of public libraries in test_package.
         // +2 since we are not manually excluding anything.
@@ -305,8 +303,6 @@ void main() {
 
       var p = results.packageGraph;
       expect(p.defaultPackage.name, 'sky_engine');
-      // ignore: deprecated_member_use_from_same_package
-      expect(p.defaultPackage.hasDocumentationFile, isFalse);
       expect(p.defaultPackage.documentationFile, isNull);
       expect(p.libraries, hasLength(3));
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -146,8 +146,6 @@ int x;
         writeToJoinedPath(['README.md'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
-        // ignore: deprecated_member_use_from_same_package
-        expect(packageGraph.defaultPackage.hasDocumentationFile, true);
         expect(packageGraph.defaultPackage.documentationFile, isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
       });
@@ -156,8 +154,6 @@ int x;
         writeToJoinedPath(['README'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
-        // ignore: deprecated_member_use_from_same_package
-        expect(packageGraph.defaultPackage.hasDocumentationFile, true);
         expect(packageGraph.defaultPackage.documentationFile, isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
       });
@@ -462,8 +458,6 @@ int x;
             projectPath, packageMetaProvider, packageConfigProvider);
 
         expect(packageGraph.defaultPackage.hasDocumentation, isFalse);
-        // ignore: deprecated_member_use_from_same_package
-        expect(packageGraph.defaultPackage.hasDocumentationFile, isFalse);
         expect(packageGraph.defaultPackage.documentationFile, isNull);
         expect(packageGraph.defaultPackage.documentation, isNull);
       });


### PR DESCRIPTION
Some of the recent refactors have been technical violations of semantic versioning, so going ahead and committing to that by removing Dartdoc's backlog of deprecations in preparation for 4.0.0.