### PR TITLE
Add an option to skip unreachable SDK libraries

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -33,6 +33,7 @@ import 'package:dartdoc/src/package_meta.dart'
 import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:dartdoc/src/render/renderer_factory.dart';
 import 'package:dartdoc/src/special_elements.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path show Context;
 
 /// Everything you need to instantiate a PackageGraph object for documenting.
@@ -49,7 +50,9 @@ class PubPackageBuilder implements PackageBuilder {
   final PackageConfigProvider packageConfigProvider;
 
   PubPackageBuilder(
-      this.config, this.packageMetaProvider, this.packageConfigProvider);
+      this.config, this.packageMetaProvider, this.packageConfigProvider,
+      {@visibleForTesting skipUnreachableSdkLibraries = false})
+      : _skipUnreachableSdkLibraries = skipUnreachableSdkLibraries;
 
   @override
   Future<PackageGraph> buildPackageGraph() async {
@@ -131,7 +134,7 @@ class PubPackageBuilder implements PackageBuilder {
   );
 
   /// Returns an Iterable with the SDK files we should parse.
-  Iterable<String> getSdkFilesToDocument() sync* {
+  Iterable<String> _getSdkFilesToDocument() sync* {
     for (var sdkLib in sdk.sdkLibraries) {
       var source = sdk.mapDartUri(sdkLib.shortName)!;
       yield source.fullName;
@@ -174,6 +177,15 @@ class PubPackageBuilder implements PackageBuilder {
       }
     }
   }
+
+  /// Whether to skip unreachable libraries when gathering all of the libraries
+  /// for the package graph.
+  ///
+  /// **TESTING ONLY**
+  ///
+  /// When generating dartdoc for any package, this flag should be `false`. This
+  /// is used in tests to dramatically speed up unit tests.
+  final bool _skipUnreachableSdkLibraries;
 
   /// Parses libraries with the analyzer and invokes [addLibrary] with each
   /// result.
@@ -219,7 +231,9 @@ class PubPackageBuilder implements PackageBuilder {
       // for that package.
       for (var meta in current.difference(lastPass)) {
         if (meta.isSdk) {
-          files.addAll(getSdkFilesToDocument());
+          if (!_skipUnreachableSdkLibraries) {
+            files.addAll(_getSdkFilesToDocument());
+          }
         } else {
           files.addAll(await findFilesToDocumentInPackage(meta.dir.path,
                   autoIncludeDependencies: false, filterExcludes: false)
@@ -330,7 +344,7 @@ class PubPackageBuilder implements PackageBuilder {
   Future<Set<String>> _getFiles() async {
     Iterable<String> files;
     if (config.topLevelPackageMeta.isSdk) {
-      files = getSdkFilesToDocument();
+      files = _getSdkFilesToDocument();
     } else {
       files = await findFilesToDocumentInPackage(config.inputDir,
               autoIncludeDependencies: config.autoIncludeDependencies)

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -106,7 +106,8 @@ void main() {
       return await Dartdoc.fromContext(
         context,
         PubPackageBuilder(
-            context, pubPackageMetaProvider, PhysicalPackageConfigProvider()),
+            context, pubPackageMetaProvider, PhysicalPackageConfigProvider(),
+            skipUnreachableSdkLibraries: true),
       );
     }
 

--- a/test/mustachio/renderers_output_test.dart
+++ b/test/mustachio/renderers_output_test.dart
@@ -48,7 +48,8 @@ void main() {
     var dartdoc = await Dartdoc.fromContext(
       context,
       PubPackageBuilder(
-          context, pubPackageMetaProvider, PhysicalPackageConfigProvider()),
+          context, pubPackageMetaProvider, PhysicalPackageConfigProvider(),
+          skipUnreachableSdkLibraries: true),
     );
 
     var packageGraph = await dartdoc.packageBuilder.buildPackageGraph();

--- a/test/warnings_test.dart
+++ b/test/warnings_test.dart
@@ -237,7 +237,8 @@ class Lib2Class {}
     var dartdoc = await Dartdoc.fromContext(
       context,
       PubPackageBuilder(
-          context, pubPackageMetaProvider, PhysicalPackageConfigProvider()),
+          context, pubPackageMetaProvider, PhysicalPackageConfigProvider(),
+          skipUnreachableSdkLibraries: true),
     );
 
     var packageGraph = await dartdoc.packageBuilder.buildPackageGraph();


### PR DESCRIPTION
This option should only be used in tests, but it can speed up tests a lot. Using this in `dartdoc_test.dart` speeds up the test by 60 seconds.

This option will allow us to write more unit tests that build a package graph each go (many tests require the package graph to be built up with elements in order to assert on them), and convert end-to-end tests to unit tests.