### PR TITLE
Stop testing beta in the bots

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [dev]
+        sdk: [dev, stable]
         job: [main, flutter, sdk-analyzer, packages, sdk-docs]
         include:
           - os: macos-latest
@@ -28,14 +28,14 @@ jobs:
           - os: windows-latest
             sdk: dev
             job: main
-        #exclude:
+        exclude:
             # Do not try to run flutter against the "stable" sdk,
             # it is unlikely to work and produces uninteresting
             # results.
-          #- sdk: beta
-          #  job: flutter
-          #- sdk: beta
-          #  job: sdk-analyzer
+          - sdk: stable
+            job: flutter
+          - sdk: stable
+            job: sdk-analyzer
 
     steps:
       - name: Store date

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,6 @@ jobs:
           - sdk: stable
             job: sdk-analyzer
           - sdk: stable
-            job: main
-          - sdk: stable
             job: sdk-docs
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [dev, beta]
+        sdk: [dev]
         job: [main, flutter, sdk-analyzer, packages, sdk-docs]
         include:
           - os: macos-latest
@@ -28,17 +28,14 @@ jobs:
           - os: windows-latest
             sdk: dev
             job: main
-        exclude:
+        #exclude:
             # Do not try to run flutter against the "stable" sdk,
             # it is unlikely to work and produces uninteresting
             # results.
-          - sdk: beta
-            job: flutter
-          - sdk: beta
-            job: sdk-analyzer
-            # TODO(jcollins-g): Delete exception as 2.15 beta 2 gets underway
-          - sdk: beta
-            job: sdk-docs
+          #- sdk: beta
+          #  job: flutter
+          #- sdk: beta
+          #  job: sdk-analyzer
 
     steps:
       - name: Store date

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,10 @@ jobs:
             job: flutter
           - sdk: stable
             job: sdk-analyzer
+          - sdk: stable
+            job: main
+          - sdk: stable
+            job: sdk-docs
 
     steps:
       - name: Store date


### PR DESCRIPTION
This PR is formalizing that doc generation for the stable and 2.15 beta1 Dart SDKs are no longer supported.   You should still be able generate docs for packages using those SDKs, though.