### PR TITLE
Fix up documentation on comment reference parser to align with wiki

### DIFF
--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -100,7 +100,9 @@ class CommentReferenceParser {
   /// ```text
   ///   <rawCommentReference> ::= <prefix>?<commentReference><suffix>?
   ///
-  ///   <commentReference> ::= (<packageName> '.')? (<libraryName> '.')? <dartdocIdentifier> <typeArguments> ('.' <identifier> <typeArguments>)*
+  ///   <commentReference> ::= <globalScopeReference>? <dartdocIdentifier> <typeArguments>? ('.' <identifier> <typeArguments>?)*
+  ///
+  ///   <globalScopeReference> ::= (<packageName> '.')? (<libraryName> '.')
   /// ```
   List<CommentReferenceNode> _parseRawCommentReference() {
     var children = <CommentReferenceNode>[];


### PR DESCRIPTION
Just a quick documentation update.