### PR TITLE
Check nodoc and needsPrecache in one pass

### DIFF
--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -12,8 +12,8 @@ final RegExp _categoryRegExp = RegExp(
 /// Mixin implementing dartdoc categorization for ModelElements.
 abstract class Categorization implements ModelElement {
   @override
-  String buildDocumentationAddition(String? rawDocs) =>
-      _stripAndSetDartdocCategories(rawDocs ??= '');
+  String buildDocumentationAddition(String rawDocs) =>
+      _stripAndSetDartdocCategories(rawDocs);
 
   /// Parse `{@category ...}` and related information in API comments, stripping
   /// out that information from the given comments and returning the stripped

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -231,24 +231,25 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
 
   static final _canonicalRegExp = RegExp(r'{@canonicalFor\s([^}]+)}');
 
-  /// Hide canonicalFor from doc while leaving a note to ourselves to
+  /// Hides [canonicalFor] from doc while leaving a note to ourselves to
   /// help with ambiguous canonicalization determination.
   ///
   /// Example:
-  ///   {@canonicalFor libname.ClassName}
+  ///
+  ///     {@canonicalFor libname.ClassName}
   @override
-  String buildDocumentationAddition(String? rawDocs) {
+  String buildDocumentationAddition(String rawDocs) {
     rawDocs = super.buildDocumentationAddition(rawDocs);
-    var newCanonicalFor = <String?>{};
-    var notFoundInAllModelElements = <String?>{};
+    var newCanonicalFor = <String>{};
+    var notFoundInAllModelElements = <String>{};
     rawDocs = rawDocs.replaceAllMapped(_canonicalRegExp, (Match match) {
-      newCanonicalFor.add(match.group(1));
-      notFoundInAllModelElements.add(match.group(1));
+      var elementName = match.group(1)!;
+      newCanonicalFor.add(elementName);
+      if (!_allOriginalModelElementNames.contains(elementName)) {
+        notFoundInAllModelElements.add(elementName);
+      }
       return '';
     });
-    if (notFoundInAllModelElements.isNotEmpty) {
-      notFoundInAllModelElements.removeAll(_allOriginalModelElementNames);
-    }
     for (var notFound in notFoundInAllModelElements) {
       warn(PackageWarning.ignoredCanonicalFor, message: notFound);
     }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -932,19 +932,16 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
   /// Given an element's location, look up the nodoc configuration data and
   /// determine whether to unconditionally treat the element as "nodoc".
   bool configSetsNodocFor(String fullName) {
-    var noDocForName = _configSetsNodocFor[fullName];
-    if (noDocForName == null) {
+    return _configSetsNodocFor.putIfAbsent(fullName, () {
       var file = resourceProvider.getFile(fullName);
       // Direct lookup instead of generating a custom context will save some
       // cycles.  We can't use the element's [DartdocOptionContext] because that
       // might not be where the element was defined, which is what's important
       // for nodoc's semantics.  Looking up the defining element just to pull
       // a context is again, slow.
-      List<String> globs = config.optionSet['nodoc'].valueAt(file.parent2);
-      noDocForName = utils.matchGlobs(globs, fullName);
-      _configSetsNodocFor[fullName] = noDocForName;
-    }
-    return noDocForName;
+      var globs = config.optionSet['nodoc'].valueAt(file.parent2);
+      return utils.matchGlobs(globs, fullName);
+    });
   }
 
   String? getMacro(String? name) {

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -48,7 +48,7 @@ void main() {
           contains('package:test_package has no documentable libraries')),
     );
     await process.shouldExit(0);
-  });
+  }, timeout: Timeout.factor(2));
 
   group('invoking dartdoc on a basic package', () {
     late String packagePath;


### PR DESCRIPTION
Introduce a new DocumentationComment method, `_scanForDirectives`, which determines whether a comment has `@nodoc`, `{@inject-html`, `{@template`, and `{@tool`, all in one scan.

* Add dartdoc here and there.
* Simplify code here and there.
* Make the parameter to buildDocumentationComment non-nullable.