### PR TITLE
Remove the auto 'pub get' behavior from dartdoc

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -16692,7 +16692,6 @@ const _invisibleGetters = {
     'resourceProvider',
     'pathContext',
     'isSdk',
-    'needsPubGet',
     'requiresFlutter',
     'name',
     'hostedAt',

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -51,13 +51,11 @@ class PubPackageBuilder implements PackageBuilder {
   @override
   Future<PackageGraph> buildPackageGraph() async {
     if (!config.sdkDocs) {
+      // TODO(devoncarew): We may no longer need to emit this error.
       if (config.topLevelPackageMeta.requiresFlutter &&
           config.flutterRoot == null) {
         throw DartdocOptionError(
             'Top level package requires Flutter but FLUTTER_ROOT environment variable not set');
-      }
-      if (config.topLevelPackageMeta.needsPubGet) {
-        config.topLevelPackageMeta.runPubGet(config.flutterRoot);
       }
     }
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -4,7 +4,7 @@
 
 library dartdoc.package_meta;
 
-import 'dart:io' show Platform, Process;
+import 'dart:io' show Platform;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
@@ -16,8 +16,6 @@ import 'package:dartdoc/src/failure.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
-
-import 'logging.dart';
 
 final Map<String, PackageMeta?> _packageMetaCache = {};
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -126,11 +126,7 @@ abstract class PackageMeta {
   /// "both"), or null if this package is not part of a SDK.
   String? sdkType(String? flutterRootPath);
 
-  bool get needsPubGet => false;
-
   bool get requiresFlutter;
-
-  void runPubGet(String? flutterRoot);
 
   String get name;
 
@@ -347,44 +343,6 @@ class _FilePackageMeta extends PubPackageMeta {
   bool get isSdk => false;
 
   @override
-  bool get needsPubGet => !(resourceProvider
-      .getFile(pathContext.join(dir.path, '.dart_tool', 'package_config.json'))
-      .exists);
-
-  @override
-  void runPubGet(String? flutterRoot) {
-    String binPath;
-    List<String> parameters;
-    if (requiresFlutter) {
-      if (flutterRoot == null) {
-        throw DartdocFailure('Package requires flutter but FLUTTER_ROOT unset');
-      }
-      binPath = p.join(flutterRoot, 'bin', 'flutter');
-      if (Platform.isWindows) binPath += '.bat';
-      parameters = ['pub', 'get'];
-    } else {
-      binPath = p.join(p.dirname(Platform.resolvedExecutable), 'dart');
-      if (Platform.isWindows) binPath += '.exe';
-      parameters = ['pub', 'get'];
-    }
-
-    var result =
-        Process.runSync(binPath, parameters, workingDirectory: dir.path);
-
-    var trimmedStdout = (result.stdout as String).trim();
-    if (trimmedStdout.isNotEmpty) {
-      logInfo(trimmedStdout);
-    }
-
-    if (result.exitCode != 0) {
-      var buf = StringBuffer();
-      buf.writeln('${result.stdout}');
-      buf.writeln('${result.stderr}');
-      throw DartdocFailure('pub get failed: ${buf.toString().trim()}');
-    }
-  }
-
-  @override
   String get name => _pubspec['name'] ?? '';
 
   @override
@@ -457,11 +415,6 @@ class _SdkMeta extends PubPackageMeta {
 
   @override
   bool get isSdk => true;
-
-  @override
-  void runPubGet(String? flutterRoot) {
-    throw 'unsupported operation';
-  }
 
   @override
   String get name => 'Dart';

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -51,6 +51,7 @@ Future<PackageGraph> bootBasicPackage(
     PackageConfigProvider packageConfigProvider,
     {List<String> excludeLibraries = const [],
     List<String> additionalArguments = const []}) async {
+  // TODO(devoncarew): Should this test method run 'pub get'?
   var resourceProvider = packageMetaProvider.resourceProvider;
   var dir = resourceProvider.getFolder(resourceProvider.pathContext
       .absolute(resourceProvider.pathContext.normalize(dirPath)));


### PR DESCRIPTION
- this removed the behavior from dartdoc of automatically running 'pub get'
- fix https://github.com/dart-lang/dartdoc/issues/2862

I'm seeing test failures locally - creating a PR here to verify. I'm guessing that some of the tests were relying on the auto 'pub get' behavior, and that we'll have to put in a few manual pub gets in some places in the tests.

cc @srawlins 