### PR TITLE
Tidying in CommentReferable and related code

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2955,11 +2955,11 @@ class _Renderer_Container extends RendererBase<Container> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
                           c, remainingNames, 'Iterable<ModelElement>'),
-                  isNullValue: (CT_ c) => c.allModelElements == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.allModelElements, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Iterable']!);
+                    return c.allModelElements.map((e) => _render_ModelElement(
+                        e, ast, r.template, sink,
+                        parent: r));
                   },
                 ),
                 'constantFields': Property(
@@ -12398,7 +12398,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -12614,7 +12614,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -16725,7 +16725,6 @@ const _invisibleGetters = {
     'allLibraries',
     'allLibrariesAdded',
     'allLocalModelElements',
-    'allModelElements',
     'config',
     'dartCoreObject',
     'defaultPackage',

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -157,9 +157,8 @@ class _IterableBlockParser extends md.BlockParser {
   }
 }
 
-/// Return false if the passed [referable] is an unnamed [Constructor],
-/// or if it is shadowing another type of element, or is a parameter of
-/// one of the above.
+/// Returns false if [referable] is an unnamed [Constructor], or if it is
+/// shadowing another type of element, or is a parameter of one of the above.
 bool _rejectUnnamedAndShadowingConstructors(CommentReferable? referable) {
   if (referable is Constructor) {
     if (referable.isUnnamedConstructor) return false;
@@ -186,8 +185,8 @@ MatchingLinkResult _getMatchingLinkElementCommentReferable(
   var commentReference =
       warnable.commentRefs[codeRef] ?? ModelCommentReference.synthetic(codeRef);
 
-  late final bool Function(CommentReferable?) filter;
-  late final bool Function(CommentReferable?) allowTree;
+  bool Function(CommentReferable?) filter;
+  bool Function(CommentReferable?) allowTree;
 
   // Constructor references are pretty ambiguous by nature since they can be
   // declared with the same name as the class they are constructing, and even

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -90,13 +90,13 @@ class Accessor extends ModelElement implements EnclosedElement {
   /// for a synthetic accessor just in case it is inherited somewhere
   /// down the line due to split inheritance.
   bool get _hasSyntheticDocumentationComment =>
-      (isGetter || definingCombo.hasNodoc || _comboDocsAreIndependent()) &&
+      (isGetter || definingCombo.hasNodoc || _comboDocsAreIndependent) &&
       definingCombo.hasDocumentationComment;
 
   // If we're a setter, and a getter exists, do not add synthetic
   // documentation if the combo's documentation is actually derived
   // from that getter.
-  bool _comboDocsAreIndependent() {
+  bool get _comboDocsAreIndependent {
     if (isSetter && definingCombo.hasGetter) {
       if (definingCombo.getter!.isSynthetic ||
           !definingCombo.documentationFrom.contains(this)) {

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -7,7 +7,6 @@ import 'package:analyzer/dart/element/scope.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:meta/meta.dart';
 
 /// A [Container] represents a Dart construct that can contain methods,
@@ -63,22 +62,21 @@ abstract class Container extends ModelElement
   bool get isMixin =>
       element is ClassElement && (element as ClassElement).isMixin;
 
-  @mustCallSuper
-  Iterable<ModelElement>? get allModelElements => quiver.concat([
-        instanceMethods,
-        instanceFields,
-        instanceOperators,
-        instanceAccessors,
-        staticFields,
-        staticAccessors,
-        staticMethods,
-      ]);
+  Iterable<ModelElement> get allModelElements => [
+        ...instanceMethods,
+        ...instanceFields,
+        ...instanceOperators,
+        ...instanceAccessors,
+        ...staticFields,
+        ...staticAccessors,
+        ...staticMethods,
+      ];
 
   List<ModelElement>? _allCanonicalModelElements;
 
   List<ModelElement> get allCanonicalModelElements {
     return (_allCanonicalModelElements ??=
-        allModelElements!.where((e) => e.isCanonical).toList());
+        allModelElements.where((e) => e.isCanonical).toList());
   }
 
   /// All methods, including operators and statics, declared as part of this
@@ -181,7 +179,7 @@ abstract class Container extends ModelElement
 
   Set<Element?>? _allElements;
   Set<Element?> get allElements =>
-      _allElements ??= allModelElements!.map((e) => e.element).toSet();
+      _allElements ??= allModelElements.map((e) => e.element).toSet();
 
   Map<String?, List<ModelElement>>? _membersByName;
 
@@ -193,11 +191,11 @@ abstract class Container extends ModelElement
   T memberByExample<T extends ModelElement>(T example) {
     if (_membersByName == null) {
       _membersByName = {};
-      for (var me in allModelElements!) {
-        if (!_membersByName!.containsKey(me.name)) {
-          _membersByName![me.name] = [];
+      for (var element in allModelElements) {
+        if (!_membersByName!.containsKey(element.name)) {
+          _membersByName![element.name] = [];
         }
-        _membersByName![me.name]!.add(me);
+        _membersByName![element.name]!.add(element);
       }
     }
     ModelElement member;
@@ -261,7 +259,7 @@ abstract class Container extends ModelElement
   @mustCallSuper
   late final Map<String, CommentReferable> referenceChildren = () {
     var referenceChildren = <String, CommentReferable>{
-      for (var element in allModelElements!
+      for (var element in allModelElements
           .whereNotType<Accessor>()
           .whereNotType<Constructor>())
         element.referenceName: element,
@@ -270,7 +268,7 @@ abstract class Container extends ModelElement
     referenceChildren.addEntriesIfAbsent(extraReferenceChildren);
     // Process unscoped parameters last to make sure they don't override
     // other options.
-    for (var modelElement in allModelElements!) {
+    for (var modelElement in allModelElements) {
       // Don't complain about references to parameter names, but prefer
       // referring to anything else.
       // TODO(jcollins-g): Figure out something good to do in the ecosystem

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -7,7 +7,6 @@ import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:dartdoc/src/quiver.dart' as quiver;
 
 /// Extension methods
 class Extension extends Container implements EnclosedElement {
@@ -93,12 +92,10 @@ class Extension extends Container implements EnclosedElement {
   }
 
   @override
-  late final List<ModelElement> allModelElements = List.of(
-      quiver.concat<ModelElement>([
-        super.allModelElements!,
-        typeParameters,
-      ]),
-      growable: false);
+  late final List<ModelElement> allModelElements = [
+    ...super.allModelElements,
+    ...typeParameters,
+  ];
 
   @override
   String get filePath => '${library.dirName}/$fileName';

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -10,7 +10,6 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:meta/meta.dart';
 
 /// A mixin to build an [InheritingContainer] capable of being constructed
@@ -235,7 +234,7 @@ abstract class InheritingContainer extends Container
 
   @override
   Iterable<Method> get instanceMethods =>
-      quiver.concat([super.instanceMethods, inheritedMethods]);
+      [...super.instanceMethods, ...inheritedMethods];
 
   @override
   bool get publicInheritedInstanceMethods =>
@@ -243,19 +242,17 @@ abstract class InheritingContainer extends Container
 
   @override
   Iterable<Operator> get instanceOperators =>
-      quiver.concat([super.instanceOperators, inheritedOperators]);
+      [...super.instanceOperators, ...inheritedOperators];
 
   @override
   bool get publicInheritedInstanceOperators =>
       publicInstanceOperators.every((f) => f.isInherited);
 
   @override
-  late final List<ModelElement> allModelElements = List.of(
-      quiver.concat<ModelElement>([
-        super.allModelElements!,
-        typeParameters,
-      ]),
-      growable: false);
+  late final List<ModelElement> allModelElements = [
+    ...super.allModelElements,
+    ...typeParameters,
+  ];
 
   /// Returns the [InheritingContainer] with the library in which [element] is defined.
   InheritingContainer get definingContainer =>

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -18,7 +18,6 @@ import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart' show PackageMeta;
-import 'package:dartdoc/src/quiver.dart' as quiver;
 import 'package:dartdoc/src/warnings.dart';
 
 /// Find all hashable children of a given element that are defined in the
@@ -91,18 +90,17 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   }
 
   static Iterable<Element> _getDefinedElements(
-      CompilationUnitElement compilationUnit) {
-    return quiver.concat([
-      compilationUnit.accessors,
-      compilationUnit.classes,
-      compilationUnit.enums,
-      compilationUnit.extensions,
-      compilationUnit.functions,
-      compilationUnit.mixins,
-      compilationUnit.topLevelVariables,
-      compilationUnit.typeAliases,
-    ]);
-  }
+          CompilationUnitElement compilationUnit) =>
+      [
+        ...compilationUnit.accessors,
+        ...compilationUnit.classes,
+        ...compilationUnit.enums,
+        ...compilationUnit.extensions,
+        ...compilationUnit.functions,
+        ...compilationUnit.mixins,
+        ...compilationUnit.topLevelVariables,
+        ...compilationUnit.typeAliases,
+      ];
 
   /// Allow scope for Libraries.
   @override
@@ -196,8 +194,8 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   }
 
   @override
-  late final Iterable<TopLevelVariable> constants =
-      _variables.where((v) => v.isConst).toList(growable: false);
+  Iterable<TopLevelVariable> get constants =>
+      _variables.where((v) => v.isConst);
 
   /// Map of import prefixes ('import "foo" as prefix;') to [Library].
   late final Map<String, Set<Library>> prefixToLibrary = () {
@@ -455,9 +453,9 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     return modelElements;
   }();
 
-  late final Iterable<ModelElement> allModelElements = [
-    for (var modelElements in modelElementsMap.values) ...modelElements,
-  ];
+  Iterable<ModelElement> get allModelElements => [
+        for (var modelElements in modelElementsMap.values) ...modelElements,
+      ];
 
   late final Iterable<ModelElement> allCanonicalModelElements =
       allModelElements.where((e) => e.isCanonical).toList(growable: false);


### PR DESCRIPTION
Simple things:

* sort named parameters alike.
* privatize private APIs.
* remove some use of quiver.
* make late fields actually getters, particularly when they just filter another late field.