### PR TITLE
Use late final in package_graph and package

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -11712,18 +11712,6 @@ class _Renderer_Package extends RendererBase<Package> {
                         parent: r);
                   },
                 ),
-                'documentationFile': Property(
-                  getValue: (CT_ c) => c.documentationFile,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'File'),
-                  isNullValue: (CT_ c) => c.documentationFile == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.documentationFile, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['File']!);
-                  },
-                ),
                 'documentationFrom': Property(
                   getValue: (CT_ c) => c.documentationFrom,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -16661,8 +16649,8 @@ const _invisibleGetters = {
     'allLibrariesAdded',
     'packageWarningCounter',
     'publicPackages',
+    'libraries',
     'publicLibraries',
-    'localLibraries',
     'localPublicLibraries',
     'inheritThrough',
     'invisibleAnnotations',
@@ -16682,7 +16670,6 @@ const _invisibleGetters = {
     'documentedPackages',
     'libraryElementReexportedBy',
     'allHrefs',
-    'libraries',
     'referenceParents'
   },
   'PackageMeta': {

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
@@ -113,7 +112,7 @@ class Package extends LibraryContainer
 
   @override
   late final String? documentation = () {
-    final docFile = documentationFile;
+    final docFile = packageMeta.getReadmeContents();
     return docFile != null
         ? packageGraph.resourceProvider
             .readAsMalformedAllowedStringSync(docFile)
@@ -125,8 +124,6 @@ class Package extends LibraryContainer
 
   @override
   bool get hasExtendedDocumentation => hasDocumentation;
-
-  late final File? documentationFile = packageMeta.getReadmeContents();
 
   @override
   String get oneLineDoc => '';

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -107,29 +107,18 @@ class Package extends LibraryContainer
 
   LibraryContainer? get defaultCategory => nameToCategory[null];
 
-  String? _documentationAsHtml;
+  @override
+  late final String? documentationAsHtml =
+      Documentation.forElement(this).asHtml;
 
   @override
-  String? get documentationAsHtml {
-    if (_documentationAsHtml != null) return _documentationAsHtml;
-    _documentationAsHtml = Documentation.forElement(this).asHtml;
-
-    return _documentationAsHtml;
-  }
-
-  String? _documentation;
-
-  @override
-  String? get documentation {
-    if (_documentation == null) {
-      final docFile = documentationFile;
-      if (docFile != null) {
-        _documentation = packageGraph.resourceProvider
-            .readAsMalformedAllowedStringSync(docFile);
-      }
-    }
-    return _documentation;
-  }
+  late final String? documentation = () {
+    final docFile = documentationFile;
+    return docFile != null
+        ? packageGraph.resourceProvider
+            .readAsMalformedAllowedStringSync(docFile)
+        : null;
+  }();
 
   @override
   bool get hasDocumentation => documentation?.isNotEmpty == true;
@@ -137,10 +126,7 @@ class Package extends LibraryContainer
   @override
   bool get hasExtendedDocumentation => hasDocumentation;
 
-  File? _documentationFile;
-
-  File? get documentationFile =>
-      _documentationFile ??= packageMeta.getReadmeContents();
+  late final File? documentationFile = packageMeta.getReadmeContents();
 
   @override
   String get oneLineDoc => '';
@@ -162,21 +148,21 @@ class Package extends LibraryContainer
   /// Return true if this is the default package, this is part of an embedder
   /// SDK, or if [DartdocOptionContext.autoIncludeDependencies] is true -- but
   /// only if the package was not excluded on the command line.
-  late final bool isLocal = (
-          // Document as local if this is the default package.
-          _isLocalPublicByDefault ||
-              // Assume we want to document an embedded SDK as local if
-              // it has libraries defined in the default package.
-              // TODO(jcollins-g): Handle case where embedder SDKs can be
-              // assembled from multiple locations?
-              packageGraph.hasEmbedderSdk &&
-                  packageMeta.isSdk &&
-                  libraries.any((l) => _pathContext.isWithin(
-                      packageGraph.packageMeta.dir.path,
-                      (l.element.source.fullName)))) &&
-      // Regardless of the above rules, do not document as local if
-      // we excluded this package by name.
-      !_isExcluded;
+  late final bool isLocal = () {
+    // Do not document as local if we excluded this package by name.
+    if (_isExcluded) return false;
+    // Document as local if this is the default package.
+    if (_isLocalPublicByDefault) return true;
+    // Assume we want to document an embedded SDK as local if it has libraries
+    // defined in the default package.
+    // TODO(jcollins-g): Handle case where embedder SDKs can be assembled from
+    // multiple locations?
+    if (!packageGraph.hasEmbedderSdk) return false;
+    if (!packageMeta.isSdk) return false;
+    final packagePath = packageGraph.packageMeta.dir.path;
+    return libraries.any(
+        (l) => _pathContext.isWithin(packagePath, l.element.source.fullName));
+  }();
 
   /// True if the global config excludes this package by name.
   late final bool _isExcluded = packageGraph.config.isPackageExcluded(name);

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -621,22 +621,22 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     }
   }
 
-  Iterable<Library> get libraries =>
+  late final Iterable<Library> libraries =
       packages.expand((p) => p.libraries).toList()..sort();
 
-  late final Iterable<Library> publicLibraries = () {
+  late final Set<Library> publicLibraries = () {
     assert(allLibrariesAdded);
-    return utils.filterNonPublic(libraries).toList();
+    return utils.filterNonPublic(libraries).toSet();
   }();
 
-  late final Iterable<Library> localLibraries = () {
+  late final List<Library> _localLibraries = () {
     assert(allLibrariesAdded);
     return localPackages.expand((p) => p.libraries).toList()..sort();
   }();
 
-  late final Iterable<Library> localPublicLibraries = () {
+  late final Set<Library> localPublicLibraries = () {
     assert(allLibrariesAdded);
-    return utils.filterNonPublic(localLibraries).toList();
+    return utils.filterNonPublic(_localLibraries).toSet();
   }();
 
   /// Return the set of [Class]es objects should inherit through if they
@@ -903,7 +903,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
   }();
 
   late final Iterable<ModelElement> allLocalModelElements = [
-    for (var library in localLibraries) ...library.allModelElements
+    for (var library in _localLibraries) ...library.allModelElements
   ];
 
   late final Iterable<ModelElement> allCanonicalModelElements =

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -242,7 +242,7 @@ void main() {
         var packageGraph = results.packageGraph;
         var p = packageGraph.defaultPackage;
         expect(p.name, 'test_package');
-        expect(p.documentationFile, isNotNull);
+        expect(p.packageMeta.getReadmeContents(), isNotNull);
         // Total number of public libraries in test_package.
         // +2 since we are not manually excluding anything.
         expect(packageGraph.defaultPackage.publicLibraries,
@@ -288,7 +288,7 @@ void main() {
 
       var p = results.packageGraph;
       expect(p.defaultPackage.name, 'sky_engine');
-      expect(p.defaultPackage.documentationFile, isNull);
+      expect(p.defaultPackage.packageMeta.getReadmeContents(), isNull);
       expect(p.libraries, hasLength(3));
       expect(p.libraries.map((lib) => lib.name).contains('dart:core'), isTrue);
       expect(p.libraries.map((lib) => lib.name).contains('dart:async'), isTrue);

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -146,7 +146,8 @@ int x;
         writeToJoinedPath(['README.md'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
-        expect(packageGraph.defaultPackage.documentationFile, isNotNull);
+        expect(packageGraph.defaultPackage.packageMeta.getReadmeContents(),
+            isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
       });
 
@@ -154,7 +155,8 @@ int x;
         writeToJoinedPath(['README'], 'Readme text.');
         var packageGraph = await utils.bootBasicPackage(
             projectPath, packageMetaProvider, packageConfigProvider);
-        expect(packageGraph.defaultPackage.documentationFile, isNotNull);
+        expect(packageGraph.defaultPackage.packageMeta.getReadmeContents(),
+            isNotNull);
         expect(packageGraph.defaultPackage.hasDocumentation, true);
       });
 
@@ -458,7 +460,8 @@ int x;
             projectPath, packageMetaProvider, packageConfigProvider);
 
         expect(packageGraph.defaultPackage.hasDocumentation, isFalse);
-        expect(packageGraph.defaultPackage.documentationFile, isNull);
+        expect(packageGraph.defaultPackage.packageMeta.getReadmeContents(),
+            isNull);
         expect(packageGraph.defaultPackage.documentation, isNull);
       });
 


### PR DESCRIPTION
Also change the type of `publicLibraries` and `localPublicLibraries` to Sets, as there is code looking for "canonical library" which often calls `.contains` on these fields.

Also remove documentationFile, which was only used once in lib code, and a few times in tests.