### PR TITLE
Add support for new VM service message

### DIFF
--- a/tool/subprocess_launcher.dart
+++ b/tool/subprocess_launcher.dart
@@ -82,7 +82,7 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
     var portAsString = Completer<String>();
     void parsePortAsString(String line) {
       if (!portAsString.isCompleted && coverageEnabled) {
-        var m = _observatoryPortRegexp.matchAsPrefix(line);
+        var m = _vmServicePortRegexp.matchAsPrefix(line);
         if (m != null) {
           if (m.group(1) != null) portAsString.complete(m.group(1));
         }
@@ -126,8 +126,8 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
     return results;
   }
 
-  static final _observatoryPortRegexp =
-      RegExp(r'^Observatory listening on http://.*:(\d+)');
+  static final _vmServicePortRegexp =
+      RegExp(r'^(?:Observatory|Dart VM Service) listening on http://.*:(\d+)');
 }
 
 class SubprocessLauncher {

--- a/tool/subprocess_launcher.dart
+++ b/tool/subprocess_launcher.dart
@@ -126,8 +126,8 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
     return results;
   }
 
-  static final _vmServicePortRegexp =
-      RegExp(r'^(?:Observatory|The Dart VM Service is) listening on http://.*:(\d+)');
+  static final _vmServicePortRegexp = RegExp(
+      r'^(?:Observatory|The Dart VM service is) listening on http://.*:(\d+)');
 }
 
 class SubprocessLauncher {

--- a/tool/subprocess_launcher.dart
+++ b/tool/subprocess_launcher.dart
@@ -127,7 +127,7 @@ class CoverageSubprocessLauncher extends SubprocessLauncher {
   }
 
   static final _vmServicePortRegexp =
-      RegExp(r'^(?:Observatory|Dart VM Service) listening on http://.*:(\d+)');
+      RegExp(r'^(?:Observatory|The Dart VM Service is) listening on http://.*:(\d+)');
 }
 
 class SubprocessLauncher {


### PR DESCRIPTION
"Observatory listening on..." is eventually being updated to "Dart VM
Service listening on...". This change allows for parsing the VM service
URI from messages of either format.

See https://github.com/dart-lang/sdk/issues/46756