### PR TITLE
Move import-export error tests to use test_descriptor

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,9 +18,7 @@ analyzer:
     - 'testing/test_package/**'
     - 'testing/test_package_custom_templates/**'
     - 'testing/test_package_experiments/**'
-    - 'testing/test_package_export_error/**'
     - 'testing/test_package_extensions/**'
-    - 'testing/test_package_import_export_error/**'
     - 'testing/test_package_imported/**'
     - 'testing/test_package_options/**'
     # This package imports flutter, which is perhaps not found by the base `dart analyze` tool.
@@ -29,7 +27,6 @@ analyzer:
     - 'testing/sky_engine/**'
     # These packages have compile-time errors.
     - 'testing/test_package_bad/**'
-    - 'testing/test_package_export_error/**'
 linter:
   rules:
     always_declare_return_types: true

--- a/analysis_options_presubmit.yaml
+++ b/analysis_options_presubmit.yaml
@@ -23,9 +23,7 @@ analyzer:
     - 'testing/test_package/**'
     - 'testing/test_package_custom_templates/**'
     - 'testing/test_package_experiments/**'
-    - 'testing/test_package_export_error/**'
     - 'testing/test_package_extensions/**'
-    - 'testing/test_package_import_export_error/**'
     - 'testing/test_package_imported/**'
     - 'testing/test_package_options/**'
     # This package imports flutter, which is perhaps not found by the base `dart analyze` tool.

--- a/test/constant_values_test.dart
+++ b/test/constant_values_test.dart
@@ -8,8 +8,8 @@ import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
-import 'package:test_descriptor/test_descriptor.dart' as d;
 
+import 'src/test_descriptor_utils.dart' as d;
 import 'src/utils.dart' as utils;
 
 void main() {
@@ -39,19 +39,20 @@ void main() {
             additionalArguments: ['--no-link-to-remote']));
 
     setUp(() async {
-      await d.dir(libraryName, [
-        d.file('pubspec.yaml', '''
+      await d.package(
+        libraryName,
+        pubspec: '''
 name: constructor_tearoffs
 version: 0.0.1
 environment:
   sdk: '>=2.15.0-0 <3.0.0'
-'''),
-        d.file('analysis_options.yaml', '''
+''',
+        analysisOptions: '''
 analyzer:
   enable-experiment:
     - constructor-tearoffs
-'''),
-        d.dir('lib', [
+''',
+        libFiles: [
           d.file('lib.dart', '''
 library $libraryName;
 
@@ -77,8 +78,8 @@ const aTearOffUnnamedConstructorArgsTypedef = Ft<String>.new;
 const aTearOffNamedConstructor = F.alternative;
 const aTearOffNamedConstructorArgs = F<int>.alternative;
 '''),
-        ]),
-      ]).create();
+        ],
+      ).create();
 
       library = (await bootstrapPackageGraph())
           .libraries
@@ -162,19 +163,20 @@ const aTearOffNamedConstructorArgs = F<int>.alternative;
             additionalArguments: ['--no-link-to-remote']));
 
     setUp(() async {
-      await d.dir(libraryName, [
-        d.file('pubspec.yaml', '''
+      await d.package(
+        libraryName,
+        pubspec: '''
 name: named_arguments_anywhere
 version: 0.0.1
 environment:
   sdk: '>=2.17.0-0 <3.0.0'
-'''),
-        d.file('analysis_options.yaml', '''
+''',
+        analysisOptions: '''
 analyzer:
   enable-experiment:
     - named-arguments-anywhere
-'''),
-        d.dir('lib', [
+''',
+        libFiles: [
           d.file('lib.dart', '''
 library $libraryName;
 
@@ -188,8 +190,8 @@ const q = C(1, c: 2, 3, d: 4);
 
 const r = C(c: 1, d: 2, 3, 4);
 '''),
-        ]),
-      ]).create();
+        ],
+      ).create();
 
       library = (await bootstrapPackageGraph())
           .libraries

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -44,8 +44,6 @@ final Folder _testPackageBadDir = _getFolder('testing/test_package_bad');
 final Folder _testSkyEnginePackage = _getFolder('testing/sky_engine');
 final Folder _testPackageIncludeExclude =
     _getFolder('testing/test_package_include_exclude');
-final Folder _testPackageImportExportError =
-    _getFolder('testing/test_package_import_export_error');
 final Folder _testPackageOptions = _getFolder('testing/test_package_options');
 final Folder _testPackageCustomTemplates =
     _getFolder('testing/test_package_custom_templates');
@@ -170,21 +168,6 @@ void main() {
       expect(unresolvedToolErrors.length, equals(1));
       expect(unresolvedToolErrors.first,
           contains('Tool "drill" returned non-zero exit code'));
-    });
-
-    test('with broken reexport chain', () async {
-      var dartdoc =
-          await buildDartdoc([], _testPackageImportExportError, tempDir);
-      var results = await dartdoc.generateDocsBase();
-      var p = results.packageGraph;
-      var unresolvedExportWarnings = p
-          .packageWarningCounter.countedWarnings.values
-          .map((e) => e[PackageWarning.unresolvedExport] ?? {})
-          .expand((element) => element);
-
-      expect(unresolvedExportWarnings.length, equals(1));
-      expect(unresolvedExportWarnings.first,
-          equals('"package:not_referenced_in_pubspec/library3.dart"'));
     });
 
     group('include/exclude parameters', () {

--- a/test/src/test_descriptor_utils.dart
+++ b/test/src/test_descriptor_utils.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_descriptor/test_descriptor.dart' as d;
+export 'package:test_descriptor/test_descriptor.dart';
+
+const _defaultPubspec = '''
+name: test_package
+version: 0.0.1
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+''';
+
+d.DirectoryDescriptor package(
+  String name, {
+  String pubspec = _defaultPubspec,
+  String? dartdocOptions,
+  String? analysisOptions,
+  List<d.FileDescriptor> libFiles = const [],
+}) {
+  return d.dir(name, [
+    d.file('pubspec.yaml', pubspec),
+    if (dartdocOptions != null) d.file('dartdoc_options.yaml', dartdocOptions),
+    if (analysisOptions != null)
+      d.file('analysis_options.yaml', analysisOptions),
+    d.dir('lib', [...libFiles]),
+  ]);
+}

--- a/testing/test_package_export_error/lib/library1.dart
+++ b/testing/test_package_export_error/lib/library1.dart
@@ -1,5 +1,0 @@
-library library1;
-
-/// An invalid reexport - a non-existent library3.dart from 'not_referenced_in_pubspec'
-/// package.
-export 'package:not_referenced_in_pubspec/library3.dart' show Lib3Class;

--- a/testing/test_package_export_error/lib/library2.dart
+++ b/testing/test_package_export_error/lib/library2.dart
@@ -1,5 +1,0 @@
-library library2;
-
-export 'package:test_package_export_error/library1.dart';
-
-class Lib2Class {}

--- a/testing/test_package_export_error/pubspec.yaml
+++ b/testing/test_package_export_error/pubspec.yaml
@@ -1,5 +1,0 @@
-name: test_package_export_error
-version: 0.0.1
-description: A simple console application.
-environment:
-  sdk: '>=2.0.0 <3.0.0'

--- a/testing/test_package_import_export_error/lib/main.dart
+++ b/testing/test_package_import_export_error/lib/main.dart
@@ -1,6 +1,0 @@
-library main;
-
-export 'package:test_package_export_error/library2.dart';
-
-/// This is an important class.
-class BugFreeClass {}

--- a/testing/test_package_import_export_error/pubspec.yaml
+++ b/testing/test_package_import_export_error/pubspec.yaml
@@ -1,9 +1,0 @@
-name: test_package_import_export_error
-version: 0.0.1
-description: A simple console application.
-environment:
-  sdk: '>=2.0.0 <3.0.0'
-
-dependencies:
-  test_package_export_error:
-    path: ../test_package_export_error


### PR DESCRIPTION
This allows removing 2 test packages from testing/.

Also split warnings tests into individual test cases.