### PR TITLE
Cleanups for enum and InheritingContainer code

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1308,43 +1308,21 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.writeln();
     buffer.write('''
     <section>
-      <dl class="dl-horizontal">''');
-    if (context2.hasPublicSuperChainReversed == true) {
-      buffer.writeln();
-      buffer.write('''
-        <dt>Inheritance</dt>
-        <dd><ul class="gt-separated dark clazz-relationships">
-          <li>''');
-      buffer.write(context0.linkedObjectType);
-      buffer.write('''</li>''');
-      var context3 = context2.publicSuperChainReversed;
-      for (var context4 in context3) {
-        buffer.writeln();
-        buffer.write('''
-          <li>''');
-        buffer.write(context4.linkedName);
-        buffer.write('''</li>''');
-      }
-      buffer.writeln();
-      buffer.write('''
-          <li>''');
-      buffer.write(context2.name);
-      buffer.write('''</li>
-        </ul></dd>''');
-    }
-    buffer.writeln();
+      <dl class="dl-horizontal">
+        ''');
+    buffer.write(_renderClass_partial_super_chain_5(context2, context0));
     if (context2.hasPublicInterfaces == true) {
       buffer.writeln();
       buffer.write('''
         <dt>Implemented types</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">''');
-      var context5 = context2.publicInterfaces;
-      for (var context6 in context5) {
+      var context3 = context2.publicInterfaces;
+      for (var context4 in context3) {
         buffer.writeln();
         buffer.write('''
             <li>''');
-        buffer.write(context6.linkedName);
+        buffer.write(context4.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -1358,12 +1336,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
         <dt>Mixed in types</dt>
         <dd><ul class="comma-separated clazz-relationships">''');
-      var context7 = context2.publicMixedInTypes;
-      for (var context8 in context7) {
+      var context5 = context2.publicMixedInTypes;
+      for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
           <li>''');
-        buffer.write(context8.linkedName);
+        buffer.write(context6.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -1376,12 +1354,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
         <dt>Implementers</dt>
         <dd><ul class="comma-separated clazz-relationships">''');
-      var context9 = context2.publicImplementorsSorted;
-      for (var context10 in context9) {
+      var context7 = context2.publicImplementorsSorted;
+      for (var context8 in context7) {
         buffer.writeln();
         buffer.write('''
           <li>''');
-        buffer.write(context10.linkedName);
+        buffer.write(context8.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -1394,12 +1372,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
         <dt>Available Extensions</dt>
         <dd><ul class="comma-separated clazz-relationships">''');
-      var context11 = context2.potentiallyApplicableExtensionsSorted;
-      for (var context12 in context11) {
+      var context9 = context2.potentiallyApplicableExtensionsSorted;
+      for (var context10 in context9) {
         buffer.writeln();
         buffer.write('''
           <li>''');
-        buffer.write(context12.linkedName);
+        buffer.write(context10.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -1412,12 +1390,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
         <dt>Annotations</dt>
         <dd><ul class="annotation-list clazz-relationships">''');
-      var context13 = context2.annotations;
-      for (var context14 in context13) {
+      var context11 = context2.annotations;
+      for (var context12 in context11) {
         buffer.writeln();
         buffer.write('''
           <li>''');
-        buffer.write(context14.linkedNameWithParameters);
+        buffer.write(context12.linkedNameWithParameters);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -1437,30 +1415,30 @@ String renderClass(_i1.ClassTemplateData context0) {
       <h2>Constructors</h2>
 
       <dl class="constructor-summary-list">''');
-    var context15 = context2.publicConstructorsSorted;
-    for (var context16 in context15) {
+    var context13 = context2.publicConstructorsSorted;
+    for (var context14 in context13) {
       buffer.writeln();
       buffer.write('''
         <dt id="''');
-      buffer.writeEscaped(context16.htmlId);
+      buffer.writeEscaped(context14.htmlId);
       buffer.write('''" class="callable">
           <span class="name">''');
-      buffer.write(context16.linkedName);
+      buffer.write(context14.linkedName);
       buffer.write('''</span><span class="signature">(''');
-      buffer.write(context16.linkedParams);
+      buffer.write(context14.linkedParams);
       buffer.write(''')</span>
         </dt>
         <dd>
           ''');
-      buffer.write(context16.oneLineDoc);
+      buffer.write(context14.oneLineDoc);
       buffer.write(' ');
-      buffer.write(context16.extendedDocLink);
-      if (context16.isConst == true) {
+      buffer.write(context14.extendedDocLink);
+      if (context14.isConst == true) {
         buffer.writeln();
         buffer.write('''
           <div class="constructor-modifier features">const</div>''');
       }
-      if (context16.isFactory == true) {
+      if (context14.isFactory == true) {
         buffer.writeln();
         buffer.write('''
           <div class="constructor-modifier features">factory</div>''');
@@ -1486,11 +1464,11 @@ String renderClass(_i1.ClassTemplateData context0) {
       <h2>Properties</h2>
 
       <dl class="properties">''');
-    var context17 = context2.publicInstanceFieldsSorted;
-    for (var context18 in context17) {
+    var context15 = context2.publicInstanceFieldsSorted;
+    for (var context16 in context15) {
       buffer.write('\n        ');
       buffer.write(
-          _renderClass_partial_property_5(context18, context2, context0));
+          _renderClass_partial_property_6(context16, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -1508,11 +1486,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">''');
-    var context19 = context2.publicInstanceMethodsSorted;
-    for (var context20 in context19) {
+    var context17 = context2.publicInstanceMethodsSorted;
+    for (var context18 in context17) {
       buffer.write('\n        ');
       buffer.write(
-          _renderClass_partial_callable_6(context20, context2, context0));
+          _renderClass_partial_callable_7(context18, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -1530,11 +1508,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''" id="operators">
       <h2>Operators</h2>
       <dl class="callables">''');
-    var context21 = context2.publicInstanceOperatorsSorted;
-    for (var context22 in context21) {
+    var context19 = context2.publicInstanceOperatorsSorted;
+    for (var context20 in context19) {
       buffer.write('\n        ');
       buffer.write(
-          _renderClass_partial_callable_6(context22, context2, context0));
+          _renderClass_partial_callable_7(context20, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -1549,11 +1527,11 @@ String renderClass(_i1.ClassTemplateData context0) {
       <h2>Static Properties</h2>
 
       <dl class="properties">''');
-    var context23 = context2.publicVariableStaticFieldsSorted;
-    for (var context24 in context23) {
+    var context21 = context2.publicVariableStaticFieldsSorted;
+    for (var context22 in context21) {
       buffer.write('\n        ');
       buffer.write(
-          _renderClass_partial_property_5(context24, context2, context0));
+          _renderClass_partial_property_6(context22, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -1567,11 +1545,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     <section class="summary offset-anchor" id="static-methods">
       <h2>Static Methods</h2>
       <dl class="callables">''');
-    var context25 = context2.publicStaticMethodsSorted;
-    for (var context26 in context25) {
+    var context23 = context2.publicStaticMethodsSorted;
+    for (var context24 in context23) {
       buffer.write('\n        ');
       buffer.write(
-          _renderClass_partial_callable_6(context26, context2, context0));
+          _renderClass_partial_callable_7(context24, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -1586,11 +1564,11 @@ String renderClass(_i1.ClassTemplateData context0) {
       <h2>Constants</h2>
 
       <dl class="properties">''');
-    var context27 = context2.publicConstantFieldsSorted;
-    for (var context28 in context27) {
+    var context25 = context2.publicConstantFieldsSorted;
+    for (var context26 in context25) {
       buffer.write('\n        ');
       buffer.write(
-          _renderClass_partial_constant_7(context28, context2, context0));
+          _renderClass_partial_constant_8(context26, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -1604,7 +1582,7 @@ String renderClass(_i1.ClassTemplateData context0) {
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderClass_partial_search_sidebar_8(context0));
+  buffer.write(_renderClass_partial_search_sidebar_9(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -1626,7 +1604,7 @@ String renderClass(_i1.ClassTemplateData context0) {
   </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderClass_partial_footer_9(context0));
+  buffer.write(_renderClass_partial_footer_10(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -1842,7 +1820,40 @@ String _renderClass_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderClass_partial_property_5(
+String _renderClass_partial_super_chain_5(
+    _i8.Class context1, _i1.ClassTemplateData context0) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicSuperChainReversed == true) {
+    buffer.writeln();
+    buffer.write('''
+  <dt>Inheritance</dt>
+  <dd><ul class="gt-separated dark ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">
+    <li>''');
+    buffer.write(context0.linkedObjectType);
+    buffer.write('''</li>''');
+    var context2 = context1.publicSuperChainReversed;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+    <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    <li>''');
+    buffer.write(context1.name);
+    buffer.write('''</li>
+  </ul></dd>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _renderClass_partial_property_6(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -1860,7 +1871,7 @@ String _renderClass_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderClass_partial_property_5_partial_categorization_0(
+  buffer.write(__renderClass_partial_property_6_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -1875,7 +1886,7 @@ String _renderClass_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderClass_partial_property_5_partial_features_1(
+  buffer.write(__renderClass_partial_property_6_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -1885,7 +1896,7 @@ String _renderClass_partial_property_5(
   return buffer.toString();
 }
 
-String __renderClass_partial_property_5_partial_categorization_0(
+String __renderClass_partial_property_6_partial_categorization_0(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -1900,7 +1911,7 @@ String __renderClass_partial_property_5_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderClass_partial_property_5_partial_features_1(
+String __renderClass_partial_property_6_partial_features_1(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -1913,7 +1924,7 @@ String __renderClass_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_callable_6(
+String _renderClass_partial_callable_7(
     _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -1939,7 +1950,7 @@ String _renderClass_partial_callable_6(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderClass_partial_callable_6_partial_categorization_0(
+  buffer.write(__renderClass_partial_callable_7_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -1954,7 +1965,7 @@ String _renderClass_partial_callable_6(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderClass_partial_callable_6_partial_features_1(
+  buffer.write(__renderClass_partial_callable_7_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -1964,7 +1975,7 @@ String _renderClass_partial_callable_6(
   return buffer.toString();
 }
 
-String __renderClass_partial_callable_6_partial_categorization_0(
+String __renderClass_partial_callable_7_partial_categorization_0(
     _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -1979,7 +1990,7 @@ String __renderClass_partial_callable_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderClass_partial_callable_6_partial_features_1(
+String __renderClass_partial_callable_7_partial_features_1(
     _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -1992,7 +2003,7 @@ String __renderClass_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_constant_7(
+String _renderClass_partial_constant_8(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -2009,7 +2020,7 @@ String _renderClass_partial_constant_7(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderClass_partial_constant_7_partial_categorization_0(
+  buffer.write(__renderClass_partial_constant_8_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -2020,7 +2031,7 @@ String _renderClass_partial_constant_7(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderClass_partial_constant_7_partial_features_1(
+  buffer.write(__renderClass_partial_constant_8_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -2035,7 +2046,7 @@ String _renderClass_partial_constant_7(
   return buffer.toString();
 }
 
-String __renderClass_partial_constant_7_partial_categorization_0(
+String __renderClass_partial_constant_8_partial_categorization_0(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -2050,7 +2061,7 @@ String __renderClass_partial_constant_7_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderClass_partial_constant_7_partial_features_1(
+String __renderClass_partial_constant_8_partial_features_1(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -2063,7 +2074,7 @@ String __renderClass_partial_constant_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_search_sidebar_8(_i1.ClassTemplateData context0) {
+String _renderClass_partial_search_sidebar_9(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -2122,7 +2133,7 @@ String _renderClass_partial_search_sidebar_8(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderClass_partial_footer_9(_i1.ClassTemplateData context0) {
+String _renderClass_partial_footer_10(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -2603,15 +2614,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.write('''
       <div>''');
   buffer.write(_renderEnum_partial_source_link_1(context1, context0));
-  buffer.write('''<h1><span class="kind-enum">''');
+  buffer.writeln();
+  buffer.write('''
+        <h1>
+          <span class="kind-enum">''');
   buffer.write(context1.name);
-  buffer.write('''</span> ''');
+  buffer.write('''</span>
+          ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
   buffer.write(_renderEnum_partial_feature_set_2(context1, context0));
   buffer.write(' ');
   buffer.write(_renderEnum_partial_categorization_3(context1, context0));
-  buffer.write('''</h1></div>''');
+  buffer.writeln();
+  buffer.write('''
+        </h1>
+      </div>''');
   buffer.writeln();
   var context2 = context0.eNum;
   buffer.write('\n    ');
@@ -2621,42 +2639,20 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.writeln();
     buffer.write('''
     <section>
-      <dl class="dl-horizontal">''');
-    if (context2.hasPublicSuperChainReversed == true) {
-      buffer.writeln();
-      buffer.write('''
-        <dt>Inheritance</dt>
-        <dd><ul class="gt-separated dark eNum-relationships">
-          <li>''');
-      buffer.write(context0.linkedObjectType);
-      buffer.write('''</li>''');
-      var context3 = context2.publicSuperChainReversed;
-      for (var context4 in context3) {
-        buffer.writeln();
-        buffer.write('''
-          <li>''');
-        buffer.write(context4.linkedName);
-        buffer.write('''</li>''');
-      }
-      buffer.writeln();
-      buffer.write('''
-          <li>''');
-      buffer.write(context2.name);
-      buffer.write('''</li>
-        </ul></dd>''');
-    }
-    buffer.writeln();
+      <dl class="dl-horizontal">
+        ''');
+    buffer.write(_renderEnum_partial_super_chain_5(context2, context0));
     if (context2.hasAnnotations == true) {
       buffer.writeln();
       buffer.write('''
         <dt>Annotations</dt>
         <dd><ul class="annotation-list eNum-relationships">''');
-      var context5 = context2.annotations;
-      for (var context6 in context5) {
+      var context3 = context2.annotations;
+      for (var context4 in context3) {
         buffer.writeln();
         buffer.write('''
           <li>''');
-        buffer.write(context6.linkedNameWithParameters);
+        buffer.write(context4.linkedNameWithParameters);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -2676,11 +2672,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
       <h2>Constants</h2>
 
       <dl class="properties">''');
-    var context7 = context2.publicConstantFieldsSorted;
-    for (var context8 in context7) {
+    var context5 = context2.publicConstantFieldsSorted;
+    for (var context6 in context5) {
       buffer.write('\n        ');
       buffer
-          .write(_renderEnum_partial_constant_5(context8, context2, context0));
+          .write(_renderEnum_partial_constant_6(context6, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -2691,19 +2687,23 @@ String renderEnum(_i1.EnumTemplateData context0) {
   if (context2.hasPublicInstanceFields == true) {
     buffer.writeln();
     buffer.write('''
-    <section class="summary offset-anchor''');
+    <section
+        class="
+          summary
+          offset-anchor''');
     if (context2.publicInheritedInstanceFields == true) {
-      buffer.write(''' inherited''');
+      buffer.write('''inherited''');
     }
-    buffer.write('''" id="instance-properties">
+    buffer.write('''"
+        id="instance-properties">
       <h2>Properties</h2>
 
       <dl class="properties">''');
-    var context9 = context2.publicInstanceFieldsSorted;
-    for (var context10 in context9) {
+    var context7 = context2.publicInstanceFieldsSorted;
+    for (var context8 in context7) {
       buffer.write('\n        ');
       buffer
-          .write(_renderEnum_partial_property_6(context10, context2, context0));
+          .write(_renderEnum_partial_property_7(context8, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -2714,18 +2714,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
   if (context2.hasPublicInstanceMethods == true) {
     buffer.writeln();
     buffer.write('''
-    <section class="summary offset-anchor''');
+    <section
+        class="
+          summary
+          offset-anchor''');
     if (context2.publicInheritedInstanceMethods == true) {
-      buffer.write(''' inherited''');
+      buffer.write('''inherited''');
     }
-    buffer.write('''" id="instance-methods">
+    buffer.write('''"
+        id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">''');
-    var context11 = context2.publicInstanceMethodsSorted;
-    for (var context12 in context11) {
+    var context9 = context2.publicInstanceMethodsSorted;
+    for (var context10 in context9) {
       buffer.write('\n        ');
       buffer
-          .write(_renderEnum_partial_callable_7(context12, context2, context0));
+          .write(_renderEnum_partial_callable_8(context10, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -2736,18 +2740,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
   if (context2.hasPublicInstanceOperators == true) {
     buffer.writeln();
     buffer.write('''
-    <section class="summary offset-anchor''');
+    <section
+        class="
+          summary
+          offset-anchor''');
     if (context2.publicInheritedInstanceOperators == true) {
-      buffer.write(''' inherited''');
+      buffer.write('''inherited''');
     }
-    buffer.write('''" id="operators">
+    buffer.write('''"
+        id="operators">
       <h2>Operators</h2>
       <dl class="callables">''');
-    var context13 = context2.publicInstanceOperatorsSorted;
-    for (var context14 in context13) {
+    var context11 = context2.publicInstanceOperatorsSorted;
+    for (var context12 in context11) {
       buffer.write('\n        ');
       buffer
-          .write(_renderEnum_partial_callable_7(context14, context2, context0));
+          .write(_renderEnum_partial_callable_8(context12, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -2762,11 +2770,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
       <h2>Static Properties</h2>
 
       <dl class="properties">''');
-    var context15 = context2.publicVariableStaticFieldsSorted;
-    for (var context16 in context15) {
+    var context13 = context2.publicVariableStaticFieldsSorted;
+    for (var context14 in context13) {
       buffer.write('\n        ');
       buffer
-          .write(_renderEnum_partial_property_6(context16, context2, context0));
+          .write(_renderEnum_partial_property_7(context14, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -2780,11 +2788,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
     <section class="summary offset-anchor" id="static-methods">
       <h2>Static Methods</h2>
       <dl class="callables">''');
-    var context17 = context2.publicStaticMethodsSorted;
-    for (var context18 in context17) {
+    var context15 = context2.publicStaticMethodsSorted;
+    for (var context16 in context15) {
       buffer.write('\n        ');
       buffer
-          .write(_renderEnum_partial_callable_7(context18, context2, context0));
+          .write(_renderEnum_partial_callable_8(context16, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -2793,11 +2801,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
   }
   buffer.writeln();
   buffer.write('''
-  </div> <!-- /.main-content -->
+  </div><!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderEnum_partial_search_sidebar_8(context0));
+  buffer.write(_renderEnum_partial_search_sidebar_9(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -2816,10 +2824,10 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.write(context0.sidebarForContainer);
   buffer.writeln();
   buffer.write('''
-  </div><!--/.sidebar-offcanvas-->
+  </div><!-- /.sidebar-offcanvas -->
 
 ''');
-  buffer.write(_renderEnum_partial_footer_9(context0));
+  buffer.write(_renderEnum_partial_footer_10(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -3035,7 +3043,40 @@ String _renderEnum_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderEnum_partial_constant_5(
+String _renderEnum_partial_super_chain_5(
+    _i12.Enum context1, _i1.EnumTemplateData context0) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicSuperChainReversed == true) {
+    buffer.writeln();
+    buffer.write('''
+  <dt>Inheritance</dt>
+  <dd><ul class="gt-separated dark ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">
+    <li>''');
+    buffer.write(context0.linkedObjectType);
+    buffer.write('''</li>''');
+    var context2 = context1.publicSuperChainReversed;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+    <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    <li>''');
+    buffer.write(context1.name);
+    buffer.write('''</li>
+  </ul></dd>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _renderEnum_partial_constant_6(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -3052,7 +3093,7 @@ String _renderEnum_partial_constant_5(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderEnum_partial_constant_5_partial_categorization_0(
+  buffer.write(__renderEnum_partial_constant_6_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -3063,7 +3104,7 @@ String _renderEnum_partial_constant_5(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderEnum_partial_constant_5_partial_features_1(
+  buffer.write(__renderEnum_partial_constant_6_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -3078,7 +3119,7 @@ String _renderEnum_partial_constant_5(
   return buffer.toString();
 }
 
-String __renderEnum_partial_constant_5_partial_categorization_0(
+String __renderEnum_partial_constant_6_partial_categorization_0(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -3093,7 +3134,7 @@ String __renderEnum_partial_constant_5_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderEnum_partial_constant_5_partial_features_1(
+String __renderEnum_partial_constant_6_partial_features_1(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -3106,7 +3147,7 @@ String __renderEnum_partial_constant_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_property_6(
+String _renderEnum_partial_property_7(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -3124,7 +3165,7 @@ String _renderEnum_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderEnum_partial_property_6_partial_categorization_0(
+  buffer.write(__renderEnum_partial_property_7_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -3139,7 +3180,7 @@ String _renderEnum_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderEnum_partial_property_6_partial_features_1(
+  buffer.write(__renderEnum_partial_property_7_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -3149,7 +3190,7 @@ String _renderEnum_partial_property_6(
   return buffer.toString();
 }
 
-String __renderEnum_partial_property_6_partial_categorization_0(
+String __renderEnum_partial_property_7_partial_categorization_0(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -3164,7 +3205,7 @@ String __renderEnum_partial_property_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderEnum_partial_property_6_partial_features_1(
+String __renderEnum_partial_property_7_partial_features_1(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -3177,7 +3218,7 @@ String __renderEnum_partial_property_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_callable_7(
+String _renderEnum_partial_callable_8(
     _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -3203,7 +3244,7 @@ String _renderEnum_partial_callable_7(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderEnum_partial_callable_7_partial_categorization_0(
+  buffer.write(__renderEnum_partial_callable_8_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -3218,7 +3259,7 @@ String _renderEnum_partial_callable_7(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderEnum_partial_callable_7_partial_features_1(
+  buffer.write(__renderEnum_partial_callable_8_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -3228,7 +3269,7 @@ String _renderEnum_partial_callable_7(
   return buffer.toString();
 }
 
-String __renderEnum_partial_callable_7_partial_categorization_0(
+String __renderEnum_partial_callable_8_partial_categorization_0(
     _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -3243,7 +3284,7 @@ String __renderEnum_partial_callable_7_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderEnum_partial_callable_7_partial_features_1(
+String __renderEnum_partial_callable_8_partial_features_1(
     _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -3256,7 +3297,7 @@ String __renderEnum_partial_callable_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_search_sidebar_8(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_search_sidebar_9(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -3315,7 +3356,7 @@ String _renderEnum_partial_search_sidebar_8(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_footer_9(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_footer_10(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -7114,30 +7155,8 @@ String renderMixin(_i1.MixinTemplateData context0) {
       buffer.write('''
         </ul></dd>''');
     }
-    buffer.writeln();
-    if (context2.hasPublicSuperChainReversed == true) {
-      buffer.writeln();
-      buffer.write('''
-        <dt>Inheritance</dt>
-        <dd><ul class="gt-separated dark mixin-relationships">
-          <li>''');
-      buffer.write(context0.linkedObjectType);
-      buffer.write('''</li>''');
-      var context5 = context2.publicSuperChainReversed;
-      for (var context6 in context5) {
-        buffer.writeln();
-        buffer.write('''
-          <li>''');
-        buffer.write(context6.linkedName);
-        buffer.write('''</li>''');
-      }
-      buffer.writeln();
-      buffer.write('''
-          <li>''');
-      buffer.write(context2.name);
-      buffer.write('''</li>
-        </ul></dd>''');
-    }
+    buffer.write('\n\n        ');
+    buffer.write(_renderMixin_partial_super_chain_5(context2, context0));
     buffer.writeln();
     if (context2.hasPublicInterfaces == true) {
       buffer.writeln();
@@ -7145,12 +7164,12 @@ String renderMixin(_i1.MixinTemplateData context0) {
         <dt>Implements</dt>
         <dd>
           <ul class="comma-separated mixin-relationships">''');
-      var context7 = context2.publicInterfaces;
-      for (var context8 in context7) {
+      var context5 = context2.publicInterfaces;
+      for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
             <li>''');
-        buffer.write(context8.linkedName);
+        buffer.write(context6.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -7165,12 +7184,12 @@ String renderMixin(_i1.MixinTemplateData context0) {
         <dt>Mixin Applications</dt>
         <dd>
           <ul class="comma-separated mixin-relationships">''');
-      var context9 = context2.publicImplementorsSorted;
-      for (var context10 in context9) {
+      var context7 = context2.publicImplementorsSorted;
+      for (var context8 in context7) {
         buffer.writeln();
         buffer.write('''
             <li>''');
-        buffer.write(context10.linkedName);
+        buffer.write(context8.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -7184,12 +7203,12 @@ String renderMixin(_i1.MixinTemplateData context0) {
       buffer.write('''
         <dt>Annotations</dt>
         <dd><ul class="annotation-list mixin-relationships">''');
-      var context11 = context2.annotations;
-      for (var context12 in context11) {
+      var context9 = context2.annotations;
+      for (var context10 in context9) {
         buffer.writeln();
         buffer.write('''
           <li>''');
-        buffer.write(context12.linkedNameWithParameters);
+        buffer.write(context10.linkedNameWithParameters);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -7213,11 +7232,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
       <h2>Properties</h2>
 
       <dl class="properties">''');
-    var context13 = context2.publicInstanceFields;
-    for (var context14 in context13) {
+    var context11 = context2.publicInstanceFields;
+    for (var context12 in context11) {
       buffer.write('\n        ');
       buffer.write(
-          _renderMixin_partial_property_5(context14, context2, context0));
+          _renderMixin_partial_property_6(context12, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -7235,11 +7254,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''" id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">''');
-    var context15 = context2.publicInstanceMethods;
-    for (var context16 in context15) {
+    var context13 = context2.publicInstanceMethods;
+    for (var context14 in context13) {
       buffer.write('\n        ');
       buffer.write(
-          _renderMixin_partial_callable_6(context16, context2, context0));
+          _renderMixin_partial_callable_7(context14, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -7257,11 +7276,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''" id="operators">
       <h2>Operators</h2>
       <dl class="callables">''');
-    var context17 = context2.publicInstanceOperatorsSorted;
-    for (var context18 in context17) {
+    var context15 = context2.publicInstanceOperatorsSorted;
+    for (var context16 in context15) {
       buffer.write('\n        ');
       buffer.write(
-          _renderMixin_partial_callable_6(context18, context2, context0));
+          _renderMixin_partial_callable_7(context16, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -7276,11 +7295,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
       <h2>Static Properties</h2>
 
       <dl class="properties">''');
-    var context19 = context2.publicVariableStaticFieldsSorted;
-    for (var context20 in context19) {
+    var context17 = context2.publicVariableStaticFieldsSorted;
+    for (var context18 in context17) {
       buffer.write('\n        ');
       buffer.write(
-          _renderMixin_partial_property_5(context20, context2, context0));
+          _renderMixin_partial_property_6(context18, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -7294,11 +7313,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     <section class="summary offset-anchor" id="static-methods">
       <h2>Static Methods</h2>
       <dl class="callables">''');
-    var context21 = context2.publicStaticMethods;
-    for (var context22 in context21) {
+    var context19 = context2.publicStaticMethods;
+    for (var context20 in context19) {
       buffer.write('\n        ');
       buffer.write(
-          _renderMixin_partial_callable_6(context22, context2, context0));
+          _renderMixin_partial_callable_7(context20, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -7313,11 +7332,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
       <h2>Constants</h2>
 
       <dl class="properties">''');
-    var context23 = context2.publicConstantFieldsSorted;
-    for (var context24 in context23) {
+    var context21 = context2.publicConstantFieldsSorted;
+    for (var context22 in context21) {
       buffer.write('\n        ');
       buffer.write(
-          _renderMixin_partial_constant_7(context24, context2, context0));
+          _renderMixin_partial_constant_8(context22, context2, context0));
     }
     buffer.writeln();
     buffer.write('''
@@ -7330,7 +7349,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderMixin_partial_search_sidebar_8(context0));
+  buffer.write(_renderMixin_partial_search_sidebar_9(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -7352,7 +7371,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
   </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderMixin_partial_footer_9(context0));
+  buffer.write(_renderMixin_partial_footer_10(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -7568,7 +7587,40 @@ String _renderMixin_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderMixin_partial_property_5(
+String _renderMixin_partial_super_chain_5(
+    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicSuperChainReversed == true) {
+    buffer.writeln();
+    buffer.write('''
+  <dt>Inheritance</dt>
+  <dd><ul class="gt-separated dark ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">
+    <li>''');
+    buffer.write(context0.linkedObjectType);
+    buffer.write('''</li>''');
+    var context2 = context1.publicSuperChainReversed;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+    <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    <li>''');
+    buffer.write(context1.name);
+    buffer.write('''</li>
+  </ul></dd>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _renderMixin_partial_property_6(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -7586,7 +7638,7 @@ String _renderMixin_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderMixin_partial_property_5_partial_categorization_0(
+  buffer.write(__renderMixin_partial_property_6_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -7601,7 +7653,7 @@ String _renderMixin_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderMixin_partial_property_5_partial_features_1(
+  buffer.write(__renderMixin_partial_property_6_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -7611,7 +7663,7 @@ String _renderMixin_partial_property_5(
   return buffer.toString();
 }
 
-String __renderMixin_partial_property_5_partial_categorization_0(
+String __renderMixin_partial_property_6_partial_categorization_0(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -7626,7 +7678,7 @@ String __renderMixin_partial_property_5_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderMixin_partial_property_5_partial_features_1(
+String __renderMixin_partial_property_6_partial_features_1(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -7639,7 +7691,7 @@ String __renderMixin_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_callable_6(
+String _renderMixin_partial_callable_7(
     _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -7665,7 +7717,7 @@ String _renderMixin_partial_callable_6(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderMixin_partial_callable_6_partial_categorization_0(
+  buffer.write(__renderMixin_partial_callable_7_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -7680,7 +7732,7 @@ String _renderMixin_partial_callable_6(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderMixin_partial_callable_6_partial_features_1(
+  buffer.write(__renderMixin_partial_callable_7_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -7690,7 +7742,7 @@ String _renderMixin_partial_callable_6(
   return buffer.toString();
 }
 
-String __renderMixin_partial_callable_6_partial_categorization_0(
+String __renderMixin_partial_callable_7_partial_categorization_0(
     _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -7705,7 +7757,7 @@ String __renderMixin_partial_callable_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderMixin_partial_callable_6_partial_features_1(
+String __renderMixin_partial_callable_7_partial_features_1(
     _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -7718,7 +7770,7 @@ String __renderMixin_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_constant_7(
+String _renderMixin_partial_constant_8(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
@@ -7735,7 +7787,7 @@ String _renderMixin_partial_constant_7(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderMixin_partial_constant_7_partial_categorization_0(
+  buffer.write(__renderMixin_partial_constant_8_partial_categorization_0(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -7746,7 +7798,7 @@ String _renderMixin_partial_constant_7(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderMixin_partial_constant_7_partial_features_1(
+  buffer.write(__renderMixin_partial_constant_8_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
   buffer.write('''
@@ -7761,7 +7813,7 @@ String _renderMixin_partial_constant_7(
   return buffer.toString();
 }
 
-String __renderMixin_partial_constant_7_partial_categorization_0(
+String __renderMixin_partial_constant_8_partial_categorization_0(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -7776,7 +7828,7 @@ String __renderMixin_partial_constant_7_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderMixin_partial_constant_7_partial_features_1(
+String __renderMixin_partial_constant_8_partial_features_1(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -7789,7 +7841,7 @@ String __renderMixin_partial_constant_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_search_sidebar_8(_i1.MixinTemplateData context0) {
+String _renderMixin_partial_search_sidebar_9(_i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -7848,7 +7900,7 @@ String _renderMixin_partial_search_sidebar_8(_i1.MixinTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderMixin_partial_footer_9(_i1.MixinTemplateData context0) {
+String _renderMixin_partial_footer_10(_i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -597,37 +597,20 @@ String renderClass(_i1.ClassTemplateData context0) {
   buffer.write(_renderClass_partial_documentation_4(context2, context0));
   buffer.writeln();
   if (context2.hasModifiers == true) {
-    if (context2.hasPublicSuperChainReversed == true) {
-      buffer.writeln();
-      buffer.write('''
-**Inheritance**
-
-- ''');
-      buffer.write(context0.linkedObjectType);
-      var context3 = context2.publicSuperChainReversed;
-      for (var context4 in context3) {
-        buffer.writeln();
-        buffer.write('''
-- ''');
-        buffer.write(context4.linkedName);
-      }
-      buffer.writeln();
-      buffer.write('''
-- ''');
-      buffer.write(context2.name);
-    }
+    buffer.writeln();
+    buffer.write(_renderClass_partial_super_chain_5(context2, context0));
     buffer.writeln();
     if (context2.hasPublicInterfaces == true) {
       buffer.writeln();
       buffer.write('''
 **Implemented types**
 ''');
-      var context5 = context2.publicInterfaces;
-      for (var context6 in context5) {
+      var context3 = context2.publicInterfaces;
+      for (var context4 in context3) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context6.linkedName);
+        buffer.write(context4.linkedName);
       }
     }
     buffer.writeln();
@@ -636,12 +619,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
 **Mixed in types**
 ''');
-      var context7 = context2.publicMixedInTypes;
-      for (var context8 in context7) {
+      var context5 = context2.publicMixedInTypes;
+      for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context8.linkedName);
+        buffer.write(context6.linkedName);
       }
     }
     buffer.writeln();
@@ -650,12 +633,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
 **Implementers**
 ''');
-      var context9 = context2.publicImplementorsSorted;
-      for (var context10 in context9) {
+      var context7 = context2.publicImplementorsSorted;
+      for (var context8 in context7) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context10.linkedName);
+        buffer.write(context8.linkedName);
       }
     }
     buffer.writeln();
@@ -664,8 +647,8 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
 **Available Extensions**
 ''');
-      var context11 = context2.potentiallyApplicableExtensions;
-      if (context11 != null) {
+      var context9 = context2.potentiallyApplicableExtensions;
+      if (context9 != null) {
         buffer.writeln();
         buffer.write('''
 - ''');
@@ -678,12 +661,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
 **Annotations**
 ''');
-      var context12 = context2.annotations;
-      for (var context13 in context12) {
+      var context10 = context2.annotations;
+      for (var context11 in context10) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context13.linkedNameWithParameters);
+        buffer.write(context11.linkedNameWithParameters);
       }
     }
   }
@@ -693,24 +676,24 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Constructors
 ''');
-    var context14 = context2.publicConstructorsSorted;
-    for (var context15 in context14) {
+    var context12 = context2.publicConstructorsSorted;
+    for (var context13 in context12) {
       buffer.writeln();
-      buffer.write(context15.linkedName);
+      buffer.write(context13.linkedName);
       buffer.write(''' (''');
-      buffer.write(context15.linkedParams);
+      buffer.write(context13.linkedParams);
       buffer.write(''')
 
 ''');
-      buffer.write(context15.oneLineDoc);
+      buffer.write(context13.oneLineDoc);
       buffer.write(' ');
-      buffer.write(context15.extendedDocLink);
+      buffer.write(context13.extendedDocLink);
       buffer.write('  ');
-      if (context15.isConst == true) {
+      if (context13.isConst == true) {
         buffer.write('''_const_''');
       }
       buffer.write(' ');
-      if (context15.isFactory == true) {
+      if (context13.isFactory == true) {
         buffer.write('''_factory_''');
       }
       buffer.writeln();
@@ -722,11 +705,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Properties
 ''');
-    var context16 = context2.publicInstanceFieldsSorted;
-    for (var context17 in context16) {
+    var context14 = context2.publicInstanceFieldsSorted;
+    for (var context15 in context14) {
       buffer.writeln();
       buffer.write(
-          _renderClass_partial_property_5(context17, context2, context0));
+          _renderClass_partial_property_6(context15, context2, context0));
       buffer.writeln();
     }
   }
@@ -736,11 +719,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Methods
 ''');
-    var context18 = context2.publicInstanceMethodsSorted;
-    for (var context19 in context18) {
+    var context16 = context2.publicInstanceMethodsSorted;
+    for (var context17 in context16) {
       buffer.writeln();
       buffer.write(
-          _renderClass_partial_callable_6(context19, context2, context0));
+          _renderClass_partial_callable_7(context17, context2, context0));
       buffer.writeln();
     }
   }
@@ -750,11 +733,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Operators
 ''');
-    var context20 = context2.publicInstanceOperatorsSorted;
-    for (var context21 in context20) {
+    var context18 = context2.publicInstanceOperatorsSorted;
+    for (var context19 in context18) {
       buffer.writeln();
       buffer.write(
-          _renderClass_partial_callable_6(context21, context2, context0));
+          _renderClass_partial_callable_7(context19, context2, context0));
       buffer.writeln();
     }
   }
@@ -764,11 +747,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Static Properties
 ''');
-    var context22 = context2.publicVariableStaticFieldsSorted;
-    for (var context23 in context22) {
+    var context20 = context2.publicVariableStaticFieldsSorted;
+    for (var context21 in context20) {
       buffer.writeln();
       buffer.write(
-          _renderClass_partial_property_5(context23, context2, context0));
+          _renderClass_partial_property_6(context21, context2, context0));
       buffer.writeln();
     }
   }
@@ -778,11 +761,11 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Static Methods
 ''');
-    var context24 = context2.publicStaticMethodsSorted;
-    for (var context25 in context24) {
+    var context22 = context2.publicStaticMethodsSorted;
+    for (var context23 in context22) {
       buffer.writeln();
       buffer.write(
-          _renderClass_partial_callable_6(context25, context2, context0));
+          _renderClass_partial_callable_7(context23, context2, context0));
       buffer.writeln();
     }
   }
@@ -792,16 +775,16 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Constants
 ''');
-    var context26 = context2.publicConstantFieldsSorted;
-    for (var context27 in context26) {
+    var context24 = context2.publicConstantFieldsSorted;
+    for (var context25 in context24) {
       buffer.writeln();
       buffer.write(
-          _renderClass_partial_constant_7(context27, context2, context0));
+          _renderClass_partial_constant_8(context25, context2, context0));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_footer_8(context0));
+  buffer.write(_renderClass_partial_footer_9(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -875,7 +858,33 @@ String _renderClass_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderClass_partial_property_5(
+String _renderClass_partial_super_chain_5(
+    _i8.Class context1, _i1.ClassTemplateData context0) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicSuperChainReversed == true) {
+    buffer.writeln();
+    buffer.write('''
+**Inheritance**
+
+- ''');
+    buffer.write(context0.linkedObjectType);
+    var context2 = context1.publicSuperChainReversed;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+    buffer.writeln();
+    buffer.write('''
+- ''');
+    buffer.write(context1.name);
+  }
+
+  return buffer.toString();
+}
+
+String _renderClass_partial_property_6(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -885,7 +894,7 @@ String _renderClass_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderClass_partial_property_5_partial_categorization_0(
+  buffer.write(__renderClass_partial_property_6_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -893,14 +902,14 @@ String _renderClass_partial_property_5(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderClass_partial_property_5_partial_features_1(
+  buffer.write(__renderClass_partial_property_6_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderClass_partial_property_5_partial_categorization_0(
+String __renderClass_partial_property_6_partial_categorization_0(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -918,7 +927,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderClass_partial_property_5_partial_features_1(
+String __renderClass_partial_property_6_partial_features_1(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -931,7 +940,7 @@ String __renderClass_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_callable_6(
+String _renderClass_partial_callable_7(
     _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -942,7 +951,7 @@ String _renderClass_partial_callable_6(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderClass_partial_callable_6_partial_categorization_0(
+  buffer.write(__renderClass_partial_callable_7_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -950,14 +959,14 @@ String _renderClass_partial_callable_6(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderClass_partial_callable_6_partial_features_1(
+  buffer.write(__renderClass_partial_callable_7_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderClass_partial_callable_6_partial_categorization_0(
+String __renderClass_partial_callable_7_partial_categorization_0(
     _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -975,7 +984,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderClass_partial_callable_6_partial_features_1(
+String __renderClass_partial_callable_7_partial_features_1(
     _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -988,7 +997,7 @@ String __renderClass_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_constant_7(
+String _renderClass_partial_constant_8(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -996,7 +1005,7 @@ String _renderClass_partial_constant_7(
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderClass_partial_constant_7_partial_categorization_0(
+  buffer.write(__renderClass_partial_constant_8_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -1004,14 +1013,14 @@ String _renderClass_partial_constant_7(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderClass_partial_constant_7_partial_features_1(
+  buffer.write(__renderClass_partial_constant_8_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderClass_partial_constant_7_partial_categorization_0(
+String __renderClass_partial_constant_8_partial_categorization_0(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -1029,7 +1038,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderClass_partial_constant_7_partial_features_1(
+String __renderClass_partial_constant_8_partial_features_1(
     _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -1042,7 +1051,7 @@ String __renderClass_partial_constant_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_footer_8(_i1.ClassTemplateData context0) {
+String _renderClass_partial_footer_9(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -1206,37 +1215,20 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.write(_renderEnum_partial_documentation_3(context2, context0));
   buffer.writeln();
   if (context2.hasModifiers == true) {
-    if (context2.hasPublicSuperChainReversed == true) {
-      buffer.writeln();
-      buffer.write('''
-**Inheritance**
-
-- ''');
-      buffer.write(context0.linkedObjectType);
-      var context3 = context2.publicSuperChainReversed;
-      for (var context4 in context3) {
-        buffer.writeln();
-        buffer.write('''
-- ''');
-        buffer.write(context4.linkedName);
-      }
-      buffer.writeln();
-      buffer.write('''
-- ''');
-      buffer.write(context2.name);
-    }
+    buffer.writeln();
+    buffer.write(_renderEnum_partial_super_chain_4(context2, context0));
     buffer.writeln();
     if (context2.hasAnnotations == true) {
       buffer.writeln();
       buffer.write('''
 **Annotations**
 ''');
-      var context5 = context2.annotations;
-      for (var context6 in context5) {
+      var context3 = context2.annotations;
+      for (var context4 in context3) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context6.linkedNameWithParameters);
+        buffer.write(context4.linkedNameWithParameters);
       }
     }
   }
@@ -1246,11 +1238,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.write('''
 ## Constants
 ''');
-    var context7 = context2.publicConstantFieldsSorted;
-    for (var context8 in context7) {
+    var context5 = context2.publicConstantFieldsSorted;
+    for (var context6 in context5) {
       buffer.writeln();
       buffer
-          .write(_renderEnum_partial_constant_4(context8, context2, context0));
+          .write(_renderEnum_partial_constant_5(context6, context2, context0));
       buffer.writeln();
     }
   }
@@ -1260,11 +1252,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.write('''
 ## Properties
 ''');
-    var context9 = context2.publicInstanceFieldsSorted;
-    for (var context10 in context9) {
+    var context7 = context2.publicInstanceFieldsSorted;
+    for (var context8 in context7) {
       buffer.writeln();
       buffer
-          .write(_renderEnum_partial_property_5(context10, context2, context0));
+          .write(_renderEnum_partial_property_6(context8, context2, context0));
       buffer.writeln();
     }
   }
@@ -1274,11 +1266,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.write('''
 ## Methods
 ''');
-    var context11 = context2.publicInstanceMethodsSorted;
-    for (var context12 in context11) {
+    var context9 = context2.publicInstanceMethodsSorted;
+    for (var context10 in context9) {
       buffer.writeln();
       buffer
-          .write(_renderEnum_partial_callable_6(context12, context2, context0));
+          .write(_renderEnum_partial_callable_7(context10, context2, context0));
       buffer.writeln();
     }
   }
@@ -1288,11 +1280,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.write('''
 ## Operators
 ''');
-    var context13 = context2.publicInstanceOperatorsSorted;
-    for (var context14 in context13) {
+    var context11 = context2.publicInstanceOperatorsSorted;
+    for (var context12 in context11) {
       buffer.writeln();
       buffer
-          .write(_renderEnum_partial_callable_6(context14, context2, context0));
+          .write(_renderEnum_partial_callable_7(context12, context2, context0));
       buffer.writeln();
     }
   }
@@ -1302,11 +1294,11 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.write('''
 ## Static Properties
 ''');
-    var context15 = context2.publicVariableStaticFieldsSorted;
-    for (var context16 in context15) {
+    var context13 = context2.publicVariableStaticFieldsSorted;
+    for (var context14 in context13) {
       buffer.writeln();
       buffer
-          .write(_renderEnum_partial_property_5(context16, context2, context0));
+          .write(_renderEnum_partial_property_6(context14, context2, context0));
       buffer.writeln();
     }
   }
@@ -1316,16 +1308,16 @@ String renderEnum(_i1.EnumTemplateData context0) {
     buffer.write('''
 ## Static Methods
 ''');
-    var context17 = context2.publicStaticMethodsSorted;
-    for (var context18 in context17) {
+    var context15 = context2.publicStaticMethodsSorted;
+    for (var context16 in context15) {
       buffer.writeln();
       buffer
-          .write(_renderEnum_partial_callable_6(context18, context2, context0));
+          .write(_renderEnum_partial_callable_7(context16, context2, context0));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_footer_7(context0));
+  buffer.write(_renderEnum_partial_footer_8(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -1381,7 +1373,33 @@ String _renderEnum_partial_documentation_3(
   return buffer.toString();
 }
 
-String _renderEnum_partial_constant_4(
+String _renderEnum_partial_super_chain_4(
+    _i12.Enum context1, _i1.EnumTemplateData context0) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicSuperChainReversed == true) {
+    buffer.writeln();
+    buffer.write('''
+**Inheritance**
+
+- ''');
+    buffer.write(context0.linkedObjectType);
+    var context2 = context1.publicSuperChainReversed;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+    buffer.writeln();
+    buffer.write('''
+- ''');
+    buffer.write(context1.name);
+  }
+
+  return buffer.toString();
+}
+
+String _renderEnum_partial_constant_5(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -1389,7 +1407,7 @@ String _renderEnum_partial_constant_4(
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderEnum_partial_constant_4_partial_categorization_0(
+  buffer.write(__renderEnum_partial_constant_5_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -1397,14 +1415,14 @@ String _renderEnum_partial_constant_4(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderEnum_partial_constant_4_partial_features_1(
+  buffer.write(__renderEnum_partial_constant_5_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderEnum_partial_constant_4_partial_categorization_0(
+String __renderEnum_partial_constant_5_partial_categorization_0(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -1422,7 +1440,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderEnum_partial_constant_4_partial_features_1(
+String __renderEnum_partial_constant_5_partial_features_1(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -1435,7 +1453,7 @@ String __renderEnum_partial_constant_4_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_property_5(
+String _renderEnum_partial_property_6(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -1445,7 +1463,7 @@ String _renderEnum_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderEnum_partial_property_5_partial_categorization_0(
+  buffer.write(__renderEnum_partial_property_6_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -1453,14 +1471,14 @@ String _renderEnum_partial_property_5(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderEnum_partial_property_5_partial_features_1(
+  buffer.write(__renderEnum_partial_property_6_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderEnum_partial_property_5_partial_categorization_0(
+String __renderEnum_partial_property_6_partial_categorization_0(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -1478,7 +1496,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderEnum_partial_property_5_partial_features_1(
+String __renderEnum_partial_property_6_partial_features_1(
     _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -1491,7 +1509,7 @@ String __renderEnum_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_callable_6(
+String _renderEnum_partial_callable_7(
     _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -1502,7 +1520,7 @@ String _renderEnum_partial_callable_6(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderEnum_partial_callable_6_partial_categorization_0(
+  buffer.write(__renderEnum_partial_callable_7_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -1510,14 +1528,14 @@ String _renderEnum_partial_callable_6(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderEnum_partial_callable_6_partial_features_1(
+  buffer.write(__renderEnum_partial_callable_7_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderEnum_partial_callable_6_partial_categorization_0(
+String __renderEnum_partial_callable_7_partial_categorization_0(
     _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -1535,7 +1553,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderEnum_partial_callable_6_partial_features_1(
+String __renderEnum_partial_callable_7_partial_features_1(
     _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -1548,7 +1566,7 @@ String __renderEnum_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_footer_7(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_footer_8(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -3121,38 +3139,20 @@ String renderMixin(_i1.MixinTemplateData context0) {
         buffer.write(context4.linkedName);
       }
     }
-    buffer.writeln();
-    if (context2.hasPublicSuperChainReversed == true) {
-      buffer.writeln();
-      buffer.write('''
-**Inheritance**
-
-- ''');
-      buffer.write(context0.linkedObjectType);
-      var context5 = context2.publicSuperChainReversed;
-      for (var context6 in context5) {
-        buffer.writeln();
-        buffer.write('''
-- ''');
-        buffer.write(context6.linkedName);
-      }
-      buffer.writeln();
-      buffer.write('''
-- ''');
-      buffer.write(context2.name);
-    }
+    buffer.write('\n\n');
+    buffer.write(_renderMixin_partial_super_chain_5(context2, context0));
     buffer.writeln();
     if (context2.hasPublicInterfaces == true) {
       buffer.writeln();
       buffer.write('''
 **Implemented types**
 ''');
-      var context7 = context2.publicInterfaces;
-      for (var context8 in context7) {
+      var context5 = context2.publicInterfaces;
+      for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context8.linkedName);
+        buffer.write(context6.linkedName);
       }
     }
     buffer.writeln();
@@ -3161,12 +3161,12 @@ String renderMixin(_i1.MixinTemplateData context0) {
       buffer.write('''
 **Mixin Applications**
 ''');
-      var context9 = context2.publicImplementorsSorted;
-      for (var context10 in context9) {
+      var context7 = context2.publicImplementorsSorted;
+      for (var context8 in context7) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context10.linkedName);
+        buffer.write(context8.linkedName);
       }
     }
     buffer.writeln();
@@ -3175,12 +3175,12 @@ String renderMixin(_i1.MixinTemplateData context0) {
       buffer.write('''
 **Annotations**
 ''');
-      var context11 = context2.annotations;
-      for (var context12 in context11) {
+      var context9 = context2.annotations;
+      for (var context10 in context9) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context12.linkedNameWithParameters);
+        buffer.write(context10.linkedNameWithParameters);
       }
     }
   }
@@ -3190,11 +3190,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''
 ## Properties
 ''');
-    var context13 = context2.publicInstanceFieldsSorted;
-    for (var context14 in context13) {
+    var context11 = context2.publicInstanceFieldsSorted;
+    for (var context12 in context11) {
       buffer.writeln();
       buffer.write(
-          _renderMixin_partial_property_5(context14, context2, context0));
+          _renderMixin_partial_property_6(context12, context2, context0));
       buffer.writeln();
     }
   }
@@ -3204,11 +3204,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''
 ## Methods
 ''');
-    var context15 = context2.publicInstanceMethodsSorted;
-    for (var context16 in context15) {
+    var context13 = context2.publicInstanceMethodsSorted;
+    for (var context14 in context13) {
       buffer.writeln();
       buffer.write(
-          _renderMixin_partial_callable_6(context16, context2, context0));
+          _renderMixin_partial_callable_7(context14, context2, context0));
       buffer.writeln();
     }
   }
@@ -3218,11 +3218,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''
 ## Operators
 ''');
-    var context17 = context2.publicInstanceOperatorsSorted;
-    for (var context18 in context17) {
+    var context15 = context2.publicInstanceOperatorsSorted;
+    for (var context16 in context15) {
       buffer.writeln();
       buffer.write(
-          _renderMixin_partial_callable_6(context18, context2, context0));
+          _renderMixin_partial_callable_7(context16, context2, context0));
       buffer.writeln();
     }
   }
@@ -3232,11 +3232,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''
 ## Static Properties
 ''');
-    var context19 = context2.publicVariableStaticFieldsSorted;
-    for (var context20 in context19) {
+    var context17 = context2.publicVariableStaticFieldsSorted;
+    for (var context18 in context17) {
       buffer.writeln();
       buffer.write(
-          _renderMixin_partial_property_5(context20, context2, context0));
+          _renderMixin_partial_property_6(context18, context2, context0));
       buffer.writeln();
     }
   }
@@ -3246,11 +3246,11 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''
 ## Static Methods
 ''');
-    var context21 = context2.publicStaticMethodsSorted;
-    for (var context22 in context21) {
+    var context19 = context2.publicStaticMethodsSorted;
+    for (var context20 in context19) {
       buffer.writeln();
       buffer.write(
-          _renderMixin_partial_callable_6(context22, context2, context0));
+          _renderMixin_partial_callable_7(context20, context2, context0));
       buffer.writeln();
     }
   }
@@ -3260,16 +3260,16 @@ String renderMixin(_i1.MixinTemplateData context0) {
     buffer.write('''
 ## Constants
 ''');
-    var context23 = context2.publicConstantFieldsSorted;
-    for (var context24 in context23) {
+    var context21 = context2.publicConstantFieldsSorted;
+    for (var context22 in context21) {
       buffer.writeln();
       buffer.write(
-          _renderMixin_partial_constant_7(context24, context2, context0));
+          _renderMixin_partial_constant_8(context22, context2, context0));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderMixin_partial_footer_8(context0));
+  buffer.write(_renderMixin_partial_footer_9(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -3343,7 +3343,33 @@ String _renderMixin_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderMixin_partial_property_5(
+String _renderMixin_partial_super_chain_5(
+    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicSuperChainReversed == true) {
+    buffer.writeln();
+    buffer.write('''
+**Inheritance**
+
+- ''');
+    buffer.write(context0.linkedObjectType);
+    var context2 = context1.publicSuperChainReversed;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+    buffer.writeln();
+    buffer.write('''
+- ''');
+    buffer.write(context1.name);
+  }
+
+  return buffer.toString();
+}
+
+String _renderMixin_partial_property_6(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -3353,7 +3379,7 @@ String _renderMixin_partial_property_5(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderMixin_partial_property_5_partial_categorization_0(
+  buffer.write(__renderMixin_partial_property_6_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -3361,14 +3387,14 @@ String _renderMixin_partial_property_5(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderMixin_partial_property_5_partial_features_1(
+  buffer.write(__renderMixin_partial_property_6_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderMixin_partial_property_5_partial_categorization_0(
+String __renderMixin_partial_property_6_partial_categorization_0(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -3386,7 +3412,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderMixin_partial_property_5_partial_features_1(
+String __renderMixin_partial_property_6_partial_features_1(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -3399,7 +3425,7 @@ String __renderMixin_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_callable_6(
+String _renderMixin_partial_callable_7(
     _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -3410,7 +3436,7 @@ String _renderMixin_partial_callable_6(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderMixin_partial_callable_6_partial_categorization_0(
+  buffer.write(__renderMixin_partial_callable_7_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -3418,14 +3444,14 @@ String _renderMixin_partial_callable_6(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderMixin_partial_callable_6_partial_features_1(
+  buffer.write(__renderMixin_partial_callable_7_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderMixin_partial_callable_6_partial_categorization_0(
+String __renderMixin_partial_callable_7_partial_categorization_0(
     _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -3443,7 +3469,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderMixin_partial_callable_6_partial_features_1(
+String __renderMixin_partial_callable_7_partial_features_1(
     _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -3456,7 +3482,7 @@ String __renderMixin_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_constant_7(
+String _renderMixin_partial_constant_8(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
@@ -3464,7 +3490,7 @@ String _renderMixin_partial_constant_7(
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderMixin_partial_constant_7_partial_categorization_0(
+  buffer.write(__renderMixin_partial_constant_8_partial_categorization_0(
       context2, context1, context0));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
@@ -3472,14 +3498,14 @@ String _renderMixin_partial_constant_7(
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderMixin_partial_constant_7_partial_features_1(
+  buffer.write(__renderMixin_partial_constant_8_partial_features_1(
       context2, context1, context0));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderMixin_partial_constant_7_partial_categorization_0(
+String __renderMixin_partial_constant_8_partial_categorization_0(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
@@ -3497,7 +3523,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderMixin_partial_constant_7_partial_features_1(
+String __renderMixin_partial_constant_8_partial_features_1(
     _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
@@ -3510,7 +3536,7 @@ String __renderMixin_partial_constant_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_footer_8(_i1.MixinTemplateData context0) {
+String _renderMixin_partial_footer_9(_i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1915,6 +1915,28 @@ class _Renderer_Class extends RendererBase<Class> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.publicInheritedInstanceFields == true,
                 ),
+                'relationshipsClass': Property(
+                  getValue: (CT_ c) => c.relationshipsClass,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.relationshipsClass, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
               }) as Map<String, Property<CT_>>;
 
   _Renderer_Class(Class context, RendererBase<Object>? parent,
@@ -4625,6 +4647,28 @@ class _Renderer_Enum extends RendererBase<Enum> {
                     _render_String(c.kind, ast, r.template, sink, parent: r);
                   },
                 ),
+                'relationshipsClass': Property(
+                  getValue: (CT_ c) => c.relationshipsClass,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.relationshipsClass, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
               }) as Map<String, Property<CT_>>;
 
   _Renderer_Enum(Enum context, RendererBase<Object>? parent, Template template,
@@ -7268,7 +7312,7 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<DefinedElementType>'),
+                          c, remainingNames, 'List<DefinedElementType>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicSuperChain.map((e) =>
@@ -7287,6 +7331,28 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                     return c.publicSuperChainReversed.map((e) =>
                         _render_DefinedElementType(e, ast, r.template, sink,
                             parent: r));
+                  },
+                ),
+                'relationshipsClass': Property(
+                  getValue: (CT_ c) => c.relationshipsClass,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.relationshipsClass, ast, r.template, sink,
+                        parent: r);
                   },
                 ),
                 'superChain': Property(
@@ -9721,6 +9787,28 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                         _render_ParameterizedElementType(
                             e, ast, r.template, sink,
                             parent: r));
+                  },
+                ),
+                'relationshipsClass': Property(
+                  getValue: (CT_ c) => c.relationshipsClass,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.relationshipsClass, ast, r.template, sink,
+                        parent: r);
                   },
                 ),
                 'superclassConstraints': Property(

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -2,39 +2,27 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO(jcollins-g): Consider Enum as subclass of Container?
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/enum_field_renderer.dart';
-import 'package:dartdoc/src/special_elements.dart';
 
 class Enum extends InheritingContainer with TypeImplementing {
   Enum(ClassElement element, Library? library, PackageGraph packageGraph)
       : super(element, library, packageGraph);
 
-  List<InheritingContainer?>? _inheritanceChain;
   @override
-  List<InheritingContainer?> get inheritanceChain {
-    if (_inheritanceChain == null) {
-      _inheritanceChain = [];
-      _inheritanceChain!.add(this);
-
-      for (var c
-          in superChain.map((e) => (e.modelElement as InheritingContainer))) {
-        _inheritanceChain!.addAll(c.inheritanceChain);
-      }
-
-      _inheritanceChain!.addAll(interfaces.expand(
-          (e) => (e.modelElement as InheritingContainer).inheritanceChain));
-
-      assert(_inheritanceChain!
-          .contains(packageGraph.specialClasses[SpecialClass.enumClass]));
-    }
-    return _inheritanceChain!.toList(growable: false);
-  }
+  late final List<InheritingContainer?> inheritanceChain = [
+    this,
+    for (var container in superChain.modelElements)
+      ...container.inheritanceChain,
+    ...interfaces.expandInheritanceChain,
+  ];
 
   @override
   String get kind => 'enum';
+
+  @override
+  String get relationshipsClass => 'eNum-relationships';
 }
 
 /// Enum's fields are virtual, so we do a little work to create

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -213,14 +213,13 @@ mixin TypeImplementing on InheritingContainer {
 /// Members follow similar naming rules to [Container], with the following
 /// additions:
 ///
-/// **instance**: As with [Container], but also includes inherited children.
-/// **inherited**: Filtered getters giving only inherited children.
+/// * **instance**: As with [Container], but also includes inherited children.
+/// * **inherited**: Filtered getters giving only inherited children.
 abstract class InheritingContainer extends Container
     with ExtensionTarget
     implements EnclosedElement {
-  @override
-
   /// [ClassElement] is analogous to [InheritingContainer].
+  @override
   ClassElement? get element => super.element as ClassElement?;
 
   DefinedElementType? _supertype;
@@ -335,6 +334,7 @@ abstract class InheritingContainer extends Container
           as DefinedElementType?)!;
 
   /// Not the same as superChain as it may include mixins.
+  ///
   /// It's really not even the same as ordinary Dart inheritance, either,
   /// because we pretend that interfaces are part of the inheritance chain
   /// to include them in the set of things we might link to for documentation
@@ -363,11 +363,12 @@ abstract class InheritingContainer extends Container
     return typeChain;
   }
 
-  Iterable<DefinedElementType> get publicSuperChain =>
-      model_utils.filterNonPublic(superChain);
+  late final List<DefinedElementType> publicSuperChain = [
+    ...model_utils.filterNonPublic(superChain)
+  ];
 
   Iterable<DefinedElementType> get publicSuperChainReversed =>
-      publicSuperChain.toList().reversed;
+      publicSuperChain.reversed;
 
   List<ExecutableElement?>? __inheritedElements;
 
@@ -573,4 +574,17 @@ abstract class InheritingContainer extends Container
 
   @override
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
+
+  /// The CSS class to use in an inheritance list.
+  String get relationshipsClass;
+}
+
+extension DefinedElementTypeIterableExtensions on Iterable<DefinedElementType> {
+  /// Returns the `ModelElement` for each element.
+  Iterable<InheritingContainer> get modelElements =>
+      map((e) => e.modelElement as InheritingContainer);
+
+  /// Expands the `ModelElement` for each element to its inheritance chain.
+  Iterable<InheritingContainer?> get expandInheritanceChain =>
+      expand((e) => (e.modelElement as InheritingContainer).inheritanceChain);
 }

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -44,29 +44,21 @@ class Mixin extends InheritingContainer with TypeImplementing {
   @override
   String get kind => 'mixin';
 
-  List<InheritingContainer?>? _inheritanceChain;
+  @override
+  late final List<InheritingContainer?> inheritanceChain = [
+    this,
+
+    // Mix-in interfaces come before other interfaces.
+    ...superclassConstraints!.expandInheritanceChain,
+
+    for (var container in superChain.modelElements)
+      ...container.inheritanceChain,
+
+    // Interfaces need to come last, because classes in the superChain might
+    // implement them even when they aren't mentioned.
+    ...interfaces.expandInheritanceChain,
+  ];
 
   @override
-  List<InheritingContainer?> get inheritanceChain {
-    if (_inheritanceChain == null) {
-      _inheritanceChain = [];
-      _inheritanceChain!.add(this);
-
-      // Mix-in interfaces come before other interfaces.
-      _inheritanceChain!.addAll(superclassConstraints!.expand(
-          (ParameterizedElementType i) =>
-              (i.modelElement as InheritingContainer).inheritanceChain));
-
-      for (var c
-          in superChain.map((e) => (e.modelElement as InheritingContainer))) {
-        _inheritanceChain!.addAll(c.inheritanceChain);
-      }
-
-      /// Interfaces need to come last, because classes in the superChain might
-      /// implement them even when they aren't mentioned.
-      _inheritanceChain!.addAll(interfaces.expand(
-          (e) => (e.modelElement as InheritingContainer).inheritanceChain));
-    }
-    return _inheritanceChain!.toList(growable: false);
-  }
+  String get relationshipsClass => 'mixin-relationships';
 }

--- a/lib/templates/html/_super_chain.html
+++ b/lib/templates/html/_super_chain.html
@@ -1,0 +1,10 @@
+{{ #hasPublicSuperChainReversed }}
+  <dt>Inheritance</dt>
+  <dd><ul class="gt-separated dark {{ relationshipsClass }}">
+    <li>{{{ linkedObjectType }}}</li>
+    {{ #publicSuperChainReversed }}
+    <li>{{{ linkedName }}}</li>
+    {{ /publicSuperChainReversed }}
+    <li>{{{ name }}}</li>
+  </ul></dd>
+{{/hasPublicSuperChainReversed }}

--- a/lib/templates/html/class.html
+++ b/lib/templates/html/class.html
@@ -11,17 +11,7 @@
     {{#hasModifiers}}
     <section>
       <dl class="dl-horizontal">
-        {{#hasPublicSuperChainReversed}}
-        <dt>Inheritance</dt>
-        <dd><ul class="gt-separated dark clazz-relationships">
-          <li>{{{linkedObjectType}}}</li>
-          {{#publicSuperChainReversed}}
-          <li>{{{linkedName}}}</li>
-          {{/publicSuperChainReversed}}
-          <li>{{{name}}}</li>
-        </ul></dd>
-        {{/hasPublicSuperChainReversed}}
-
+        {{ >super_chain }}
         {{#hasPublicInterfaces}}
         <dt>Implemented types</dt>
         <dd>

--- a/lib/templates/html/enum.html
+++ b/lib/templates/html/enum.html
@@ -1,118 +1,128 @@
 {{>head}}
 
   <div id="dartdoc-main-content" class="main-content">
-    {{#self}}
-      <div>{{>source_link}}<h1><span class="kind-enum">{{{name}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
-    {{/self}}
+    {{ #self }}
+      <div>{{ >source_link }}
+        <h1>
+          <span class="kind-enum">{{{ name }}}</span>
+          {{ kind }} {{ >feature_set }} {{ >categorization }}
+        </h1>
+      </div>
+    {{ /self }}
 
-    {{#eNum}}
-    {{>documentation}}
+    {{ #eNum }}
+    {{ >documentation }}
 
-    {{#hasModifiers}}
+    {{ #hasModifiers }}
     <section>
       <dl class="dl-horizontal">
-        {{#hasPublicSuperChainReversed}}
-        <dt>Inheritance</dt>
-        <dd><ul class="gt-separated dark eNum-relationships">
-          <li>{{{linkedObjectType}}}</li>
-          {{#publicSuperChainReversed}}
-          <li>{{{linkedName}}}</li>
-          {{/publicSuperChainReversed}}
-          <li>{{{name}}}</li>
-        </ul></dd>
-        {{/hasPublicSuperChainReversed}}
-
-        {{#hasAnnotations}}
+        {{ >super_chain }}
+        {{ #hasAnnotations }}
         <dt>Annotations</dt>
         <dd><ul class="annotation-list eNum-relationships">
-          {{#annotations}}
-          <li>{{{linkedNameWithParameters}}}</li>
-          {{/annotations}}
+          {{ #annotations }}
+          <li>{{{ linkedNameWithParameters }}}</li>
+          {{ /annotations }}
         </ul></dd>
-        {{/hasAnnotations}}
+        {{ /hasAnnotations }}
       </dl>
     </section>
-    {{/hasModifiers}}
+    {{ /hasModifiers }}
 
-    {{#hasPublicConstantFields}}
+    {{ #hasPublicConstantFields }}
     <section class="summary offset-anchor" id="constants">
       <h2>Constants</h2>
 
       <dl class="properties">
-        {{#publicConstantFieldsSorted}}
-        {{>constant}}
-        {{/publicConstantFieldsSorted}}
+        {{ #publicConstantFieldsSorted }}
+        {{ >constant }}
+        {{ /publicConstantFieldsSorted }}
       </dl>
     </section>
-    {{/hasPublicConstantFields}}
+    {{ /hasPublicConstantFields }}
 
-    {{#hasPublicInstanceFields}}
-    <section class="summary offset-anchor{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}" id="instance-properties">
+    {{ #hasPublicInstanceFields }}
+    <section
+        class="
+          summary
+          offset-anchor
+          {{ #publicInheritedInstanceFields }}inherited{{ /publicInheritedInstanceFields }}"
+        id="instance-properties">
       <h2>Properties</h2>
 
       <dl class="properties">
-        {{#publicInstanceFieldsSorted}}
-        {{>property}}
-        {{/publicInstanceFieldsSorted}}
+        {{ #publicInstanceFieldsSorted }}
+        {{ >property }}
+        {{ /publicInstanceFieldsSorted }}
       </dl>
     </section>
-    {{/hasPublicInstanceFields}}
+    {{ /hasPublicInstanceFields }}
 
-    {{#hasPublicInstanceMethods}}
-    <section class="summary offset-anchor{{ #publicInheritedInstanceMethods }} inherited{{ /publicInheritedInstanceMethods }}" id="instance-methods">
+    {{ #hasPublicInstanceMethods }}
+    <section
+        class="
+          summary
+          offset-anchor
+          {{ #publicInheritedInstanceMethods }}inherited{{ /publicInheritedInstanceMethods }}"
+        id="instance-methods">
       <h2>Methods</h2>
       <dl class="callables">
-        {{#publicInstanceMethodsSorted}}
-        {{>callable}}
-        {{/publicInstanceMethodsSorted}}
+        {{ #publicInstanceMethodsSorted }}
+        {{ >callable }}
+        {{ /publicInstanceMethodsSorted }}
       </dl>
     </section>
-    {{/hasPublicInstanceMethods}}
+    {{ /hasPublicInstanceMethods }}
 
-    {{#hasPublicInstanceOperators}}
-    <section class="summary offset-anchor{{ #publicInheritedInstanceOperators }} inherited{{ /publicInheritedInstanceOperators}}" id="operators">
+    {{ #hasPublicInstanceOperators }}
+    <section
+        class="
+          summary
+          offset-anchor
+          {{ #publicInheritedInstanceOperators }}inherited{{ /publicInheritedInstanceOperators }}"
+        id="operators">
       <h2>Operators</h2>
       <dl class="callables">
-        {{#publicInstanceOperatorsSorted}}
-        {{>callable}}
-        {{/publicInstanceOperatorsSorted}}
+        {{ #publicInstanceOperatorsSorted }}
+        {{ >callable }}
+        {{ /publicInstanceOperatorsSorted }}
       </dl>
     </section>
-    {{/hasPublicInstanceOperators}}
+    {{ /hasPublicInstanceOperators }}
 
-    {{#hasPublicVariableStaticFields}}
+    {{ #hasPublicVariableStaticFields }}
     <section class="summary offset-anchor" id="static-properties">
       <h2>Static Properties</h2>
 
       <dl class="properties">
-        {{#publicVariableStaticFieldsSorted}}
-        {{>property}}
-        {{/publicVariableStaticFieldsSorted}}
+        {{ #publicVariableStaticFieldsSorted }}
+        {{ >property }}
+        {{ /publicVariableStaticFieldsSorted }}
       </dl>
     </section>
-    {{/hasPublicVariableStaticFields}}
+    {{ /hasPublicVariableStaticFields }}
 
-    {{#hasPublicStaticMethods}}
+    {{ #hasPublicStaticMethods }}
     <section class="summary offset-anchor" id="static-methods">
       <h2>Static Methods</h2>
       <dl class="callables">
-        {{#publicStaticMethodsSorted}}
-        {{>callable}}
-        {{/publicStaticMethodsSorted}}
+        {{ #publicStaticMethodsSorted }}
+        {{ >callable }}
+        {{ /publicStaticMethodsSorted }}
       </dl>
     </section>
-    {{/hasPublicStaticMethods}}
-    {{/eNum}}
-  </div> <!-- /.main-content -->
+    {{ /hasPublicStaticMethods }}
+    {{ /eNum }}
+  </div><!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    {{{sidebarForLibrary}}}
+    {{ >search_sidebar}}
+    <h5>{{ parent.name }} {{ parent.kind }}</h5>
+    {{{ sidebarForLibrary }}}
   </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-    {{{sidebarForContainer}}}
-  </div><!--/.sidebar-offcanvas-->
+    {{{ sidebarForContainer }}}
+  </div><!-- /.sidebar-offcanvas -->
 
-{{>footer}}
+{{ >footer }}

--- a/lib/templates/html/mixin.html
+++ b/lib/templates/html/mixin.html
@@ -20,16 +20,7 @@
         </ul></dd>
         {{/hasPublicSuperclassConstraints}}
 
-        {{#hasPublicSuperChainReversed}}
-        <dt>Inheritance</dt>
-        <dd><ul class="gt-separated dark mixin-relationships">
-          <li>{{{linkedObjectType}}}</li>
-          {{#publicSuperChainReversed}}
-          <li>{{{linkedName}}}</li>
-          {{/publicSuperChainReversed}}
-          <li>{{{name}}}</li>
-        </ul></dd>
-        {{/hasPublicSuperChainReversed}}
+        {{ >super_chain }}
 
         {{#hasPublicInterfaces}}
         <dt>Implements</dt>

--- a/lib/templates/md/_super_chain.md
+++ b/lib/templates/md/_super_chain.md
@@ -1,0 +1,9 @@
+{{#hasPublicSuperChainReversed}}
+**Inheritance**
+
+- {{{linkedObjectType}}}
+{{#publicSuperChainReversed}}
+- {{{linkedName}}}
+{{/publicSuperChainReversed}}
+- {{{name}}}
+{{/hasPublicSuperChainReversed}}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -12,15 +12,7 @@
 {{>documentation}}
 
 {{#hasModifiers}}
-{{#hasPublicSuperChainReversed}}
-**Inheritance**
-
-- {{{linkedObjectType}}}
-{{#publicSuperChainReversed}}
-- {{{linkedName}}}
-{{/publicSuperChainReversed}}
-- {{{name}}}
-{{/hasPublicSuperChainReversed}}
+{{ >super_chain }}
 
 {{#hasPublicInterfaces}}
 **Implemented types**

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -11,15 +11,7 @@
 {{>documentation}}
 
 {{#hasModifiers}}
-{{#hasPublicSuperChainReversed}}
-**Inheritance**
-
-- {{{linkedObjectType}}}
-{{#publicSuperChainReversed}}
-- {{{linkedName}}}
-{{/publicSuperChainReversed}}
-- {{{name}}}
-{{/hasPublicSuperChainReversed}}
+{{ >super_chain }}
 
 {{#hasAnnotations}}
 **Annotations**

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -20,15 +20,7 @@
 {{/publicSuperclassConstraints}}
 {{/hasPublicSuperclassConstraints}}
 
-{{#hasPublicSuperChainReversed}}
-**Inheritance**
-
-- {{{linkedObjectType}}}
-{{#publicSuperChainReversed}}
-- {{{linkedName}}}
-{{/publicSuperChainReversed}}
-- {{{name}}}
-{{/hasPublicSuperChainReversed}}
+{{ >super_chain }}
 
 {{#hasPublicInterfaces}}
 **Implemented types**

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -69,6 +69,7 @@ void main() {
         '_sidebar_for_library',
         '_source_code',
         '_source_link',
+        '_super_chain',
         '_type',
         '_typedef',
         '_type_multiline',


### PR DESCRIPTION
* Attempt to format the mustache in enum.html. I like the additional whitespace and the wrapping.
* Put the inheritance chain template code into a partial to reduce duplication. In HTML and MD.
  * There is a single difference in the HTML versions of the inheritance chain section: CSS class names, so extract this into getters.
* Tidy Class.isErrorOrException.
* Make `Class.inheritanceChain`, `Enum.inheritanceChain`, and `Mixin.inheritanceChain` all late final fields.
* Make `InheritingContainer.publicSuperChain` a late final field; when it is accessed once it is always accessed multiple times.