### PR TITLE
Get rid of a backlog of potentially suboptimal coding practices in dartdoc

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,6 @@
 # Change analysis_options.yaml and analysis_options_presubmit.yaml
 # together.
-include: package:lints/core.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   errors:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,6 @@
 # Change analysis_options.yaml and analysis_options_presubmit.yaml
 # together.
-include: package:pedantic/analysis_options.1.11.0.yaml
+include: package:lints/core.yaml
 
 analyzer:
   errors:
@@ -19,45 +19,19 @@ analyzer:
     - 'testing/test_package_export_error/**'
 linter:
   rules:
-    - always_declare_return_types
-    - avoid_dynamic_calls
-    - avoid_single_cascade_in_expression_statements
-    - avoid_unused_constructor_parameters
-    - annotate_overrides
-    - avoid_init_to_null
-    - directives_ordering
-    - no_adjacent_strings_in_list
-    - package_api_docs
-    - prefer_final_fields
-    - prefer_initializing_formals
-    - prefer_void_to_null
-    - slash_for_doc_comments
-    - type_annotate_public_apis
-    #    - unnecessary_brace_in_string_interps
+    always_declare_return_types: true
+    annotate_overrides: true
+    avoid_dynamic_calls: true
+    avoid_single_cascade_in_expression_statements: true
+    avoid_unused_constructor_parameters: true
+    avoid_init_to_null: true
+    directives_ordering: true
+    no_adjacent_strings_in_list: true
+    package_api_docs: true
+    prefer_final_fields: true
+    prefer_initializing_formals: true
+    prefer_void_to_null: true
+    slash_for_doc_comments: true
+    type_annotate_public_apis: true
     # Work in progress canonical score lints
-    - avoid_empty_else
-    - avoid_relative_lib_imports
-    - avoid_shadowing_type_parameters
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - curly_braces_in_flow_control_structures
-    - empty_catches
-    - file_names
-    - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - no_duplicate_case_values
-    #    - non_constant_identifier_names
-    - package_prefixed_library_names
-    - prefer_generic_function_type_aliases
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_iterable_whereType
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - unawaited_futures
-    - unnecessary_overrides
-    - unrelated_type_equality_checks
-    - valid_regexps
-    - void_checks
+    unawaited_futures: true

--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -23,10 +23,10 @@ analyzer:
 linter:
   rules:
     always_declare_return_types: true
+    annotate_overrides: true
     avoid_dynamic_calls: true
     avoid_single_cascade_in_expression_statements: true
     avoid_unused_constructor_parameters: true
-    annotate_overrides: true
     avoid_init_to_null: true
     directives_ordering: true
     no_adjacent_strings_in_list: true
@@ -37,28 +37,4 @@ linter:
     slash_for_doc_comments: true
     type_annotate_public_apis: true
     # Work in progress canonical score lints
-    avoid_empty_else: true
-    avoid_relative_lib_imports: true
-    avoid_shadowing_type_parameters: true
-    await_only_futures: true
-    camel_case_extensions: true
-    camel_case_types: true
-    curly_braces_in_flow_control_structures: true
-    empty_catches: true
-    file_names: true
-    hash_and_equals: true
-    iterable_contains_unrelated_type: true
-    list_remove_unrelated_type: true
-    no_duplicate_case_values: true
-    package_prefixed_library_names: true
-    prefer_generic_function_type_aliases: true
-    prefer_is_empty: true
-    prefer_is_not_empty: true
-    prefer_iterable_whereType: true
-    prefer_typing_uninitialized_variables: true
-    provide_deprecation_message: true
     unawaited_futures: true
-    unnecessary_overrides: true
-    unrelated_type_equality_checks: true
-    valid_regexps: true
-    void_checks: true

--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -1,6 +1,6 @@
 # Change analysis_options.yaml and analysis_options_presubmit.yaml
 # together.
-include: package:pedantic/analysis_options.1.11.0.yaml
+include: package:lints/core.yaml
 
 analyzer:
   errors:
@@ -22,45 +22,43 @@ analyzer:
     - 'testing/test_package_export_error/**'
 linter:
   rules:
-    - always_declare_return_types
-    - avoid_dynamic_calls
-    - avoid_single_cascade_in_expression_statements
-    - avoid_unused_constructor_parameters
-    - annotate_overrides
-    - avoid_init_to_null
-    - directives_ordering
-    - no_adjacent_strings_in_list
-    - package_api_docs
-    - prefer_final_fields
-    - prefer_initializing_formals
-    - prefer_void_to_null
-    - slash_for_doc_comments
-    - type_annotate_public_apis
-    #    - unnecessary_brace_in_string_interps
+    always_declare_return_types: true
+    avoid_dynamic_calls: true
+    avoid_single_cascade_in_expression_statements: true
+    avoid_unused_constructor_parameters: true
+    annotate_overrides: true
+    avoid_init_to_null: true
+    directives_ordering: true
+    no_adjacent_strings_in_list: true
+    package_api_docs: true
+    prefer_final_fields: true
+    prefer_initializing_formals: true
+    prefer_void_to_null: true
+    slash_for_doc_comments: true
+    type_annotate_public_apis: true
     # Work in progress canonical score lints
-    - avoid_empty_else
-    - avoid_relative_lib_imports
-    - avoid_shadowing_type_parameters
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - curly_braces_in_flow_control_structures
-    - empty_catches
-    - file_names
-    - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - no_duplicate_case_values
-    #    - non_constant_identifier_names
-    - package_prefixed_library_names
-    - prefer_generic_function_type_aliases
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_iterable_whereType
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - unawaited_futures
-    - unnecessary_overrides
-    - unrelated_type_equality_checks
-    - valid_regexps
-    - void_checks
+    avoid_empty_else: true
+    avoid_relative_lib_imports: true
+    avoid_shadowing_type_parameters: true
+    await_only_futures: true
+    camel_case_extensions: true
+    camel_case_types: true
+    curly_braces_in_flow_control_structures: true
+    empty_catches: true
+    file_names: true
+    hash_and_equals: true
+    iterable_contains_unrelated_type: true
+    list_remove_unrelated_type: true
+    no_duplicate_case_values: true
+    package_prefixed_library_names: true
+    prefer_generic_function_type_aliases: true
+    prefer_is_empty: true
+    prefer_is_not_empty: true
+    prefer_iterable_whereType: true
+    prefer_typing_uninitialized_variables: true
+    provide_deprecation_message: true
+    unawaited_futures: true
+    unnecessary_overrides: true
+    unrelated_type_equality_checks: true
+    valid_regexps: true
+    void_checks: true

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -370,7 +370,7 @@ class Dartdoc {
     var indexPath = path.joinAll([origin, 'index.html']);
     var file = config.resourceProvider.getFile(fullPath);
     if (!file.exists) {
-      return null;
+      return;
     }
     var decoder = JsonDecoder();
     List<Object> jsonData = decoder.convert(file.readAsStringSync());
@@ -415,7 +415,7 @@ class Dartdoc {
       // Remove so that we properly count that the file doesn't exist for
       // the orphan check.
       visited.remove(fullPath);
-      return null;
+      return;
     }
     visited.add(fullPath);
     var stringLinks = stringLinksAndHref.item1;

--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -132,12 +132,11 @@ class CommentReferenceParser {
         if (typeVariablesResult.type == _TypeVariablesResultType.endOfFile) {
           break;
         } else if (typeVariablesResult.type ==
-            _TypeVariablesResultType.notTypeVariables) {
-          // Do nothing, _index has not moved.
-          ;
-        } else if (typeVariablesResult.type ==
             _TypeVariablesResultType.parsedTypeVariables) {
           children.add(typeVariablesResult.node);
+        } else {
+          assert(typeVariablesResult.type ==
+              _TypeVariablesResultType.notTypeVariables);
         }
       }
       if (_atEnd || _thisChar != $dot) {

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -556,7 +556,9 @@ abstract class DartdocOption<T extends Object> {
   /// Apply the function [visit] to [this] and all children.
   void traverse(void Function(DartdocOption option) visit) {
     visit(this);
-    _children.values.forEach((d) => d.traverse(visit));
+    for (var value in _children.values) {
+      value.traverse(visit);
+    }
   }
 }
 
@@ -731,7 +733,7 @@ class DartdocOptionSet extends DartdocOption<void> {
 
   /// [DartdocOptionSet] always has the null value.
   @override
-  void valueAt(Folder dir) => null;
+  void valueAt(Folder dir) {}
 
   /// Since we have no value, [_onMissing] does nothing.
   @override
@@ -742,7 +744,9 @@ class DartdocOptionSet extends DartdocOption<void> {
   /// configuration object.
   @override
   void traverse(void Function(DartdocOption option) visitor) {
-    _children.values.forEach((d) => d.traverse(visitor));
+    for (var value in _children.values) {
+      value.traverse(visitor);
+    }
   }
 }
 
@@ -1033,7 +1037,9 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
         }
       }
     }
-    canonicalPaths.forEach((p) => _yamlAtCanonicalPathCache[p] = yamlData);
+    for (var canonicalPath in canonicalPaths) {
+      _yamlAtCanonicalPathCache[canonicalPath] = yamlData;
+    }
     return yamlData;
   }
 }
@@ -1137,7 +1143,7 @@ abstract class _DartdocArgOption<T> implements DartdocOption<T> {
   /// 'something-bar-over-the-hill' (with default skip).
   /// This allows argument names to reflect nested structure.
   static String _keysToArgName(Iterable<String> keys, [int skip = 1]) {
-    var argName = "${keys.skip(skip).join('-')}";
+    var argName = keys.skip(skip).join('-');
     argName = argName.replaceAll('_', '-');
     // Do not consume the lowercase character after the uppercase one, to handle
     // two character words.

--- a/lib/src/experiment_options.dart
+++ b/lib/src/experiment_options.dart
@@ -9,6 +9,7 @@
 library dartdoc.experiment_options;
 
 import 'package:analyzer/file_system/file_system.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/analysis/experiments.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -11,10 +11,10 @@ import 'package:dartdoc/src/model_utils.dart';
 /// it were.
 class EmptyGenerator extends Generator {
   @override
-  Future<void> generate(PackageGraph _packageGraph, FileWriter writer) {
-    logProgress(_packageGraph.defaultPackage.documentationAsHtml);
-    for (var package in {_packageGraph.defaultPackage}
-      ..addAll(_packageGraph.localPackages)) {
+  Future<void> generate(PackageGraph packageGraph, FileWriter writer) {
+    logProgress(packageGraph.defaultPackage.documentationAsHtml);
+    for (var package in {packageGraph.defaultPackage}
+      ..addAll(packageGraph.localPackages)) {
       for (var category in filterNonDocumented(package.categories)) {
         logProgress(category.documentationAsHtml);
       }

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -59,7 +59,7 @@ class HtmlGeneratorBackend extends DartdocGeneratorBackend {
   }
 
   Future<void> _copyResources(FileWriter writer) async {
-    for (var resourcePath in resources.resource_names) {
+    for (var resourcePath in resources.resourceNames) {
       if (!resourcePath.startsWith(_dartdocResourcePrefix)) {
         throw StateError('Resource paths must start with '
             '$_dartdocResourcePrefix, encountered $resourcePath');

--- a/lib/src/generator/html_resources.g.dart
+++ b/lib/src/generator/html_resources.g.dart
@@ -1,6 +1,6 @@
-// WARNING: This file is auto-generated. Do not taunt.
+// WARNING: This file is auto-generated. Do not edit.
 
-const List<String> resource_names = [
+const List<String> resourceNames = [
   'package:dartdoc/resources/favicon.png',
   'package:dartdoc/resources/github.css',
   'package:dartdoc/resources/highlight.pack.js',

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -7,7 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
 import 'dart:convert' as _i19;
 

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -7,6 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:convert' as _i19;
 

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -7,7 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
 import 'dart:convert' as _i19;
 

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -7,6 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:convert' as _i19;
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -4,6 +4,7 @@
 // files in the tool/mustachio/ directory.
 
 // ignore_for_file: camel_case_types, deprecated_member_use_from_same_package
+// ignore_for_file: non_constant_identifier_names
 // ignore_for_file: unused_import
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -4,7 +4,7 @@
 // files in the tool/mustachio/ directory.
 
 // ignore_for_file: camel_case_types, deprecated_member_use_from_same_package
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 // ignore_for_file: unused_import
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/lib/src/io_utils.dart
+++ b/lib/src/io_utils.dart
@@ -12,8 +12,10 @@ import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
-import 'package:analyzer/src/generated/sdk.dart';
-import 'package:analyzer/src/test_utilities/mock_sdk.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart' show SdkLibrary;
+// ignore: implementation_imports
+import 'package:analyzer/src/test_utilities/mock_sdk.dart' show MockSdkLibrary;
 import 'package:path/path.dart' as path show Context;
 
 Encoding utf8AllowMalformed = Utf8Codec(allowMalformed: true);

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -117,7 +117,7 @@ void startLogging(LoggingContext config) {
           // the backspace to occur for stderr as well.
           stderr.write('${ansi.backspace} ${ansi.backspace}');
         }
-        stderr.writeln('$message');
+        stderr.writeln(message);
       }
       writingProgress = false;
     });

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -284,9 +284,9 @@ void showWarningsForGenericsOutsideSquareBracketsBlocks(
       PackageWarningMode.ignore) {
     for (var position in findFreeHangingGenericsPositions(text)) {
       var priorContext =
-          '${text.substring(max(position - maxPriorContext, 0), position)}';
+          text.substring(max(position - maxPriorContext, 0), position);
       var postContext =
-          '${text.substring(position, min(position + maxPostContext, text.length))}';
+          text.substring(position, min(position + maxPostContext, text.length));
       priorContext = priorContext.replaceAll(allBeforeFirstNewline, '');
       postContext = postContext.replaceAll(allAfterLastNewline, '');
       var errorMessage = '$priorContext$postContext';

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show ExecutableMember;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -70,10 +70,11 @@ extension CommentReferableEntryGenerators on Iterable<CommentReferable> {
 extension CommentReferableEntryBuilder on Map<String, CommentReferable> {
   /// Like [Map.putIfAbsent] except works on an iterable of entries.
   void addEntriesIfAbsent(
-          Iterable<MapEntry<String, CommentReferable>> entries) =>
-      entries.forEach((e) {
-        if (!containsKey(e.key)) this[e.key] = e.value;
-      });
+          Iterable<MapEntry<String, CommentReferable>> entries) {
+    for (var entry in entries) {
+      if (!containsKey(entry.key)) this[entry.key] = entry.value;
+    }
+  }
 }
 
 /// Support comment reference lookups on a Nameable object.

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -70,7 +70,7 @@ extension CommentReferableEntryGenerators on Iterable<CommentReferable> {
 extension CommentReferableEntryBuilder on Map<String, CommentReferable> {
   /// Like [Map.putIfAbsent] except works on an iterable of entries.
   void addEntriesIfAbsent(
-          Iterable<MapEntry<String, CommentReferable>> entries) {
+      Iterable<MapEntry<String, CommentReferable>> entries) {
     for (var entry in entries) {
       if (!containsKey(entry.key)) this[entry.key] = entry.value;
     }

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -741,7 +741,7 @@ mixin DocumentationComment
       if (result.isEmpty) {
         warn(PackageWarning.missingCodeBlockLanguage,
             message:
-            'A fenced code block in Markdown should have a language specified');
+                'A fenced code block in Markdown should have a language specified');
       }
     }
   }

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -393,7 +393,7 @@ mixin DocumentationComment
 
   /// Matches YouTube IDs from supported YouTube URLs.
   static final _validYouTubeUrlPattern =
-      RegExp('https://www\.youtube\.com/watch\\?v=([^&]+)\$');
+      RegExp(r'https://www\.youtube\.com/watch\?v=([^&]+)$');
 
   /// An argument parser used in [_injectYouTube] to parse a `{@youtube}`
   /// directive.
@@ -736,14 +736,14 @@ mixin DocumentationComment
         firstOfPair.add(results[i]);
       }
     }
-    firstOfPair.forEach((element) {
+    for (var element in firstOfPair) {
       final result = element.group(2).trim();
       if (result.isEmpty) {
         warn(PackageWarning.missingCodeBlockLanguage,
             message:
-                'A fenced code block in Markdown should have a language specified');
+            'A fenced code block in Markdown should have a language specified');
       }
-    });
+    }
   }
 
   /// Returns the documentation for this literal element unless

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/source_code_renderer.dart';
@@ -83,7 +82,7 @@ class Field extends ModelElement
   /// for the setter is covariant.
   @override
   bool get isCovariant =>
-      setter?.isCovariant == true || (field as FieldElementImpl).isCovariant;
+      setter?.isCovariant == true || field.isCovariant;
 
   @override
   bool get isFinal {

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -81,8 +81,7 @@ class Field extends ModelElement
   /// Returns true if the FieldElement is covariant, or if the first parameter
   /// for the setter is covariant.
   @override
-  bool get isCovariant =>
-      setter?.isCovariant == true || field.isCovariant;
+  bool get isCovariant => setter?.isCovariant == true || field.isCovariant;
 
   @override
   bool get isFinal {

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -8,7 +8,8 @@ import 'package:analyzer/dart/ast/ast.dart'
     show Expression, InstanceCreationExpression;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
-import 'package:analyzer/src/dart/element/element.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/element.dart' show ConstVariableElement;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/annotation.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -68,7 +69,7 @@ mixin GetterSetterCombo on ModelElement {
     // TODO(jcollins-g): this logic really should be integrated into Constructor,
     // but that's not trivial because of linkedName's usage.
     if (targetClass.name == target.name) {
-      return original.replaceAll(constructorName, '${target.linkedName}');
+      return original.replaceAll(constructorName, target.linkedName);
     }
     return original.replaceAll('${targetClass.name}.${target.name}',
         '${targetClass.linkedName}.${target.linkedName}');
@@ -147,10 +148,10 @@ mixin GetterSetterCombo on ModelElement {
       } else {
         var buffer = StringBuffer();
         if (hasPublicGetter && getter.oneLineDoc.isNotEmpty) {
-          buffer.write('${getter.oneLineDoc}');
+          buffer.write(getter.oneLineDoc);
         }
         if (hasPublicSetter && setter.oneLineDoc.isNotEmpty) {
-          buffer.write('${getterSetterBothAvailable ? "" : setter.oneLineDoc}');
+          buffer.write(getterSetterBothAvailable ? "" : setter.oneLineDoc);
         }
         _oneLineDoc = buffer.toString();
       }

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -9,7 +9,8 @@ import 'package:analyzer/dart/ast/ast.dart'
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/element/element.dart' show ConstVariableElement;
+import 'package:analyzer/src/dart/element/element.dart'
+    show ConstVariableElement;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/annotation.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -4,14 +4,16 @@
 
 import 'dart:collection';
 
-import 'package:analyzer/dart/ast/ast.dart' hide CommentReference;
+import 'package:analyzer/dart/ast/ast.dart' show CompilationUnit;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
-import 'package:analyzer/src/dart/element/inheritance_manager3.dart';
-import 'package:analyzer/src/generated/sdk.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/inheritance_manager3.dart' show InheritanceManager3;
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart' show SdkLibrary;
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -31,26 +33,22 @@ class _HashableChildLibraryElementVisitor
   void visitElement(Element element) {
     libraryProcessor(element);
     super.visitElement(element);
-    return null;
   }
 
   @override
   void visitExportElement(ExportElement element) {
     // [ExportElement]s are not always hashable; skip them.
-    return null;
   }
 
   @override
   void visitImportElement(ImportElement element) {
     // [ImportElement]s are not always hashable; skip them.
-    return null;
   }
 
   @override
   void visitParameterElement(ParameterElement element) {
     // [ParameterElement]s without names do not provide sufficiently distinct
     // hashes / comparison, so just skip them all. (dart-lang/sdk#30146)
-    return null;
   }
 }
 
@@ -595,11 +593,11 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
         }),
       ]);
       _modelElementsMap = HashMap<Element, Set<ModelElement>>();
-      results.forEach((modelElement) {
+      for (var modelElement in results) {
         _modelElementsMap
             .putIfAbsent(modelElement.element, () => {})
             .add(modelElement);
-      });
+      }
       _modelElementsMap.putIfAbsent(element, () => {}).add(this);
     }
     return _modelElementsMap;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -11,7 +11,8 @@ import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/element/inheritance_manager3.dart' show InheritanceManager3;
+import 'package:analyzer/src/dart/element/inheritance_manager3.dart'
+    show InheritanceManager3;
 // ignore: implementation_imports
 import 'package:analyzer/src/generated/sdk.dart' show SdkLibrary;
 import 'package:dartdoc/src/io_utils.dart';

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show ExecutableMember;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -10,7 +10,7 @@ import 'dart:convert';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart' show FunctionType;
 import 'package:analyzer/source/line_info.dart';
-import 'package:analyzer/src/dart/element/element.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member;
 import 'package:collection/collection.dart';
@@ -231,7 +231,7 @@ abstract class ModelElement extends Canonicalization
     assert(library != null ||
         e is ParameterElement ||
         e is TypeParameterElement ||
-        e is GenericFunctionTypeElementImpl ||
+        e is GenericFunctionTypeElement ||
         e.kind == ElementKind.DYNAMIC ||
         e.kind == ElementKind.NEVER);
 

--- a/lib/src/model/operator.dart
+++ b/lib/src/model/operator.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show Member;
 import 'package:dartdoc/src/comment_references/parser.dart';
 import 'package:dartdoc/src/model/model.dart';

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -26,7 +26,7 @@ import 'package:pub_semver/pub_semver.dart';
 // Unlikely to be mistaken for an identifier, html tag, or something else that
 // might reasonably exist normally.
 @internal
-const String htmlBasePlaceholder = '\%\%__HTMLBASE_dartdoc_internal__\%\%';
+const String htmlBasePlaceholder = r'%%__HTMLBASE_dartdoc_internal__%%';
 
 /// A [LibraryContainer] that contains [Library] objects related to a particular
 /// package.

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -11,9 +11,11 @@ import 'package:analyzer/file_system/file_system.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/context/builder.dart' show EmbedderYamlLocator;
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart' show AnalysisContextCollectionImpl;
+import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart'
+    show AnalysisContextCollectionImpl;
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/sdk/sdk.dart' show EmbedderSdk, FolderBasedDartSdk;
+import 'package:analyzer/src/dart/sdk/sdk.dart'
+    show EmbedderSdk, FolderBasedDartSdk;
 // ignore: implementation_imports
 import 'package:analyzer/src/generated/engine.dart' show AnalysisOptionsImpl;
 // ignore: implementation_imports

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -8,12 +8,18 @@ import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
-import 'package:analyzer/src/context/builder.dart';
-import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart';
-import 'package:analyzer/src/dart/sdk/sdk.dart';
-import 'package:analyzer/src/generated/engine.dart';
-import 'package:analyzer/src/generated/java_io.dart';
-import 'package:analyzer/src/generated/sdk.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/context/builder.dart' show EmbedderYamlLocator;
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart' show AnalysisContextCollectionImpl;
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/sdk/sdk.dart' show EmbedderSdk, FolderBasedDartSdk;
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/engine.dart' show AnalysisOptionsImpl;
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/java_io.dart' show JavaFile;
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart' show DartSdk;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart' hide Package;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -7,9 +7,10 @@ import 'dart:collection';
 import 'package:analyzer/dart/ast/ast.dart' hide CommentReference;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
-import 'package:analyzer/src/generated/sdk.dart';
-import 'package:analyzer/src/generated/source.dart';
-import 'package:analyzer/src/generated/source_io.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart' show DartSdk, SdkLibrary;
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/source_io.dart' show Source;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';
 import 'package:dartdoc/src/logging.dart';
@@ -941,9 +942,9 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     assert(allLibrariesAdded);
     if (_allLocalModelElements == null) {
       _allLocalModelElements = [];
-      localLibraries.forEach((library) {
+      for (var library in localLibraries) {
         _allLocalModelElements.addAll(library.allModelElements);
-      });
+      }
     }
     return _allLocalModelElements;
   }

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show ParameterMember;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -61,8 +62,8 @@ class Parameter extends ModelElement implements EnclosedElement {
   int get hashCode => element == null ? 0 : element.hashCode;
 
   @override
-  bool operator ==(Object object) =>
-      object is Parameter && (element.type == object.element.type);
+  bool operator ==(Object other) =>
+      other is Parameter && (element.type == other.element.type);
 
   bool get isCovariant => element.isCovariant;
 

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
-import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 
 import '../../dartdoc.dart';
@@ -37,7 +36,7 @@ class Prefix extends ModelElement implements EnclosedElement {
   Scope get scope => element.scope;
 
   @override
-  PrefixElementImpl get element => super.element;
+  PrefixElement get element => super.element;
 
   @override
   ModelElement get enclosingElement => library;
@@ -47,8 +46,7 @@ class Prefix extends ModelElement implements EnclosedElement {
       throw UnimplementedError('prefixes have no generated files in dartdoc');
 
   @override
-  String get href =>
-      canonicalModelElement == null ? null : canonicalModelElement.href;
+  String get href => canonicalModelElement?.href;
 
   @override
   String get kind => 'prefix';

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -10,7 +10,8 @@ import 'dart:io' show Platform;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
-import 'package:analyzer/src/dart/ast/utilities.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/ast/utilities.dart' show NodeLocator2;
 import 'package:dartdoc/src/failure.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:glob/glob.dart';
@@ -115,7 +116,7 @@ String getFileContentsFor(Element e, ResourceProvider resourceProvider) {
   return _fileContents[location];
 }
 
-final RegExp slashes = RegExp('[\/]');
+final RegExp slashes = RegExp(r'[\/]');
 bool hasPrivateName(Element e) {
   if (e.name == null) return false;
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -10,7 +10,8 @@ import 'dart:io' show Platform, Process;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
-import 'package:analyzer/src/generated/sdk.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart' show DartSdk;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -29,8 +29,9 @@ class FunctionTypeElementTypeRendererHtml
   @override
   String renderLinkedName(FunctionTypeElementType elementType) {
     var buf = StringBuffer();
-    buf.write('${elementType.returnType.linkedName} ');
-    buf.write('${elementType.nameWithGenerics}');
+    buf.write(elementType.returnType.linkedName);
+    buf.write(' ');
+    buf.write(elementType.nameWithGenerics);
     buf.write('<span class="signature">(');
     buf.write(
         ParameterRendererHtml().renderLinkedParams(elementType.parameters));
@@ -203,8 +204,9 @@ class FunctionTypeElementTypeRendererMd
   @override
   String renderLinkedName(FunctionTypeElementType elementType) {
     var buf = StringBuffer();
-    buf.write('${elementType.returnType.linkedName} ');
-    buf.write('${elementType.nameWithGenerics}');
+    buf.write(elementType.returnType.linkedName);
+    buf.write(' ');
+    buf.write(elementType.nameWithGenerics);
     buf.write('(');
     buf.write(ParameterRendererMd().renderLinkedParams(elementType.parameters));
     buf.write(')');

--- a/lib/src/render/language_feature_renderer.dart
+++ b/lib/src/render/language_feature_renderer.dart
@@ -56,8 +56,8 @@ class LanguageFeatureRendererMd extends LanguageFeatureRenderer {
   String renderLanguageFeatureLabel(LanguageFeature feature) {
     final featureUrl = feature.featureUrl;
     if (featureUrl != null) {
-      return '*[\<${feature.name}\>]($featureUrl)*';
+      return r'*[<' + feature.name + r'>](' + featureUrl + ')*';
     }
-    return '*\<${feature.name}\>*';
+    return r'*<' + feature.name + r'>*';
   }
 }

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -14,7 +14,7 @@ class ParameterRendererHtmlList extends ParameterRendererHtml {
   const ParameterRendererHtmlList();
 
   @override
-  String listItem(String listItem) => '<li>$listItem</li>\n';
+  String listItem(String item) => '<li>$item</li>\n';
   @override
   // TODO(jcollins-g): consider comma separated lists and more advanced css.
   String orderedList(String listItems) =>
@@ -26,7 +26,7 @@ class ParameterRendererHtml extends ParameterRenderer {
   const ParameterRendererHtml();
 
   @override
-  String listItem(String listItem) => listItem;
+  String listItem(String item) => item;
   @override
   String orderedList(String listItems) => listItems;
   @override
@@ -41,8 +41,8 @@ class ParameterRendererHtml extends ParameterRenderer {
   }
 
   @override
-  String parameter(String parameter, String htmlId) =>
-      '<span class="parameter" id="$htmlId">$parameter</span>';
+  String parameter(String parameter, String id) =>
+      '<span class="parameter" id="$id">$parameter</span>';
   @override
   String parameterName(String parameterName) =>
       '<span class="parameter-name">$parameterName</span>';

--- a/lib/src/special_elements.dart
+++ b/lib/src/special_elements.dart
@@ -111,7 +111,8 @@ class SpecialClasses {
 
   /// Throw an [AssertionError] if not all required specials are found.
   void assertSpecials() {
-    for (var classDefinition in _specialClassDefinitions.values.where((d) => d.required)) {
+    for (var classDefinition
+        in _specialClassDefinitions.values.where((d) => d.required)) {
       assert(_specialClass.containsKey(classDefinition.specialClass));
     }
   }

--- a/lib/src/special_elements.dart
+++ b/lib/src/special_elements.dart
@@ -10,7 +10,8 @@
 library dartdoc.special_elements;
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/generated/sdk.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart' show DartSdk;
 import 'package:dartdoc/src/model/model.dart';
 
 /// Which of the [SpecialClasses] to get.
@@ -110,9 +111,9 @@ class SpecialClasses {
 
   /// Throw an [AssertionError] if not all required specials are found.
   void assertSpecials() {
-    _specialClassDefinitions.values.forEach((_SpecialClassDefinition d) {
-      if (d.required) assert(_specialClass.containsKey(d.specialClass));
-    });
+    for (var classDefinition in _specialClassDefinitions.values.where((d) => d.required)) {
+      assert(_specialClass.containsKey(classDefinition.specialClass));
+    }
   }
 
   Class operator [](SpecialClass specialClass) => _specialClass[specialClass];

--- a/lib/src/tool_definition.dart
+++ b/lib/src/tool_definition.dart
@@ -249,7 +249,6 @@ class SnapshotCache {
     if (snapshotCache != null && snapshotCache.exists) {
       snapshotCache.delete();
     }
-    return null;
   }
 }
 

--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -48,7 +48,10 @@ class Tuple3<T1, T2, T3> {
 
   @override
   bool operator ==(Object other) =>
-      other is Tuple3 && other.item1 == item1 && other.item2 == item2 && other.item3 == item3;
+      other is Tuple3 &&
+      other.item1 == item1 &&
+      other.item2 == item2 &&
+      other.item3 == item3;
 
   @override
   int get hashCode =>

--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -22,8 +22,8 @@ class Tuple2<T1, T2> {
   String toString() => '[$item1, $item2]';
 
   @override
-  bool operator ==(Object o) =>
-      o is Tuple2 && o.item1 == item1 && o.item2 == item2;
+  bool operator ==(Object other) =>
+      other is Tuple2 && other.item1 == item1 && other.item2 == item2;
 
   @override
   int get hashCode => quiver.hash2(item1.hashCode, item2.hashCode);
@@ -47,8 +47,8 @@ class Tuple3<T1, T2, T3> {
   String toString() => '[$item1, $item2, $item3]';
 
   @override
-  bool operator ==(Object o) =>
-      o is Tuple3 && o.item1 == item1 && o.item2 == item2 && o.item3 == item3;
+  bool operator ==(Object other) =>
+      other is Tuple3 && other.item1 == item1 && other.item2 == item2 && other.item3 == item3;
 
   @override
   int get hashCode =>
@@ -76,12 +76,12 @@ class Tuple4<T1, T2, T3, T4> {
   String toString() => '[$item1, $item2, $item3, $item4]';
 
   @override
-  bool operator ==(Object o) =>
-      o is Tuple4 &&
-      o.item1 == item1 &&
-      o.item2 == item2 &&
-      o.item3 == item3 &&
-      o.item4 == item4;
+  bool operator ==(Object other) =>
+      other is Tuple4 &&
+      other.item1 == item1 &&
+      other.item2 == item2 &&
+      other.item3 == item3 &&
+      other.item4 == item4;
 
   @override
   int get hashCode => quiver.hash4(

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -402,6 +402,7 @@ class PackageWarningOptions {
     void ignoreWarning(PackageWarning kind) {
       newOptions.ignore(kind);
     }
+
     if (allowWarningsInPackages != null &&
         !allowWarningsInPackages.contains(packageMeta.name)) {
       PackageWarning.values.forEach(ignoreWarning);

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -399,25 +399,24 @@ class PackageWarningOptions {
         option.parent['ignoreWarningsInPackages'].valueAt(dir);
     List<String> ignoreErrorsInPackages =
         option.parent['ignoreErrorsInPackages'].valueAt(dir);
+    void ignoreWarning(PackageWarning kind) {
+      newOptions.ignore(kind);
+    }
     if (allowWarningsInPackages != null &&
         !allowWarningsInPackages.contains(packageMeta.name)) {
-      PackageWarning.values
-          .forEach((PackageWarning kind) => newOptions.ignore(kind));
+      PackageWarning.values.forEach(ignoreWarning);
     }
     if (allowErrorsInPackages != null &&
         !allowErrorsInPackages.contains(packageMeta.name)) {
-      PackageWarning.values
-          .forEach((PackageWarning kind) => newOptions.ignore(kind));
+      PackageWarning.values.forEach(ignoreWarning);
     }
     if (ignoreWarningsInPackages != null &&
         ignoreWarningsInPackages.contains(packageMeta.name)) {
-      PackageWarning.values
-          .forEach((PackageWarning kind) => newOptions.ignore(kind));
+      PackageWarning.values.forEach(ignoreWarning);
     }
     if (ignoreErrorsInPackages != null &&
         ignoreErrorsInPackages.contains(packageMeta.name)) {
-      PackageWarning.values
-          .forEach((PackageWarning kind) => newOptions.ignore(kind));
+      PackageWarning.values.forEach(ignoreWarning);
     }
     return newOptions;
   }

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -17,7 +17,7 @@ abstract class Base extends Nameable with CommentReferable {
   ModelObjectBuilder get modelBuilder =>
       throw UnimplementedError('not needed for this test');
 
-  List<Base> children;
+  List<Base> get children;
 
   Base parent;
 
@@ -99,10 +99,11 @@ class TopChild extends Child {
   final String name;
   @override
   final List<GenericChild> children;
+  final Top _parent;
   @override
-  final Top parent;
+  Top get parent => _parent;
 
-  TopChild(this.name, this.children, this.parent);
+  TopChild(this.name, this.children, this._parent);
 
   @override
   Map<String, CommentReferable> get referenceChildren =>
@@ -117,10 +118,11 @@ class GenericChild extends Child {
   final String name;
   @override
   final List<GenericChild> children;
+  final Base _parent;
   @override
-  final Base parent;
+  Base get parent => _parent;
 
-  GenericChild(this.name, this.children, this.parent);
+  GenericChild(this.name, this.children, this._parent);
 
   @override
   Map<String, CommentReferable> get referenceChildren =>

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -234,7 +234,7 @@ void main() {
 
       var outFile = File(path.join(tempDir.path, 'index.html'));
       var footerRegex =
-          RegExp('<footer>(.*\s*?\n?)+?</footer>', multiLine: true);
+          RegExp(r'<footer>(.*\s*?\n?)+?</footer>', multiLine: true);
       // get footer, check for version number
       var m = footerRegex.firstMatch(outFile.readAsStringSync());
       var version = RegExp(r'(\d+\.)?(\d+\.)?(\*|\d+)');

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// ignore_for_file: non_constant_identifier_names
 
 library dartdoc.dartdoc_test;
 

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -236,7 +236,7 @@ void main() {
       expect(
           useSomethingInAnotherPackage.modelType.linkedName,
           matches(
-              '<a href=\"https://pub.dev/documentation/meta/[^\"]*/meta/Required-class.html\">Required</a>'));
+              r'<a href="https://pub.dev/documentation/meta/[^"]*/meta/Required-class.html">Required</a>'));
       var stringLink = RegExp(
           'https://api.dart.dev/(dev|stable|edge|be|beta)/${Platform.version.split(' ').first}/dart-core/String-class.html">String</a>');
       expect(useSomethingInTheSdk.modelType.linkedName, contains(stringLink));

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// ignore_for_file: non_constant_identifier_names
 
 /// This test library handles checks against the model for configurations
 /// that require different PackageGraph configurations.  Since those

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -300,8 +300,9 @@ void main() {
           .firstWhere((m) => m.name == 'injectSimpleHtml');
       injectHtmlFromTool = htmlInjection.instanceMethods
           .firstWhere((m) => m.name == 'injectHtmlFromTool');
-      injectionPackageGraph.allLocalModelElements
-          .forEach((m) => m.documentation);
+      for (var modelElement in injectionPackageGraph.allLocalModelElements) {
+        modelElement.documentation;
+      }
     });
 
     test('can inject HTML', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 // ignore_for_file: non_constant_identifier_names
 
 library dartdoc.model_test;
@@ -458,7 +459,7 @@ void main() {
       expect(
           complexNullableMembers.nameWithGenerics,
           equals(
-              'ComplexNullableMembers&lt;<wbr><span class=\"type-parameter\">T extends String?</span>&gt;'));
+              'ComplexNullableMembers&lt;<wbr><span class="type-parameter">T extends String?</span>&gt;'));
       expect(
           aComplexType.modelType.linkedName,
           equals(
@@ -484,7 +485,7 @@ void main() {
       expect(
           nullableField.modelType.linkedName,
           equals(
-              'Iterable<span class=\"signature\">&lt;<wbr><span class=\"type-parameter\">BigInt</span>&gt;</span>?'));
+              'Iterable<span class="signature">&lt;<wbr><span class="type-parameter">BigInt</span>&gt;</span>?'));
       expect(
           methodWithNullables.linkedParams,
           equals(
@@ -623,7 +624,9 @@ void main() {
           .firstWhere((m) => m.name == 'invokeToolParentDoc');
       invokeToolParentDocOriginal = ImplementingClassForTool.instanceMethods
           .firstWhere((m) => m.name == 'invokeToolParentDoc');
-      packageGraph.allLocalModelElements.forEach((m) => m.documentation);
+      for (var modelElement in packageGraph.allLocalModelElements) {
+        modelElement.documentation;
+      }
     });
 
     test(
@@ -4174,7 +4177,6 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
         expect(location.columnNumber, greaterThanOrEqualTo(0));
       }
 
-      ;
       var simpleProperty =
           fakeLibrary.properties.firstWhere((p) => p.name == 'simpleProperty');
       expectValidLocation(simpleProperty.getter.characterLocation);
@@ -4266,12 +4268,11 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
     test(
         'Verify that combos with a generic typedef modelType can render correctly',
         () {
-      // TODO(jcollins-g): After analyzer 2.0.0, this can be `isEmpty`.
-      expect(genericTypedefCombo.modelType.typeArguments, isNotNull);
+      expect(genericTypedefCombo.modelType.typeArguments, isEmpty);
       expect(
           genericTypedefCombo.modelType.linkedName,
           equals(
-              '<a href=\"%%__HTMLBASE_dartdoc_internal__%%fake/NewGenericTypedef.html\">NewGenericTypedef</a>'));
+              '<a href="%%__HTMLBASE_dartdoc_internal__%%fake/NewGenericTypedef.html">NewGenericTypedef</a>'));
     });
 
     test('Verify that final and late show up (or not) appropriately', () {
@@ -5106,8 +5107,8 @@ String topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('Traditional accessors are not terminated with semicolon', () {
       expect(implicitGetterExplicitSetter.setter.sourceCode.trim(),
-          endsWith('\{\}'));
-      expect(explicitGetterSetter.setter.sourceCode.trim(), endsWith('\{\}'));
+          endsWith('{}'));
+      expect(explicitGetterSetter.setter.sourceCode.trim(), endsWith('{}'));
     });
 
     test('Whole declaration is visible when declaration spans many lines', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// ignore_for_file: non_constant_identifier_names
 
 library dartdoc.model_test;
 

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -125,7 +125,7 @@ void main() {
         .getFolder(pathContext.join(outputPath, 'static-assets'));
     expect(output, doesExist);
 
-    for (var resource in resource_names.map((r) =>
+    for (var resource in resourceNames.map((r) =>
         pathContext.relative(Uri.parse(r).path, from: 'dartdoc/resources'))) {
       expect(resourceProvider.getFile(pathContext.join(output.path, resource)),
           doesExist);

--- a/test/mustachio/foo.aot_renderers_for_html.dart
+++ b/test/mustachio/foo.aot_renderers_for_html.dart
@@ -7,7 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
 import 'dart:convert' as _i2;
 

--- a/test/mustachio/foo.aot_renderers_for_html.dart
+++ b/test/mustachio/foo.aot_renderers_for_html.dart
@@ -7,6 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:convert' as _i2;
 

--- a/test/mustachio/foo.aot_renderers_for_md.dart
+++ b/test/mustachio/foo.aot_renderers_for_md.dart
@@ -7,7 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
 import 'dart:convert' as _i2;
 

--- a/test/mustachio/foo.aot_renderers_for_md.dart
+++ b/test/mustachio/foo.aot_renderers_for_md.dart
@@ -7,6 +7,7 @@
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:convert' as _i2;
 

--- a/test/mustachio/foo.dart
+++ b/test/mustachio/foo.dart
@@ -15,6 +15,7 @@ class Foo extends FooBase<Baz> {
   bool b1;
   List<int> l1;
   @override
+  // ignore: overridden_fields
   Baz baz;
   Property1 p1;
   int length;

--- a/test/mustachio/foo.runtime_renderers.dart
+++ b/test/mustachio/foo.runtime_renderers.dart
@@ -4,6 +4,7 @@
 // files in the tool/mustachio/ directory.
 
 // ignore_for_file: camel_case_types, deprecated_member_use_from_same_package
+// ignore_for_file: non_constant_identifier_names
 // ignore_for_file: unused_import
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/test/mustachio/foo.runtime_renderers.dart
+++ b/test/mustachio/foo.runtime_renderers.dart
@@ -4,7 +4,7 @@
 // files in the tool/mustachio/ directory.
 
 // ignore_for_file: camel_case_types, deprecated_member_use_from_same_package
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 // ignore_for_file: unused_import
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/test/source_linker_test.dart
+++ b/test/source_linker_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 void main() {
   group('Source link computations', () {
     test('Basic usage', () {
-      var sourceLinkerHref = () => SourceLinker(
+      String sourceLinkerHref() => SourceLinker(
               excludes: [],
               lineNumber: 14,
               root: 'path',
@@ -24,7 +24,7 @@ void main() {
     });
 
     test('Throw when missing a revision if one is in the template', () {
-      var sourceLinkerHref = () => SourceLinker(
+      String sourceLinkerHref() => SourceLinker(
               excludes: [],
               lineNumber: 20,
               root: 'path',
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('Allow a missing revision as long as it is not in the template', () {
-      var sourceLinkerHref = () => SourceLinker(
+      String sourceLinkerHref() => SourceLinker(
               excludes: [],
               lineNumber: 71,
               root: 'path',
@@ -47,7 +47,7 @@ void main() {
     });
 
     test('Throw if only revision specified', () {
-      var sourceLinkerHref = () => SourceLinker(
+      String sourceLinkerHref() => SourceLinker(
             excludes: [],
             lineNumber: 20,
             revision: '12345',
@@ -56,7 +56,7 @@ void main() {
     });
 
     test('Hide a path inside an exclude', () {
-      var sourceLinkerHref = () => SourceLinker(
+      String sourceLinkerHref() => SourceLinker(
               excludes: ['path/under/exclusion'],
               lineNumber: 14,
               root: 'path',
@@ -68,7 +68,7 @@ void main() {
     });
 
     test('Check that paths outside exclusions work', () {
-      var sourceLinkerHref = () => SourceLinker(
+      String sourceLinkerHref() => SourceLinker(
               excludes: ['path/under/exclusion'],
               lineNumber: 14,
               root: 'path',

--- a/tool/builder.dart
+++ b/tool/builder.dart
@@ -9,9 +9,9 @@ import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
 
 String _resourcesFile(Iterable<String> packagePaths) => '''
-// WARNING: This file is auto-generated. Do not taunt.
+// WARNING: This file is auto-generated. Do not edit.
 
-const List<String> resource_names = [
+const List<String> resourceNames = [
 ${packagePaths.map((p) => "  '$p'").join(',\n')}
 ];
 ''';

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -305,7 +305,7 @@ void dartfmt() async {
     if (filesToFix.isNotEmpty) {
       fail(
           'dart format found files needing reformatting. Use this command to reformat:\n'
-          'dart format ${filesToFix.map((f) => "\'$f\'").join(' ')}');
+          'dart format ${filesToFix.map((f) => "'$f'").join(' ')}');
     }
   } else {
     log('Skipping dartfmt check, requires latest dev version of SDK');
@@ -320,11 +320,11 @@ void dartfmt() async {
   tryPublish,
   smokeTest,
 )
-void presubmit() => null;
+void presubmit() {}
 
 @Task('Run long tests, self-test dartdoc, and run the publish test')
 @Depends(presubmit, longTest, testDartdoc)
-void buildbot() => null;
+void buildbot() {}
 
 @Task('Generate docs for the Dart SDK')
 Future<void> buildSdkDocs() async {
@@ -397,12 +397,16 @@ class WarningsCollection {
     if (onlyOriginal.isNotEmpty) {
       printBuffer.writeln(
           '*** $title : ${onlyOriginal.length} warnings from $branch, missing in ${current.branch}:');
-      onlyOriginal.forEach((key) => printBuffer.writeln(_fromKey(key)));
+      for (var key in onlyOriginal) {
+        printBuffer.writeln(_fromKey(key));
+      }
     }
     if (onlyCurrent.isNotEmpty) {
       printBuffer.writeln(
           '*** $title : ${onlyCurrent.length} new warnings in ${current.branch}, missing in $branch');
-      onlyCurrent.forEach((key) => printBuffer.writeln(current._fromKey(key)));
+      for (var key in onlyCurrent) {
+        printBuffer.writeln(current._fromKey(key));
+      }
     }
     if (quantityChangedOuts.isNotEmpty) {
       printBuffer.writeln('*** $title : Identical warning quantity changed');
@@ -557,7 +561,7 @@ Future<List<Map<Object, Object>>> _buildSdkDocs(
         '--enable-asserts',
         path.join('bin', 'dartdoc.dart'),
         '--output',
-        '$sdkDocsPath',
+        sdkDocsPath,
         '--sdk-docs',
         '--json',
         '--show-progress',
@@ -654,7 +658,7 @@ Future<void> startTestPackageDocsServer() async {
     '--port',
     '8002',
     '--path',
-    '${testPackageDocsDir.absolute.path}',
+    testPackageDocsDir.absolute.path,
   ]);
 }
 
@@ -684,7 +688,7 @@ Future<void> serveSdkDocs() async {
     '--port',
     '8000',
     '--path',
-    '${sdkDocsDir.path}',
+    sdkDocsDir.path,
   ]);
 }
 
@@ -831,7 +835,7 @@ $analyzerOptions
         '--link-to-remote',
         '--show-progress',
         '--enable-experiment',
-        '${languageExperiments.join(",")}',
+        languageExperiments.join(","),
         ...extraDartdocParameters,
       ],
       workingDirectory: languageTestPackageDir.absolute.path);
@@ -1138,7 +1142,9 @@ Future<void> test() async {
 @Task('Clean up pub data from test directories')
 Future<void> clean() async {
   var toDelete = nonRootPubData;
-  toDelete.forEach((e) => e.deleteSync(recursive: true));
+  for (var e in toDelete) {
+    e.deleteSync(recursive: true);
+  }
 }
 
 Iterable<FileSystemEntity> get nonRootPubData {

--- a/tool/mustachio/codegen_aot_compiler.dart
+++ b/tool/mustachio/codegen_aot_compiler.dart
@@ -67,6 +67,7 @@ Future<String> compileTemplatesToRenderers(
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
+// ignore_for_file: non_constant_identifier_names
 
 ${library.accept(DartEmitter.scoped(orderDirectives: true))}
 ''');

--- a/tool/mustachio/codegen_aot_compiler.dart
+++ b/tool/mustachio/codegen_aot_compiler.dart
@@ -67,7 +67,7 @@ Future<String> compileTemplatesToRenderers(
 // the variable is not used; generally when the section is checking if a
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
 ${library.accept(DartEmitter.scoped(orderDirectives: true))}
 ''');

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -80,7 +80,7 @@ class RuntimeRenderersBuilder {
 // files in the tool/mustachio/ directory.
 
 // ignore_for_file: camel_case_types, deprecated_member_use_from_same_package
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 // ignore_for_file: unused_import
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -80,6 +80,7 @@ class RuntimeRenderersBuilder {
 // files in the tool/mustachio/ directory.
 
 // ignore_for_file: camel_case_types, deprecated_member_use_from_same_package
+// ignore_for_file: non_constant_identifier_names
 // ignore_for_file: unused_import
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/generator/template_data.dart';

--- a/tool/subprocess_launcher.dart
+++ b/tool/subprocess_launcher.dart
@@ -220,7 +220,7 @@ class SubprocessLauncher {
       }).join(' '));
       stderr.write(' ');
     }
-    stderr.write('$executable');
+    stderr.write(executable);
     if (arguments.isNotEmpty) {
       for (var arg in arguments) {
         if (arg.contains(_quotables)) {


### PR DESCRIPTION
Get us completely off of pedantic for lints/hints, fix all the problems highlighted by the "recommended" set, and eliminate declarations that are now duplicates in the analysis options.