### PR TITLE
Tidy many things seen in a profiling flame graph

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -6833,6 +6833,29 @@ class _Renderer_Inheritable extends RendererBase<Inheritable> {
                         parent: r);
                   },
                 ),
+                'canonicalModelElement': Property(
+                  getValue: (CT_ c) => c.canonicalModelElement,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_ModelElement.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as ModelElement,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.canonicalModelElement == null,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_ModelElement(
+                        c.canonicalModelElement!, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
                 'features': Property(
                   getValue: (CT_ c) => c.features,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -16560,6 +16583,7 @@ const _invisibleGetters = {
   'HashMap': {'hashCode', 'runtimeType'},
   'Inheritable': {
     'canonicalLibrary',
+    'canonicalModelElement',
     'features',
     'inheritance',
     'isCovariant',

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -257,34 +257,32 @@ abstract class Container extends ModelElement
   /// parameter-global.
   Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren => [];
 
-  Map<String, CommentReferable>? _referenceChildren;
   @override
   @mustCallSuper
-  Map<String, CommentReferable> get referenceChildren {
-    if (_referenceChildren == null) {
-      _referenceChildren = {};
-      _referenceChildren!.addEntries(allModelElements!
+  late final Map<String, CommentReferable> referenceChildren = () {
+    var referenceChildren = <String, CommentReferable>{
+      for (var element in allModelElements!
           .whereNotType<Accessor>()
-          .whereNotType<Constructor>()
-          .generateEntries());
+          .whereNotType<Constructor>())
+        element.referenceName: element,
+    };
 
-      _referenceChildren!.addEntriesIfAbsent(extraReferenceChildren);
-      // Process unscoped parameters last to make sure they don't override
-      // other options.
-      for (var modelElement in allModelElements!) {
-        // Don't complain about references to parameter names, but prefer
-        // referring to anything else.
-        // TODO(jcollins-g): Figure out something good to do in the ecosystem
-        // here to wean people off the habit of unscoped parameter references.
-        if (modelElement.hasParameters) {
-          _referenceChildren!
-              .addEntriesIfAbsent(modelElement.parameters.generateEntries());
-        }
+    referenceChildren.addEntriesIfAbsent(extraReferenceChildren);
+    // Process unscoped parameters last to make sure they don't override
+    // other options.
+    for (var modelElement in allModelElements!) {
+      // Don't complain about references to parameter names, but prefer
+      // referring to anything else.
+      // TODO(jcollins-g): Figure out something good to do in the ecosystem
+      // here to wean people off the habit of unscoped parameter references.
+      if (modelElement.hasParameters) {
+        referenceChildren
+            .addEntriesIfAbsent(modelElement.parameters.generateEntries());
       }
-      _referenceChildren!['this'] = this;
     }
-    return _referenceChildren!;
-  }
+    referenceChildren['this'] = this;
+    return referenceChildren;
+  }();
 
   @override
   Iterable<CommentReferable> get referenceParents => [definingLibrary, library];

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -42,21 +42,19 @@ mixin Inheritable on ContainerMember {
       canonicalEnclosingContainer?.canonicalLibrary;
 
   @override
-  ModelElement? buildCanonicalModelElement() {
+  late final ModelElement? canonicalModelElement = () {
+    final canonicalEnclosingContainer = this.canonicalEnclosingContainer;
+    if (canonicalEnclosingContainer == null) {
+      return null;
+    }
     // TODO(jcollins-g): factor out extension logic into [Extendable]
     if (canonicalEnclosingContainer is Extension) {
       return this;
     }
-    if (canonicalEnclosingContainer is Container) {
-      return canonicalEnclosingContainer!.allCanonicalModelElements
-          .firstWhereOrNull((m) =>
-              m.name == name && m.isPropertyAccessor == isPropertyAccessor);
-    }
-    if (canonicalEnclosingContainer != null) {
-      throw UnimplementedError('$canonicalEnclosingContainer: unknown type');
-    }
-    return null;
-  }
+    return canonicalEnclosingContainer.allCanonicalModelElements
+        .firstWhereOrNull((m) =>
+            m.name == name && m.isPropertyAccessor == isPropertyAccessor);
+  }();
 
   @override
   Container? computeCanonicalEnclosingContainer() {

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -494,18 +494,16 @@ abstract class ModelElement extends Canonicalization
       (element is TypeAliasElement &&
           (element as TypeAliasElement).aliasedElement is FunctionTypedElement);
 
-  ModelElement? buildCanonicalModelElement() {
+  // The canonical ModelElement for this ModelElement,
+  // or null if there isn't one.
+  late final ModelElement? canonicalModelElement = () {
     Container? preferredClass;
     if (enclosingElement is Class || enclosingElement is Extension) {
       preferredClass = enclosingElement as Container?;
     }
     return packageGraph.findCanonicalModelElementFor(element,
         preferredClass: preferredClass);
-  }
-
-  // The canonical ModelElement for this ModelElement,
-  // or null if there isn't one.
-  late final ModelElement? canonicalModelElement = buildCanonicalModelElement();
+  }();
 
   bool get hasSourceHref => sourceHref.isNotEmpty;
 
@@ -635,11 +633,11 @@ abstract class ModelElement extends Canonicalization
     if (library != canonicalLibrary) return false;
     // If there's no inheritance to deal with, we're done.
     if (this is! Inheritable) return true;
-    var i = this as Inheritable;
+    final self = this as Inheritable;
     // If we're the defining element, or if the defining element is not in the
     // set of libraries being documented, then this element should be treated as
-    // canonical (given library == canonicalLibrary).
-    return i.enclosingElement == i.canonicalEnclosingContainer;
+    // canonical (given `library == canonicalLibrary`).
+    return self.enclosingElement == self.canonicalEnclosingContainer;
   }
 
   /// Returns the docs, stripped of their leading comments syntax.


### PR DESCRIPTION
* Container.referenceChildren, documentationFromHtml, elementDocumentation, hasNodoc, GetterSetterCombo.hasPublicGetter, GetterSetterCombo.hasPublicSetter, _getterSetterDocumentationComment can all be `late final`
* Simplify casting in documentationFrom.
* Changed two buildCanonicalModelElement methods into late final fields.
* Improve many doc comments and comments.
* Change some variables to be longer names.