### PR TITLE
add runtime perf stats; remove some async

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -12,7 +12,7 @@ import 'package:dartdoc/options.dart';
 /// Analyzes Dart files and generates a representation of included libraries,
 /// classes, and members. Uses the current directory to look for libraries.
 Future<void> main(List<String> arguments) async {
-  var config = await parseOptions(pubPackageMetaProvider, arguments);
+  var config = parseOptions(pubPackageMetaProvider, arguments);
   if (config == null) {
     // There was an error while parsing options.
     return;
@@ -22,6 +22,6 @@ Future<void> main(List<String> arguments) async {
       PubPackageBuilder(config, pubPackageMetaProvider, packageConfigProvider);
   final dartdoc = config.generateDocs
       ? await Dartdoc.fromContext(config, packageBuilder)
-      : await Dartdoc.withEmptyGenerator(config, packageBuilder);
+      : Dartdoc.withEmptyGenerator(config, packageBuilder);
   dartdoc.executeGuarded();
 }

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -66,8 +66,8 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
   bool get version => optionSet['version'].valueAt(context);
 }
 
-Future<List<DartdocOption<bool>>> createDartdocProgramOptions(
-    PackageMetaProvider packageMetaProvider) async {
+List<DartdocOption<bool>> createDartdocProgramOptions(
+    PackageMetaProvider packageMetaProvider) {
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgOnly<bool>('generateDocs', true, resourceProvider,
@@ -82,12 +82,12 @@ Future<List<DartdocOption<bool>>> createDartdocProgramOptions(
   ];
 }
 
-Future<DartdocProgramOptionContext?> parseOptions(
+DartdocProgramOptionContext? parseOptions(
   PackageMetaProvider packageMetaProvider,
   List<String> arguments, {
   OptionGenerator? additionalOptions,
-}) async {
-  var optionRoot = await DartdocOptionRoot.fromOptionGenerators(
+}) {
+  var optionRoot = DartdocOptionRoot.fromOptionGenerators(
       'dartdoc',
       [
         createDartdocOptions,
@@ -126,7 +126,6 @@ Future<DartdocProgramOptionContext?> parseOptions(
   } on DartdocOptionError catch (e) {
     stderr.writeln(' fatal error: ${e.message}');
     stderr.writeln('');
-    await stderr.flush();
     _printUsage(optionRoot.argParser);
     exitCode = 64;
     return null;

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -14,7 +14,6 @@
 ///
 library dartdoc.dartdoc_options;
 
-import 'dart:async';
 import 'dart:io' show Platform, stdout;
 
 import 'package:analyzer/dart/element/element.dart';
@@ -453,7 +452,7 @@ abstract class DartdocOption<T extends Object?> {
   ArgResults get _argResults => root.__argResults;
 
   /// To avoid accessing early, call [add] on the option's parent before
-  /// looking up unless this is a [DartdocRootOption].
+  /// looking up unless this is a [DartdocOptionRoot].
   late final DartdocOption<dynamic> parent;
 
   /// The [DartdocOptionRoot] containing this object.
@@ -664,8 +663,7 @@ abstract class DartdocSyntheticOption<T> implements DartdocOption<T> {
   }
 }
 
-typedef OptionGenerator = Future<List<DartdocOption>> Function(
-    PackageMetaProvider);
+typedef OptionGenerator = List<DartdocOption> Function(PackageMetaProvider);
 
 /// This is a [DartdocOptionSet] used as a root node.
 class DartdocOptionRoot extends DartdocOptionSet {
@@ -681,14 +679,14 @@ class DartdocOptionRoot extends DartdocOptionSet {
   /// [name] is the top level key for the option set.
   /// [optionGenerators] is a sequence of asynchronous functions that return
   /// [DartdocOption]s that will be added to the new option set.
-  static Future<DartdocOptionRoot> fromOptionGenerators(
+  static DartdocOptionRoot fromOptionGenerators(
       String name,
       Iterable<OptionGenerator> optionGenerators,
-      PackageMetaProvider packageMetaProvider) async {
+      PackageMetaProvider packageMetaProvider) {
     var optionSet =
         DartdocOptionRoot(name, packageMetaProvider.resourceProvider);
     for (var generator in optionGenerators) {
-      optionSet.addAll(await generator(packageMetaProvider));
+      optionSet.addAll(generator(packageMetaProvider));
     }
     return optionSet;
   }
@@ -841,7 +839,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
   /// Otherwise, the child's value overrides values in parents.
   bool get parentDirOverridesChild;
 
-  /// The name of the option, with nested options joined by [.].  For example:
+  /// The name of the option, with nested options joined by `.`.  For example:
   ///
   /// ```yaml
   /// dartdoc:
@@ -1344,9 +1342,9 @@ class DartdocOptionContext extends DartdocOptionContextBase
 
 /// Instantiate dartdoc's configuration file and options parser with the
 /// given command line arguments.
-Future<List<DartdocOption>> createDartdocOptions(
+List<DartdocOption> createDartdocOptions(
   PackageMetaProvider packageMetaProvider,
-) async {
+) {
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgOnly<bool>('allowTools', false, resourceProvider,
@@ -1596,8 +1594,8 @@ Future<List<DartdocOption>> createDartdocOptions(
         hide: false),
     // TODO(jcollins-g): refactor so there is a single static "create" for
     // each DartdocOptionContext that traverses the inheritance tree itself.
-    ...await createExperimentOptions(resourceProvider),
-    ...await createPackageWarningOptions(packageMetaProvider),
-    ...await createSourceLinkerOptions(resourceProvider),
+    ...createExperimentOptions(resourceProvider),
+    ...createPackageWarningOptions(packageMetaProvider),
+    ...createSourceLinkerOptions(resourceProvider),
   ];
 }

--- a/lib/src/experiment_options.dart
+++ b/lib/src/experiment_options.dart
@@ -21,8 +21,8 @@ abstract class DartdocExperimentOptionContext
 
 // TODO(jcollins-g): Implement YAML parsing for these flags and generation
 // of [DartdocExperimentOptionContext], once a YAML file is available.
-Future<List<DartdocOption<Object>>> createExperimentOptions(
-    ResourceProvider resourceProvider) async {
+List<DartdocOption<Object>> createExperimentOptions(
+    ResourceProvider resourceProvider) {
   return [
     // TODO(jcollins-g): Consider loading experiment values from dartdoc_options.yaml?
     DartdocOptionArgOnly<List<String>>(

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -28,6 +28,6 @@ class EmptyGenerator extends Generator {
   }
 }
 
-Future<Generator> initEmptyGenerator(DartdocOptionContext config) async {
+Generator initEmptyGenerator(DartdocOptionContext config) {
   return EmptyGenerator();
 }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -43,8 +43,8 @@ abstract class Generator {
   Future<void> generate(PackageGraph packageGraph, FileWriter writer);
 }
 
-Future<List<DartdocOption>> createGeneratorOptions(
-    PackageMetaProvider packageMetaProvider) async {
+List<DartdocOption> createGeneratorOptions(
+    PackageMetaProvider packageMetaProvider) {
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgFile<List<String>>('footer', [], resourceProvider,

--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -39,15 +39,15 @@ extension ResourceLoader on ResourceProvider {
 
   /// Helper function for resolving to a non-relative, non-package URI.
   @visibleForTesting
-  Future<Uri> resolveResourceUri(Uri uri) {
+  Future<Uri> resolveResourceUri(Uri uri) async {
     if (uri.scheme == 'package') {
-      return Isolate.resolvePackageUri(uri).then((resolvedUri) {
-        if (resolvedUri == null) {
-          throw ArgumentError.value(uri, 'uri', 'Unknown package');
-        }
-        return resolvedUri;
-      });
+      var resolvedUri = await Isolate.resolvePackageUri(uri);
+      if (resolvedUri == null) {
+        throw ArgumentError.value(uri, 'uri', 'Unknown package');
+      }
+      return resolvedUri;
+    } else {
+      return Uri.base.resolveUri(uri);
     }
-    return Future<Uri>.value(Uri.base.resolveUri(uri));
   }
 }

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -346,7 +346,7 @@ class RuntimeTemplates implements Templates {
   /// Creates a [Templates] from a custom set of template files, found in [dir].
   static Future<Templates> _create(Folder dir, String format,
       {required ResourceProvider resourceProvider}) async {
-    Future<Template> loadTemplate(String templatePath) async {
+    Future<Template> loadTemplate(String templatePath) {
       var templateFile = dir.getChildAssumingFile('$templatePath.$format');
       if (!templateFile.exists) {
         throw DartdocFailure(

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -132,8 +132,8 @@ abstract class LoggingContext implements DartdocOptionContextBase {
   bool get quiet => optionSet['quiet'].valueAt(context);
 }
 
-Future<List<DartdocOption<Object>>> createLoggingOptions(
-    PackageMetaProvider packageMetaProvider) async {
+List<DartdocOption<Object>> createLoggingOptions(
+    PackageMetaProvider packageMetaProvider) {
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgOnly<bool>('json', false, resourceProvider,

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -264,8 +264,10 @@ md.Node _makeLinkNode(String codeRef, Warnable warnable) {
 @visibleForTesting
 MatchingLinkResult getMatchingLinkElement(Warnable warnable, String codeRef) {
   var result = _getMatchingLinkElementCommentReferable(codeRef, warnable);
-  markdownStats.totalReferences++;
-  if (result.commentReferable != null) markdownStats.resolvedReferences++;
+  runtimeStats.totalReferences++;
+  if (result.commentReferable != null) {
+    runtimeStats.resolvedReferences++;
+  }
   return result;
 }
 

--- a/lib/src/matching_link_result.dart
+++ b/lib/src/matching_link_result.dart
@@ -27,24 +27,83 @@ class MatchingLinkResult {
   }
 }
 
-class _MarkdownStats {
+class _RuntimeStats {
   int totalReferences = 0;
   int resolvedReferences = 0;
 
+  List<_PerfTask> perfTasks = [];
+  List<_PerfTask> taskQueue = [];
+
   String _valueAndPercent(int references) {
-    return '$references (${references.toDouble() / totalReferences.toDouble() * 100}%)';
+    final percent = references.toDouble() / totalReferences.toDouble() * 100;
+    return '$references (${percent.toStringAsFixed(3)}%)';
+  }
+
+  /// Start a new, named, performance task.
+  ///
+  /// Performance tasks may be nested. Note that this API currently depends on
+  /// inner tasks ending before their parent tasks, and, sibling tasks being
+  /// sequential (and not parallelized).
+  void startPerfTask(String name) {
+    if (taskQueue.isEmpty) {
+      var task = _PerfTask(name);
+      perfTasks.add(task);
+      taskQueue.add(task);
+    } else {
+      var task = _PerfTask(name);
+      taskQueue.last.children.add(task);
+      taskQueue.add(task);
+    }
+  }
+
+  /// End the last started performance task.
+  void endPerfTask() {
+    taskQueue.removeLast().finish();
   }
 
   String buildReport() {
-    var report = StringBuffer();
-    report.writeln('Reference Counts:');
-    report.writeln('total references: $totalReferences');
-    report.writeln(
-        'resolved references:  ${_valueAndPercent(resolvedReferences)}');
+    final report = StringBuffer();
+    report.writeln('\nReference Counts:');
+    report.writeln('  total references: $totalReferences');
+    report.writeln('  resolved references:  '
+        '${_valueAndPercent(resolvedReferences)}');
+
+    if (perfTasks.isNotEmpty) {
+      report.writeln('\nRuntime performance:');
+      for (var task in perfTasks) {
+        task.writeTo(report);
+      }
+    }
+
     return report.toString();
   }
 }
 
-/// TODO(jcollins-g): perhaps a more generic stats gathering apparatus for
-/// dartdoc would be useful, and one that isn't process-global.
-final markdownStats = _MarkdownStats();
+/// TODO(jcollins-g): re-write to something that isn't process-global?
+final _RuntimeStats runtimeStats = _RuntimeStats();
+
+class _PerfTask {
+  final String name;
+  final Stopwatch timer = Stopwatch();
+  List<_PerfTask> children = [];
+
+  _PerfTask(this.name) {
+    timer.start();
+  }
+
+  void finish() {
+    timer.stop();
+  }
+
+  void writeTo(StringBuffer buf) {
+    _writeTo(buf, '');
+  }
+
+  void _writeTo(StringBuffer buf, String indent) {
+    buf.write('$indent$name '.padRight(32));
+    buf.writeln('${timer.elapsedMilliseconds}ms'.padLeft(8));
+    for (var child in children) {
+      child._writeTo(buf, '  $indent');
+    }
+  }
+}

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -160,7 +160,7 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   }
 
   /// Given a [result] found in an implementation of [lookupViaScope] or
-  /// [_lookupViaReferenceChildren], recurse through children, skipping over
+  /// [ReferenceChildrenLookup], recurse through children, skipping over
   /// results that do not match the filter.
   CommentReferable? recurseChildrenAndFilter(
       ReferenceChildrenLookup referenceLookup, CommentReferable result,

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -93,7 +93,8 @@ mixin DocumentationComment
   }
 
   /// Process a [documentationComment], performing various actions based on
-  /// `{@}`-style directives, except `{@tool}`, returning the processed result.
+  /// `{@}`-style directives (except tool directives), returning the processed
+  /// result.
   String _processCommentWithoutTools(String documentationComment) {
     var docs = stripComments(documentationComment);
     if (!docs.contains('{@')) {

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -17,7 +17,7 @@ import 'package:meta/meta.dart';
 /// with a direct call to a [Constructor] in Dart.
 ///
 /// Note that [Constructor]s are not considered to be modifiers so a
-/// [hasModifier] override is not necessary for this mixin.
+/// [hasModifiers] override is not necessary for this mixin.
 mixin Constructable on InheritingContainer {
   List<Constructor>? _constructors;
   Iterable<Constructor> get constructors => _constructors ??= [

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -26,6 +26,7 @@ import 'package:analyzer/src/generated/sdk.dart' show DartSdk;
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/logging.dart';
+import 'package:dartdoc/src/matching_link_result.dart';
 import 'package:dartdoc/src/model/model.dart' hide Package;
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart'
@@ -69,8 +70,11 @@ class PubPackageBuilder implements PackageBuilder {
 
     var rendererFactory = RendererFactory.forFormat(config.format);
 
+    runtimeStats.startPerfTask('_calculatePackageMap');
     await _calculatePackageMap();
+    runtimeStats.endPerfTask();
 
+    runtimeStats.startPerfTask('getLibraries');
     var newGraph = PackageGraph.uninitialized(
       config,
       sdk,
@@ -79,7 +83,11 @@ class PubPackageBuilder implements PackageBuilder {
       packageMetaProvider,
     );
     await getLibraries(newGraph);
+    runtimeStats.endPerfTask();
+
+    runtimeStats.startPerfTask('initializePackageGraph');
     await newGraph.initializePackageGraph();
+    runtimeStats.endPerfTask();
     return newGraph;
   }
 

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -10,6 +10,8 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/generated/sdk.dart' show DartSdk, SdkLibrary;
 // ignore: implementation_imports
 import 'package:analyzer/src/generated/source.dart' show Source;
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/timestamped_data.dart';
 import 'package:collection/collection.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -12,6 +12,7 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:meta/meta.dart';
 import 'parser.dart';
 
+// TODO(devoncarew): See is we can make this synchronous.
 /// The signature of a partial resolver function.
 typedef PartialResolver = Future<File> Function(String uri);
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -232,7 +232,7 @@ abstract class PubPackageMeta extends PackageMeta {
   }
 
   /// This factory is guaranteed to return the same object for any given
-  /// [dir.absolute.path].  Multiple [dir.absolute.path]s will resolve to the
+  /// `dir.absolute.path`.  Multiple `dir.absolute.path`s will resolve to the
   /// same object if they are part of the same package.  Returns null
   /// if the directory is not part of a known package.
   static PackageMeta? fromDir(

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -26,8 +26,8 @@ abstract class SourceLinkerOptionContext implements DartdocOptionContextBase {
       optionSet['linkToSource']['uriTemplate'].valueAt(context);
 }
 
-Future<List<DartdocOption<Object?>>> createSourceLinkerOptions(
-    ResourceProvider resourceProvider) async {
+List<DartdocOption<Object?>> createSourceLinkerOptions(
+    ResourceProvider resourceProvider) {
   return [
     DartdocOptionSet('linkToSource', resourceProvider)
       ..addAll([

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -27,9 +27,9 @@ abstract class PackageWarningOptionContext implements DartdocOptionContextBase {
   bool get verboseWarnings => optionSet['verboseWarnings'].valueAt(context);
 }
 
-Future<List<DartdocOption<Object?>>> createPackageWarningOptions(
+List<DartdocOption<Object?>> createPackageWarningOptions(
   PackageMetaProvider packageMetaProvider,
-) async {
+) {
   var resourceProvider = packageMetaProvider.resourceProvider;
   return [
     DartdocOptionArgOnly<bool>('allowNonLocalWarnings', false, resourceProvider,

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -81,7 +81,7 @@ void main() {
 int x;
 ''');
 
-      var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+      var optionSet = DartdocOptionRoot.fromOptionGenerators(
           'dartdoc', [createDartdocOptions], packageMetaProvider);
       optionSet.parseArguments([]);
       packageGraph = await utils.bootBasicPackage(

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -57,7 +57,7 @@ void main() {
     late Folder tempDir;
 
     setUpAll(() async {
-      var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+      var optionSet = DartdocOptionRoot.fromOptionGenerators(
           'dartdoc',
           [createDartdocProgramOptions, createLoggingOptions],
           pubPackageMetaProvider);

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -105,7 +105,7 @@ void main() {
             'resources/$resource', 'CONTENT');
       }
 
-      var optionRoot = await DartdocOptionRoot.fromOptionGenerators(
+      var optionRoot = DartdocOptionRoot.fromOptionGenerators(
           'dartdoc',
           [
             createDartdocOptions,

--- a/test/mustachio/renderers_output_test.dart
+++ b/test/mustachio/renderers_output_test.dart
@@ -24,7 +24,7 @@ import 'package:test/test.dart';
 /// the '--input' flag.
 Future<DartdocGeneratorOptionContext> _generatorContextFromArgv(
     List<String> argv) async {
-  var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+  var optionSet = DartdocOptionRoot.fromOptionGenerators(
       'dartdoc',
       [
         createDartdocOptions,

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -39,7 +39,7 @@ void main() {
         packageMetaProvider.resourceProvider as MemoryResourceProvider;
     sdkFolder = packageMetaProvider.defaultSdkDir;
 
-    optionSet = await DartdocOptionRoot.fromOptionGenerators(
+    optionSet = DartdocOptionRoot.fromOptionGenerators(
         'dartdoc', [createDartdocOptions], packageMetaProvider);
     packageConfigProvider = utils.getTestPackageConfigProvider(sdkFolder.path)
         as FakePackageConfigProvider;

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -40,7 +40,7 @@ final Folder testPackageToolError = _resourceProvider.getFolder(_pathContext
 /// [DartdocOptionSet] based on the current working directory.
 Future<DartdocOptionContext> contextFromArgv(
     List<String> argv, PackageMetaProvider packageMetaProvider) async {
-  var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+  var optionSet = DartdocOptionRoot.fromOptionGenerators(
       'dartdoc', [createDartdocOptions], packageMetaProvider);
   optionSet.parseArguments(argv);
   return DartdocOptionContext.fromDefaultContextLocation(
@@ -52,7 +52,7 @@ Future<DartdocOptionContext> contextFromArgv(
 /// directory and/or the '--input' flag.
 Future<DartdocGeneratorOptionContext> generatorContextFromArgv(
     List<String> argv) async {
-  var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+  var optionSet = DartdocOptionRoot.fromOptionGenerators(
       'dartdoc',
       [
         createDartdocOptions,

--- a/test/warnings_test.dart
+++ b/test/warnings_test.dart
@@ -20,7 +20,7 @@ import 'src/test_descriptor_utils.dart' as d;
 
 void main() async {
   var resourceProvider = PhysicalResourceProvider.INSTANCE;
-  var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+  var optionSet = DartdocOptionRoot.fromOptionGenerators(
       'dartdoc', [createDartdocOptions], pubPackageMetaProvider);
 
   test('excluding package from "allowed warnings" list ignores all', () async {
@@ -221,7 +221,7 @@ class Lib2Class {}
 
     var tempDir = resourceProvider.createSystemTemp('dartdoc.test.');
 
-    var optionSet = await DartdocOptionRoot.fromOptionGenerators(
+    var optionSet = DartdocOptionRoot.fromOptionGenerators(
         'dartdoc',
         [
           createDartdocOptions,


### PR DESCRIPTION
This was work done during a very casual look at the runtime perf of dartdoc; this PR does not contain any actual perf improvements.

- add some simple runtime perf stats, to how much time we're spending in various parts of doc generation
- remove some uses of async (where we could just collapse to simple sync calls, and then iteratively remove async from callers and APIs; this makes the perf a little easier to trace in things like DevTools
- fix a few minor issues in dartdoc's own API comments

Here's some sample perf stats (from documenting dartdoc itself):

```
generateDocs                     31,323ms
  buildPackageGraph              2,3106ms
    _calculatePackageMap             18ms
    getLibraries                 16,787ms
    initializePackageGraph        6,299ms
  generator.generate              1,865ms
  validateLinks                   6,343ms
```
