### PR TITLE
Switch integration tests to use test_process.

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -14,7 +14,8 @@ import 'package:dartdoc/options.dart';
 Future<void> main(List<String> arguments) async {
   var config = parseOptions(pubPackageMetaProvider, arguments);
   if (config == null) {
-    // There was an error while parsing options.
+    // Do not run dartdoc as there was either a fatal error parsing options, or
+    // `--help` was passed, or `--version` was passed.
     return;
   }
   final packageConfigProvider = PhysicalPackageConfigProvider();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
   lints: ^1.0.1
   test: ^1.19.0
   test_descriptor: ^2.0.0
+  test_process: ^2.0.2
 
 executables:
   dartdoc: null

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -103,11 +103,13 @@ void main() {
         ['--input', 'non-existant'],
         workingDirectory: packageDir.io.path,
       );
+      var fullPath =
+          path.canonicalize(path.join(packageDir.io.path, 'non-existant'));
       await expectLater(
         process.stderr,
         emitsThrough(
             ' fatal error: Argument --input, set to non-existant, resolves to '
-            'missing path: "${path.join(packageDir.io.path, 'non-existant')}"'),
+            'missing path: "$fullPath"'),
       );
       await process.shouldExit(64);
     });


### PR DESCRIPTION
This decouples the integration tests from SubprocessLauncher which is used by `--tool`.

test_process provides a nice stream-based API for validating stdout and stderr.

This PR also moves a lot of test cases from using the existing testing/ packages to packages generated on-the-fly with test_descriptor.