### PR TITLE
Fix categoryOrder option

### DIFF
--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -95,18 +95,9 @@ abstract class Categorization implements ModelElement {
     return _samples;
   }
 
-  late final Iterable<Category> categories = () {
-    var categoryNames = this.categoryNames;
-    if (categoryNames == null) {
-      return <Category>[];
-    }
-
-    return categoryNames
-        .map((n) => package?.nameToCategory[n])
-        .whereNotNull()
-        .toList()
-      ..sort();
-  }();
+  late final Iterable<Category> categories = [
+    ...?categoryNames?.map((n) => package?.nameToCategory[n]).whereNotNull()
+  ]..sort();
 
   @override
   Iterable<Category> get displayedCategories {

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -83,8 +83,9 @@ void main() {
 
     Future<Dartdoc> buildDartdoc(
         List<String> argv, Folder packageRoot, Folder tempDir) async {
-      var context = await generatorContextFromArgv(argv
-        ..addAll(['--input', packageRoot.path, '--output', tempDir.path]));
+      var context = await generatorContextFromArgv(
+          [...argv, '--input', packageRoot.path, '--output', tempDir.path],
+          pubPackageMetaProvider);
 
       return await Dartdoc.fromContext(
         context,

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -12,7 +12,6 @@ import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/generator/generator_frontend.dart';
 import 'package:dartdoc/src/generator/html_generator.dart';
 import 'package:dartdoc/src/generator/html_resources.g.dart';
-import 'package:dartdoc/src/generator/resource_loader.dart';
 import 'package:dartdoc/src/generator/templates.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -44,67 +43,7 @@ void main() {
       pathContext = resourceProvider.pathContext;
       packageConfigProvider = utils
           .getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
-      for (var template in [
-        '_accessor_getter',
-        '_accessor_setter',
-        '_callable',
-        '_callable_multiline',
-        '_categorization',
-        '_class',
-        '_constant',
-        '_documentation',
-        '_extension',
-        '_features',
-        '_feature_set',
-        '_footer',
-        '_head',
-        '_library',
-        '_mixin',
-        '_name_summary',
-        '_packages',
-        '_property',
-        '_search_sidebar',
-        '_sidebar_for_category',
-        '_sidebar_for_container',
-        '_sidebar_for_library',
-        '_source_code',
-        '_source_link',
-        '_super_chain',
-        '_type',
-        '_typedef',
-        '_type_multiline',
-        '_typedef_multiline',
-        '404error',
-        'category',
-        'class',
-        'constructor',
-        'enum',
-        'extension',
-        'function',
-        'index',
-        'library',
-        'method',
-        'mixin',
-        'property',
-        'top_level_property',
-        'typedef',
-      ]) {
-        await resourceProvider.writeDartdocResource(
-            'templates/html/$template.html', 'CONTENT');
-      }
-
-      for (var resource in [
-        'favicon.png',
-        'github.css',
-        'highlight.pack.js',
-        'play_button.svg',
-        'readme.md',
-        'script.js',
-        'styles.css',
-      ]) {
-        await resourceProvider.writeDartdocResource(
-            'resources/$resource', 'CONTENT');
-      }
+      await utils.writeDartdocResources(resourceProvider);
 
       var optionRoot = DartdocOptionRoot.fromOptionGenerators(
           'dartdoc',
@@ -202,13 +141,5 @@ class _DoesExist extends Matcher {
     } else {
       return mismatchDescription.add(' does not exist');
     }
-  }
-}
-
-/// Extension methods just for tests.
-extension on ResourceProvider {
-  Future<void> writeDartdocResource(String path, String content) async {
-    var fileUri = await resolveResourceUri(Uri.parse('package:dartdoc/$path'));
-    getFile(fileUri.toFilePath()).writeAsStringSync(content);
   }
 }

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -276,9 +276,9 @@ class C3
 '''),
       ],
       files: [
-        d.file('One.md', ''),
-        d.file('Two.md', ''),
-        d.file('Three.md', ''),
+        d.file('one.md', ''),
+        d.file('two.md', ''),
+        d.file('three.md', ''),
       ],
       resourceProvider: resourceProvider,
     );
@@ -325,10 +325,10 @@ class C4
 '''),
       ],
       files: [
-        d.file('One.md', ''),
-        d.file('Two.md', ''),
-        d.file('Three.md', ''),
-        d.file('Four.md', ''),
+        d.file('one.md', ''),
+        d.file('two.md', ''),
+        d.file('three.md', ''),
+        d.file('four.md', ''),
       ],
       resourceProvider: resourceProvider,
     );
@@ -360,8 +360,8 @@ class C1
 '''),
       ],
       files: [
-        d.file('One.md', ''),
-        d.file('Two.md', ''),
+        d.file('one.md', ''),
+        d.file('two.md', ''),
       ],
       resourceProvider: resourceProvider,
     );

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -254,11 +254,11 @@ class Foo {}
 dartdoc:
   categories:
     One:
-      markdown: One.md
+      markdown: one.md
     Two:
-      markdown: Two.md
+      markdown: two.md
     Three:
-      markdown: Three.md
+      markdown: three.md
   categoryOrder: ["Three", "One", "Two"]
 ''',
       libFiles: [
@@ -298,13 +298,13 @@ class C3
 dartdoc:
   categories:
     Three:
-      markdown: Three.md
+      markdown: three.md
     One:
-      markdown: One.md
+      markdown: one.md
     Two:
-      markdown: Two.md
+      markdown: two.md
     Four:
-      markdown: Four.md
+      markdown: four.md
   categoryOrder: ["Two", "One"]
 ''',
       libFiles: [
@@ -347,9 +347,9 @@ class C4
 dartdoc:
   categories:
     One:
-      markdown: One.md
+      markdown: one.md
     Two:
-      markdown: Two.md
+      markdown: two.md
 ''',
       libFiles: [
         d.file('lib.dart', '''


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/2958

* Add tests for categoryOrder
* Convert options_test.dart to use MemoryResourceProvider
* Move utils for copying package:dartdoc resources to a MemoryResourceProvider
* Properly memoize Package.nameToCategory
* Simplify logic in two `categories` fields.