### PR TITLE
Mustachio: Cut context types down to only used ones

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -9,22 +9,21 @@
 // ignore_for_file: unused_local_variable
 // ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
-import 'dart:convert' as _i19;
+import 'dart:convert' as _i18;
 
 import 'package:dartdoc/src/generator/template_data.dart' as _i1;
-import 'package:dartdoc/src/model/accessor.dart' as _i17;
+import 'package:dartdoc/src/model/accessor.dart' as _i16;
 import 'package:dartdoc/src/model/category.dart' as _i2;
 import 'package:dartdoc/src/model/class.dart' as _i8;
 import 'package:dartdoc/src/model/constructor.dart' as _i11;
 import 'package:dartdoc/src/model/container.dart' as _i4;
-import 'package:dartdoc/src/model/documentable.dart' as _i18;
+import 'package:dartdoc/src/model/documentable.dart' as _i17;
 import 'package:dartdoc/src/model/enum.dart' as _i12;
 import 'package:dartdoc/src/model/extension.dart' as _i13;
 import 'package:dartdoc/src/model/field.dart' as _i9;
 import 'package:dartdoc/src/model/library.dart' as _i3;
-import 'package:dartdoc/src/model/library_container.dart' as _i15;
 import 'package:dartdoc/src/model/method.dart' as _i10;
-import 'package:dartdoc/src/model/mixin.dart' as _i16;
+import 'package:dartdoc/src/model/mixin.dart' as _i15;
 import 'package:dartdoc/src/model/model_function.dart' as _i6;
 import 'package:dartdoc/src/model/package.dart' as _i14;
 import 'package:dartdoc/src/model/top_level_variable.dart' as _i5;
@@ -46,7 +45,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
   buffer.writeEscaped(context1.kind);
   buffer.write('''</h1>
   ''');
-  buffer.write(_renderCategory_partial_documentation_1(context1, context0));
+  buffer.write(_renderCategory_partial_documentation_1(context1));
   buffer.writeln();
   if (context1.hasPublicLibraries == true) {
     buffer.writeln();
@@ -58,8 +57,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context2 = context1.publicLibrariesSorted;
     for (var context3 in context2) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_library_2(context3, context1, context0));
+      buffer.write(_renderCategory_partial_library_2(context3));
     }
     buffer.writeln();
     buffer.write('''
@@ -77,8 +75,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context4 = context1.publicClassesSorted;
     for (var context5 in context4) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_container_3(context5, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context5));
     }
     buffer.writeln();
     buffer.write('''
@@ -96,8 +93,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context6 = context1.publicMixinsSorted;
     for (var context7 in context6) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_container_3(context7, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context7));
     }
     buffer.writeln();
     buffer.write('''
@@ -115,8 +111,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context8 = context1.publicConstantsSorted;
     for (var context9 in context8) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_constant_4(context9, context1, context0));
+      buffer.write(_renderCategory_partial_constant_4(context9));
     }
     buffer.writeln();
     buffer.write('''
@@ -134,8 +129,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context10 = context1.publicPropertiesSorted;
     for (var context11 in context10) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_property_5(context11, context1, context0));
+      buffer.write(_renderCategory_partial_property_5(context11));
     }
     buffer.writeln();
     buffer.write('''
@@ -153,8 +147,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context12 = context1.publicFunctionsSorted;
     for (var context13 in context12) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_callable_6(context13, context1, context0));
+      buffer.write(_renderCategory_partial_callable_6(context13));
     }
     buffer.writeln();
     buffer.write('''
@@ -172,8 +165,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context14 = context1.publicEnumsSorted;
     for (var context15 in context14) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_container_3(context15, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context15));
     }
     buffer.writeln();
     buffer.write('''
@@ -191,8 +183,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context16 = context1.publicTypedefsSorted;
     for (var context17 in context16) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_typedef_7(context17, context1, context0));
+      buffer.write(_renderCategory_partial_typedef_7(context17));
     }
     buffer.writeln();
     buffer.write('''
@@ -210,8 +201,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context18 = context1.publicExceptionsSorted;
     for (var context19 in context18) {
       buffer.write('\n      ');
-      buffer.write(
-          _renderCategory_partial_container_3(context19, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context19));
     }
     buffer.writeln();
     buffer.write('''
@@ -281,8 +271,8 @@ String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -293,7 +283,7 @@ String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -347,27 +337,27 @@ String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -405,8 +395,7 @@ String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderCategory_partial_documentation_1(
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_documentation_1(_i2.Category context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -423,8 +412,7 @@ String _renderCategory_partial_documentation_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_library_2(_i3.Library context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_library_2(_i3.Library context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -432,8 +420,8 @@ String _renderCategory_partial_library_2(_i3.Library context2,
   <span class="name">''');
   buffer.write(context2.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderCategory_partial_library_2_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_library_2_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -452,15 +440,13 @@ String _renderCategory_partial_library_2(_i3.Library context2,
 }
 
 String __renderCategory_partial_library_2_partial_categorization_0(
-    _i3.Library context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i3.Library context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -468,8 +454,7 @@ String __renderCategory_partial_library_2_partial_categorization_0(
   return buffer.toString();
 }
 
-String _renderCategory_partial_container_3(_i4.Container context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_container_3(_i4.Container context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -482,8 +467,8 @@ String _renderCategory_partial_container_3(_i4.Container context2,
   buffer.write(context2.linkedName);
   buffer.write(context2.linkedGenericParameters);
   buffer.write('''</span> ''');
-  buffer.write(__renderCategory_partial_container_3_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -501,15 +486,13 @@ String _renderCategory_partial_container_3(_i4.Container context2,
 }
 
 String __renderCategory_partial_container_3_partial_categorization_0(
-    _i4.Container context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i4.Container context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -517,8 +500,7 @@ String __renderCategory_partial_container_3_partial_categorization_0(
   return buffer.toString();
 }
 
-String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -534,8 +516,8 @@ String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2,
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderCategory_partial_constant_4_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_constant_4_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -545,8 +527,8 @@ String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2,
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderCategory_partial_constant_4_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderCategory_partial_constant_4_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
   <div>
@@ -561,15 +543,13 @@ String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2,
 }
 
 String __renderCategory_partial_constant_4_partial_categorization_0(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -578,9 +558,7 @@ String __renderCategory_partial_constant_4_partial_categorization_0(
 }
 
 String __renderCategory_partial_constant_4_partial_features_1(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -592,8 +570,7 @@ String __renderCategory_partial_constant_4_partial_features_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_property_5(_i5.TopLevelVariable context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_property_5(_i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -610,8 +587,8 @@ String _renderCategory_partial_property_5(_i5.TopLevelVariable context2,
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderCategory_partial_property_5_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_property_5_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -625,8 +602,8 @@ String _renderCategory_partial_property_5(_i5.TopLevelVariable context2,
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderCategory_partial_property_5_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderCategory_partial_property_5_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -636,15 +613,13 @@ String _renderCategory_partial_property_5(_i5.TopLevelVariable context2,
 }
 
 String __renderCategory_partial_property_5_partial_categorization_0(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -653,9 +628,7 @@ String __renderCategory_partial_property_5_partial_categorization_0(
 }
 
 String __renderCategory_partial_property_5_partial_features_1(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -667,8 +640,7 @@ String __renderCategory_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -693,8 +665,8 @@ String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2,
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderCategory_partial_callable_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_callable_6_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -708,8 +680,8 @@ String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2,
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderCategory_partial_callable_6_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderCategory_partial_callable_6_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -719,15 +691,13 @@ String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2,
 }
 
 String __renderCategory_partial_callable_6_partial_categorization_0(
-    _i6.ModelFunctionTyped context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i6.ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -736,9 +706,7 @@ String __renderCategory_partial_callable_6_partial_categorization_0(
 }
 
 String __renderCategory_partial_callable_6_partial_features_1(
-    _i6.ModelFunctionTyped context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i6.ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -750,59 +718,57 @@ String __renderCategory_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_typedef_7(_i7.Typedef context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_typedef_7(_i7.Typedef context2) {
   final buffer = StringBuffer();
   if (context2.isCallable == true) {
-    var context3 = context2.asCallable;
+    var context4 = context2.asCallable;
     buffer.writeln();
     buffer.write('''
   <dt id="''');
-    buffer.writeEscaped(context3.htmlId);
+    buffer.writeEscaped(context4.htmlId);
     buffer.write('''" class="callable''');
-    if (context3.isInherited == true) {
+    if (context4.isInherited == true) {
       buffer.write(''' inherited''');
     }
     buffer.write('''">
     <span class="name''');
-    if (context3.isDeprecated == true) {
+    if (context4.isDeprecated == true) {
       buffer.write(''' deprecated''');
     }
     buffer.write('''">''');
-    buffer.write(context3.linkedName);
+    buffer.write(context4.linkedName);
     buffer.write('''</span>''');
-    buffer.write(context3.linkedGenericParameters);
+    buffer.write(context4.linkedGenericParameters);
     buffer.write('''<span class="signature">
       <span class="returntype parameter">= ''');
-    buffer.write(context3.modelType.linkedName);
+    buffer.write(context4.modelType.linkedName);
     buffer.write('''</span>
     </span>
     ''');
-    buffer.write(__renderCategory_partial_typedef_7_partial_categorization_0(
-        context3, context2, context1, context0));
+    buffer.write(
+        __renderCategory_partial_typedef_7_partial_categorization_0(context4));
     buffer.writeln();
     buffer.write('''
   </dt>
   <dd''');
-    if (context3.isInherited == true) {
+    if (context4.isInherited == true) {
       buffer.write(''' class="inherited"''');
     }
     buffer.write('''>
     ''');
-    buffer.write(context3.oneLineDoc);
+    buffer.write(context4.oneLineDoc);
     buffer.write(' ');
-    buffer.write(context3.extendedDocLink);
+    buffer.write(context4.extendedDocLink);
     buffer.write('\n    ');
-    buffer.write(__renderCategory_partial_typedef_7_partial_features_1(
-        context3, context2, context1, context0));
+    buffer
+        .write(__renderCategory_partial_typedef_7_partial_features_1(context4));
     buffer.writeln();
     buffer.write('''
   </dd>''');
   }
   if (context2.isCallable != true) {
     buffer.write('\n  ');
-    buffer.write(__renderCategory_partial_typedef_7_partial_type_2(
-        context2, context1, context0));
+    buffer.write(__renderCategory_partial_typedef_7_partial_type_2(context2));
   }
   buffer.writeln();
 
@@ -810,16 +776,13 @@ String _renderCategory_partial_typedef_7(_i7.Typedef context2,
 }
 
 String __renderCategory_partial_typedef_7_partial_categorization_0(
-    _i7.FunctionTypedef context3,
-    _i7.Typedef context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i7.FunctionTypedef context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -828,10 +791,7 @@ String __renderCategory_partial_typedef_7_partial_categorization_0(
 }
 
 String __renderCategory_partial_typedef_7_partial_features_1(
-    _i7.FunctionTypedef context3,
-    _i7.Typedef context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i7.FunctionTypedef context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -843,8 +803,7 @@ String __renderCategory_partial_typedef_7_partial_features_1(
   return buffer.toString();
 }
 
-String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -871,7 +830,7 @@ String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
   ''');
   buffer.write(
       ___renderCategory_partial_typedef_7_partial_type_2_partial_categorization_0(
-          context2, context1, context0));
+          context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -887,7 +846,7 @@ String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
   buffer.write('\n  ');
   buffer.write(
       ___renderCategory_partial_typedef_7_partial_type_2_partial_features_1(
-          context2, context1, context0));
+          context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -898,15 +857,13 @@ String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
 
 String
     ___renderCategory_partial_typedef_7_partial_type_2_partial_categorization_0(
-        _i7.Typedef context2,
-        _i2.Category context1,
-        _i1.CategoryTemplateData context0) {
+        _i7.Typedef context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context9 = context2.displayedCategories;
+    for (var context10 in context9) {
       buffer.write('\n    ');
-      buffer.write(context4.categoryLabel);
+      buffer.write(context10.categoryLabel);
     }
   }
   buffer.writeln();
@@ -915,9 +872,7 @@ String
 }
 
 String ___renderCategory_partial_typedef_7_partial_type_2_partial_features_1(
-    _i7.Typedef context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i7.Typedef context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -939,27 +894,27 @@ String _renderCategory_partial_search_sidebar_8(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -992,19 +947,19 @@ String _renderCategory_partial_search_sidebar_8(
 String _renderCategory_partial_packages_9(_i1.CategoryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
-  var context1 = context0.localPackages;
-  for (var context2 in context1) {
-    if (context2.isFirstPackage == true) {
-      if (context2.hasDocumentedCategories == true) {
+  var context12 = context0.localPackages;
+  for (var context13 in context12) {
+    if (context13.isFirstPackage == true) {
+      if (context13.hasDocumentedCategories == true) {
         buffer.writeln();
         buffer.write('''
       <li class="section-title">Topics</li>''');
-        var context3 = context2.documentedCategoriesSorted;
-        for (var context4 in context3) {
+        var context14 = context13.documentedCategoriesSorted;
+        for (var context15 in context14) {
           buffer.writeln();
           buffer.write('''
         <li>''');
-          buffer.write(context4.linkedName);
+          buffer.write(context15.linkedName);
           buffer.write('''</li>''');
         }
       }
@@ -1012,37 +967,37 @@ String _renderCategory_partial_packages_9(_i1.CategoryTemplateData context0) {
       buffer.write('''
       <li class="section-title">Libraries</li>''');
     }
-    if (context2.isFirstPackage != true) {
+    if (context13.isFirstPackage != true) {
       buffer.writeln();
       buffer.write('''
       <li class="section-title">''');
-      buffer.writeEscaped(context2.name);
+      buffer.writeEscaped(context13.name);
       buffer.write('''</li>''');
     }
-    var context5 = context2.defaultCategory;
-    if (context5 != null) {
-      var context6 = context5.publicLibrariesSorted;
-      for (var context7 in context6) {
+    var context16 = context13.defaultCategory;
+    if (context16 != null) {
+      var context17 = context16.publicLibrariesSorted;
+      for (var context18 in context17) {
         buffer.writeln();
         buffer.write('''
       <li>''');
-        buffer.write(context7.linkedName);
+        buffer.write(context18.linkedName);
         buffer.write('''</li>''');
       }
     }
-    var context8 = context2.categoriesWithPublicLibraries;
-    for (var context9 in context8) {
+    var context19 = context13.categoriesWithPublicLibraries;
+    for (var context20 in context19) {
       buffer.writeln();
       buffer.write('''
       <li class="section-subtitle">''');
-      buffer.writeEscaped(context9.name);
+      buffer.writeEscaped(context20.name);
       buffer.write('''</li>''');
-      var context10 = context9.publicLibrariesSorted;
-      for (var context11 in context10) {
+      var context21 = context20.publicLibrariesSorted;
+      for (var context22 in context21) {
         buffer.writeln();
         buffer.write('''
         <li class="section-subitem">''');
-        buffer.write(context11.linkedName);
+        buffer.write(context22.linkedName);
         buffer.write('''</li>''');
       }
     }
@@ -1059,164 +1014,164 @@ String _renderCategory_partial_sidebar_for_category_10(
     _i1.CategoryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
-  var context1 = context0.self;
-  if (context1.hasPublicLibraries == true) {
+  var context37 = context0.self;
+  if (context37.hasPublicLibraries == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#libraries">Libraries</a></li>''');
-    var context2 = context0.self;
-    var context3 = context2.publicLibrariesSorted;
-    for (var context4 in context3) {
+    var context38 = context0.self;
+    var context39 = context38.publicLibrariesSorted;
+    for (var context40 in context39) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context4.linkedName);
+      buffer.write(context40.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context5 = context0.self;
-  if (context5.hasPublicMixins == true) {
+  var context41 = context0.self;
+  if (context41.hasPublicMixins == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#mixins">Mixins</a></li>''');
-    var context6 = context0.self;
-    var context7 = context6.publicMixinsSorted;
-    for (var context8 in context7) {
+    var context42 = context0.self;
+    var context43 = context42.publicMixinsSorted;
+    for (var context44 in context43) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context8.linkedName);
+      buffer.write(context44.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context9 = context0.self;
-  if (context9.hasPublicClasses == true) {
+  var context45 = context0.self;
+  if (context45.hasPublicClasses == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#classes">Classes</a></li>''');
-    var context10 = context0.self;
-    var context11 = context10.publicClassesSorted;
-    for (var context12 in context11) {
+    var context46 = context0.self;
+    var context47 = context46.publicClassesSorted;
+    for (var context48 in context47) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context12.linkedName);
+      buffer.write(context48.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context13 = context0.self;
-  if (context13.hasPublicConstants == true) {
+  var context49 = context0.self;
+  if (context49.hasPublicConstants == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#constants">Constants</a></li>''');
-    var context14 = context0.self;
-    var context15 = context14.publicConstantsSorted;
-    for (var context16 in context15) {
+    var context50 = context0.self;
+    var context51 = context50.publicConstantsSorted;
+    for (var context52 in context51) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context16.linkedName);
+      buffer.write(context52.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context17 = context0.self;
-  if (context17.hasPublicProperties == true) {
+  var context53 = context0.self;
+  if (context53.hasPublicProperties == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#properties">Properties</a></li>''');
-    var context18 = context0.self;
-    var context19 = context18.publicPropertiesSorted;
-    for (var context20 in context19) {
+    var context54 = context0.self;
+    var context55 = context54.publicPropertiesSorted;
+    for (var context56 in context55) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context20.linkedName);
+      buffer.write(context56.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context21 = context0.self;
-  if (context21.hasPublicFunctions == true) {
+  var context57 = context0.self;
+  if (context57.hasPublicFunctions == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#functions">Functions</a></li>''');
-    var context22 = context0.self;
-    var context23 = context22.publicFunctionsSorted;
-    for (var context24 in context23) {
+    var context58 = context0.self;
+    var context59 = context58.publicFunctionsSorted;
+    for (var context60 in context59) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context24.linkedName);
+      buffer.write(context60.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context25 = context0.self;
-  if (context25.hasPublicEnums == true) {
+  var context61 = context0.self;
+  if (context61.hasPublicEnums == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#enums">Enums</a></li>''');
-    var context26 = context0.self;
-    var context27 = context26.publicEnumsSorted;
-    for (var context28 in context27) {
+    var context62 = context0.self;
+    var context63 = context62.publicEnumsSorted;
+    for (var context64 in context63) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context28.linkedName);
+      buffer.write(context64.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context29 = context0.self;
-  if (context29.hasPublicTypedefs == true) {
+  var context65 = context0.self;
+  if (context65.hasPublicTypedefs == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#typedefs">Typedefs</a></li>''');
-    var context30 = context0.self;
-    var context31 = context30.publicTypedefsSorted;
-    for (var context32 in context31) {
+    var context66 = context0.self;
+    var context67 = context66.publicTypedefsSorted;
+    for (var context68 in context67) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context32.linkedName);
+      buffer.write(context68.linkedName);
       buffer.write('''</li>''');
     }
   }
   buffer.writeln();
-  var context33 = context0.self;
-  if (context33.hasPublicExceptions == true) {
+  var context69 = context0.self;
+  if (context69.hasPublicExceptions == true) {
     buffer.writeln();
     buffer.write('''
   <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#exceptions">Exceptions</a></li>''');
-    var context34 = context0.self;
-    var context35 = context34.publicExceptionsSorted;
-    for (var context36 in context35) {
+    var context70 = context0.self;
+    var context71 = context70.publicExceptionsSorted;
+    for (var context72 in context71) {
       buffer.writeln();
       buffer.write('''
   <li>''');
-      buffer.write(context36.linkedName);
+      buffer.write(context72.linkedName);
       buffer.write('''</li>''');
     }
   }
@@ -1289,20 +1244,20 @@ String renderClass(_i1.ClassTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderClass_partial_source_link_1(context1, context0));
+  buffer.write(_renderClass_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-class">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderClass_partial_feature_set_2(context1, context0));
+  buffer.write(_renderClass_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderClass_partial_categorization_3(context1, context0));
+  buffer.write(_renderClass_partial_categorization_3(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.clazz;
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_documentation_4(context2, context0));
+  buffer.write(_renderClass_partial_documentation_4(context2));
   buffer.writeln();
   if (context2.hasModifiers == true) {
     buffer.writeln();
@@ -1467,8 +1422,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context15 = context2.publicInstanceFieldsSorted;
     for (var context16 in context15) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderClass_partial_property_6(context16, context2, context0));
+      buffer.write(_renderClass_partial_property_6(context16));
     }
     buffer.writeln();
     buffer.write('''
@@ -1489,8 +1443,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context17 = context2.publicInstanceMethodsSorted;
     for (var context18 in context17) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderClass_partial_callable_7(context18, context2, context0));
+      buffer.write(_renderClass_partial_callable_7(context18));
     }
     buffer.writeln();
     buffer.write('''
@@ -1511,8 +1464,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context19 = context2.publicInstanceOperatorsSorted;
     for (var context20 in context19) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderClass_partial_callable_7(context20, context2, context0));
+      buffer.write(_renderClass_partial_callable_7(context20));
     }
     buffer.writeln();
     buffer.write('''
@@ -1530,8 +1482,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context21 = context2.publicVariableStaticFieldsSorted;
     for (var context22 in context21) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderClass_partial_property_6(context22, context2, context0));
+      buffer.write(_renderClass_partial_property_6(context22));
     }
     buffer.writeln();
     buffer.write('''
@@ -1548,8 +1499,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context23 = context2.publicStaticMethodsSorted;
     for (var context24 in context23) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderClass_partial_callable_7(context24, context2, context0));
+      buffer.write(_renderClass_partial_callable_7(context24));
     }
     buffer.writeln();
     buffer.write('''
@@ -1567,8 +1517,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context25 = context2.publicConstantFieldsSorted;
     for (var context26 in context25) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderClass_partial_constant_8(context26, context2, context0));
+      buffer.write(_renderClass_partial_constant_8(context26));
     }
     buffer.writeln();
     buffer.write('''
@@ -1633,8 +1582,8 @@ String _renderClass_partial_head_0(_i1.ClassTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -1645,7 +1594,7 @@ String _renderClass_partial_head_0(_i1.ClassTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -1699,27 +1648,27 @@ String _renderClass_partial_head_0(_i1.ClassTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -1757,8 +1706,7 @@ String _renderClass_partial_head_0(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderClass_partial_source_link_1(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_source_link_1(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -1772,14 +1720,13 @@ String _renderClass_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_feature_set_2(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_feature_set_2(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -1787,14 +1734,13 @@ String _renderClass_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderClass_partial_categorization_3(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_categorization_3(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1802,8 +1748,7 @@ String _renderClass_partial_categorization_3(
   return buffer.toString();
 }
 
-String _renderClass_partial_documentation_4(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_documentation_4(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -1833,12 +1778,12 @@ String _renderClass_partial_super_chain_5(
     <li>''');
     buffer.write(context0.linkedObjectType);
     buffer.write('''</li>''');
-    var context2 = context1.publicSuperChainReversed;
-    for (var context3 in context2) {
+    var context4 = context1.publicSuperChainReversed;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
     <li>''');
-      buffer.write(context3.linkedName);
+      buffer.write(context5.linkedName);
       buffer.write('''</li>''');
     }
     buffer.writeln();
@@ -1853,8 +1798,7 @@ String _renderClass_partial_super_chain_5(
   return buffer.toString();
 }
 
-String _renderClass_partial_property_6(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_property_6(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -1871,8 +1815,8 @@ String _renderClass_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderClass_partial_property_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderClass_partial_property_6_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -1886,8 +1830,7 @@ String _renderClass_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderClass_partial_property_6_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderClass_partial_property_6_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -1897,13 +1840,13 @@ String _renderClass_partial_property_6(
 }
 
 String __renderClass_partial_property_6_partial_categorization_0(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1911,8 +1854,7 @@ String __renderClass_partial_property_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderClass_partial_property_6_partial_features_1(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String __renderClass_partial_property_6_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -1924,8 +1866,7 @@ String __renderClass_partial_property_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_callable_7(
-    _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_callable_7(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -1950,8 +1891,8 @@ String _renderClass_partial_callable_7(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderClass_partial_callable_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderClass_partial_callable_7_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -1965,8 +1906,7 @@ String _renderClass_partial_callable_7(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderClass_partial_callable_7_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderClass_partial_callable_7_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -1976,13 +1916,13 @@ String _renderClass_partial_callable_7(
 }
 
 String __renderClass_partial_callable_7_partial_categorization_0(
-    _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1991,7 +1931,7 @@ String __renderClass_partial_callable_7_partial_categorization_0(
 }
 
 String __renderClass_partial_callable_7_partial_features_1(
-    _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -2003,8 +1943,7 @@ String __renderClass_partial_callable_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_constant_8(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_constant_8(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -2020,8 +1959,8 @@ String _renderClass_partial_constant_8(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderClass_partial_constant_8_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderClass_partial_constant_8_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -2031,8 +1970,7 @@ String _renderClass_partial_constant_8(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderClass_partial_constant_8_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderClass_partial_constant_8_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
   <div>
@@ -2047,13 +1985,13 @@ String _renderClass_partial_constant_8(
 }
 
 String __renderClass_partial_constant_8_partial_categorization_0(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2061,8 +1999,7 @@ String __renderClass_partial_constant_8_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderClass_partial_constant_8_partial_features_1(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String __renderClass_partial_constant_8_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -2083,27 +2020,27 @@ String _renderClass_partial_search_sidebar_9(_i1.ClassTemplateData context0) {
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -2194,13 +2131,13 @@ String renderConstructor(_i1.ConstructorTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderConstructor_partial_source_link_1(context1, context0));
+  buffer.write(_renderConstructor_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-constructor">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderConstructor_partial_feature_set_2(context1, context0));
+  buffer.write(_renderConstructor_partial_feature_set_2(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.constructor;
@@ -2244,9 +2181,9 @@ String renderConstructor(_i1.ConstructorTemplateData context0) {
     </section>
 
     ''');
-  buffer.write(_renderConstructor_partial_documentation_3(context2, context0));
+  buffer.write(_renderConstructor_partial_documentation_3(context2));
   buffer.write('\n\n    ');
-  buffer.write(_renderConstructor_partial_source_code_4(context2, context0));
+  buffer.write(_renderConstructor_partial_source_code_4(context2));
   buffer.writeln();
   buffer.writeln();
   buffer.write('''
@@ -2301,8 +2238,8 @@ String _renderConstructor_partial_head_0(_i1.ConstructorTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -2313,7 +2250,7 @@ String _renderConstructor_partial_head_0(_i1.ConstructorTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -2367,27 +2304,27 @@ String _renderConstructor_partial_head_0(_i1.ConstructorTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -2425,8 +2362,7 @@ String _renderConstructor_partial_head_0(_i1.ConstructorTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderConstructor_partial_source_link_1(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_source_link_1(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -2440,14 +2376,13 @@ String _renderConstructor_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderConstructor_partial_feature_set_2(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_feature_set_2(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -2455,8 +2390,7 @@ String _renderConstructor_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderConstructor_partial_documentation_3(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_documentation_3(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -2473,8 +2407,7 @@ String _renderConstructor_partial_documentation_3(
   return buffer.toString();
 }
 
-String _renderConstructor_partial_source_code_4(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_source_code_4(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -2501,27 +2434,27 @@ String _renderConstructor_partial_search_sidebar_5(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -2613,7 +2546,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderEnum_partial_source_link_1(context1, context0));
+  buffer.write(_renderEnum_partial_source_link_1(context1));
   buffer.writeln();
   buffer.write('''
         <h1>
@@ -2623,9 +2556,9 @@ String renderEnum(_i1.EnumTemplateData context0) {
           ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderEnum_partial_feature_set_2(context1, context0));
+  buffer.write(_renderEnum_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderEnum_partial_categorization_3(context1, context0));
+  buffer.write(_renderEnum_partial_categorization_3(context1));
   buffer.writeln();
   buffer.write('''
         </h1>
@@ -2633,7 +2566,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.writeln();
   var context2 = context0.eNum;
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_documentation_4(context2, context0));
+  buffer.write(_renderEnum_partial_documentation_4(context2));
   buffer.writeln();
   if (context2.hasModifiers == true) {
     buffer.writeln();
@@ -2675,8 +2608,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context5 = context2.publicConstantFieldsSorted;
     for (var context6 in context5) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderEnum_partial_constant_6(context6, context2, context0));
+      buffer.write(_renderEnum_partial_constant_6(context6));
     }
     buffer.writeln();
     buffer.write('''
@@ -2702,8 +2634,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderEnum_partial_property_7(context8, context2, context0));
+      buffer.write(_renderEnum_partial_property_7(context8));
     }
     buffer.writeln();
     buffer.write('''
@@ -2728,8 +2659,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context9 = context2.publicInstanceMethodsSorted;
     for (var context10 in context9) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderEnum_partial_callable_8(context10, context2, context0));
+      buffer.write(_renderEnum_partial_callable_8(context10));
     }
     buffer.writeln();
     buffer.write('''
@@ -2754,8 +2684,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context11 = context2.publicInstanceOperatorsSorted;
     for (var context12 in context11) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderEnum_partial_callable_8(context12, context2, context0));
+      buffer.write(_renderEnum_partial_callable_8(context12));
     }
     buffer.writeln();
     buffer.write('''
@@ -2773,8 +2702,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context13 = context2.publicVariableStaticFieldsSorted;
     for (var context14 in context13) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderEnum_partial_property_7(context14, context2, context0));
+      buffer.write(_renderEnum_partial_property_7(context14));
     }
     buffer.writeln();
     buffer.write('''
@@ -2791,8 +2719,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context15 = context2.publicStaticMethodsSorted;
     for (var context16 in context15) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderEnum_partial_callable_8(context16, context2, context0));
+      buffer.write(_renderEnum_partial_callable_8(context16));
     }
     buffer.writeln();
     buffer.write('''
@@ -2856,8 +2783,8 @@ String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -2868,7 +2795,7 @@ String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -2922,27 +2849,27 @@ String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -2980,8 +2907,7 @@ String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_source_link_1(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_source_link_1(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -2995,14 +2921,13 @@ String _renderEnum_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_feature_set_2(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_feature_set_2(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -3010,14 +2935,13 @@ String _renderEnum_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderEnum_partial_categorization_3(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_categorization_3(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3025,8 +2949,7 @@ String _renderEnum_partial_categorization_3(
   return buffer.toString();
 }
 
-String _renderEnum_partial_documentation_4(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_documentation_4(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -3056,12 +2979,12 @@ String _renderEnum_partial_super_chain_5(
     <li>''');
     buffer.write(context0.linkedObjectType);
     buffer.write('''</li>''');
-    var context2 = context1.publicSuperChainReversed;
-    for (var context3 in context2) {
+    var context4 = context1.publicSuperChainReversed;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
     <li>''');
-      buffer.write(context3.linkedName);
+      buffer.write(context5.linkedName);
       buffer.write('''</li>''');
     }
     buffer.writeln();
@@ -3076,8 +2999,7 @@ String _renderEnum_partial_super_chain_5(
   return buffer.toString();
 }
 
-String _renderEnum_partial_constant_6(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_constant_6(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -3093,8 +3015,8 @@ String _renderEnum_partial_constant_6(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderEnum_partial_constant_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderEnum_partial_constant_6_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -3104,8 +3026,7 @@ String _renderEnum_partial_constant_6(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderEnum_partial_constant_6_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderEnum_partial_constant_6_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
   <div>
@@ -3120,13 +3041,13 @@ String _renderEnum_partial_constant_6(
 }
 
 String __renderEnum_partial_constant_6_partial_categorization_0(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3134,8 +3055,7 @@ String __renderEnum_partial_constant_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderEnum_partial_constant_6_partial_features_1(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String __renderEnum_partial_constant_6_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3147,8 +3067,7 @@ String __renderEnum_partial_constant_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_property_7(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_property_7(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -3165,8 +3084,8 @@ String _renderEnum_partial_property_7(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderEnum_partial_property_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderEnum_partial_property_7_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -3180,8 +3099,7 @@ String _renderEnum_partial_property_7(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderEnum_partial_property_7_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderEnum_partial_property_7_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -3191,13 +3109,13 @@ String _renderEnum_partial_property_7(
 }
 
 String __renderEnum_partial_property_7_partial_categorization_0(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3205,8 +3123,7 @@ String __renderEnum_partial_property_7_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderEnum_partial_property_7_partial_features_1(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String __renderEnum_partial_property_7_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3218,8 +3135,7 @@ String __renderEnum_partial_property_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_callable_8(
-    _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_callable_8(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -3244,8 +3160,8 @@ String _renderEnum_partial_callable_8(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderEnum_partial_callable_8_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderEnum_partial_callable_8_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -3259,8 +3175,7 @@ String _renderEnum_partial_callable_8(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderEnum_partial_callable_8_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderEnum_partial_callable_8_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -3270,13 +3185,13 @@ String _renderEnum_partial_callable_8(
 }
 
 String __renderEnum_partial_callable_8_partial_categorization_0(
-    _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3285,7 +3200,7 @@ String __renderEnum_partial_callable_8_partial_categorization_0(
 }
 
 String __renderEnum_partial_callable_8_partial_features_1(
-    _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3306,27 +3221,27 @@ String _renderEnum_partial_search_sidebar_9(_i1.EnumTemplateData context0) {
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -3476,8 +3391,8 @@ String _renderError_partial_head_0(_i1.PackageTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -3488,7 +3403,7 @@ String _renderError_partial_head_0(_i1.PackageTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -3542,27 +3457,27 @@ String _renderError_partial_head_0(_i1.PackageTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -3609,27 +3524,27 @@ String _renderError_partial_search_sidebar_1(_i1.PackageTemplateData context0) {
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -3662,19 +3577,19 @@ String _renderError_partial_search_sidebar_1(_i1.PackageTemplateData context0) {
 String _renderError_partial_packages_2(_i1.PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
-  var context1 = context0.localPackages;
-  for (var context2 in context1) {
-    if (context2.isFirstPackage == true) {
-      if (context2.hasDocumentedCategories == true) {
+  var context12 = context0.localPackages;
+  for (var context13 in context12) {
+    if (context13.isFirstPackage == true) {
+      if (context13.hasDocumentedCategories == true) {
         buffer.writeln();
         buffer.write('''
       <li class="section-title">Topics</li>''');
-        var context3 = context2.documentedCategoriesSorted;
-        for (var context4 in context3) {
+        var context14 = context13.documentedCategoriesSorted;
+        for (var context15 in context14) {
           buffer.writeln();
           buffer.write('''
         <li>''');
-          buffer.write(context4.linkedName);
+          buffer.write(context15.linkedName);
           buffer.write('''</li>''');
         }
       }
@@ -3682,37 +3597,37 @@ String _renderError_partial_packages_2(_i1.PackageTemplateData context0) {
       buffer.write('''
       <li class="section-title">Libraries</li>''');
     }
-    if (context2.isFirstPackage != true) {
+    if (context13.isFirstPackage != true) {
       buffer.writeln();
       buffer.write('''
       <li class="section-title">''');
-      buffer.writeEscaped(context2.name);
+      buffer.writeEscaped(context13.name);
       buffer.write('''</li>''');
     }
-    var context5 = context2.defaultCategory;
-    if (context5 != null) {
-      var context6 = context5.publicLibrariesSorted;
-      for (var context7 in context6) {
+    var context16 = context13.defaultCategory;
+    if (context16 != null) {
+      var context17 = context16.publicLibrariesSorted;
+      for (var context18 in context17) {
         buffer.writeln();
         buffer.write('''
       <li>''');
-        buffer.write(context7.linkedName);
+        buffer.write(context18.linkedName);
         buffer.write('''</li>''');
       }
     }
-    var context8 = context2.categoriesWithPublicLibraries;
-    for (var context9 in context8) {
+    var context19 = context13.categoriesWithPublicLibraries;
+    for (var context20 in context19) {
       buffer.writeln();
       buffer.write('''
       <li class="section-subtitle">''');
-      buffer.writeEscaped(context9.name);
+      buffer.writeEscaped(context20.name);
       buffer.write('''</li>''');
-      var context10 = context9.publicLibrariesSorted;
-      for (var context11 in context10) {
+      var context21 = context20.publicLibrariesSorted;
+      for (var context22 in context21) {
         buffer.writeln();
         buffer.write('''
         <li class="section-subitem">''');
-        buffer.write(context11.linkedName);
+        buffer.write(context22.linkedName);
         buffer.write('''</li>''');
       }
     }
@@ -3787,20 +3702,20 @@ String renderExtension<T extends _i13.Extension>(
   buffer.writeln();
   buffer.write('''
     <div>''');
-  buffer.write(_renderExtension_partial_source_link_1(context1, context0));
+  buffer.write(_renderExtension_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-class">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderExtension_partial_feature_set_2(context1, context0));
+  buffer.write(_renderExtension_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderExtension_partial_categorization_3(context1, context0));
+  buffer.write(_renderExtension_partial_categorization_3(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.extension;
   buffer.write('\n    ');
-  buffer.write(_renderExtension_partial_documentation_4(context2, context0));
+  buffer.write(_renderExtension_partial_documentation_4(context2));
   buffer.writeln();
   buffer.write('''
     <section>
@@ -3831,8 +3746,7 @@ String renderExtension<T extends _i13.Extension>(
     var context4 = context2.publicInstanceFieldsSorted;
     for (var context5 in context4) {
       buffer.write('\n            ');
-      buffer.write(
-          _renderExtension_partial_property_5(context5, context2, context0));
+      buffer.write(_renderExtension_partial_property_5(context5));
     }
     buffer.writeln();
     buffer.write('''
@@ -3849,8 +3763,7 @@ String renderExtension<T extends _i13.Extension>(
     var context6 = context2.publicInstanceMethodsSorted;
     for (var context7 in context6) {
       buffer.write('\n            ');
-      buffer.write(
-          _renderExtension_partial_callable_6(context7, context2, context0));
+      buffer.write(_renderExtension_partial_callable_6(context7));
     }
     buffer.writeln();
     buffer.write('''
@@ -3867,8 +3780,7 @@ String renderExtension<T extends _i13.Extension>(
     var context8 = context2.publicInstanceOperatorsSorted;
     for (var context9 in context8) {
       buffer.write('\n            ');
-      buffer.write(
-          _renderExtension_partial_callable_6(context9, context2, context0));
+      buffer.write(_renderExtension_partial_callable_6(context9));
     }
     buffer.writeln();
     buffer.write('''
@@ -3886,8 +3798,7 @@ String renderExtension<T extends _i13.Extension>(
     var context10 = context2.publicVariableStaticFieldsSorted;
     for (var context11 in context10) {
       buffer.write('\n            ');
-      buffer.write(
-          _renderExtension_partial_property_5(context11, context2, context0));
+      buffer.write(_renderExtension_partial_property_5(context11));
     }
     buffer.writeln();
     buffer.write('''
@@ -3904,8 +3815,7 @@ String renderExtension<T extends _i13.Extension>(
     var context12 = context2.publicStaticMethodsSorted;
     for (var context13 in context12) {
       buffer.write('\n            ');
-      buffer.write(
-          _renderExtension_partial_callable_6(context13, context2, context0));
+      buffer.write(_renderExtension_partial_callable_6(context13));
     }
     buffer.writeln();
     buffer.write('''
@@ -3923,8 +3833,7 @@ String renderExtension<T extends _i13.Extension>(
     var context14 = context2.publicConstantFieldsSorted;
     for (var context15 in context14) {
       buffer.write('\n            ');
-      buffer.write(
-          _renderExtension_partial_constant_7(context15, context2, context0));
+      buffer.write(_renderExtension_partial_constant_7(context15));
     }
     buffer.writeln();
     buffer.write('''
@@ -3990,8 +3899,8 @@ String _renderExtension_partial_head_0<T extends _i13.Extension>(
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -4002,7 +3911,7 @@ String _renderExtension_partial_head_0<T extends _i13.Extension>(
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -4056,27 +3965,27 @@ String _renderExtension_partial_head_0<T extends _i13.Extension>(
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -4114,8 +4023,7 @@ String _renderExtension_partial_head_0<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_source_link_1<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_source_link_1(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -4129,14 +4037,13 @@ String _renderExtension_partial_source_link_1<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_feature_set_2<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_feature_set_2(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -4144,14 +4051,13 @@ String _renderExtension_partial_feature_set_2<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_categorization_3<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_categorization_3(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4159,8 +4065,7 @@ String _renderExtension_partial_categorization_3<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_documentation_4<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_documentation_4(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -4177,10 +4082,7 @@ String _renderExtension_partial_documentation_4<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_property_5<T extends _i13.Extension>(
-    _i9.Field context2,
-    _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_property_5(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -4197,8 +4099,8 @@ String _renderExtension_partial_property_5<T extends _i13.Extension>(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderExtension_partial_property_5_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderExtension_partial_property_5_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -4212,8 +4114,8 @@ String _renderExtension_partial_property_5<T extends _i13.Extension>(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderExtension_partial_property_5_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderExtension_partial_property_5_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -4222,15 +4124,14 @@ String _renderExtension_partial_property_5<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String __renderExtension_partial_property_5_partial_categorization_0<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_property_5_partial_categorization_0(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4238,9 +4139,8 @@ String __renderExtension_partial_property_5_partial_categorization_0<
   return buffer.toString();
 }
 
-String __renderExtension_partial_property_5_partial_features_1<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_property_5_partial_features_1(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4252,10 +4152,7 @@ String __renderExtension_partial_property_5_partial_features_1<
   return buffer.toString();
 }
 
-String _renderExtension_partial_callable_6<T extends _i13.Extension>(
-    _i10.Method context2,
-    _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_callable_6(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -4280,8 +4177,8 @@ String _renderExtension_partial_callable_6<T extends _i13.Extension>(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderExtension_partial_callable_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderExtension_partial_callable_6_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -4295,8 +4192,8 @@ String _renderExtension_partial_callable_6<T extends _i13.Extension>(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderExtension_partial_callable_6_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderExtension_partial_callable_6_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -4305,15 +4202,14 @@ String _renderExtension_partial_callable_6<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String __renderExtension_partial_callable_6_partial_categorization_0<
-        T extends _i13.Extension>(_i10.Method context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_callable_6_partial_categorization_0(
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4321,9 +4217,8 @@ String __renderExtension_partial_callable_6_partial_categorization_0<
   return buffer.toString();
 }
 
-String __renderExtension_partial_callable_6_partial_features_1<
-        T extends _i13.Extension>(_i10.Method context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_callable_6_partial_features_1(
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4335,10 +4230,7 @@ String __renderExtension_partial_callable_6_partial_features_1<
   return buffer.toString();
 }
 
-String _renderExtension_partial_constant_7<T extends _i13.Extension>(
-    _i9.Field context2,
-    _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_constant_7(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -4354,8 +4246,8 @@ String _renderExtension_partial_constant_7<T extends _i13.Extension>(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderExtension_partial_constant_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderExtension_partial_constant_7_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -4365,8 +4257,8 @@ String _renderExtension_partial_constant_7<T extends _i13.Extension>(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderExtension_partial_constant_7_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderExtension_partial_constant_7_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
   <div>
@@ -4380,15 +4272,14 @@ String _renderExtension_partial_constant_7<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String __renderExtension_partial_constant_7_partial_categorization_0<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_constant_7_partial_categorization_0(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4396,9 +4287,8 @@ String __renderExtension_partial_constant_7_partial_categorization_0<
   return buffer.toString();
 }
 
-String __renderExtension_partial_constant_7_partial_features_1<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_constant_7_partial_features_1(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4420,27 +4310,27 @@ String _renderExtension_partial_search_sidebar_8<T extends _i13.Extension>(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -4532,15 +4422,15 @@ String renderFunction(_i1.FunctionTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderFunction_partial_source_link_1(context1, context0));
+  buffer.write(_renderFunction_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-function">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderFunction_partial_feature_set_2(context1, context0));
+  buffer.write(_renderFunction_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderFunction_partial_categorization_3(context1, context0));
+  buffer.write(_renderFunction_partial_categorization_3(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.function;
@@ -4548,15 +4438,14 @@ String renderFunction(_i1.FunctionTemplateData context0) {
   buffer.write('''
     <section class="multi-line-signature">
         ''');
-  buffer
-      .write(_renderFunction_partial_callable_multiline_4(context2, context0));
+  buffer.write(_renderFunction_partial_callable_multiline_4(context2));
   buffer.writeln();
   buffer.write('''
     </section>
     ''');
-  buffer.write(_renderFunction_partial_documentation_5(context2, context0));
+  buffer.write(_renderFunction_partial_documentation_5(context2));
   buffer.write('\n\n    ');
-  buffer.write(_renderFunction_partial_source_code_6(context2, context0));
+  buffer.write(_renderFunction_partial_source_code_6(context2));
   buffer.writeln();
   buffer.writeln();
   buffer.write('''
@@ -4611,8 +4500,8 @@ String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -4623,7 +4512,7 @@ String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -4677,27 +4566,27 @@ String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -4735,8 +4624,7 @@ String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderFunction_partial_source_link_1(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_source_link_1(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -4750,14 +4638,13 @@ String _renderFunction_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderFunction_partial_feature_set_2(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_feature_set_2(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -4765,14 +4652,13 @@ String _renderFunction_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderFunction_partial_categorization_3(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_categorization_3(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4781,19 +4667,19 @@ String _renderFunction_partial_categorization_3(
 }
 
 String _renderFunction_partial_callable_multiline_4(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+    _i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
     buffer.write('''
 <div>
   <ol class="annotation-list">''');
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
+    var context4 = context1.annotations;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
     <li>''');
-      buffer.write(context3.linkedNameWithParameters);
+      buffer.write(context5.linkedNameWithParameters);
       buffer.write('''</li>''');
     }
     buffer.writeln();
@@ -4810,7 +4696,7 @@ String _renderFunction_partial_callable_multiline_4(
 ''');
   buffer.write(
       __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
-          context1, context0));
+          context1));
   buffer.write(context1.genericParameters);
   buffer.write('''(<wbr>''');
   if (context1.hasParameters == true) {
@@ -4823,7 +4709,7 @@ String _renderFunction_partial_callable_multiline_4(
 }
 
 String __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+    _i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -4839,8 +4725,7 @@ String __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
   return buffer.toString();
 }
 
-String _renderFunction_partial_documentation_5(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_documentation_5(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -4857,8 +4742,7 @@ String _renderFunction_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderFunction_partial_source_code_6(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_source_code_6(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -4885,27 +4769,27 @@ String _renderFunction_partial_search_sidebar_7(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -4994,7 +4878,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
   <div id="dartdoc-main-content" class="main-content">''');
   var context1 = context0.defaultPackage;
   buffer.write('\n      ');
-  buffer.write(_renderIndex_partial_documentation_1(context1, context0));
+  buffer.write(_renderIndex_partial_documentation_1(context1));
   buffer.writeln();
   var context2 = context0.localPackages;
   for (var context3 in context2) {
@@ -5021,8 +4905,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
       var context5 = context4.publicLibrariesSorted;
       for (var context6 in context5) {
         buffer.write('\n          ');
-        buffer.write(_renderIndex_partial_library_2(
-            context6, context4, context3, context0));
+        buffer.write(_renderIndex_partial_library_2(context6));
       }
     }
     var context7 = context3.categoriesWithPublicLibraries;
@@ -5035,8 +4918,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
       var context9 = context8.publicLibrariesSorted;
       for (var context10 in context9) {
         buffer.write('\n            ');
-        buffer.write(_renderIndex_partial_library_2(
-            context10, context8, context3, context0));
+        buffer.write(_renderIndex_partial_library_2(context10));
       }
     }
     buffer.writeln();
@@ -5098,8 +4980,8 @@ String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -5110,7 +4992,7 @@ String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -5164,27 +5046,27 @@ String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -5222,8 +5104,7 @@ String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderIndex_partial_documentation_1(
-    _i14.Package context1, _i1.PackageTemplateData context0) {
+String _renderIndex_partial_documentation_1(_i14.Package context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -5240,11 +5121,7 @@ String _renderIndex_partial_documentation_1(
   return buffer.toString();
 }
 
-String _renderIndex_partial_library_2(
-    _i3.Library context3,
-    _i15.LibraryContainer context2,
-    _i14.Package context1,
-    _i1.PackageTemplateData context0) {
+String _renderIndex_partial_library_2(_i3.Library context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -5252,8 +5129,8 @@ String _renderIndex_partial_library_2(
   <span class="name">''');
   buffer.write(context3.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderIndex_partial_library_2_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderIndex_partial_library_2_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -5272,16 +5149,13 @@ String _renderIndex_partial_library_2(
 }
 
 String __renderIndex_partial_library_2_partial_categorization_0(
-    _i3.Library context3,
-    _i15.LibraryContainer context2,
-    _i14.Package context1,
-    _i1.PackageTemplateData context0) {
+    _i3.Library context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -5298,27 +5172,27 @@ String _renderIndex_partial_search_sidebar_3(_i1.PackageTemplateData context0) {
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -5351,19 +5225,19 @@ String _renderIndex_partial_search_sidebar_3(_i1.PackageTemplateData context0) {
 String _renderIndex_partial_packages_4(_i1.PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
-  var context1 = context0.localPackages;
-  for (var context2 in context1) {
-    if (context2.isFirstPackage == true) {
-      if (context2.hasDocumentedCategories == true) {
+  var context12 = context0.localPackages;
+  for (var context13 in context12) {
+    if (context13.isFirstPackage == true) {
+      if (context13.hasDocumentedCategories == true) {
         buffer.writeln();
         buffer.write('''
       <li class="section-title">Topics</li>''');
-        var context3 = context2.documentedCategoriesSorted;
-        for (var context4 in context3) {
+        var context14 = context13.documentedCategoriesSorted;
+        for (var context15 in context14) {
           buffer.writeln();
           buffer.write('''
         <li>''');
-          buffer.write(context4.linkedName);
+          buffer.write(context15.linkedName);
           buffer.write('''</li>''');
         }
       }
@@ -5371,37 +5245,37 @@ String _renderIndex_partial_packages_4(_i1.PackageTemplateData context0) {
       buffer.write('''
       <li class="section-title">Libraries</li>''');
     }
-    if (context2.isFirstPackage != true) {
+    if (context13.isFirstPackage != true) {
       buffer.writeln();
       buffer.write('''
       <li class="section-title">''');
-      buffer.writeEscaped(context2.name);
+      buffer.writeEscaped(context13.name);
       buffer.write('''</li>''');
     }
-    var context5 = context2.defaultCategory;
-    if (context5 != null) {
-      var context6 = context5.publicLibrariesSorted;
-      for (var context7 in context6) {
+    var context16 = context13.defaultCategory;
+    if (context16 != null) {
+      var context17 = context16.publicLibrariesSorted;
+      for (var context18 in context17) {
         buffer.writeln();
         buffer.write('''
       <li>''');
-        buffer.write(context7.linkedName);
+        buffer.write(context18.linkedName);
         buffer.write('''</li>''');
       }
     }
-    var context8 = context2.categoriesWithPublicLibraries;
-    for (var context9 in context8) {
+    var context19 = context13.categoriesWithPublicLibraries;
+    for (var context20 in context19) {
       buffer.writeln();
       buffer.write('''
       <li class="section-subtitle">''');
-      buffer.writeEscaped(context9.name);
+      buffer.writeEscaped(context20.name);
       buffer.write('''</li>''');
-      var context10 = context9.publicLibrariesSorted;
-      for (var context11 in context10) {
+      var context21 = context20.publicLibrariesSorted;
+      for (var context22 in context21) {
         buffer.writeln();
         buffer.write('''
         <li class="section-subitem">''');
-        buffer.write(context11.linkedName);
+        buffer.write(context22.linkedName);
         buffer.write('''</li>''');
       }
     }
@@ -5475,20 +5349,20 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderLibrary_partial_source_link_1(context1, context0));
+  buffer.write(_renderLibrary_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-library">''');
   buffer.write(context1.name);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderLibrary_partial_feature_set_2(context1, context0));
+  buffer.write(_renderLibrary_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderLibrary_partial_categorization_3(context1, context0));
+  buffer.write(_renderLibrary_partial_categorization_3(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.library;
   buffer.write('\n    ');
-  buffer.write(_renderLibrary_partial_documentation_4(context2, context0));
+  buffer.write(_renderLibrary_partial_documentation_4(context2));
   buffer.writeln();
   var context3 = context0.library;
   if (context3.hasPublicClasses == true) {
@@ -5502,8 +5376,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context5 = context4.publicClassesSorted;
     for (var context6 in context5) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_container_5(
-          context6, context4, context3, context0));
+      buffer.write(_renderLibrary_partial_container_5(context6));
     }
     buffer.writeln();
     buffer.write('''
@@ -5523,8 +5396,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context9 = context8.publicMixinsSorted;
     for (var context10 in context9) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_container_5(
-          context10, context8, context7, context0));
+      buffer.write(_renderLibrary_partial_container_5(context10));
     }
     buffer.writeln();
     buffer.write('''
@@ -5544,8 +5416,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context13 = context12.publicExtensionsSorted;
     for (var context14 in context13) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_extension_6(
-          context14, context12, context11, context0));
+      buffer.write(_renderLibrary_partial_extension_6(context14));
     }
     buffer.writeln();
     buffer.write('''
@@ -5565,8 +5436,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context17 = context16.publicConstantsSorted;
     for (var context18 in context17) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_constant_7(
-          context18, context16, context15, context0));
+      buffer.write(_renderLibrary_partial_constant_7(context18));
     }
     buffer.writeln();
     buffer.write('''
@@ -5586,8 +5456,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context21 = context20.publicPropertiesSorted;
     for (var context22 in context21) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_property_8(
-          context22, context20, context19, context0));
+      buffer.write(_renderLibrary_partial_property_8(context22));
     }
     buffer.writeln();
     buffer.write('''
@@ -5607,8 +5476,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context25 = context24.publicFunctionsSorted;
     for (var context26 in context25) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_callable_9(
-          context26, context24, context23, context0));
+      buffer.write(_renderLibrary_partial_callable_9(context26));
     }
     buffer.writeln();
     buffer.write('''
@@ -5628,8 +5496,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context29 = context28.publicEnumsSorted;
     for (var context30 in context29) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_container_5(
-          context30, context28, context27, context0));
+      buffer.write(_renderLibrary_partial_container_5(context30));
     }
     buffer.writeln();
     buffer.write('''
@@ -5649,8 +5516,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context33 = context32.publicTypedefsSorted;
     for (var context34 in context33) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_typedef_10(
-          context34, context32, context31, context0));
+      buffer.write(_renderLibrary_partial_typedef_10(context34));
     }
     buffer.writeln();
     buffer.write('''
@@ -5670,8 +5536,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context37 = context36.publicExceptionsSorted;
     for (var context38 in context37) {
       buffer.write('\n        ');
-      buffer.write(_renderLibrary_partial_container_5(
-          context38, context36, context35, context0));
+      buffer.write(_renderLibrary_partial_container_5(context38));
     }
     buffer.writeln();
     buffer.write('''
@@ -5741,8 +5606,8 @@ String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -5753,7 +5618,7 @@ String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -5807,27 +5672,27 @@ String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -5865,8 +5730,7 @@ String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderLibrary_partial_source_link_1(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_source_link_1(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -5880,14 +5744,13 @@ String _renderLibrary_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_feature_set_2(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_feature_set_2(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -5895,14 +5758,13 @@ String _renderLibrary_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_categorization_3(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_categorization_3(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -5910,8 +5772,7 @@ String _renderLibrary_partial_categorization_3(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_documentation_4(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_documentation_4(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -5928,11 +5789,7 @@ String _renderLibrary_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_container_5(
-    _i4.Container context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_container_5(_i4.Container context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -5945,8 +5802,8 @@ String _renderLibrary_partial_container_5(
   buffer.write(context3.linkedName);
   buffer.write(context3.linkedGenericParameters);
   buffer.write('''</span> ''');
-  buffer.write(__renderLibrary_partial_container_5_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_container_5_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -5964,16 +5821,13 @@ String _renderLibrary_partial_container_5(
 }
 
 String __renderLibrary_partial_container_5_partial_categorization_0(
-    _i4.Container context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i4.Container context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -5981,11 +5835,7 @@ String __renderLibrary_partial_container_5_partial_categorization_0(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_extension_6(
-    _i13.Extension context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_extension_6(_i13.Extension context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -5997,8 +5847,8 @@ String _renderLibrary_partial_extension_6(
   buffer.write('''">''');
   buffer.write(context3.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderLibrary_partial_extension_6_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_extension_6_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -6017,16 +5867,13 @@ String _renderLibrary_partial_extension_6(
 }
 
 String __renderLibrary_partial_extension_6_partial_categorization_0(
-    _i13.Extension context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i13.Extension context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -6034,11 +5881,7 @@ String __renderLibrary_partial_extension_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_constant_7(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_constant_7(_i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -6054,8 +5897,8 @@ String _renderLibrary_partial_constant_7(
   buffer.write(context3.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderLibrary_partial_constant_7_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_constant_7_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -6065,8 +5908,7 @@ String _renderLibrary_partial_constant_7(
   buffer.write(' ');
   buffer.write(context3.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderLibrary_partial_constant_7_partial_features_1(
-      context3, context2, context1, context0));
+  buffer.write(__renderLibrary_partial_constant_7_partial_features_1(context3));
   buffer.writeln();
   buffer.write('''
   <div>
@@ -6081,16 +5923,13 @@ String _renderLibrary_partial_constant_7(
 }
 
 String __renderLibrary_partial_constant_7_partial_categorization_0(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -6099,10 +5938,7 @@ String __renderLibrary_partial_constant_7_partial_categorization_0(
 }
 
 String __renderLibrary_partial_constant_7_partial_features_1(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -6114,11 +5950,7 @@ String __renderLibrary_partial_constant_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_property_8(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_property_8(_i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -6135,8 +5967,8 @@ String _renderLibrary_partial_property_8(
   buffer.write(' ');
   buffer.write(context3.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderLibrary_partial_property_8_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_property_8_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -6150,8 +5982,7 @@ String _renderLibrary_partial_property_8(
   buffer.write(' ');
   buffer.write(context3.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderLibrary_partial_property_8_partial_features_1(
-      context3, context2, context1, context0));
+  buffer.write(__renderLibrary_partial_property_8_partial_features_1(context3));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -6161,16 +5992,13 @@ String _renderLibrary_partial_property_8(
 }
 
 String __renderLibrary_partial_property_8_partial_categorization_0(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -6179,10 +6007,7 @@ String __renderLibrary_partial_property_8_partial_categorization_0(
 }
 
 String __renderLibrary_partial_property_8_partial_features_1(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -6194,11 +6019,7 @@ String __renderLibrary_partial_property_8_partial_features_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_callable_9(
-    _i6.ModelFunctionTyped context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_callable_9(_i6.ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -6223,8 +6044,8 @@ String _renderLibrary_partial_callable_9(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderLibrary_partial_callable_9_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_callable_9_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -6238,8 +6059,7 @@ String _renderLibrary_partial_callable_9(
   buffer.write(' ');
   buffer.write(context3.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderLibrary_partial_callable_9_partial_features_1(
-      context3, context2, context1, context0));
+  buffer.write(__renderLibrary_partial_callable_9_partial_features_1(context3));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -6249,16 +6069,13 @@ String _renderLibrary_partial_callable_9(
 }
 
 String __renderLibrary_partial_callable_9_partial_categorization_0(
-    _i6.ModelFunctionTyped context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i6.ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.write('\n    ');
-      buffer.write(context5!.categoryLabel);
+      buffer.write(context9!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -6267,10 +6084,7 @@ String __renderLibrary_partial_callable_9_partial_categorization_0(
 }
 
 String __renderLibrary_partial_callable_9_partial_features_1(
-    _i6.ModelFunctionTyped context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i6.ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -6282,62 +6096,57 @@ String __renderLibrary_partial_callable_9_partial_features_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_typedef_10(
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_typedef_10(_i7.Typedef context3) {
   final buffer = StringBuffer();
   if (context3.isCallable == true) {
-    var context4 = context3.asCallable;
+    var context5 = context3.asCallable;
     buffer.writeln();
     buffer.write('''
   <dt id="''');
-    buffer.writeEscaped(context4.htmlId);
+    buffer.writeEscaped(context5.htmlId);
     buffer.write('''" class="callable''');
-    if (context4.isInherited == true) {
+    if (context5.isInherited == true) {
       buffer.write(''' inherited''');
     }
     buffer.write('''">
     <span class="name''');
-    if (context4.isDeprecated == true) {
+    if (context5.isDeprecated == true) {
       buffer.write(''' deprecated''');
     }
     buffer.write('''">''');
-    buffer.write(context4.linkedName);
+    buffer.write(context5.linkedName);
     buffer.write('''</span>''');
-    buffer.write(context4.linkedGenericParameters);
+    buffer.write(context5.linkedGenericParameters);
     buffer.write('''<span class="signature">
       <span class="returntype parameter">= ''');
-    buffer.write(context4.modelType.linkedName);
+    buffer.write(context5.modelType.linkedName);
     buffer.write('''</span>
     </span>
     ''');
-    buffer.write(__renderLibrary_partial_typedef_10_partial_categorization_0(
-        context4, context3, context2, context1, context0));
+    buffer.write(
+        __renderLibrary_partial_typedef_10_partial_categorization_0(context5));
     buffer.writeln();
     buffer.write('''
   </dt>
   <dd''');
-    if (context4.isInherited == true) {
+    if (context5.isInherited == true) {
       buffer.write(''' class="inherited"''');
     }
     buffer.write('''>
     ''');
-    buffer.write(context4.oneLineDoc);
+    buffer.write(context5.oneLineDoc);
     buffer.write(' ');
-    buffer.write(context4.extendedDocLink);
+    buffer.write(context5.extendedDocLink);
     buffer.write('\n    ');
-    buffer.write(__renderLibrary_partial_typedef_10_partial_features_1(
-        context4, context3, context2, context1, context0));
+    buffer
+        .write(__renderLibrary_partial_typedef_10_partial_features_1(context5));
     buffer.writeln();
     buffer.write('''
   </dd>''');
   }
   if (context3.isCallable != true) {
     buffer.write('\n  ');
-    buffer.write(__renderLibrary_partial_typedef_10_partial_type_2(
-        context3, context2, context1, context0));
+    buffer.write(__renderLibrary_partial_typedef_10_partial_type_2(context3));
   }
   buffer.writeln();
 
@@ -6345,17 +6154,13 @@ String _renderLibrary_partial_typedef_10(
 }
 
 String __renderLibrary_partial_typedef_10_partial_categorization_0(
-    _i7.FunctionTypedef context4,
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i7.FunctionTypedef context4) {
   final buffer = StringBuffer();
   if (context4.hasCategoryNames == true) {
-    var context5 = context4.displayedCategories;
-    for (var context6 in context5) {
+    var context9 = context4.displayedCategories;
+    for (var context10 in context9) {
       buffer.write('\n    ');
-      buffer.write(context6.categoryLabel);
+      buffer.write(context10.categoryLabel);
     }
   }
   buffer.writeln();
@@ -6364,11 +6169,7 @@ String __renderLibrary_partial_typedef_10_partial_categorization_0(
 }
 
 String __renderLibrary_partial_typedef_10_partial_features_1(
-    _i7.FunctionTypedef context4,
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i7.FunctionTypedef context4) {
   final buffer = StringBuffer();
   if (context4.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -6380,11 +6181,7 @@ String __renderLibrary_partial_typedef_10_partial_features_1(
   return buffer.toString();
 }
 
-String __renderLibrary_partial_typedef_10_partial_type_2(
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String __renderLibrary_partial_typedef_10_partial_type_2(_i7.Typedef context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -6411,7 +6208,7 @@ String __renderLibrary_partial_typedef_10_partial_type_2(
   ''');
   buffer.write(
       ___renderLibrary_partial_typedef_10_partial_type_2_partial_categorization_0(
-          context3, context2, context1, context0));
+          context3));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -6427,7 +6224,7 @@ String __renderLibrary_partial_typedef_10_partial_type_2(
   buffer.write('\n  ');
   buffer.write(
       ___renderLibrary_partial_typedef_10_partial_type_2_partial_features_1(
-          context3, context2, context1, context0));
+          context3));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -6438,16 +6235,13 @@ String __renderLibrary_partial_typedef_10_partial_type_2(
 
 String
     ___renderLibrary_partial_typedef_10_partial_type_2_partial_categorization_0(
-        _i7.Typedef context3,
-        _i3.Library context2,
-        _i3.Library context1,
-        _i1.LibraryTemplateData context0) {
+        _i7.Typedef context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context10 = context3.displayedCategories;
+    for (var context11 in context10) {
       buffer.write('\n    ');
-      buffer.write(context5.categoryLabel);
+      buffer.write(context11.categoryLabel);
     }
   }
   buffer.writeln();
@@ -6456,10 +6250,7 @@ String
 }
 
 String ___renderLibrary_partial_typedef_10_partial_type_2_partial_features_1(
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i7.Typedef context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -6481,27 +6272,27 @@ String _renderLibrary_partial_search_sidebar_11(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -6534,19 +6325,19 @@ String _renderLibrary_partial_search_sidebar_11(
 String _renderLibrary_partial_packages_12(_i1.LibraryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
-  var context1 = context0.localPackages;
-  for (var context2 in context1) {
-    if (context2.isFirstPackage == true) {
-      if (context2.hasDocumentedCategories == true) {
+  var context12 = context0.localPackages;
+  for (var context13 in context12) {
+    if (context13.isFirstPackage == true) {
+      if (context13.hasDocumentedCategories == true) {
         buffer.writeln();
         buffer.write('''
       <li class="section-title">Topics</li>''');
-        var context3 = context2.documentedCategoriesSorted;
-        for (var context4 in context3) {
+        var context14 = context13.documentedCategoriesSorted;
+        for (var context15 in context14) {
           buffer.writeln();
           buffer.write('''
         <li>''');
-          buffer.write(context4.linkedName);
+          buffer.write(context15.linkedName);
           buffer.write('''</li>''');
         }
       }
@@ -6554,37 +6345,37 @@ String _renderLibrary_partial_packages_12(_i1.LibraryTemplateData context0) {
       buffer.write('''
       <li class="section-title">Libraries</li>''');
     }
-    if (context2.isFirstPackage != true) {
+    if (context13.isFirstPackage != true) {
       buffer.writeln();
       buffer.write('''
       <li class="section-title">''');
-      buffer.writeEscaped(context2.name);
+      buffer.writeEscaped(context13.name);
       buffer.write('''</li>''');
     }
-    var context5 = context2.defaultCategory;
-    if (context5 != null) {
-      var context6 = context5.publicLibrariesSorted;
-      for (var context7 in context6) {
+    var context16 = context13.defaultCategory;
+    if (context16 != null) {
+      var context17 = context16.publicLibrariesSorted;
+      for (var context18 in context17) {
         buffer.writeln();
         buffer.write('''
       <li>''');
-        buffer.write(context7.linkedName);
+        buffer.write(context18.linkedName);
         buffer.write('''</li>''');
       }
     }
-    var context8 = context2.categoriesWithPublicLibraries;
-    for (var context9 in context8) {
+    var context19 = context13.categoriesWithPublicLibraries;
+    for (var context20 in context19) {
       buffer.writeln();
       buffer.write('''
       <li class="section-subtitle">''');
-      buffer.writeEscaped(context9.name);
+      buffer.writeEscaped(context20.name);
       buffer.write('''</li>''');
-      var context10 = context9.publicLibrariesSorted;
-      for (var context11 in context10) {
+      var context21 = context20.publicLibrariesSorted;
+      for (var context22 in context21) {
         buffer.writeln();
         buffer.write('''
         <li class="section-subitem">''');
-        buffer.write(context11.linkedName);
+        buffer.write(context22.linkedName);
         buffer.write('''</li>''');
       }
     }
@@ -6658,13 +6449,13 @@ String renderMethod(_i1.MethodTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderMethod_partial_source_link_1(context1, context0));
+  buffer.write(_renderMethod_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-method">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderMethod_partial_feature_set_2(context1, context0));
+  buffer.write(_renderMethod_partial_feature_set_2(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.method;
@@ -6672,16 +6463,16 @@ String renderMethod(_i1.MethodTemplateData context0) {
   buffer.write('''
     <section class="multi-line-signature">
       ''');
-  buffer.write(_renderMethod_partial_callable_multiline_3(context2, context0));
+  buffer.write(_renderMethod_partial_callable_multiline_3(context2));
   buffer.write('\n      ');
-  buffer.write(_renderMethod_partial_features_4(context2, context0));
+  buffer.write(_renderMethod_partial_features_4(context2));
   buffer.writeln();
   buffer.write('''
     </section>
     ''');
-  buffer.write(_renderMethod_partial_documentation_5(context2, context0));
+  buffer.write(_renderMethod_partial_documentation_5(context2));
   buffer.write('\n\n    ');
-  buffer.write(_renderMethod_partial_source_code_6(context2, context0));
+  buffer.write(_renderMethod_partial_source_code_6(context2));
   buffer.writeln();
   buffer.writeln();
   buffer.write('''
@@ -6736,8 +6527,8 @@ String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -6748,7 +6539,7 @@ String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -6802,27 +6593,27 @@ String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -6860,8 +6651,7 @@ String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderMethod_partial_source_link_1(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_source_link_1(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -6875,14 +6665,13 @@ String _renderMethod_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderMethod_partial_feature_set_2(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_feature_set_2(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -6890,20 +6679,19 @@ String _renderMethod_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderMethod_partial_callable_multiline_3(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_callable_multiline_3(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
     buffer.write('''
 <div>
   <ol class="annotation-list">''');
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
+    var context4 = context1.annotations;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
     <li>''');
-      buffer.write(context3.linkedNameWithParameters);
+      buffer.write(context5.linkedNameWithParameters);
       buffer.write('''</li>''');
     }
     buffer.writeln();
@@ -6920,7 +6708,7 @@ String _renderMethod_partial_callable_multiline_3(
 ''');
   buffer.write(
       __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
-          context1, context0));
+          context1));
   buffer.write(context1.genericParameters);
   buffer.write('''(<wbr>''');
   if (context1.hasParameters == true) {
@@ -6933,7 +6721,7 @@ String _renderMethod_partial_callable_multiline_3(
 }
 
 String __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+    _i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -6949,8 +6737,7 @@ String __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
   return buffer.toString();
 }
 
-String _renderMethod_partial_features_4(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_features_4(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -6962,8 +6749,7 @@ String _renderMethod_partial_features_4(
   return buffer.toString();
 }
 
-String _renderMethod_partial_documentation_5(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_documentation_5(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -6980,8 +6766,7 @@ String _renderMethod_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderMethod_partial_source_code_6(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_source_code_6(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -7007,27 +6792,27 @@ String _renderMethod_partial_search_sidebar_7(_i1.MethodTemplateData context0) {
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -7118,20 +6903,20 @@ String renderMixin(_i1.MixinTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderMixin_partial_source_link_1(context1, context0));
+  buffer.write(_renderMixin_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-mixin">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderMixin_partial_feature_set_2(context1, context0));
+  buffer.write(_renderMixin_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderMixin_partial_categorization_3(context1, context0));
+  buffer.write(_renderMixin_partial_categorization_3(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.mixin;
   buffer.write('\n    ');
-  buffer.write(_renderMixin_partial_documentation_4(context2, context0));
+  buffer.write(_renderMixin_partial_documentation_4(context2));
   buffer.writeln();
   if (context2.hasModifiers == true) {
     buffer.writeln();
@@ -7235,8 +7020,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context11 = context2.publicInstanceFields;
     for (var context12 in context11) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderMixin_partial_property_6(context12, context2, context0));
+      buffer.write(_renderMixin_partial_property_6(context12));
     }
     buffer.writeln();
     buffer.write('''
@@ -7257,8 +7041,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context13 = context2.publicInstanceMethods;
     for (var context14 in context13) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderMixin_partial_callable_7(context14, context2, context0));
+      buffer.write(_renderMixin_partial_callable_7(context14));
     }
     buffer.writeln();
     buffer.write('''
@@ -7279,8 +7062,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context15 = context2.publicInstanceOperatorsSorted;
     for (var context16 in context15) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderMixin_partial_callable_7(context16, context2, context0));
+      buffer.write(_renderMixin_partial_callable_7(context16));
     }
     buffer.writeln();
     buffer.write('''
@@ -7298,8 +7080,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context17 = context2.publicVariableStaticFieldsSorted;
     for (var context18 in context17) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderMixin_partial_property_6(context18, context2, context0));
+      buffer.write(_renderMixin_partial_property_6(context18));
     }
     buffer.writeln();
     buffer.write('''
@@ -7316,8 +7097,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context19 = context2.publicStaticMethods;
     for (var context20 in context19) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderMixin_partial_callable_7(context20, context2, context0));
+      buffer.write(_renderMixin_partial_callable_7(context20));
     }
     buffer.writeln();
     buffer.write('''
@@ -7335,8 +7115,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context21 = context2.publicConstantFieldsSorted;
     for (var context22 in context21) {
       buffer.write('\n        ');
-      buffer.write(
-          _renderMixin_partial_constant_8(context22, context2, context0));
+      buffer.write(_renderMixin_partial_constant_8(context22));
     }
     buffer.writeln();
     buffer.write('''
@@ -7400,8 +7179,8 @@ String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -7412,7 +7191,7 @@ String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -7466,27 +7245,27 @@ String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -7524,8 +7303,7 @@ String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderMixin_partial_source_link_1(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_source_link_1(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -7539,14 +7317,13 @@ String _renderMixin_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_feature_set_2(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_feature_set_2(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -7554,14 +7331,13 @@ String _renderMixin_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderMixin_partial_categorization_3(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_categorization_3(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -7569,8 +7345,7 @@ String _renderMixin_partial_categorization_3(
   return buffer.toString();
 }
 
-String _renderMixin_partial_documentation_4(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_documentation_4(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -7588,7 +7363,7 @@ String _renderMixin_partial_documentation_4(
 }
 
 String _renderMixin_partial_super_chain_5(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i15.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context1.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -7600,12 +7375,12 @@ String _renderMixin_partial_super_chain_5(
     <li>''');
     buffer.write(context0.linkedObjectType);
     buffer.write('''</li>''');
-    var context2 = context1.publicSuperChainReversed;
-    for (var context3 in context2) {
+    var context4 = context1.publicSuperChainReversed;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
     <li>''');
-      buffer.write(context3.linkedName);
+      buffer.write(context5.linkedName);
       buffer.write('''</li>''');
     }
     buffer.writeln();
@@ -7620,8 +7395,7 @@ String _renderMixin_partial_super_chain_5(
   return buffer.toString();
 }
 
-String _renderMixin_partial_property_6(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_property_6(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -7638,8 +7412,8 @@ String _renderMixin_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span> ''');
-  buffer.write(__renderMixin_partial_property_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderMixin_partial_property_6_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -7653,8 +7427,7 @@ String _renderMixin_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderMixin_partial_property_6_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderMixin_partial_property_6_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -7664,13 +7437,13 @@ String _renderMixin_partial_property_6(
 }
 
 String __renderMixin_partial_property_6_partial_categorization_0(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -7678,8 +7451,7 @@ String __renderMixin_partial_property_6_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderMixin_partial_property_6_partial_features_1(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String __renderMixin_partial_property_6_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -7691,8 +7463,7 @@ String __renderMixin_partial_property_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_callable_7(
-    _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_callable_7(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -7717,8 +7488,8 @@ String _renderMixin_partial_callable_7(
   buffer.write('''</span>
   </span>
   ''');
-  buffer.write(__renderMixin_partial_callable_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderMixin_partial_callable_7_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -7732,8 +7503,7 @@ String _renderMixin_partial_callable_7(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderMixin_partial_callable_7_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderMixin_partial_callable_7_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
 </dd>
@@ -7743,13 +7513,13 @@ String _renderMixin_partial_callable_7(
 }
 
 String __renderMixin_partial_callable_7_partial_categorization_0(
-    _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -7758,7 +7528,7 @@ String __renderMixin_partial_callable_7_partial_categorization_0(
 }
 
 String __renderMixin_partial_callable_7_partial_features_1(
-    _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -7770,8 +7540,7 @@ String __renderMixin_partial_callable_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_constant_8(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_constant_8(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -7787,8 +7556,8 @@ String _renderMixin_partial_constant_8(
   buffer.write(context2.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(__renderMixin_partial_constant_8_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderMixin_partial_constant_8_partial_categorization_0(context2));
   buffer.writeln();
   buffer.write('''
 </dt>
@@ -7798,8 +7567,7 @@ String _renderMixin_partial_constant_8(
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('\n  ');
-  buffer.write(__renderMixin_partial_constant_8_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderMixin_partial_constant_8_partial_features_1(context2));
   buffer.writeln();
   buffer.write('''
   <div>
@@ -7814,13 +7582,13 @@ String _renderMixin_partial_constant_8(
 }
 
 String __renderMixin_partial_constant_8_partial_categorization_0(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.write('\n    ');
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -7828,8 +7596,7 @@ String __renderMixin_partial_constant_8_partial_categorization_0(
   return buffer.toString();
 }
 
-String __renderMixin_partial_constant_8_partial_features_1(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String __renderMixin_partial_constant_8_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -7850,27 +7617,27 @@ String _renderMixin_partial_search_sidebar_9(_i1.MixinTemplateData context0) {
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -7961,13 +7728,13 @@ String renderProperty(_i1.PropertyTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderProperty_partial_source_link_1(context1, context0));
+  buffer.write(_renderProperty_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-property">''');
   buffer.writeEscaped(context1.name);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderProperty_partial_feature_set_2(context1, context0));
+  buffer.write(_renderProperty_partial_feature_set_2(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.self;
@@ -7978,29 +7745,27 @@ String renderProperty(_i1.PropertyTemplateData context0) {
           ''');
     buffer.write(context2.modelType.linkedName);
     buffer.write('\n          ');
-    buffer.write(_renderProperty_partial_name_summary_3(context2, context0));
+    buffer.write(_renderProperty_partial_name_summary_3(context2));
     buffer.write('\n          ');
-    buffer.write(_renderProperty_partial_features_4(context2, context0));
+    buffer.write(_renderProperty_partial_features_4(context2));
     buffer.writeln();
     buffer.write('''
         </section>
         ''');
-    buffer.write(_renderProperty_partial_documentation_5(context2, context0));
+    buffer.write(_renderProperty_partial_documentation_5(context2));
     buffer.write('\n        ');
-    buffer.write(_renderProperty_partial_source_code_6(context2, context0));
+    buffer.write(_renderProperty_partial_source_code_6(context2));
   }
   buffer.writeln();
   if (context2.hasGetterOrSetter == true) {
     if (context2.hasGetter == true) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderProperty_partial_accessor_getter_7(context2, context0));
+      buffer.write(_renderProperty_partial_accessor_getter_7(context2));
     }
     buffer.writeln();
     if (context2.hasSetter == true) {
       buffer.write('\n        ');
-      buffer
-          .write(_renderProperty_partial_accessor_setter_8(context2, context0));
+      buffer.write(_renderProperty_partial_accessor_setter_8(context2));
     }
   }
   buffer.writeln();
@@ -8056,8 +7821,8 @@ String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -8068,7 +7833,7 @@ String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -8122,27 +7887,27 @@ String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -8180,8 +7945,7 @@ String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderProperty_partial_source_link_1(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_source_link_1(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -8195,14 +7959,13 @@ String _renderProperty_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderProperty_partial_feature_set_2(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_feature_set_2(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -8210,8 +7973,7 @@ String _renderProperty_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderProperty_partial_name_summary_3(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_name_summary_3(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -8227,8 +7989,7 @@ String _renderProperty_partial_name_summary_3(
   return buffer.toString();
 }
 
-String _renderProperty_partial_features_4(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_features_4(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -8240,8 +8001,7 @@ String _renderProperty_partial_features_4(
   return buffer.toString();
 }
 
-String _renderProperty_partial_documentation_5(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_documentation_5(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -8258,8 +8018,7 @@ String _renderProperty_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderProperty_partial_source_code_6(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_source_code_6(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -8276,26 +8035,25 @@ String _renderProperty_partial_source_code_6(
   return buffer.toString();
 }
 
-String _renderProperty_partial_accessor_getter_7(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_accessor_getter_7(_i9.Field context1) {
   final buffer = StringBuffer();
-  var context2 = context1.getter;
-  if (context2 != null) {
+  var context3 = context1.getter;
+  if (context3 != null) {
     buffer.writeln();
     buffer.write('''
 <section id="getter">
 
 <section class="multi-line-signature">
   <span class="returntype">''');
-    buffer.write(context2.modelType.returnType.linkedName);
+    buffer.write(context3.modelType.returnType.linkedName);
     buffer.write('''</span>
   ''');
     buffer.write(
         __renderProperty_partial_accessor_getter_7_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('\n  ');
     buffer.write(__renderProperty_partial_accessor_getter_7_partial_features_1(
-        context2, context1, context0));
+        context3));
     buffer.writeln();
     buffer.write('''
 </section>
@@ -8303,11 +8061,11 @@ String _renderProperty_partial_accessor_getter_7(
 ''');
     buffer.write(
         __renderProperty_partial_accessor_getter_7_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write(
         __renderProperty_partial_accessor_getter_7_partial_source_code_3(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write('''
 </section>''');
@@ -8318,9 +8076,7 @@ String _renderProperty_partial_accessor_getter_7(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_name_summary_0(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -8337,9 +8093,7 @@ String __renderProperty_partial_accessor_getter_7_partial_name_summary_0(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_features_1(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -8352,9 +8106,7 @@ String __renderProperty_partial_accessor_getter_7_partial_features_1(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_documentation_2(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -8372,9 +8124,7 @@ String __renderProperty_partial_accessor_getter_7_partial_documentation_2(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_source_code_3(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -8391,11 +8141,10 @@ String __renderProperty_partial_accessor_getter_7_partial_source_code_3(
   return buffer.toString();
 }
 
-String _renderProperty_partial_accessor_setter_8(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_accessor_setter_8(_i9.Field context1) {
   final buffer = StringBuffer();
-  var context2 = context1.setter;
-  if (context2 != null) {
+  var context3 = context1.setter;
+  if (context3 != null) {
     buffer.writeln();
     buffer.write('''
 <section id="setter">
@@ -8405,13 +8154,13 @@ String _renderProperty_partial_accessor_setter_8(
   ''');
     buffer.write(
         __renderProperty_partial_accessor_setter_8_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('''<span class="signature">(<wbr>''');
-    buffer.write(context2.linkedParamsNoMetadata);
+    buffer.write(context3.linkedParamsNoMetadata);
     buffer.write(''')</span>
   ''');
     buffer.write(__renderProperty_partial_accessor_setter_8_partial_features_1(
-        context2, context1, context0));
+        context3));
     buffer.writeln();
     buffer.write('''
 </section>
@@ -8419,11 +8168,11 @@ String _renderProperty_partial_accessor_setter_8(
 ''');
     buffer.write(
         __renderProperty_partial_accessor_setter_8_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write(
         __renderProperty_partial_accessor_setter_8_partial_source_code_3(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write('''
 </section>''');
@@ -8434,9 +8183,7 @@ String _renderProperty_partial_accessor_setter_8(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_name_summary_0(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -8453,9 +8200,7 @@ String __renderProperty_partial_accessor_setter_8_partial_name_summary_0(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_features_1(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -8468,9 +8213,7 @@ String __renderProperty_partial_accessor_setter_8_partial_features_1(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_documentation_2(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -8488,9 +8231,7 @@ String __renderProperty_partial_accessor_setter_8_partial_documentation_2(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_source_code_3(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -8517,27 +8258,27 @@ String _renderProperty_partial_search_sidebar_9(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -8617,7 +8358,7 @@ String _renderProperty_partial_footer_10(_i1.PropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String renderSidebarForContainer<T extends _i18.Documentable>(
+String renderSidebarForContainer<T extends _i17.Documentable>(
     _i1.TemplateDataWithContainer<T> context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
@@ -8849,7 +8590,7 @@ String renderSidebarForContainer<T extends _i18.Documentable>(
   return buffer.toString();
 }
 
-String renderSidebarForLibrary<T extends _i18.Documentable>(
+String renderSidebarForLibrary<T extends _i17.Documentable>(
     _i1.TemplateDataWithLibrary<T> context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
@@ -9016,18 +8757,15 @@ String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer
-      .write(_renderTopLevelProperty_partial_source_link_1(context1, context0));
+  buffer.write(_renderTopLevelProperty_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-top-level-property">''');
   buffer.write(context1.name);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer
-      .write(_renderTopLevelProperty_partial_feature_set_2(context1, context0));
+  buffer.write(_renderTopLevelProperty_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(
-      _renderTopLevelProperty_partial_categorization_3(context1, context0));
+  buffer.write(_renderTopLevelProperty_partial_categorization_3(context1));
   buffer.write('''</h1></div>
 ''');
   if (context1.hasNoGetterSetter == true) {
@@ -9037,32 +8775,26 @@ String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
           ''');
     buffer.write(context1.modelType.linkedName);
     buffer.write('\n          ');
-    buffer.write(
-        _renderTopLevelProperty_partial_name_summary_4(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_name_summary_4(context1));
     buffer.write('\n          ');
-    buffer
-        .write(_renderTopLevelProperty_partial_features_5(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_features_5(context1));
     buffer.writeln();
     buffer.write('''
         </section>
         ''');
-    buffer.write(
-        _renderTopLevelProperty_partial_documentation_6(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_documentation_6(context1));
     buffer.write('\n        ');
-    buffer.write(
-        _renderTopLevelProperty_partial_source_code_7(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_source_code_7(context1));
   }
   buffer.writeln();
   if (context1.hasExplicitGetter == true) {
     buffer.write('\n        ');
-    buffer.write(
-        _renderTopLevelProperty_partial_accessor_getter_8(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_accessor_getter_8(context1));
   }
   buffer.writeln();
   if (context1.hasExplicitSetter == true) {
     buffer.write('\n        ');
-    buffer.write(
-        _renderTopLevelProperty_partial_accessor_setter_9(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_accessor_setter_9(context1));
   }
   buffer.writeln();
   buffer.write('''
@@ -9118,8 +8850,8 @@ String _renderTopLevelProperty_partial_head_0(
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -9130,7 +8862,7 @@ String _renderTopLevelProperty_partial_head_0(
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -9184,27 +8916,27 @@ String _renderTopLevelProperty_partial_head_0(
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -9243,7 +8975,7 @@ String _renderTopLevelProperty_partial_head_0(
 }
 
 String _renderTopLevelProperty_partial_source_link_1(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -9258,13 +8990,13 @@ String _renderTopLevelProperty_partial_source_link_1(
 }
 
 String _renderTopLevelProperty_partial_feature_set_2(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -9273,13 +9005,13 @@ String _renderTopLevelProperty_partial_feature_set_2(
 }
 
 String _renderTopLevelProperty_partial_categorization_3(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -9288,7 +9020,7 @@ String _renderTopLevelProperty_partial_categorization_3(
 }
 
 String _renderTopLevelProperty_partial_name_summary_4(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -9305,7 +9037,7 @@ String _renderTopLevelProperty_partial_name_summary_4(
 }
 
 String _renderTopLevelProperty_partial_features_5(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -9318,7 +9050,7 @@ String _renderTopLevelProperty_partial_features_5(
 }
 
 String _renderTopLevelProperty_partial_documentation_6(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -9336,7 +9068,7 @@ String _renderTopLevelProperty_partial_documentation_6(
 }
 
 String _renderTopLevelProperty_partial_source_code_7(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -9354,26 +9086,26 @@ String _renderTopLevelProperty_partial_source_code_7(
 }
 
 String _renderTopLevelProperty_partial_accessor_getter_8(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
-  var context2 = context1.getter;
-  if (context2 != null) {
+  var context3 = context1.getter;
+  if (context3 != null) {
     buffer.writeln();
     buffer.write('''
 <section id="getter">
 
 <section class="multi-line-signature">
   <span class="returntype">''');
-    buffer.write(context2.modelType.returnType.linkedName);
+    buffer.write(context3.modelType.returnType.linkedName);
     buffer.write('''</span>
   ''');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('\n  ');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_features_1(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write('''
 </section>
@@ -9381,11 +9113,11 @@ String _renderTopLevelProperty_partial_accessor_getter_8(
 ''');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_source_code_3(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write('''
 </section>''');
@@ -9397,9 +9129,7 @@ String _renderTopLevelProperty_partial_accessor_getter_8(
 
 String
     __renderTopLevelProperty_partial_accessor_getter_8_partial_name_summary_0(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -9416,9 +9146,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_getter_8_partial_features_1(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -9432,9 +9160,7 @@ String __renderTopLevelProperty_partial_accessor_getter_8_partial_features_1(
 
 String
     __renderTopLevelProperty_partial_accessor_getter_8_partial_documentation_2(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -9452,9 +9178,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_getter_8_partial_source_code_3(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -9472,10 +9196,10 @@ String __renderTopLevelProperty_partial_accessor_getter_8_partial_source_code_3(
 }
 
 String _renderTopLevelProperty_partial_accessor_setter_9(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
-  var context2 = context1.setter;
-  if (context2 != null) {
+  var context3 = context1.setter;
+  if (context3 != null) {
     buffer.writeln();
     buffer.write('''
 <section id="setter">
@@ -9485,14 +9209,14 @@ String _renderTopLevelProperty_partial_accessor_setter_9(
   ''');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('''<span class="signature">(<wbr>''');
-    buffer.write(context2.linkedParamsNoMetadata);
+    buffer.write(context3.linkedParamsNoMetadata);
     buffer.write(''')</span>
   ''');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_features_1(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write('''
 </section>
@@ -9500,11 +9224,11 @@ String _renderTopLevelProperty_partial_accessor_setter_9(
 ''');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_source_code_3(
-            context2, context1, context0));
+            context3));
     buffer.writeln();
     buffer.write('''
 </section>''');
@@ -9516,9 +9240,7 @@ String _renderTopLevelProperty_partial_accessor_setter_9(
 
 String
     __renderTopLevelProperty_partial_accessor_setter_9_partial_name_summary_0(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -9535,9 +9257,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_setter_9_partial_features_1(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -9551,9 +9271,7 @@ String __renderTopLevelProperty_partial_accessor_setter_9_partial_features_1(
 
 String
     __renderTopLevelProperty_partial_accessor_setter_9_partial_documentation_2(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -9571,9 +9289,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_setter_9_partial_source_code_3(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -9600,27 +9316,27 @@ String _renderTopLevelProperty_partial_search_sidebar_10(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -9712,15 +9428,15 @@ String renderTypedef(_i1.TypedefTemplateData context0) {
   buffer.writeln();
   buffer.write('''
       <div>''');
-  buffer.write(_renderTypedef_partial_source_link_1(context1, context0));
+  buffer.write(_renderTypedef_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-typedef">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span> ''');
   buffer.writeEscaped(context1.kind);
   buffer.write(' ');
-  buffer.write(_renderTypedef_partial_feature_set_2(context1, context0));
+  buffer.write(_renderTypedef_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderTypedef_partial_categorization_3(context1, context0));
+  buffer.write(_renderTypedef_partial_categorization_3(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   buffer.write('''
@@ -9728,16 +9444,16 @@ String renderTypedef(_i1.TypedefTemplateData context0) {
     <section class="multi-line-signature">''');
   var context2 = context0.typeDef;
   buffer.write('\n        ');
-  buffer.write(_renderTypedef_partial_typedef_multiline_4(context2, context0));
+  buffer.write(_renderTypedef_partial_typedef_multiline_4(context2));
   buffer.writeln();
   buffer.write('''
     </section>
 ''');
   var context3 = context0.typeDef;
   buffer.write('\n    ');
-  buffer.write(_renderTypedef_partial_documentation_5(context3, context0));
+  buffer.write(_renderTypedef_partial_documentation_5(context3));
   buffer.write('\n    ');
-  buffer.write(_renderTypedef_partial_source_code_6(context3, context0));
+  buffer.write(_renderTypedef_partial_source_code_6(context3));
   buffer.writeln();
   buffer.write('''
 
@@ -9792,8 +9508,8 @@ String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) {
   <title>''');
   buffer.writeEscaped(context0.title);
   buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
+  var context7 = context0.relCanonicalPrefix;
+  if (context7 != null) {
     buffer.writeln();
     buffer.write('''
   <link rel="canonical" href="''');
@@ -9804,7 +9520,7 @@ String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) {
   }
   buffer.writeln();
   if (context0.useBaseHref == true) {
-    var context2 = context0.htmlBase;
+    var context8 = context0.htmlBase;
     buffer.writeln();
     buffer.write('''
   <!-- required because all the links are pseudo-absolute -->
@@ -9858,27 +9574,27 @@ String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) {
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
+  var context9 = context0.navLinks;
+  for (var context10 in context9) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context10.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context10.name);
     buffer.write('''</a></li>''');
   }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
+  var context11 = context0.navLinksWithGenerics;
+  for (var context12 in context11) {
     buffer.writeln();
     buffer.write('''
     <li><a href="''');
-    buffer.write(context6.href);
+    buffer.write(context12.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
-    if (context6.hasGenericParameters == true) {
+    buffer.writeEscaped(context12.name);
+    if (context12.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
+      buffer.write(context12.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -9916,8 +9632,7 @@ String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderTypedef_partial_source_link_1(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_source_link_1(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -9931,14 +9646,13 @@ String _renderTypedef_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_feature_set_2(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_feature_set_2(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -9946,14 +9660,13 @@ String _renderTypedef_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_categorization_3(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_categorization_3(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -9961,22 +9674,21 @@ String _renderTypedef_partial_categorization_3(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_typedef_multiline_4(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_typedef_multiline_4(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.isCallable == true) {
-    var context2 = context1.asCallable;
-    if (context2.hasAnnotations == true) {
+    var context5 = context1.asCallable;
+    if (context5.hasAnnotations == true) {
       buffer.writeln();
       buffer.write('''
     <div>
       <ol class="annotation-list">''');
-      var context3 = context2.annotations;
-      for (var context4 in context3) {
+      var context6 = context5.annotations;
+      for (var context7 in context6) {
         buffer.writeln();
         buffer.write('''
       <li>''');
-        buffer.write(context4.linkedNameWithParameters);
+        buffer.write(context7.linkedNameWithParameters);
         buffer.write('''</li>''');
       }
       buffer.writeln();
@@ -9984,27 +9696,27 @@ String _renderTypedef_partial_typedef_multiline_4(
     </ol>
     </div>''');
     }
-    if (context2.isConst == true) {
+    if (context5.isConst == true) {
       buffer.write('''const ''');
     }
     buffer.write('''<span class="name ''');
-    if (context2.isDeprecated == true) {
+    if (context5.isDeprecated == true) {
       buffer.write('''deprecated''');
     }
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context5.name);
     buffer.write('''</span>''');
-    buffer.write(context2.linkedGenericParameters);
+    buffer.write(context5.linkedGenericParameters);
     buffer.write(''' =
      <span class="returntype">''');
-    buffer.write(context2.modelType.linkedName);
+    buffer.write(context5.modelType.linkedName);
     buffer.write('''</span>''');
   }
   if (context1.isCallable != true) {
     buffer.write('\n  ');
     buffer.write(
         __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
-            context1, context0));
+            context1));
   }
   buffer.writeln();
 
@@ -10012,19 +9724,19 @@ String _renderTypedef_partial_typedef_multiline_4(
 }
 
 String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+    _i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
     buffer.write('''
 <div>
   <ol class="annotation-list">''');
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
+    var context6 = context1.annotations;
+    for (var context7 in context6) {
       buffer.writeln();
       buffer.write('''
     <li>''');
-      buffer.write(context3.linkedNameWithParameters);
+      buffer.write(context7.linkedNameWithParameters);
       buffer.write('''</li>''');
     }
     buffer.writeln();
@@ -10035,7 +9747,7 @@ String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
   buffer.writeln();
   buffer.write(
       ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
-          context1, context0));
+          context1));
   buffer.write(context1.genericParameters);
   buffer.write(''' = ''');
   buffer.write(context1.modelType.linkedName);
@@ -10047,7 +9759,7 @@ String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
 
 String
     ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
-        _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+        _i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -10063,8 +9775,7 @@ String
   return buffer.toString();
 }
 
-String _renderTypedef_partial_documentation_5(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_documentation_5(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -10081,8 +9792,7 @@ String _renderTypedef_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_source_code_6(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_source_code_6(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -10109,27 +9819,27 @@ String _renderTypedef_partial_search_sidebar_7(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context5 = context0.navLinks;
+  for (var context6 in context5) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context6.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context7 = context0.navLinksWithGenerics;
+  for (var context8 in context7) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context8.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context8.name);
+    if (context8.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context8.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -10211,6 +9921,6 @@ String _renderTypedef_partial_footer_8(_i1.TypedefTemplateData context0) {
 
 extension on StringBuffer {
   void writeEscaped(String? value) {
-    write(_i19.htmlEscape.convert(value ?? ''));
+    write(_i18.htmlEscape.convert(value ?? ''));
   }
 }

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -9,22 +9,20 @@
 // ignore_for_file: unused_local_variable
 // ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
 
-import 'dart:convert' as _i19;
+import 'dart:convert' as _i17;
 
 import 'package:dartdoc/src/generator/template_data.dart' as _i1;
-import 'package:dartdoc/src/model/accessor.dart' as _i17;
+import 'package:dartdoc/src/model/accessor.dart' as _i16;
 import 'package:dartdoc/src/model/category.dart' as _i2;
 import 'package:dartdoc/src/model/class.dart' as _i8;
 import 'package:dartdoc/src/model/constructor.dart' as _i11;
 import 'package:dartdoc/src/model/container.dart' as _i4;
-import 'package:dartdoc/src/model/documentable.dart' as _i18;
 import 'package:dartdoc/src/model/enum.dart' as _i12;
 import 'package:dartdoc/src/model/extension.dart' as _i13;
 import 'package:dartdoc/src/model/field.dart' as _i9;
 import 'package:dartdoc/src/model/library.dart' as _i3;
-import 'package:dartdoc/src/model/library_container.dart' as _i15;
 import 'package:dartdoc/src/model/method.dart' as _i10;
-import 'package:dartdoc/src/model/mixin.dart' as _i16;
+import 'package:dartdoc/src/model/mixin.dart' as _i15;
 import 'package:dartdoc/src/model/model_function.dart' as _i6;
 import 'package:dartdoc/src/model/package.dart' as _i14;
 import 'package:dartdoc/src/model/top_level_variable.dart' as _i5;
@@ -42,7 +40,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderCategory_partial_documentation_1(context1, context0));
+  buffer.write(_renderCategory_partial_documentation_1(context1));
   buffer.writeln();
   if (context1.hasPublicLibraries == true) {
     buffer.writeln();
@@ -52,8 +50,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context2 = context1.publicLibrariesSorted;
     for (var context3 in context2) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_library_2(context3, context1, context0));
+      buffer.write(_renderCategory_partial_library_2(context3));
       buffer.writeln();
     }
   }
@@ -66,8 +63,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context4 = context1.publicClassesSorted;
     for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_container_3(context5, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context5));
       buffer.writeln();
     }
   }
@@ -80,8 +76,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context6 = context1.publicMixinsSorted;
     for (var context7 in context6) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_container_3(context7, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context7));
       buffer.writeln();
     }
   }
@@ -94,8 +89,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context8 = context1.publicConstantsSorted;
     for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_constant_4(context9, context1, context0));
+      buffer.write(_renderCategory_partial_constant_4(context9));
       buffer.writeln();
     }
   }
@@ -108,8 +102,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context10 = context1.publicPropertiesSorted;
     for (var context11 in context10) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_property_5(context11, context1, context0));
+      buffer.write(_renderCategory_partial_property_5(context11));
       buffer.writeln();
     }
   }
@@ -122,8 +115,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context12 = context1.publicFunctionsSorted;
     for (var context13 in context12) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_callable_6(context13, context1, context0));
+      buffer.write(_renderCategory_partial_callable_6(context13));
       buffer.writeln();
     }
   }
@@ -136,8 +128,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context14 = context1.publicEnumsSorted;
     for (var context15 in context14) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_container_3(context15, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context15));
       buffer.writeln();
     }
   }
@@ -150,8 +141,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context16 = context1.publicTypedefsSorted;
     for (var context17 in context16) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_typedef_7(context17, context1, context0));
+      buffer.write(_renderCategory_partial_typedef_7(context17));
       buffer.writeln();
     }
   }
@@ -164,8 +154,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
     var context18 = context1.publicExceptionsSorted;
     for (var context19 in context18) {
       buffer.writeln();
-      buffer.write(
-          _renderCategory_partial_container_3(context19, context1, context0));
+      buffer.write(_renderCategory_partial_container_3(context19));
       buffer.writeln();
     }
   }
@@ -184,8 +173,7 @@ String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderCategory_partial_documentation_1(
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_documentation_1(_i2.Category context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -196,8 +184,7 @@ String _renderCategory_partial_documentation_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_library_2(_i3.Library context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_library_2(_i3.Library context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -213,15 +200,14 @@ String _renderCategory_partial_library_2(_i3.Library context2,
   return buffer.toString();
 }
 
-String _renderCategory_partial_container_3(_i4.Container context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_container_3(_i4.Container context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
   buffer.write(context2.linkedGenericParameters);
   buffer.writeln();
-  buffer.write(__renderCategory_partial_container_3_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
@@ -232,18 +218,16 @@ String _renderCategory_partial_container_3(_i4.Container context2,
 }
 
 String __renderCategory_partial_container_3_partial_categorization_0(
-    _i4.Container context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i4.Container context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -251,42 +235,39 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_constant_4(_i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderCategory_partial_constant_4_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_constant_4_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderCategory_partial_constant_4_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderCategory_partial_constant_4_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderCategory_partial_constant_4_partial_categorization_0(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -295,9 +276,7 @@ Categories:''');
 }
 
 String __renderCategory_partial_constant_4_partial_features_1(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -309,8 +288,7 @@ String __renderCategory_partial_constant_4_partial_features_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_property_5(_i5.TopLevelVariable context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_property_5(_i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -319,34 +297,32 @@ String _renderCategory_partial_property_5(_i5.TopLevelVariable context2,
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderCategory_partial_property_5_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_property_5_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderCategory_partial_property_5_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderCategory_partial_property_5_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderCategory_partial_property_5_partial_categorization_0(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4.categoryLabel);
+      buffer.write(context8.categoryLabel);
     }
   }
   buffer.writeln();
@@ -355,9 +331,7 @@ Categories:''');
 }
 
 String __renderCategory_partial_property_5_partial_features_1(
-    _i5.TopLevelVariable context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i5.TopLevelVariable context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -369,8 +343,7 @@ String __renderCategory_partial_property_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -380,34 +353,32 @@ String _renderCategory_partial_callable_6(_i6.ModelFunctionTyped context2,
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderCategory_partial_callable_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderCategory_partial_callable_6_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderCategory_partial_callable_6_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderCategory_partial_callable_6_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderCategory_partial_callable_6_partial_categorization_0(
-    _i6.ModelFunctionTyped context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i6.ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -416,9 +387,7 @@ Categories:''');
 }
 
 String __renderCategory_partial_callable_6_partial_features_1(
-    _i6.ModelFunctionTyped context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i6.ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -430,34 +399,32 @@ String __renderCategory_partial_callable_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderCategory_partial_typedef_7(_i7.Typedef context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String _renderCategory_partial_typedef_7(_i7.Typedef context2) {
   final buffer = StringBuffer();
   if (context2.isCallable == true) {
-    var context3 = context2.asCallable;
+    var context4 = context2.asCallable;
     buffer.writeln();
     buffer.write('''
     ##### ''');
-    buffer.write(context3.linkedName);
-    buffer.write(context3.linkedGenericParameters);
+    buffer.write(context4.linkedName);
+    buffer.write(context4.linkedGenericParameters);
     buffer.write(''' = ''');
-    buffer.write(context3.modelType.linkedName);
+    buffer.write(context4.modelType.linkedName);
     buffer.write('\n    ');
-    buffer.write(__renderCategory_partial_typedef_7_partial_categorization_0(
-        context3, context2, context1, context0));
+    buffer.write(
+        __renderCategory_partial_typedef_7_partial_categorization_0(context4));
     buffer.write('\n\n    ');
-    buffer.write(context3.oneLineDoc);
+    buffer.write(context4.oneLineDoc);
     buffer.write(' ');
-    buffer.write(context3.extendedDocLink);
+    buffer.write(context4.extendedDocLink);
     buffer.write('  ');
     buffer.write('\n    ');
-    buffer.write(__renderCategory_partial_typedef_7_partial_features_1(
-        context3, context2, context1, context0));
+    buffer
+        .write(__renderCategory_partial_typedef_7_partial_features_1(context4));
   }
   if (context2.isCallable != true) {
     buffer.write('\n  ');
-    buffer.write(__renderCategory_partial_typedef_7_partial_type_2(
-        context2, context1, context0));
+    buffer.write(__renderCategory_partial_typedef_7_partial_type_2(context2));
   }
   buffer.writeln();
 
@@ -465,19 +432,16 @@ String _renderCategory_partial_typedef_7(_i7.Typedef context2,
 }
 
 String __renderCategory_partial_typedef_7_partial_categorization_0(
-    _i7.FunctionTypedef context3,
-    _i7.Typedef context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i7.FunctionTypedef context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -486,10 +450,7 @@ Categories:''');
 }
 
 String __renderCategory_partial_typedef_7_partial_features_1(
-    _i7.FunctionTypedef context3,
-    _i7.Typedef context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i7.FunctionTypedef context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''_''');
@@ -501,8 +462,7 @@ String __renderCategory_partial_typedef_7_partial_features_1(
   return buffer.toString();
 }
 
-String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
-    _i2.Category context1, _i1.CategoryTemplateData context0) {
+String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -512,7 +472,7 @@ String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
   buffer.writeln();
   buffer.write(
       ___renderCategory_partial_typedef_7_partial_type_2_partial_categorization_0(
-          context2, context1, context0));
+          context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
@@ -521,7 +481,7 @@ String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
   buffer.writeln();
   buffer.write(
       ___renderCategory_partial_typedef_7_partial_type_2_partial_features_1(
-          context2, context1, context0));
+          context2));
   buffer.writeln();
 
   return buffer.toString();
@@ -529,18 +489,16 @@ String __renderCategory_partial_typedef_7_partial_type_2(_i7.Typedef context2,
 
 String
     ___renderCategory_partial_typedef_7_partial_type_2_partial_categorization_0(
-        _i7.Typedef context2,
-        _i2.Category context1,
-        _i1.CategoryTemplateData context0) {
+        _i7.Typedef context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context9 = context2.displayedCategories;
+    for (var context10 in context9) {
       buffer.writeln();
-      buffer.write(context4.categoryLabel);
+      buffer.write(context10.categoryLabel);
     }
   }
   buffer.writeln();
@@ -549,9 +507,7 @@ Categories:''');
 }
 
 String ___renderCategory_partial_typedef_7_partial_type_2_partial_features_1(
-    _i7.Typedef context2,
-    _i2.Category context1,
-    _i1.CategoryTemplateData context0) {
+    _i7.Typedef context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -586,15 +542,15 @@ String renderClass(_i1.ClassTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_source_link_1(context1, context0));
+  buffer.write(_renderClass_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderClass_partial_categorization_2(context1, context0));
+  buffer.write(_renderClass_partial_categorization_2(context1));
   buffer.writeln();
-  buffer.write(_renderClass_partial_feature_set_3(context1, context0));
+  buffer.write(_renderClass_partial_feature_set_3(context1));
   buffer.writeln();
   var context2 = context0.clazz;
   buffer.writeln();
-  buffer.write(_renderClass_partial_documentation_4(context2, context0));
+  buffer.write(_renderClass_partial_documentation_4(context2));
   buffer.writeln();
   if (context2.hasModifiers == true) {
     buffer.writeln();
@@ -708,8 +664,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context14 = context2.publicInstanceFieldsSorted;
     for (var context15 in context14) {
       buffer.writeln();
-      buffer.write(
-          _renderClass_partial_property_6(context15, context2, context0));
+      buffer.write(_renderClass_partial_property_6(context15));
       buffer.writeln();
     }
   }
@@ -722,8 +677,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context16 = context2.publicInstanceMethodsSorted;
     for (var context17 in context16) {
       buffer.writeln();
-      buffer.write(
-          _renderClass_partial_callable_7(context17, context2, context0));
+      buffer.write(_renderClass_partial_callable_7(context17));
       buffer.writeln();
     }
   }
@@ -736,8 +690,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context18 = context2.publicInstanceOperatorsSorted;
     for (var context19 in context18) {
       buffer.writeln();
-      buffer.write(
-          _renderClass_partial_callable_7(context19, context2, context0));
+      buffer.write(_renderClass_partial_callable_7(context19));
       buffer.writeln();
     }
   }
@@ -750,8 +703,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context20 = context2.publicVariableStaticFieldsSorted;
     for (var context21 in context20) {
       buffer.writeln();
-      buffer.write(
-          _renderClass_partial_property_6(context21, context2, context0));
+      buffer.write(_renderClass_partial_property_6(context21));
       buffer.writeln();
     }
   }
@@ -764,8 +716,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context22 = context2.publicStaticMethodsSorted;
     for (var context23 in context22) {
       buffer.writeln();
-      buffer.write(
-          _renderClass_partial_callable_7(context23, context2, context0));
+      buffer.write(_renderClass_partial_callable_7(context23));
       buffer.writeln();
     }
   }
@@ -778,8 +729,7 @@ String renderClass(_i1.ClassTemplateData context0) {
     var context24 = context2.publicConstantFieldsSorted;
     for (var context25 in context24) {
       buffer.writeln();
-      buffer.write(
-          _renderClass_partial_constant_8(context25, context2, context0));
+      buffer.write(_renderClass_partial_constant_8(context25));
       buffer.writeln();
     }
   }
@@ -798,8 +748,7 @@ String _renderClass_partial_head_0(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderClass_partial_source_link_1(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_source_link_1(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -813,17 +762,16 @@ String _renderClass_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_categorization_2(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_categorization_2(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -831,14 +779,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderClass_partial_feature_set_3(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_feature_set_3(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -846,8 +793,7 @@ String _renderClass_partial_feature_set_3(
   return buffer.toString();
 }
 
-String _renderClass_partial_documentation_4(
-    _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_documentation_4(_i8.Class context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -868,12 +814,12 @@ String _renderClass_partial_super_chain_5(
 
 - ''');
     buffer.write(context0.linkedObjectType);
-    var context2 = context1.publicSuperChainReversed;
-    for (var context3 in context2) {
+    var context4 = context1.publicSuperChainReversed;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
 - ''');
-      buffer.write(context3.linkedName);
+      buffer.write(context5.linkedName);
     }
     buffer.writeln();
     buffer.write('''
@@ -884,8 +830,7 @@ String _renderClass_partial_super_chain_5(
   return buffer.toString();
 }
 
-String _renderClass_partial_property_6(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_property_6(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -894,32 +839,31 @@ String _renderClass_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderClass_partial_property_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderClass_partial_property_6_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderClass_partial_property_6_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderClass_partial_property_6_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderClass_partial_property_6_partial_categorization_0(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -927,8 +871,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderClass_partial_property_6_partial_features_1(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String __renderClass_partial_property_6_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -940,8 +883,7 @@ String __renderClass_partial_property_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_callable_7(
-    _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_callable_7(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -951,32 +893,31 @@ String _renderClass_partial_callable_7(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderClass_partial_callable_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderClass_partial_callable_7_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderClass_partial_callable_7_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderClass_partial_callable_7_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderClass_partial_callable_7_partial_categorization_0(
-    _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -985,7 +926,7 @@ Categories:''');
 }
 
 String __renderClass_partial_callable_7_partial_features_1(
-    _i10.Method context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -997,40 +938,38 @@ String __renderClass_partial_callable_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderClass_partial_constant_8(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String _renderClass_partial_constant_8(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderClass_partial_constant_8_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderClass_partial_constant_8_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderClass_partial_constant_8_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderClass_partial_constant_8_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderClass_partial_constant_8_partial_categorization_0(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1038,8 +977,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderClass_partial_constant_8_partial_features_1(
-    _i9.Field context2, _i8.Class context1, _i1.ClassTemplateData context0) {
+String __renderClass_partial_constant_8_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1074,9 +1012,9 @@ String renderConstructor(_i1.ConstructorTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderConstructor_partial_source_link_1(context1, context0));
+  buffer.write(_renderConstructor_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderConstructor_partial_feature_set_2(context1, context0));
+  buffer.write(_renderConstructor_partial_feature_set_2(context1));
   buffer.writeln();
   var context2 = context0.constructor;
   if (context2.hasAnnotations == true) {
@@ -1101,9 +1039,9 @@ String renderConstructor(_i1.ConstructorTemplateData context0) {
   buffer.write(''')
 
 ''');
-  buffer.write(_renderConstructor_partial_documentation_3(context2, context0));
+  buffer.write(_renderConstructor_partial_documentation_3(context2));
   buffer.write('\n\n');
-  buffer.write(_renderConstructor_partial_source_code_4(context2, context0));
+  buffer.write(_renderConstructor_partial_source_code_4(context2));
   buffer.writeln();
   buffer.write('\n\n');
   buffer.write(_renderConstructor_partial_footer_5(context0));
@@ -1120,8 +1058,7 @@ String _renderConstructor_partial_head_0(_i1.ConstructorTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderConstructor_partial_source_link_1(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_source_link_1(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -1135,14 +1072,13 @@ String _renderConstructor_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderConstructor_partial_feature_set_2(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_feature_set_2(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -1150,8 +1086,7 @@ String _renderConstructor_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderConstructor_partial_documentation_3(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_documentation_3(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -1162,8 +1097,7 @@ String _renderConstructor_partial_documentation_3(
   return buffer.toString();
 }
 
-String _renderConstructor_partial_source_code_4(
-    _i11.Constructor context1, _i1.ConstructorTemplateData context0) {
+String _renderConstructor_partial_source_code_4(_i11.Constructor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -1206,13 +1140,13 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_source_link_1(context1, context0));
+  buffer.write(_renderEnum_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderEnum_partial_feature_set_2(context1, context0));
+  buffer.write(_renderEnum_partial_feature_set_2(context1));
   buffer.writeln();
   var context2 = context0.eNum;
   buffer.writeln();
-  buffer.write(_renderEnum_partial_documentation_3(context2, context0));
+  buffer.write(_renderEnum_partial_documentation_3(context2));
   buffer.writeln();
   if (context2.hasModifiers == true) {
     buffer.writeln();
@@ -1241,8 +1175,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context5 = context2.publicConstantFieldsSorted;
     for (var context6 in context5) {
       buffer.writeln();
-      buffer
-          .write(_renderEnum_partial_constant_5(context6, context2, context0));
+      buffer.write(_renderEnum_partial_constant_5(context6));
       buffer.writeln();
     }
   }
@@ -1255,8 +1188,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.writeln();
-      buffer
-          .write(_renderEnum_partial_property_6(context8, context2, context0));
+      buffer.write(_renderEnum_partial_property_6(context8));
       buffer.writeln();
     }
   }
@@ -1269,8 +1201,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context9 = context2.publicInstanceMethodsSorted;
     for (var context10 in context9) {
       buffer.writeln();
-      buffer
-          .write(_renderEnum_partial_callable_7(context10, context2, context0));
+      buffer.write(_renderEnum_partial_callable_7(context10));
       buffer.writeln();
     }
   }
@@ -1283,8 +1214,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context11 = context2.publicInstanceOperatorsSorted;
     for (var context12 in context11) {
       buffer.writeln();
-      buffer
-          .write(_renderEnum_partial_callable_7(context12, context2, context0));
+      buffer.write(_renderEnum_partial_callable_7(context12));
       buffer.writeln();
     }
   }
@@ -1297,8 +1227,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context13 = context2.publicVariableStaticFieldsSorted;
     for (var context14 in context13) {
       buffer.writeln();
-      buffer
-          .write(_renderEnum_partial_property_6(context14, context2, context0));
+      buffer.write(_renderEnum_partial_property_6(context14));
       buffer.writeln();
     }
   }
@@ -1311,8 +1240,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context15 = context2.publicStaticMethodsSorted;
     for (var context16 in context15) {
       buffer.writeln();
-      buffer
-          .write(_renderEnum_partial_callable_7(context16, context2, context0));
+      buffer.write(_renderEnum_partial_callable_7(context16));
       buffer.writeln();
     }
   }
@@ -1331,8 +1259,7 @@ String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_source_link_1(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_source_link_1(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -1346,14 +1273,13 @@ String _renderEnum_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_feature_set_2(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_feature_set_2(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -1361,8 +1287,7 @@ String _renderEnum_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderEnum_partial_documentation_3(
-    _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_documentation_3(_i12.Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -1383,12 +1308,12 @@ String _renderEnum_partial_super_chain_4(
 
 - ''');
     buffer.write(context0.linkedObjectType);
-    var context2 = context1.publicSuperChainReversed;
-    for (var context3 in context2) {
+    var context4 = context1.publicSuperChainReversed;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
 - ''');
-      buffer.write(context3.linkedName);
+      buffer.write(context5.linkedName);
     }
     buffer.writeln();
     buffer.write('''
@@ -1399,40 +1324,38 @@ String _renderEnum_partial_super_chain_4(
   return buffer.toString();
 }
 
-String _renderEnum_partial_constant_5(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_constant_5(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderEnum_partial_constant_5_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderEnum_partial_constant_5_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderEnum_partial_constant_5_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderEnum_partial_constant_5_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderEnum_partial_constant_5_partial_categorization_0(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1440,8 +1363,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderEnum_partial_constant_5_partial_features_1(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String __renderEnum_partial_constant_5_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1453,8 +1375,7 @@ String __renderEnum_partial_constant_5_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_property_6(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_property_6(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -1463,32 +1384,31 @@ String _renderEnum_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderEnum_partial_property_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderEnum_partial_property_6_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderEnum_partial_property_6_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderEnum_partial_property_6_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderEnum_partial_property_6_partial_categorization_0(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1496,8 +1416,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderEnum_partial_property_6_partial_features_1(
-    _i9.Field context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String __renderEnum_partial_property_6_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1509,8 +1428,7 @@ String __renderEnum_partial_property_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderEnum_partial_callable_7(
-    _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+String _renderEnum_partial_callable_7(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -1520,32 +1438,31 @@ String _renderEnum_partial_callable_7(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderEnum_partial_callable_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderEnum_partial_callable_7_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderEnum_partial_callable_7_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderEnum_partial_callable_7_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderEnum_partial_callable_7_partial_categorization_0(
-    _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1554,7 +1471,7 @@ Categories:''');
 }
 
 String __renderEnum_partial_callable_7_partial_features_1(
-    _i10.Method context2, _i12.Enum context1, _i1.EnumTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1577,7 +1494,7 @@ String _renderEnum_partial_footer_8(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String renderError(_i1.PackageTemplateData context0) {
+String renderError() {
   final buffer = StringBuffer();
   buffer.write('''# 404
 
@@ -1608,15 +1525,15 @@ on ''');
   var context2 = context1.extendedType;
   buffer.write(context2.linkedName);
   buffer.write('\n\n');
-  buffer.write(_renderExtension_partial_source_link_1(context1, context0));
+  buffer.write(_renderExtension_partial_source_link_1(context1));
   buffer.write('\n\n');
-  buffer.write(_renderExtension_partial_categorization_2(context1, context0));
+  buffer.write(_renderExtension_partial_categorization_2(context1));
   buffer.writeln();
-  buffer.write(_renderExtension_partial_feature_set_3(context1, context0));
+  buffer.write(_renderExtension_partial_feature_set_3(context1));
   buffer.writeln();
   var context3 = context0.extension;
   buffer.writeln();
-  buffer.write(_renderExtension_partial_documentation_4(context3, context0));
+  buffer.write(_renderExtension_partial_documentation_4(context3));
   buffer.writeln();
   if (context3.hasPublicInstanceFields == true) {
     buffer.writeln();
@@ -1626,8 +1543,7 @@ on ''');
     var context4 = context3.publicInstanceFieldsSorted;
     for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(
-          _renderExtension_partial_property_5(context5, context3, context0));
+      buffer.write(_renderExtension_partial_property_5(context5));
       buffer.writeln();
     }
   }
@@ -1640,8 +1556,7 @@ on ''');
     var context6 = context3.publicInstanceMethodsSorted;
     for (var context7 in context6) {
       buffer.writeln();
-      buffer.write(
-          _renderExtension_partial_callable_6(context7, context3, context0));
+      buffer.write(_renderExtension_partial_callable_6(context7));
       buffer.writeln();
     }
   }
@@ -1654,8 +1569,7 @@ on ''');
     var context8 = context3.publicInstanceOperatorsSorted;
     for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(
-          _renderExtension_partial_callable_6(context9, context3, context0));
+      buffer.write(_renderExtension_partial_callable_6(context9));
       buffer.writeln();
     }
   }
@@ -1668,8 +1582,7 @@ on ''');
     var context10 = context3.publicVariableStaticFieldsSorted;
     for (var context11 in context10) {
       buffer.writeln();
-      buffer.write(
-          _renderExtension_partial_property_5(context11, context3, context0));
+      buffer.write(_renderExtension_partial_property_5(context11));
       buffer.writeln();
     }
   }
@@ -1682,8 +1595,7 @@ on ''');
     var context12 = context3.publicStaticMethodsSorted;
     for (var context13 in context12) {
       buffer.writeln();
-      buffer.write(
-          _renderExtension_partial_callable_6(context13, context3, context0));
+      buffer.write(_renderExtension_partial_callable_6(context13));
       buffer.writeln();
     }
   }
@@ -1696,8 +1608,7 @@ on ''');
     var context14 = context3.publicConstantFieldsSorted;
     for (var context15 in context14) {
       buffer.writeln();
-      buffer.write(
-          _renderExtension_partial_constant_7(context15, context3, context0));
+      buffer.write(_renderExtension_partial_constant_7(context15));
       buffer.writeln();
     }
   }
@@ -1717,8 +1628,7 @@ String _renderExtension_partial_head_0<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_source_link_1<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_source_link_1(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -1732,17 +1642,16 @@ String _renderExtension_partial_source_link_1<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_categorization_2<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_categorization_2(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1750,14 +1659,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderExtension_partial_feature_set_3<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_feature_set_3(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -1765,8 +1673,7 @@ String _renderExtension_partial_feature_set_3<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_documentation_4<T extends _i13.Extension>(
-    _i13.Extension context1, _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_documentation_4(_i13.Extension context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -1777,10 +1684,7 @@ String _renderExtension_partial_documentation_4<T extends _i13.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_property_5<T extends _i13.Extension>(
-    _i9.Field context2,
-    _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_property_5(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -1789,33 +1693,32 @@ String _renderExtension_partial_property_5<T extends _i13.Extension>(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderExtension_partial_property_5_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderExtension_partial_property_5_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderExtension_partial_property_5_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderExtension_partial_property_5_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderExtension_partial_property_5_partial_categorization_0<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_property_5_partial_categorization_0(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1823,9 +1726,8 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderExtension_partial_property_5_partial_features_1<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_property_5_partial_features_1(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1837,10 +1739,7 @@ String __renderExtension_partial_property_5_partial_features_1<
   return buffer.toString();
 }
 
-String _renderExtension_partial_callable_6<T extends _i13.Extension>(
-    _i10.Method context2,
-    _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_callable_6(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -1850,33 +1749,32 @@ String _renderExtension_partial_callable_6<T extends _i13.Extension>(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderExtension_partial_callable_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderExtension_partial_callable_6_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderExtension_partial_callable_6_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderExtension_partial_callable_6_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderExtension_partial_callable_6_partial_categorization_0<
-        T extends _i13.Extension>(_i10.Method context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_callable_6_partial_categorization_0(
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1884,9 +1782,8 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderExtension_partial_callable_6_partial_features_1<
-        T extends _i13.Extension>(_i10.Method context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_callable_6_partial_features_1(
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1898,43 +1795,39 @@ String __renderExtension_partial_callable_6_partial_features_1<
   return buffer.toString();
 }
 
-String _renderExtension_partial_constant_7<T extends _i13.Extension>(
-    _i9.Field context2,
-    _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String _renderExtension_partial_constant_7(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderExtension_partial_constant_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderExtension_partial_constant_7_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderExtension_partial_constant_7_partial_features_1(
-      context2, context1, context0));
+  buffer
+      .write(__renderExtension_partial_constant_7_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
-String __renderExtension_partial_constant_7_partial_categorization_0<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_constant_7_partial_categorization_0(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -1942,9 +1835,8 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderExtension_partial_constant_7_partial_features_1<
-        T extends _i13.Extension>(_i9.Field context2, _i13.Extension context1,
-    _i1.ExtensionTemplateData<T> context0) {
+String __renderExtension_partial_constant_7_partial_features_1(
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -1980,20 +1872,19 @@ String renderFunction(_i1.FunctionTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderFunction_partial_source_link_1(context1, context0));
+  buffer.write(_renderFunction_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderFunction_partial_categorization_2(context1, context0));
+  buffer.write(_renderFunction_partial_categorization_2(context1));
   buffer.writeln();
-  buffer.write(_renderFunction_partial_feature_set_3(context1, context0));
+  buffer.write(_renderFunction_partial_feature_set_3(context1));
   buffer.writeln();
   var context2 = context0.function;
   buffer.writeln();
-  buffer
-      .write(_renderFunction_partial_callable_multiline_4(context2, context0));
+  buffer.write(_renderFunction_partial_callable_multiline_4(context2));
   buffer.write('\n\n');
-  buffer.write(_renderFunction_partial_documentation_5(context2, context0));
+  buffer.write(_renderFunction_partial_documentation_5(context2));
   buffer.write('\n\n');
-  buffer.write(_renderFunction_partial_source_code_6(context2, context0));
+  buffer.write(_renderFunction_partial_source_code_6(context2));
   buffer.writeln();
   buffer.write('\n\n');
   buffer.write(_renderFunction_partial_footer_7(context0));
@@ -2010,8 +1901,7 @@ String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderFunction_partial_source_link_1(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_source_link_1(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -2025,17 +1915,16 @@ String _renderFunction_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderFunction_partial_categorization_2(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_categorization_2(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2043,14 +1932,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderFunction_partial_feature_set_3(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_feature_set_3(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -2059,15 +1947,15 @@ String _renderFunction_partial_feature_set_3(
 }
 
 String _renderFunction_partial_callable_multiline_4(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+    _i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
+    var context4 = context1.annotations;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
 - ''');
-      buffer.write(context3.linkedNameWithParameters);
+      buffer.write(context5.linkedNameWithParameters);
     }
   }
   buffer.write('\n\n');
@@ -2075,7 +1963,7 @@ String _renderFunction_partial_callable_multiline_4(
   buffer.write(' ');
   buffer.write(
       __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
-          context1, context0));
+          context1));
   buffer.write(context1.genericParameters);
   buffer.write('''(''');
   if (context1.hasParameters == true) {
@@ -2088,7 +1976,7 @@ String _renderFunction_partial_callable_multiline_4(
 }
 
 String __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+    _i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -2105,8 +1993,7 @@ String __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
   return buffer.toString();
 }
 
-String _renderFunction_partial_documentation_5(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_documentation_5(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -2117,8 +2004,7 @@ String _renderFunction_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderFunction_partial_source_code_6(
-    _i6.ModelFunction context1, _i1.FunctionTemplateData context0) {
+String _renderFunction_partial_source_code_6(_i6.ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -2159,7 +2045,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
   buffer.writeln();
   var context1 = context0.defaultPackage;
   buffer.writeln();
-  buffer.write(_renderIndex_partial_documentation_1(context1, context0));
+  buffer.write(_renderIndex_partial_documentation_1(context1));
   buffer.writeln();
   var context2 = context0.localPackages;
   for (var context3 in context2) {
@@ -2180,8 +2066,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
       var context5 = context4.publicLibrariesSorted;
       for (var context6 in context5) {
         buffer.writeln();
-        buffer.write(_renderIndex_partial_library_2(
-            context6, context4, context3, context0));
+        buffer.write(_renderIndex_partial_library_2(context6));
       }
     }
     buffer.writeln();
@@ -2195,8 +2080,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
       var context9 = context8.publicLibrariesSorted;
       for (var context10 in context9) {
         buffer.writeln();
-        buffer.write(_renderIndex_partial_library_2(
-            context10, context8, context3, context0));
+        buffer.write(_renderIndex_partial_library_2(context10));
       }
     }
   }
@@ -2215,8 +2099,7 @@ String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderIndex_partial_documentation_1(
-    _i14.Package context1, _i1.PackageTemplateData context0) {
+String _renderIndex_partial_documentation_1(_i14.Package context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -2227,11 +2110,7 @@ String _renderIndex_partial_documentation_1(
   return buffer.toString();
 }
 
-String _renderIndex_partial_library_2(
-    _i3.Library context3,
-    _i15.LibraryContainer context2,
-    _i14.Package context1,
-    _i1.PackageTemplateData context0) {
+String _renderIndex_partial_library_2(_i3.Library context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
@@ -2270,15 +2149,15 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderLibrary_partial_source_link_1(context1, context0));
+  buffer.write(_renderLibrary_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderLibrary_partial_categorization_2(context1, context0));
+  buffer.write(_renderLibrary_partial_categorization_2(context1));
   buffer.writeln();
-  buffer.write(_renderLibrary_partial_feature_set_3(context1, context0));
+  buffer.write(_renderLibrary_partial_feature_set_3(context1));
   buffer.writeln();
   var context2 = context0.library;
   buffer.writeln();
-  buffer.write(_renderLibrary_partial_documentation_4(context2, context0));
+  buffer.write(_renderLibrary_partial_documentation_4(context2));
   buffer.writeln();
   var context3 = context0.library;
   if (context3.hasPublicClasses == true) {
@@ -2290,8 +2169,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context5 = context4.publicClassesSorted;
     for (var context6 in context5) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_container_5(
-          context6, context4, context3, context0));
+      buffer.write(_renderLibrary_partial_container_5(context6));
       buffer.writeln();
     }
   }
@@ -2306,8 +2184,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context9 = context8.publicMixinsSorted;
     for (var context10 in context9) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_container_5(
-          context10, context8, context7, context0));
+      buffer.write(_renderLibrary_partial_container_5(context10));
       buffer.writeln();
     }
   }
@@ -2322,8 +2199,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context13 = context12.publicExtensionsSorted;
     for (var context14 in context13) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_extension_6(
-          context14, context12, context11, context0));
+      buffer.write(_renderLibrary_partial_extension_6(context14));
       buffer.writeln();
     }
   }
@@ -2338,8 +2214,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context17 = context16.publicConstantsSorted;
     for (var context18 in context17) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_constant_7(
-          context18, context16, context15, context0));
+      buffer.write(_renderLibrary_partial_constant_7(context18));
       buffer.writeln();
     }
   }
@@ -2354,8 +2229,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context21 = context20.publicPropertiesSorted;
     for (var context22 in context21) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_property_8(
-          context22, context20, context19, context0));
+      buffer.write(_renderLibrary_partial_property_8(context22));
       buffer.writeln();
     }
   }
@@ -2370,8 +2244,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context25 = context24.publicFunctionsSorted;
     for (var context26 in context25) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_callable_9(
-          context26, context24, context23, context0));
+      buffer.write(_renderLibrary_partial_callable_9(context26));
       buffer.writeln();
     }
   }
@@ -2386,8 +2259,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context29 = context28.publicEnumsSorted;
     for (var context30 in context29) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_container_5(
-          context30, context28, context27, context0));
+      buffer.write(_renderLibrary_partial_container_5(context30));
       buffer.writeln();
     }
   }
@@ -2402,8 +2274,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context33 = context32.publicTypedefsSorted;
     for (var context34 in context33) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_typedef_10(
-          context34, context32, context31, context0));
+      buffer.write(_renderLibrary_partial_typedef_10(context34));
       buffer.writeln();
     }
   }
@@ -2418,8 +2289,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
     var context37 = context36.publicExceptionsSorted;
     for (var context38 in context37) {
       buffer.writeln();
-      buffer.write(_renderLibrary_partial_container_5(
-          context38, context36, context35, context0));
+      buffer.write(_renderLibrary_partial_container_5(context38));
       buffer.writeln();
     }
   }
@@ -2438,8 +2308,7 @@ String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderLibrary_partial_source_link_1(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_source_link_1(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -2453,17 +2322,16 @@ String _renderLibrary_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_categorization_2(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_categorization_2(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2471,14 +2339,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderLibrary_partial_feature_set_3(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_feature_set_3(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -2486,8 +2353,7 @@ String _renderLibrary_partial_feature_set_3(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_documentation_4(
-    _i3.Library context1, _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_documentation_4(_i3.Library context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -2498,18 +2364,14 @@ String _renderLibrary_partial_documentation_4(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_container_5(
-    _i4.Container context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_container_5(_i4.Container context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
   buffer.write(context3.linkedGenericParameters);
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_container_5_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_container_5_partial_categorization_0(context3));
   buffer.write('\n\n');
   buffer.write(context3.oneLineDoc);
   buffer.write(' ');
@@ -2520,19 +2382,16 @@ String _renderLibrary_partial_container_5(
 }
 
 String __renderLibrary_partial_container_5_partial_categorization_0(
-    _i4.Container context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i4.Container context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2540,17 +2399,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderLibrary_partial_extension_6(
-    _i13.Extension context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_extension_6(_i13.Extension context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_extension_6_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_extension_6_partial_categorization_0(context3));
   buffer.write('\n\n');
   buffer.write(context3.oneLineDoc);
   buffer.write(' ');
@@ -2561,19 +2416,16 @@ String _renderLibrary_partial_extension_6(
 }
 
 String __renderLibrary_partial_extension_6_partial_categorization_0(
-    _i13.Extension context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i13.Extension context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2581,46 +2433,38 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderLibrary_partial_constant_7(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_constant_7(_i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
   buffer.write(''' const ''');
   buffer.write(context3.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_constant_7_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_constant_7_partial_categorization_0(context3));
   buffer.write('\n\n');
   buffer.write(context3.oneLineDoc);
   buffer.write(' ');
   buffer.write(context3.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_constant_7_partial_features_1(
-      context3, context2, context1, context0));
+  buffer.write(__renderLibrary_partial_constant_7_partial_features_1(context3));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderLibrary_partial_constant_7_partial_categorization_0(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2629,10 +2473,7 @@ Categories:''');
 }
 
 String __renderLibrary_partial_constant_7_partial_features_1(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''_''');
@@ -2644,11 +2485,7 @@ String __renderLibrary_partial_constant_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_property_8(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_property_8(_i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
@@ -2657,35 +2494,31 @@ String _renderLibrary_partial_property_8(
   buffer.write(' ');
   buffer.write(context3.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_property_8_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_property_8_partial_categorization_0(context3));
   buffer.write('\n\n');
   buffer.write(context3.oneLineDoc);
   buffer.write(' ');
   buffer.write(context3.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_property_8_partial_features_1(
-      context3, context2, context1, context0));
+  buffer.write(__renderLibrary_partial_property_8_partial_features_1(context3));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderLibrary_partial_property_8_partial_categorization_0(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(context5.categoryLabel);
+      buffer.write(context9.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2694,10 +2527,7 @@ Categories:''');
 }
 
 String __renderLibrary_partial_property_8_partial_features_1(
-    _i5.TopLevelVariable context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i5.TopLevelVariable context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''_''');
@@ -2709,11 +2539,7 @@ String __renderLibrary_partial_property_8_partial_features_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_callable_9(
-    _i6.ModelFunctionTyped context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_callable_9(_i6.ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
@@ -2723,35 +2549,31 @@ String _renderLibrary_partial_callable_9(
   buffer.write(''') ''');
   buffer.write(context3.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_callable_9_partial_categorization_0(
-      context3, context2, context1, context0));
+  buffer.write(
+      __renderLibrary_partial_callable_9_partial_categorization_0(context3));
   buffer.write('\n\n');
   buffer.write(context3.oneLineDoc);
   buffer.write(' ');
   buffer.write(context3.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderLibrary_partial_callable_9_partial_features_1(
-      context3, context2, context1, context0));
+  buffer.write(__renderLibrary_partial_callable_9_partial_features_1(context3));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderLibrary_partial_callable_9_partial_categorization_0(
-    _i6.ModelFunctionTyped context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i6.ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context8 = context3.displayedCategories;
+    for (var context9 in context8) {
       buffer.writeln();
-      buffer.write(context5!.categoryLabel);
+      buffer.write(context9!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2760,10 +2582,7 @@ Categories:''');
 }
 
 String __renderLibrary_partial_callable_9_partial_features_1(
-    _i6.ModelFunctionTyped context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i6.ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''_''');
@@ -2775,37 +2594,32 @@ String __renderLibrary_partial_callable_9_partial_features_1(
   return buffer.toString();
 }
 
-String _renderLibrary_partial_typedef_10(
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String _renderLibrary_partial_typedef_10(_i7.Typedef context3) {
   final buffer = StringBuffer();
   if (context3.isCallable == true) {
-    var context4 = context3.asCallable;
+    var context5 = context3.asCallable;
     buffer.writeln();
     buffer.write('''
     ##### ''');
-    buffer.write(context4.linkedName);
-    buffer.write(context4.linkedGenericParameters);
+    buffer.write(context5.linkedName);
+    buffer.write(context5.linkedGenericParameters);
     buffer.write(''' = ''');
-    buffer.write(context4.modelType.linkedName);
+    buffer.write(context5.modelType.linkedName);
     buffer.write('\n    ');
-    buffer.write(__renderLibrary_partial_typedef_10_partial_categorization_0(
-        context4, context3, context2, context1, context0));
+    buffer.write(
+        __renderLibrary_partial_typedef_10_partial_categorization_0(context5));
     buffer.write('\n\n    ');
-    buffer.write(context4.oneLineDoc);
+    buffer.write(context5.oneLineDoc);
     buffer.write(' ');
-    buffer.write(context4.extendedDocLink);
+    buffer.write(context5.extendedDocLink);
     buffer.write('  ');
     buffer.write('\n    ');
-    buffer.write(__renderLibrary_partial_typedef_10_partial_features_1(
-        context4, context3, context2, context1, context0));
+    buffer
+        .write(__renderLibrary_partial_typedef_10_partial_features_1(context5));
   }
   if (context3.isCallable != true) {
     buffer.write('\n  ');
-    buffer.write(__renderLibrary_partial_typedef_10_partial_type_2(
-        context3, context2, context1, context0));
+    buffer.write(__renderLibrary_partial_typedef_10_partial_type_2(context3));
   }
   buffer.writeln();
 
@@ -2813,20 +2627,16 @@ String _renderLibrary_partial_typedef_10(
 }
 
 String __renderLibrary_partial_typedef_10_partial_categorization_0(
-    _i7.FunctionTypedef context4,
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i7.FunctionTypedef context4) {
   final buffer = StringBuffer();
   if (context4.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context5 = context4.displayedCategories;
-    for (var context6 in context5) {
+    var context9 = context4.displayedCategories;
+    for (var context10 in context9) {
       buffer.writeln();
-      buffer.write(context6.categoryLabel);
+      buffer.write(context10.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2835,11 +2645,7 @@ Categories:''');
 }
 
 String __renderLibrary_partial_typedef_10_partial_features_1(
-    _i7.FunctionTypedef context4,
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i7.FunctionTypedef context4) {
   final buffer = StringBuffer();
   if (context4.hasFeatures == true) {
     buffer.write('''_''');
@@ -2851,11 +2657,7 @@ String __renderLibrary_partial_typedef_10_partial_features_1(
   return buffer.toString();
 }
 
-String __renderLibrary_partial_typedef_10_partial_type_2(
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+String __renderLibrary_partial_typedef_10_partial_type_2(_i7.Typedef context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
@@ -2865,7 +2667,7 @@ String __renderLibrary_partial_typedef_10_partial_type_2(
   buffer.writeln();
   buffer.write(
       ___renderLibrary_partial_typedef_10_partial_type_2_partial_categorization_0(
-          context3, context2, context1, context0));
+          context3));
   buffer.write('\n\n');
   buffer.write(context3.oneLineDoc);
   buffer.write(' ');
@@ -2874,7 +2676,7 @@ String __renderLibrary_partial_typedef_10_partial_type_2(
   buffer.writeln();
   buffer.write(
       ___renderLibrary_partial_typedef_10_partial_type_2_partial_features_1(
-          context3, context2, context1, context0));
+          context3));
   buffer.writeln();
 
   return buffer.toString();
@@ -2882,19 +2684,16 @@ String __renderLibrary_partial_typedef_10_partial_type_2(
 
 String
     ___renderLibrary_partial_typedef_10_partial_type_2_partial_categorization_0(
-        _i7.Typedef context3,
-        _i3.Library context2,
-        _i3.Library context1,
-        _i1.LibraryTemplateData context0) {
+        _i7.Typedef context3) {
   final buffer = StringBuffer();
   if (context3.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context4 = context3.displayedCategories;
-    for (var context5 in context4) {
+    var context10 = context3.displayedCategories;
+    for (var context11 in context10) {
       buffer.writeln();
-      buffer.write(context5.categoryLabel);
+      buffer.write(context11.categoryLabel);
     }
   }
   buffer.writeln();
@@ -2903,10 +2702,7 @@ Categories:''');
 }
 
 String ___renderLibrary_partial_typedef_10_partial_type_2_partial_features_1(
-    _i7.Typedef context3,
-    _i3.Library context2,
-    _i3.Library context1,
-    _i1.LibraryTemplateData context0) {
+    _i7.Typedef context3) {
   final buffer = StringBuffer();
   if (context3.hasFeatures == true) {
     buffer.write('''_''');
@@ -2941,19 +2737,19 @@ String renderMethod(_i1.MethodTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderMethod_partial_source_link_1(context1, context0));
+  buffer.write(_renderMethod_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderMethod_partial_feature_set_2(context1, context0));
+  buffer.write(_renderMethod_partial_feature_set_2(context1));
   buffer.writeln();
   var context2 = context0.method;
   buffer.writeln();
-  buffer.write(_renderMethod_partial_callable_multiline_3(context2, context0));
+  buffer.write(_renderMethod_partial_callable_multiline_3(context2));
   buffer.writeln();
-  buffer.write(_renderMethod_partial_features_4(context2, context0));
+  buffer.write(_renderMethod_partial_features_4(context2));
   buffer.write('\n\n');
-  buffer.write(_renderMethod_partial_documentation_5(context2, context0));
+  buffer.write(_renderMethod_partial_documentation_5(context2));
   buffer.write('\n\n');
-  buffer.write(_renderMethod_partial_source_code_6(context2, context0));
+  buffer.write(_renderMethod_partial_source_code_6(context2));
   buffer.writeln();
   buffer.write('\n\n');
   buffer.write(_renderMethod_partial_footer_7(context0));
@@ -2970,8 +2766,7 @@ String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderMethod_partial_source_link_1(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_source_link_1(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -2985,14 +2780,13 @@ String _renderMethod_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderMethod_partial_feature_set_2(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_feature_set_2(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -3000,16 +2794,15 @@ String _renderMethod_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderMethod_partial_callable_multiline_3(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_callable_multiline_3(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
+    var context4 = context1.annotations;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
 - ''');
-      buffer.write(context3.linkedNameWithParameters);
+      buffer.write(context5.linkedNameWithParameters);
     }
   }
   buffer.write('\n\n');
@@ -3017,7 +2810,7 @@ String _renderMethod_partial_callable_multiline_3(
   buffer.write(' ');
   buffer.write(
       __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
-          context1, context0));
+          context1));
   buffer.write(context1.genericParameters);
   buffer.write('''(''');
   if (context1.hasParameters == true) {
@@ -3030,7 +2823,7 @@ String _renderMethod_partial_callable_multiline_3(
 }
 
 String __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+    _i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -3047,8 +2840,7 @@ String __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
   return buffer.toString();
 }
 
-String _renderMethod_partial_features_4(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_features_4(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -3060,8 +2852,7 @@ String _renderMethod_partial_features_4(
   return buffer.toString();
 }
 
-String _renderMethod_partial_documentation_5(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_documentation_5(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -3072,8 +2863,7 @@ String _renderMethod_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderMethod_partial_source_code_6(
-    _i10.Method context1, _i1.MethodTemplateData context0) {
+String _renderMethod_partial_source_code_6(_i10.Method context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -3115,15 +2905,15 @@ String renderMixin(_i1.MixinTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderMixin_partial_source_link_1(context1, context0));
+  buffer.write(_renderMixin_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderMixin_partial_categorization_2(context1, context0));
+  buffer.write(_renderMixin_partial_categorization_2(context1));
   buffer.writeln();
-  buffer.write(_renderMixin_partial_feature_set_3(context1, context0));
+  buffer.write(_renderMixin_partial_feature_set_3(context1));
   buffer.writeln();
   var context2 = context0.mixin;
   buffer.writeln();
-  buffer.write(_renderMixin_partial_documentation_4(context2, context0));
+  buffer.write(_renderMixin_partial_documentation_4(context2));
   buffer.writeln();
   if (context2.hasModifiers == true) {
     if (context2.hasPublicSuperclassConstraints == true) {
@@ -3193,8 +2983,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context11 = context2.publicInstanceFieldsSorted;
     for (var context12 in context11) {
       buffer.writeln();
-      buffer.write(
-          _renderMixin_partial_property_6(context12, context2, context0));
+      buffer.write(_renderMixin_partial_property_6(context12));
       buffer.writeln();
     }
   }
@@ -3207,8 +2996,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context13 = context2.publicInstanceMethodsSorted;
     for (var context14 in context13) {
       buffer.writeln();
-      buffer.write(
-          _renderMixin_partial_callable_7(context14, context2, context0));
+      buffer.write(_renderMixin_partial_callable_7(context14));
       buffer.writeln();
     }
   }
@@ -3221,8 +3009,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context15 = context2.publicInstanceOperatorsSorted;
     for (var context16 in context15) {
       buffer.writeln();
-      buffer.write(
-          _renderMixin_partial_callable_7(context16, context2, context0));
+      buffer.write(_renderMixin_partial_callable_7(context16));
       buffer.writeln();
     }
   }
@@ -3235,8 +3022,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context17 = context2.publicVariableStaticFieldsSorted;
     for (var context18 in context17) {
       buffer.writeln();
-      buffer.write(
-          _renderMixin_partial_property_6(context18, context2, context0));
+      buffer.write(_renderMixin_partial_property_6(context18));
       buffer.writeln();
     }
   }
@@ -3249,8 +3035,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context19 = context2.publicStaticMethodsSorted;
     for (var context20 in context19) {
       buffer.writeln();
-      buffer.write(
-          _renderMixin_partial_callable_7(context20, context2, context0));
+      buffer.write(_renderMixin_partial_callable_7(context20));
       buffer.writeln();
     }
   }
@@ -3263,8 +3048,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
     var context21 = context2.publicConstantFieldsSorted;
     for (var context22 in context21) {
       buffer.writeln();
-      buffer.write(
-          _renderMixin_partial_constant_8(context22, context2, context0));
+      buffer.write(_renderMixin_partial_constant_8(context22));
       buffer.writeln();
     }
   }
@@ -3283,8 +3067,7 @@ String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderMixin_partial_source_link_1(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_source_link_1(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -3298,17 +3081,16 @@ String _renderMixin_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_categorization_2(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_categorization_2(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3316,14 +3098,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderMixin_partial_feature_set_3(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_feature_set_3(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -3331,8 +3112,7 @@ String _renderMixin_partial_feature_set_3(
   return buffer.toString();
 }
 
-String _renderMixin_partial_documentation_4(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_documentation_4(_i15.Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -3344,7 +3124,7 @@ String _renderMixin_partial_documentation_4(
 }
 
 String _renderMixin_partial_super_chain_5(
-    _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i15.Mixin context1, _i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   if (context1.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -3353,12 +3133,12 @@ String _renderMixin_partial_super_chain_5(
 
 - ''');
     buffer.write(context0.linkedObjectType);
-    var context2 = context1.publicSuperChainReversed;
-    for (var context3 in context2) {
+    var context4 = context1.publicSuperChainReversed;
+    for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
 - ''');
-      buffer.write(context3.linkedName);
+      buffer.write(context5.linkedName);
     }
     buffer.writeln();
     buffer.write('''
@@ -3369,8 +3149,7 @@ String _renderMixin_partial_super_chain_5(
   return buffer.toString();
 }
 
-String _renderMixin_partial_property_6(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_property_6(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -3379,32 +3158,31 @@ String _renderMixin_partial_property_6(
   buffer.write(' ');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderMixin_partial_property_6_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderMixin_partial_property_6_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderMixin_partial_property_6_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderMixin_partial_property_6_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderMixin_partial_property_6_partial_categorization_0(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3412,8 +3190,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderMixin_partial_property_6_partial_features_1(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String __renderMixin_partial_property_6_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -3425,8 +3202,7 @@ String __renderMixin_partial_property_6_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_callable_7(
-    _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_callable_7(_i10.Method context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -3436,32 +3212,31 @@ String _renderMixin_partial_callable_7(
   buffer.write(''') ''');
   buffer.write(context2.modelType.returnType.linkedName);
   buffer.writeln();
-  buffer.write(__renderMixin_partial_callable_7_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderMixin_partial_callable_7_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderMixin_partial_callable_7_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderMixin_partial_callable_7_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderMixin_partial_callable_7_partial_categorization_0(
-    _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3470,7 +3245,7 @@ Categories:''');
 }
 
 String __renderMixin_partial_callable_7_partial_features_1(
-    _i10.Method context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i10.Method context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -3482,40 +3257,38 @@ String __renderMixin_partial_callable_7_partial_features_1(
   return buffer.toString();
 }
 
-String _renderMixin_partial_constant_8(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String _renderMixin_partial_constant_8(_i9.Field context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
   buffer.write(''' const ''');
   buffer.write(context2.modelType.linkedName);
   buffer.writeln();
-  buffer.write(__renderMixin_partial_constant_8_partial_categorization_0(
-      context2, context1, context0));
+  buffer.write(
+      __renderMixin_partial_constant_8_partial_categorization_0(context2));
   buffer.write('\n\n');
   buffer.write(context2.oneLineDoc);
   buffer.write(' ');
   buffer.write(context2.extendedDocLink);
   buffer.write('  ');
   buffer.writeln();
-  buffer.write(__renderMixin_partial_constant_8_partial_features_1(
-      context2, context1, context0));
+  buffer.write(__renderMixin_partial_constant_8_partial_features_1(context2));
   buffer.writeln();
 
   return buffer.toString();
 }
 
 String __renderMixin_partial_constant_8_partial_categorization_0(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+    _i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context3 = context2.displayedCategories;
-    for (var context4 in context3) {
+    var context7 = context2.displayedCategories;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(context4!.categoryLabel);
+      buffer.write(context8!.categoryLabel);
     }
   }
   buffer.writeln();
@@ -3523,8 +3296,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String __renderMixin_partial_constant_8_partial_features_1(
-    _i9.Field context2, _i16.Mixin context1, _i1.MixinTemplateData context0) {
+String __renderMixin_partial_constant_8_partial_features_1(_i9.Field context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -3559,36 +3331,34 @@ String renderProperty(_i1.PropertyTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderProperty_partial_source_link_1(context1, context0));
+  buffer.write(_renderProperty_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderProperty_partial_feature_set_2(context1, context0));
+  buffer.write(_renderProperty_partial_feature_set_2(context1));
   buffer.writeln();
   var context2 = context0.self;
   if (context2.hasNoGetterSetter == true) {
     buffer.writeln();
     buffer.write(context2.modelType.linkedName);
     buffer.write(' ');
-    buffer.write(_renderProperty_partial_name_summary_3(context2, context0));
+    buffer.write(_renderProperty_partial_name_summary_3(context2));
     buffer.write('  ');
     buffer.writeln();
-    buffer.write(_renderProperty_partial_features_4(context2, context0));
+    buffer.write(_renderProperty_partial_features_4(context2));
     buffer.write('\n\n');
-    buffer.write(_renderProperty_partial_documentation_5(context2, context0));
+    buffer.write(_renderProperty_partial_documentation_5(context2));
     buffer.write('\n\n');
-    buffer.write(_renderProperty_partial_source_code_6(context2, context0));
+    buffer.write(_renderProperty_partial_source_code_6(context2));
   }
   buffer.writeln();
   if (context2.hasGetterOrSetter == true) {
     if (context2.hasGetter == true) {
       buffer.writeln();
-      buffer
-          .write(_renderProperty_partial_accessor_getter_7(context2, context0));
+      buffer.write(_renderProperty_partial_accessor_getter_7(context2));
     }
     buffer.writeln();
     if (context2.hasSetter == true) {
       buffer.writeln();
-      buffer
-          .write(_renderProperty_partial_accessor_setter_8(context2, context0));
+      buffer.write(_renderProperty_partial_accessor_setter_8(context2));
     }
   }
   buffer.write('\n\n');
@@ -3606,8 +3376,7 @@ String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderProperty_partial_source_link_1(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_source_link_1(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -3621,14 +3390,13 @@ String _renderProperty_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderProperty_partial_feature_set_2(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_feature_set_2(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -3636,8 +3404,7 @@ String _renderProperty_partial_feature_set_2(
   return buffer.toString();
 }
 
-String _renderProperty_partial_name_summary_3(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_name_summary_3(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -3654,8 +3421,7 @@ String _renderProperty_partial_name_summary_3(
   return buffer.toString();
 }
 
-String _renderProperty_partial_features_4(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_features_4(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -3667,8 +3433,7 @@ String _renderProperty_partial_features_4(
   return buffer.toString();
 }
 
-String _renderProperty_partial_documentation_5(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_documentation_5(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -3679,8 +3444,7 @@ String _renderProperty_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderProperty_partial_source_code_6(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_source_code_6(_i9.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -3699,29 +3463,28 @@ String _renderProperty_partial_source_code_6(
   return buffer.toString();
 }
 
-String _renderProperty_partial_accessor_getter_7(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_accessor_getter_7(_i9.Field context1) {
   final buffer = StringBuffer();
-  var context2 = context1.getter;
-  if (context2 != null) {
+  var context3 = context1.getter;
+  if (context3 != null) {
     buffer.writeln();
-    buffer.write(context2.modelType.returnType.linkedName);
+    buffer.write(context3.modelType.returnType.linkedName);
     buffer.write(' ');
     buffer.write(
         __renderProperty_partial_accessor_getter_7_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('  ');
     buffer.writeln();
     buffer.write(__renderProperty_partial_accessor_getter_7_partial_features_1(
-        context2, context1, context0));
+        context3));
     buffer.write('\n\n');
     buffer.write(
         __renderProperty_partial_accessor_getter_7_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.write('\n\n');
     buffer.write(
         __renderProperty_partial_accessor_getter_7_partial_source_code_3(
-            context2, context1, context0));
+            context3));
   }
   buffer.writeln();
 
@@ -3729,9 +3492,7 @@ String _renderProperty_partial_accessor_getter_7(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_name_summary_0(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -3749,9 +3510,7 @@ String __renderProperty_partial_accessor_getter_7_partial_name_summary_0(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_features_1(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -3764,9 +3523,7 @@ String __renderProperty_partial_accessor_getter_7_partial_features_1(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_documentation_2(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -3778,9 +3535,7 @@ String __renderProperty_partial_accessor_getter_7_partial_documentation_2(
 }
 
 String __renderProperty_partial_accessor_getter_7_partial_source_code_3(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -3799,29 +3554,28 @@ String __renderProperty_partial_accessor_getter_7_partial_source_code_3(
   return buffer.toString();
 }
 
-String _renderProperty_partial_accessor_setter_8(
-    _i9.Field context1, _i1.PropertyTemplateData context0) {
+String _renderProperty_partial_accessor_setter_8(_i9.Field context1) {
   final buffer = StringBuffer();
-  var context2 = context1.setter;
-  if (context2 != null) {
+  var context3 = context1.setter;
+  if (context3 != null) {
     buffer.writeln();
     buffer.write(
         __renderProperty_partial_accessor_setter_8_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('''(''');
-    buffer.write(context2.linkedParamsNoMetadata);
+    buffer.write(context3.linkedParamsNoMetadata);
     buffer.write(''')  ''');
     buffer.writeln();
     buffer.write(__renderProperty_partial_accessor_setter_8_partial_features_1(
-        context2, context1, context0));
+        context3));
     buffer.write('\n\n');
     buffer.write(
         __renderProperty_partial_accessor_setter_8_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.write('\n\n');
     buffer.write(
         __renderProperty_partial_accessor_setter_8_partial_source_code_3(
-            context2, context1, context0));
+            context3));
   }
   buffer.writeln();
 
@@ -3829,9 +3583,7 @@ String _renderProperty_partial_accessor_setter_8(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_name_summary_0(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -3849,9 +3601,7 @@ String __renderProperty_partial_accessor_setter_8_partial_name_summary_0(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_features_1(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -3864,9 +3614,7 @@ String __renderProperty_partial_accessor_setter_8_partial_features_1(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_documentation_2(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -3878,9 +3626,7 @@ String __renderProperty_partial_accessor_setter_8_partial_documentation_2(
 }
 
 String __renderProperty_partial_accessor_setter_8_partial_source_code_3(
-    _i17.ContainerAccessor context2,
-    _i9.Field context1,
-    _i1.PropertyTemplateData context0) {
+    _i16.ContainerAccessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -3910,15 +3656,13 @@ String _renderProperty_partial_footer_9(_i1.PropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String renderSidebarForContainer<T extends _i18.Documentable>(
-    _i1.TemplateDataWithContainer<T> context0) {
+String renderSidebarForContainer() {
   final buffer = StringBuffer();
 
   return buffer.toString();
 }
 
-String renderSidebarForLibrary<T extends _i18.Documentable>(
-    _i1.TemplateDataWithLibrary<T> context0) {
+String renderSidebarForLibrary() {
   final buffer = StringBuffer();
 
   return buffer.toString();
@@ -3936,43 +3680,34 @@ String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer
-      .write(_renderTopLevelProperty_partial_source_link_1(context1, context0));
+  buffer.write(_renderTopLevelProperty_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(
-      _renderTopLevelProperty_partial_categorization_2(context1, context0));
+  buffer.write(_renderTopLevelProperty_partial_categorization_2(context1));
   buffer.writeln();
-  buffer
-      .write(_renderTopLevelProperty_partial_feature_set_3(context1, context0));
+  buffer.write(_renderTopLevelProperty_partial_feature_set_3(context1));
   buffer.writeln();
   if (context1.hasNoGetterSetter == true) {
     buffer.writeln();
     buffer.write(context1.modelType.linkedName);
     buffer.write(' ');
-    buffer.write(
-        _renderTopLevelProperty_partial_name_summary_4(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_name_summary_4(context1));
     buffer.write('  ');
     buffer.writeln();
-    buffer
-        .write(_renderTopLevelProperty_partial_features_5(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_features_5(context1));
     buffer.write('\n\n');
-    buffer.write(
-        _renderTopLevelProperty_partial_documentation_6(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_documentation_6(context1));
     buffer.write('\n\n');
-    buffer.write(
-        _renderTopLevelProperty_partial_source_code_7(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_source_code_7(context1));
   }
   buffer.writeln();
   if (context1.hasExplicitGetter == true) {
     buffer.writeln();
-    buffer.write(
-        _renderTopLevelProperty_partial_accessor_getter_8(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_accessor_getter_8(context1));
   }
   buffer.writeln();
   if (context1.hasExplicitSetter == true) {
     buffer.writeln();
-    buffer.write(
-        _renderTopLevelProperty_partial_accessor_setter_9(context1, context0));
+    buffer.write(_renderTopLevelProperty_partial_accessor_setter_9(context1));
   }
   buffer.write('\n\n');
   buffer.write(_renderTopLevelProperty_partial_footer_10(context0));
@@ -3991,7 +3726,7 @@ String _renderTopLevelProperty_partial_head_0(
 }
 
 String _renderTopLevelProperty_partial_source_link_1(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -4006,16 +3741,16 @@ String _renderTopLevelProperty_partial_source_link_1(
 }
 
 String _renderTopLevelProperty_partial_categorization_2(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4024,13 +3759,13 @@ Categories:''');
 }
 
 String _renderTopLevelProperty_partial_feature_set_3(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -4039,7 +3774,7 @@ String _renderTopLevelProperty_partial_feature_set_3(
 }
 
 String _renderTopLevelProperty_partial_name_summary_4(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -4057,7 +3792,7 @@ String _renderTopLevelProperty_partial_name_summary_4(
 }
 
 String _renderTopLevelProperty_partial_features_5(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -4070,7 +3805,7 @@ String _renderTopLevelProperty_partial_features_5(
 }
 
 String _renderTopLevelProperty_partial_documentation_6(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -4082,7 +3817,7 @@ String _renderTopLevelProperty_partial_documentation_6(
 }
 
 String _renderTopLevelProperty_partial_source_code_7(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -4102,29 +3837,29 @@ String _renderTopLevelProperty_partial_source_code_7(
 }
 
 String _renderTopLevelProperty_partial_accessor_getter_8(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
-  var context2 = context1.getter;
-  if (context2 != null) {
+  var context3 = context1.getter;
+  if (context3 != null) {
     buffer.writeln();
-    buffer.write(context2.modelType.returnType.linkedName);
+    buffer.write(context3.modelType.returnType.linkedName);
     buffer.write(' ');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('  ');
     buffer.writeln();
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_features_1(
-            context2, context1, context0));
+            context3));
     buffer.write('\n\n');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.write('\n\n');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_getter_8_partial_source_code_3(
-            context2, context1, context0));
+            context3));
   }
   buffer.writeln();
 
@@ -4133,9 +3868,7 @@ String _renderTopLevelProperty_partial_accessor_getter_8(
 
 String
     __renderTopLevelProperty_partial_accessor_getter_8_partial_name_summary_0(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -4153,9 +3886,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_getter_8_partial_features_1(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -4169,9 +3900,7 @@ String __renderTopLevelProperty_partial_accessor_getter_8_partial_features_1(
 
 String
     __renderTopLevelProperty_partial_accessor_getter_8_partial_documentation_2(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -4183,9 +3912,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_getter_8_partial_source_code_3(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -4205,29 +3932,29 @@ String __renderTopLevelProperty_partial_accessor_getter_8_partial_source_code_3(
 }
 
 String _renderTopLevelProperty_partial_accessor_setter_9(
-    _i5.TopLevelVariable context1, _i1.TopLevelPropertyTemplateData context0) {
+    _i5.TopLevelVariable context1) {
   final buffer = StringBuffer();
-  var context2 = context1.setter;
-  if (context2 != null) {
+  var context3 = context1.setter;
+  if (context3 != null) {
     buffer.writeln();
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_name_summary_0(
-            context2, context1, context0));
+            context3));
     buffer.write('''(''');
-    buffer.write(context2.linkedParamsNoMetadata);
+    buffer.write(context3.linkedParamsNoMetadata);
     buffer.write(''')  ''');
     buffer.writeln();
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_features_1(
-            context2, context1, context0));
+            context3));
     buffer.write('\n\n');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_documentation_2(
-            context2, context1, context0));
+            context3));
     buffer.write('\n\n');
     buffer.write(
         __renderTopLevelProperty_partial_accessor_setter_9_partial_source_code_3(
-            context2, context1, context0));
+            context3));
   }
   buffer.writeln();
 
@@ -4236,9 +3963,7 @@ String _renderTopLevelProperty_partial_accessor_setter_9(
 
 String
     __renderTopLevelProperty_partial_accessor_setter_9_partial_name_summary_0(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.isConst == true) {
     buffer.write('''const ''');
@@ -4256,9 +3981,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_setter_9_partial_features_1(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasFeatures == true) {
     buffer.write('''_''');
@@ -4272,9 +3995,7 @@ String __renderTopLevelProperty_partial_accessor_setter_9_partial_features_1(
 
 String
     __renderTopLevelProperty_partial_accessor_setter_9_partial_documentation_2(
-        _i17.Accessor context2,
-        _i5.TopLevelVariable context1,
-        _i1.TopLevelPropertyTemplateData context0) {
+        _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasDocumentation == true) {
     buffer.writeln();
@@ -4286,9 +4007,7 @@ String
 }
 
 String __renderTopLevelProperty_partial_accessor_setter_9_partial_source_code_3(
-    _i17.Accessor context2,
-    _i5.TopLevelVariable context1,
-    _i1.TopLevelPropertyTemplateData context0) {
+    _i16.Accessor context2) {
   final buffer = StringBuffer();
   if (context2.hasSourceCode == true) {
     buffer.writeln();
@@ -4331,19 +4050,19 @@ String renderTypedef(_i1.TypedefTemplateData context0) {
   buffer.write(' ');
   buffer.writeEscaped(context1.kind);
   buffer.write('\n\n');
-  buffer.write(_renderTypedef_partial_source_link_1(context1, context0));
+  buffer.write(_renderTypedef_partial_source_link_1(context1));
   buffer.writeln();
-  buffer.write(_renderTypedef_partial_categorization_2(context1, context0));
+  buffer.write(_renderTypedef_partial_categorization_2(context1));
   buffer.writeln();
-  buffer.write(_renderTypedef_partial_feature_set_3(context1, context0));
+  buffer.write(_renderTypedef_partial_feature_set_3(context1));
   buffer.writeln();
   var context2 = context0.typeDef;
   buffer.writeln();
-  buffer.write(_renderTypedef_partial_typedef_multiline_4(context2, context0));
+  buffer.write(_renderTypedef_partial_typedef_multiline_4(context2));
   buffer.write('\n\n');
-  buffer.write(_renderTypedef_partial_documentation_5(context2, context0));
+  buffer.write(_renderTypedef_partial_documentation_5(context2));
   buffer.write('\n\n');
-  buffer.write(_renderTypedef_partial_source_code_6(context2, context0));
+  buffer.write(_renderTypedef_partial_source_code_6(context2));
   buffer.write('\n\n');
   buffer.write(_renderTypedef_partial_footer_7(context0));
   buffer.writeln();
@@ -4359,8 +4078,7 @@ String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderTypedef_partial_source_link_1(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_source_link_1(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceHref == true) {
     buffer.writeln();
@@ -4374,17 +4092,16 @@ String _renderTypedef_partial_source_link_1(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_categorization_2(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_categorization_2(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
     buffer.write('''
 Categories:''');
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
+    var context4 = context1.displayedCategories;
+    for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(context3.categoryLabel);
+      buffer.write(context5.categoryLabel);
     }
   }
   buffer.writeln();
@@ -4392,14 +4109,13 @@ Categories:''');
   return buffer.toString();
 }
 
-String _renderTypedef_partial_feature_set_3(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_feature_set_3(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatureSet == true) {
-    var context2 = context1.displayedLanguageFeatures;
-    for (var context3 in context2) {
+    var context4 = context1.displayedLanguageFeatures;
+    for (var context5 in context4) {
       buffer.write('\n    ');
-      buffer.write(context3.featureLabel);
+      buffer.write(context5.featureLabel);
     }
   }
   buffer.writeln();
@@ -4407,33 +4123,32 @@ String _renderTypedef_partial_feature_set_3(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_typedef_multiline_4(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_typedef_multiline_4(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.isCallable == true) {
-    var context2 = context1.asCallable;
-    if (context2.hasAnnotations == true) {
-      var context3 = context2.annotations;
-      for (var context4 in context3) {
+    var context5 = context1.asCallable;
+    if (context5.hasAnnotations == true) {
+      var context6 = context5.annotations;
+      for (var context7 in context6) {
         buffer.writeln();
         buffer.write('''
     - ''');
-        buffer.write(context4.linkedNameWithParameters);
+        buffer.write(context7.linkedNameWithParameters);
       }
     }
     buffer.write('\n\n    ');
-    buffer.write(context2.modelType.returnType.linkedName);
+    buffer.write(context5.modelType.returnType.linkedName);
     buffer.write(' ');
-    buffer.writeEscaped(context2.name);
-    buffer.write(context2.linkedGenericParameters);
+    buffer.writeEscaped(context5.name);
+    buffer.write(context5.linkedGenericParameters);
     buffer.write(''' = ''');
-    buffer.write(context2.modelType.linkedName);
+    buffer.write(context5.modelType.linkedName);
   }
   if (context1.isCallable != true) {
     buffer.write('\n  ');
     buffer.write(
         __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
-            context1, context0));
+            context1));
   }
   buffer.writeln();
 
@@ -4441,21 +4156,21 @@ String _renderTypedef_partial_typedef_multiline_4(
 }
 
 String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+    _i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
+    var context6 = context1.annotations;
+    for (var context7 in context6) {
       buffer.writeln();
       buffer.write('''
 - ''');
-      buffer.write(context3.linkedNameWithParameters);
+      buffer.write(context7.linkedNameWithParameters);
     }
   }
   buffer.write('\n\n');
   buffer.write(
       ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
-          context1, context0));
+          context1));
   buffer.write(context1.genericParameters);
   buffer.write(''' = ''');
   buffer.write(context1.modelType.linkedName);
@@ -4466,7 +4181,7 @@ String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
 
 String
     ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
-        _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+        _i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -4483,8 +4198,7 @@ String
   return buffer.toString();
 }
 
-String _renderTypedef_partial_documentation_5(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_documentation_5(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -4495,8 +4209,7 @@ String _renderTypedef_partial_documentation_5(
   return buffer.toString();
 }
 
-String _renderTypedef_partial_source_code_6(
-    _i7.Typedef context1, _i1.TypedefTemplateData context0) {
+String _renderTypedef_partial_source_code_6(_i7.Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -4528,6 +4241,6 @@ String _renderTypedef_partial_footer_7(_i1.TypedefTemplateData context0) {
 
 extension on StringBuffer {
   void writeEscaped(String? value) {
-    write(_i19.htmlEscape.convert(value ?? ''));
+    write(_i17.htmlEscape.convert(value ?? ''));
   }
 }

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -206,7 +206,7 @@ class MarkdownAotTemplates implements Templates {
 
   @override
   String renderError(PackageTemplateData context) =>
-      aot_renderers_for_md.renderError(context);
+      aot_renderers_for_md.renderError();
 
   @override
   String renderExtension(ExtensionTemplateData context) =>
@@ -239,12 +239,12 @@ class MarkdownAotTemplates implements Templates {
   @override
   String renderSidebarForContainer(
           TemplateDataWithContainer<Documentable> context) =>
-      aot_renderers_for_md.renderSidebarForContainer(context);
+      aot_renderers_for_md.renderSidebarForContainer();
 
   @override
   String renderSidebarForLibrary(
           TemplateDataWithLibrary<Documentable> context) =>
-      aot_renderers_for_md.renderSidebarForLibrary(context);
+      aot_renderers_for_md.renderSidebarForLibrary();
 
   @override
   String renderTopLevelProperty(TopLevelPropertyTemplateData context) =>

--- a/test/mustachio/aot_compiler_builder_test.dart
+++ b/test/mustachio/aot_compiler_builder_test.dart
@@ -30,7 +30,9 @@ void main() {
     await testMustachioBuilder(
       writer,
       '''
-class Foo {}
+class Foo {
+  String s1 = 'hello';
+}
 class Bar {}
 class Baz {}
 ''',
@@ -56,7 +58,9 @@ import 'package:mustachio/annotations.dart';
 
   test('builds a public API render function', () async {
     await testMustachioBuilder(writer, '''
-class Foo<T> {}
+class Foo<T> {
+  String s1 = 'hello';
+}
 ''', libraryFrontMatter: '''
 @Renderer(#renderFoo, Context<Foo>(), 'foo')
 library foo;
@@ -72,7 +76,9 @@ import 'package:mustachio/annotations.dart';
     await testMustachioBuilder(
       writer,
       '''
-class Foo<T> {}
+class Foo<T> {
+  String s1 = 'hello';
+}
 ''',
       libraryFrontMatter: '''
 @Renderer(#renderFoo, Context<Foo>(), 'foo')
@@ -81,7 +87,7 @@ import 'package:mustachio/annotations.dart';
 ''',
       additionalAssets: {
         'foo|lib/templates/html/foo.html': '{{ >foo_header }}',
-        'foo|lib/templates/html/_foo_header.html': 'EMPTY',
+        'foo|lib/templates/html/_foo_header.html': 's1 is {{ s1 }}',
       },
     );
     var rendererAsset = AssetId('foo', 'lib/foo.aot_renderers_for_html.dart');
@@ -94,7 +100,9 @@ import 'package:mustachio/annotations.dart';
 
   test('builds a renderer for a generic, bounded type', () async {
     await testMustachioBuilder(writer, '''
-class Foo<T extends num> {}
+class Foo<T extends num> {
+  String s1 = 'hello';
+}
 class Bar {}
 class Baz {}
 ''');

--- a/test/mustachio/builder_test_base.dart
+++ b/test/mustachio/builder_test_base.dart
@@ -67,8 +67,8 @@ $sourceLibraryContent
     {
       ...annotationsAsset,
       'foo|lib/foo.dart': sourceLibraryContent,
-      'foo|lib/templates/html/foo.html': 'EMPTY',
-      'foo|lib/templates/md/foo.md': 'EMPTY',
+      'foo|lib/templates/html/foo.html': 's1 is {{ s1 }}',
+      'foo|lib/templates/md/foo.md': 's1 is {{ s1 }}',
       'foo|lib/templates/html/bar.html': 'EMPTY',
       'foo|lib/templates/md/bar.md': 'EMPTY',
       'foo|lib/templates/html/baz.html': 'EMPTY',

--- a/test/mustachio/foo.aot_renderers_for_html.dart
+++ b/test/mustachio/foo.aot_renderers_for_html.dart
@@ -75,13 +75,13 @@ String _renderFoo_partial_foo_header_0(_i1.Foo context0) {
   return buffer.toString();
 }
 
-String renderBar(_i1.Bar context0) {
+String renderBar() {
   final buffer = StringBuffer();
 
   return buffer.toString();
 }
 
-String renderBaz(_i1.Baz context0) {
+String renderBaz() {
   final buffer = StringBuffer();
 
   return buffer.toString();

--- a/test/mustachio/foo.aot_renderers_for_md.dart
+++ b/test/mustachio/foo.aot_renderers_for_md.dart
@@ -66,13 +66,13 @@ String _renderFoo_partial_foo_header_0(_i1.Foo context0) {
   return buffer.toString();
 }
 
-String renderBar(_i1.Bar context0) {
+String renderBar() {
   final buffer = StringBuffer();
 
   return buffer.toString();
 }
 
-String renderBaz(_i1.Baz context0) {
+String renderBaz() {
   final buffer = StringBuffer();
 
   return buffer.toString();

--- a/test/mustachio/runtime_renderer_builder_test.dart
+++ b/test/mustachio/runtime_renderer_builder_test.dart
@@ -161,7 +161,9 @@ class Baz {}
 
   test('builds renderers from multiple annotations', () async {
     await testMustachioBuilder(writer, '''
-class Foo {}
+class Foo {
+  String s1 = 'hello';
+}
 class Bar {}
 class Baz {}
 ''', libraryFrontMatter: '''
@@ -187,7 +189,9 @@ import 'package:mustachio/annotations.dart';
       writer = InMemoryAssetWriter();
       await testMustachioBuilder(writer, '''
 class FooBase<T> {}
-class Foo<T> extends FooBase<T> {}
+class Foo<T> extends FooBase<T> {
+  String s1 = 'hello';
+}
 class BarBase<T> {}
 class Bar<T> extends BarBase<int> {}
 class Baz {}
@@ -235,7 +239,9 @@ import 'package:mustachio/annotations.dart';
 
   test('builds a renderer for a generic, bounded type', () async {
     await testMustachioBuilder(writer, '''
-class Foo<T extends num> {}
+class Foo<T extends num> {
+  String s1 = 'hello';
+}
 class Bar {}
 class Baz {}
 ''');
@@ -263,6 +269,7 @@ abstract class Foo<T> {
   Private get _private1 => Bar();
   void set setter1(Setter s);
   Method method1(Method m);
+  String s1 = 'hello';
 }
 class Bar {}
 class Baz {}

--- a/tool/mustachio/codegen_aot_compiler.dart
+++ b/tool/mustachio/codegen_aot_compiler.dart
@@ -41,7 +41,6 @@ Future<String> compileTemplatesToRenderers(
       buildData,
     );
     rendererFunctions.addAll(await compiler._compileToRenderer());
-    //rendererFunctions.addAll(compiler._compiledPartials);
   }
   var library = Library((b) {
     b.body.addAll(rendererFunctions);
@@ -324,8 +323,6 @@ class _BlockCompiler {
       _templateCompiler._partialCounter++;
       _templateCompiler._compiledPartials
           .addAll(await partialRenderer._compileToRenderer());
-      //_templateCompiler._compiledPartials
-      //    .addAll(partialRenderer._compiledPartials);
     }
     // Call the partial's renderer function here; the definition of the renderer
     // function is written later.


### PR DESCRIPTION
Mustache's resolution is incredibly liberal: if the current context is a ClassTemplateData, and we walk into a partial, and then into the Class, and then into a Method, and then into another partial, and then into each of the Method's Parameters, and then into another partial, and we encounter a variable, `{{ foo }}`, we first look on the Parameter, then the Method, and on and on, until we find a field named `foo`.

In practice, it is exceedingly rare to access the objects at the bottom of the stack. Very rarely do we ever need access to more than the top two objects in any given partial.

Tidying up the context variables passed down probably has a negligible performance benefit, but will allow us next to deduplicate the partials.

Some tests need to access a field so that at least one context variable is given in the renderer.