### PR TITLE
Move format tests; move parameter_test to Memory

### DIFF
--- a/test/constant_values_test.dart
+++ b/test/constant_values_test.dart
@@ -2,44 +2,66 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:async/async.dart';
+import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'src/test_descriptor_utils.dart' as d;
-import 'src/utils.dart' as utils;
+import 'src/utils.dart';
 
 void main() {
-  // We can not use ExperimentalFeature.releaseVersion or even
-  // ExperimentalFeature.experimentalReleaseVersion as these are set to null
-  // even when partial analyzer implementations are available, and are often
-  // set too high after release.
-  final constructorTearoffsAllowed =
-      VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
+  const libraryName = 'constant_values';
 
-  // We can not use ExperimentalFeature.releaseVersion or even
-  // ExperimentalFeature.experimentalReleaseVersion as these are set to null
-  // even when partial analyzer implementations are available.
-  final namedArgumentsAnywhereAllowed =
-      VersionRange(min: Version.parse('2.17.0-0'), includeMin: true);
+  late PackageMetaProvider packageMetaProvider;
+  late MemoryResourceProvider resourceProvider;
+  late FakePackageConfigProvider packageConfigProvider;
+  late String packagePath;
+
+  Future<void> setUpPackage(
+    String name, {
+    String? pubspec,
+    String? analysisOptions,
+  }) async {
+    packagePath = await d.createPackage(
+      name,
+      pubspec: pubspec,
+      analysisOptions: analysisOptions,
+      resourceProvider: resourceProvider,
+    );
+
+    packageConfigProvider =
+        getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
+    packageConfigProvider.addPackageToConfigFor(
+        packagePath, name, Uri.file('$packagePath/'));
+  }
+
+  Future<Library> bootPackageWithLibrary(String libraryContent) async {
+    await d.dir('lib', [
+      d.file('lib.dart', '''
+library $libraryName;
+
+$libraryContent
+'''),
+    ]).createInMemory(resourceProvider, packagePath);
+
+    var packageGraph = await bootBasicPackage(
+      packagePath,
+      packageMetaProvider,
+      packageConfigProvider,
+    );
+    return packageGraph.libraries.named(libraryName);
+  }
 
   group('constructor-tearoffs', () {
-    late Library library;
     const libraryName = 'constructor_tearoffs';
 
-    final packageGraphMemo = AsyncMemoizer<PackageGraph>();
-    Future<PackageGraph> bootstrapPackageGraph() =>
-        packageGraphMemo.runOnce(() => utils.bootBasicPackage(
-            d.dir(libraryName).io.path,
-            pubPackageMetaProvider,
-            PhysicalPackageConfigProvider(),
-            additionalArguments: ['--no-link-to-remote']));
-
     setUp(() async {
-      await d.createPackage(
+      packageMetaProvider = testPackageMetaProvider;
+      resourceProvider =
+          packageMetaProvider.resourceProvider as MemoryResourceProvider;
+      await setUpPackage(
         libraryName,
         pubspec: '''
 name: constructor_tearoffs
@@ -52,111 +74,126 @@ analyzer:
   enable-experiment:
     - constructor-tearoffs
 ''',
-        libFiles: [
-          d.file('lib.dart', '''
-library $libraryName;
-
-class F<T> {
-  F();
-
-  F.alternative();
-}
-
-typedef Ft<T> = F<T>;
-
-void func() {}
-void funcTypeParams<T extends String, U extends num>(
-    T something, U different) {}
-
-const aFunc = func;
-const aFuncParams = funcTypeParams;
-const aFuncWithArgs = funcTypeParams<String, int>;
-const aTearOffUnnamedConstructor = F.new;
-const aTearOffUnnamedConstructorArgs = F<String>.new;
-const aTearOffUnnamedConstructorTypedef = Fstring.new;
-const aTearOffUnnamedConstructorArgsTypedef = Ft<String>.new;
-const aTearOffNamedConstructor = F.alternative;
-const aTearOffNamedConstructorArgs = F<int>.alternative;
-'''),
-        ],
       );
-
-      library = (await bootstrapPackageGraph()).libraries.named(libraryName);
     });
 
-    test('non-generic function reference', () {
+    test('non-generic function reference', () async {
+      var library = await bootPackageWithLibrary('''
+void func() {}
+const aFunc = func;
+''');
       var aFuncConstant = library.constants.named('aFunc');
       expect(aFuncConstant.constantValue, equals('func'));
     });
 
-    test('generic function reference', () {
+    test('generic function reference', () async {
+      var library = await bootPackageWithLibrary('''
+void funcTypeParams<T extends String, U extends num>(
+    T something, U different) {}
+const aFuncParams = funcTypeParams;
+''');
       var aFuncParamsConstant = library.constants.named('aFuncParams');
       expect(aFuncParamsConstant.constantValue, equals('funcTypeParams'));
     });
 
-    test('generic function reference w/ type args', () {
+    test('generic function reference w/ type args', () async {
+      var library = await bootPackageWithLibrary('''
+void funcTypeParams<T extends String, U extends num>(
+    T something, U different) {}
+const aFuncWithArgs = funcTypeParams<String, int>;
+''');
       var aFuncWithArgs = library.constants.named('aFuncWithArgs');
       expect(aFuncWithArgs.constantValue,
           equals('funcTypeParams&lt;String, int&gt;'));
     });
 
-    test('named constructor reference', () {
+    test('named constructor reference', () async {
+      var library = await bootPackageWithLibrary('''
+class F<T> {
+  F.alternative();
+}
+const aTearOffNamedConstructor = F.alternative;
+''');
       var aTearOffNamedConstructor =
           library.constants.named('aTearOffNamedConstructor');
       expect(aTearOffNamedConstructor.constantValue, equals('F.alternative'));
     });
 
-    test('named constructor reference w/ type args', () {
+    test('named constructor reference w/ type args', () async {
+      var library = await bootPackageWithLibrary('''
+class F<T> {
+  F.alternative();
+}
+const aTearOffNamedConstructorArgs = F<int>.alternative;
+''');
       var aTearOffNamedConstructorArgs =
           library.constants.named('aTearOffNamedConstructorArgs');
       expect(aTearOffNamedConstructorArgs.constantValue,
           equals('F&lt;int&gt;.alternative'));
     });
 
-    test('unnamed constructor reference', () {
+    test('unnamed constructor reference', () async {
+      var library = await bootPackageWithLibrary('''
+class F<T> {
+  F();
+}
+const aTearOffUnnamedConstructor = F.new;
+''');
       var aTearOffUnnamedConstructor =
           library.constants.named('aTearOffUnnamedConstructor');
       expect(aTearOffUnnamedConstructor.constantValue, equals('F.new'));
     });
 
-    test('unnamed constructor reference w/ type args', () {
+    test('unnamed constructor reference w/ type args', () async {
+      var library = await bootPackageWithLibrary('''
+class F<T> {
+  F();
+}
+const aTearOffUnnamedConstructorArgs = F<String>.new;
+''');
       var aTearOffUnnamedConstructorArgs =
           library.constants.named('aTearOffUnnamedConstructorArgs');
       expect(aTearOffUnnamedConstructorArgs.constantValue,
           equals('F&lt;String&gt;.new'));
     });
 
-    test('unnamed typedef constructor reference', () {
+    test('unnamed typedef constructor reference', () async {
+      var library = await bootPackageWithLibrary('''
+class F<T> {
+  F();
+}
+const aTearOffUnnamedConstructorTypedef = Fstring.new;
+''');
       var aTearOffUnnamedConstructorTypedef =
           library.constants.named('aTearOffUnnamedConstructorTypedef');
       expect(aTearOffUnnamedConstructorTypedef.constantValue,
           equals('Fstring.new'));
     });
 
-    test('unnamed typedef constructor reference w/ type args', () {
+    test('unnamed typedef constructor reference w/ type args', () async {
+      var library = await bootPackageWithLibrary('''
+class F<T> {
+  F();
+}
+const aTearOffUnnamedConstructorArgsTypedef = Ft<String>.new;
+''');
       var aTearOffUnnamedConstructorArgsTypedef =
           library.constants.named('aTearOffUnnamedConstructorArgsTypedef');
       expect(aTearOffUnnamedConstructorArgsTypedef.constantValue,
           equals('Ft&lt;String&gt;.new'));
     });
-  }, skip: !constructorTearoffsAllowed.allows(utils.platformVersion));
+  }, skip: !constructorTearoffsAllowed);
 
   group('named-arguments-anywhere', () {
-    late Library library;
     const placeholder = '%%__HTMLBASE_dartdoc_internal__%%';
-    const libraryName = 'named_arguments_anywhere';
+    const libraryName = 'constant_values';
     const linkPrefix = '$placeholder$libraryName';
 
-    final _testPackageGraphExperimentsMemo = AsyncMemoizer<PackageGraph>();
-    Future<PackageGraph> bootstrapPackageGraph() =>
-        _testPackageGraphExperimentsMemo.runOnce(() => utils.bootBasicPackage(
-            d.dir(libraryName).io.path,
-            pubPackageMetaProvider,
-            PhysicalPackageConfigProvider(),
-            additionalArguments: ['--no-link-to-remote']));
-
     setUp(() async {
-      await d.createPackage(
+      packageMetaProvider = testPackageMetaProvider;
+      resourceProvider =
+          packageMetaProvider.resourceProvider as MemoryResourceProvider;
+      await setUpPackage(
         libraryName,
         pubspec: '''
 name: named_arguments_anywhere
@@ -169,28 +206,17 @@ analyzer:
   enable-experiment:
     - named-arguments-anywhere
 ''',
-        libFiles: [
-          d.file('lib.dart', '''
-library $libraryName;
-
-class C {
-  const C(int a, int b, {required int c, required int d});
-}
-
-const p = C(1, 2, c: 3, d: 4);
-
-const q = C(1, c: 2, 3, d: 4);
-
-const r = C(c: 1, d: 2, 3, 4);
-'''),
-        ],
       );
-
-      library = (await bootstrapPackageGraph()).libraries.named(libraryName);
     });
 
     test('named parameters in a const invocation value can be specified last',
         () async {
+      var library = await bootPackageWithLibrary('''
+class C {
+  const C(int a, int b, {required int c, required int d});
+}
+const p = C(1, 2, c: 3, d: 4);
+''');
       var pConst = library.constants.named('p');
 
       expect(pConst.constantValue,
@@ -200,6 +226,12 @@ const r = C(c: 1, d: 2, 3, 4);
     test(
         'named parameters in a const invocation value can be specified anywhere',
         () async {
+      var library = await bootPackageWithLibrary('''
+class C {
+  const C(int a, int b, {required int c, required int d});
+}
+const q = C(1, c: 2, 3, d: 4);
+''');
       var qConst = library.constants.named('q');
 
       expect(qConst.constantValue,
@@ -208,10 +240,16 @@ const r = C(c: 1, d: 2, 3, 4);
 
     test('named parameters in a const invocation value can be specified first',
         () async {
+      var library = await bootPackageWithLibrary('''
+class C {
+  const C(int a, int b, {required int c, required int d});
+}
+const r = C(c: 1, d: 2, 3, 4);
+''');
       var rConst = library.constants.named('r');
 
       expect(rConst.constantValue,
           equals('<a href="$linkPrefix/C/C.html">C</a>(c: 1, d: 2, 3, 4)'));
     });
-  }, skip: !namedArgumentsAnywhereAllowed.allows(utils.platformVersion));
+  }, skip: !namedArgumentsAnywhereAllowed);
 }

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -20,13 +20,9 @@ import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../src/utils.dart';
-
-final _experimentPackageAllowed =
-    VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
 
 final _resourceProvider = pubPackageMetaProvider.resourceProvider;
 final _pathContext = _resourceProvider.pathContext;
@@ -40,8 +36,6 @@ final Folder _testPackageBadDir = _getFolder('testing/test_package_bad');
 final Folder _testSkyEnginePackage = _getFolder('testing/sky_engine');
 final Folder _testPackageCustomTemplates =
     _getFolder('testing/test_package_custom_templates');
-final Folder _testPackageExperiments =
-    _getFolder('testing/test_package_experiments');
 
 class DartdocLoggingOptionContext extends DartdocGeneratorOptionContext
     with LoggingContext {
@@ -251,30 +245,6 @@ void main() {
       }
     });
 
-    test('generate docs with bad templatesDir path fails', () async {
-      var badPath = p.join(tempDir.path, 'BAD');
-      try {
-        await buildDartdoc(
-            ['--templates-dir', badPath], _testPackageCustomTemplates, tempDir);
-        fail('dartdoc should fail with bad templatesDir path');
-      } catch (e) {
-        expect(e is DartdocFailure, isTrue);
-      }
-    });
-
-    test('generating markdown docs does not crash', () async {
-      var dartdoc =
-          await buildDartdoc(['--format', 'md'], _testPackageDir, tempDir);
-      await dartdoc.generateDocsBase();
-    });
-
-    test('generating markdown docs for experimental features does not crash',
-        () async {
-      var dartdoc = await buildDartdoc(
-          ['--format', 'md'], _testPackageExperiments, tempDir);
-      await dartdoc.generateDocsBase();
-    }, skip: !_experimentPackageAllowed.allows(platformVersion));
-
     test('rel canonical prefix does not include base href', () async {
       final prefix = 'foo.bar/baz';
       var dartdoc = await buildDartdoc(
@@ -294,17 +264,6 @@ void main() {
       expect(level2.exists, isTrue);
       expect(level2.readAsStringSync(),
           contains('<link rel="canonical" href="$prefix/ex/Apple/m.html">'));
-    });
-
-    test('generate docs with bad output format', () async {
-      try {
-        await buildDartdoc(['--format', 'bad'], _testPackageDir, tempDir);
-        fail('dartdoc should fail with bad output format');
-      } catch (e) {
-        expect(e is DartdocFailure, isTrue);
-        expect((e as DartdocFailure).message,
-            startsWith('Unsupported output format'));
-      }
     });
   }, timeout: Timeout.factor(12));
 }

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -15,7 +15,6 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/special_elements.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../src/utils.dart' as utils;
@@ -60,13 +59,6 @@ Future<PackageGraph> _bootSdkPackage() async {
 }
 
 void main() {
-  // We can not use ExperimentalFeature.releaseVersion or even
-  // ExperimentalFeature.experimentalReleaseVersion as these are set to null
-  // even when partial analyzer implementations are available, and are often
-  // set too high after release.
-  final _constructorTearoffsAllowed =
-      VersionRange(min: Version.parse('2.15.0-0'), includeMin: true);
-
   // Experimental features not yet enabled by default.  Move tests out of this
   // block when the feature is enabled by default.
   group('Experiments', () {
@@ -220,7 +212,7 @@ void main() {
         expect(referenceLookup(A, 'new'), equals(MatchingLinkResult(null)));
         expect(referenceLookup(At, 'new'), equals(MatchingLinkResult(null)));
       });
-    }, skip: !_constructorTearoffsAllowed.allows(utils.platformVersion));
+    }, skip: !utils.constructorTearoffsAllowed);
   });
 
   group('HTML is sanitized when enabled', () {

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -7,18 +7,12 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/render/enum_field_renderer.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'src/test_descriptor_utils.dart' as d;
 import 'src/utils.dart';
 
 void main() {
-  // We can not use ExperimentalFeature.releaseVersion or even
-  // ExperimentalFeature.experimentalReleaseVersion as these are set to null
-  // even when partial analyzer implementations are available.
-  final enhancedEnumsAllowed =
-      VersionRange(min: Version.parse('2.17.0-0'), includeMin: true);
   const libraryName = 'enums';
 
   late PackageMetaProvider packageMetaProvider;
@@ -27,7 +21,6 @@ void main() {
   late String packagePath;
 
   Future<void> setUpPackage(
-    PackageMetaProvider packageMetaProvider,
     String name, {
     String? pubspec,
     String? analysisOptions,
@@ -36,8 +29,7 @@ void main() {
       name,
       pubspec: pubspec,
       analysisOptions: analysisOptions,
-      resourceProvider:
-          packageMetaProvider.resourceProvider as MemoryResourceProvider,
+      resourceProvider: resourceProvider,
     );
 
     packageConfigProvider =
@@ -72,7 +64,7 @@ $libraryContent
       packageMetaProvider = testPackageMetaProvider;
       resourceProvider =
           packageMetaProvider.resourceProvider as MemoryResourceProvider;
-      await setUpPackage(packageMetaProvider, libraryName);
+      await setUpPackage(libraryName);
     });
 
     test('is found on the enclosing library', () async {
@@ -214,7 +206,6 @@ enum E {
       resourceProvider =
           packageMetaProvider.resourceProvider as MemoryResourceProvider;
       await setUpPackage(
-        packageMetaProvider,
         libraryName,
         pubspec: '''
 name: enhanced_enums
@@ -349,5 +340,5 @@ enum E<T> implements C<T>, D { one, two, three; }
     // * Add tests for referencing enum static members.
     // * Add tests for referencing enum getters, setters, operators, methods.
     // * Add tests for referencing constructors.
-  }, skip: !enhancedEnumsAllowed.allows(platformVersion));
+  }, skip: !enhancedEnumsAllowed);
 }

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -366,7 +366,7 @@ class E extends D {
         </span>
       '''));
     });
-  }, skip: superParametersAllowed);
+  }, skip: !superParametersAllowed);
 }
 
 extension on Library {

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -6,19 +6,12 @@ import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'src/test_descriptor_utils.dart' as d;
 import 'src/utils.dart';
 
 void main() {
-  // We can not use ExperimentalFeature.releaseVersion or even
-  // ExperimentalFeature.experimentalReleaseVersion as these are set to null
-  // even when partial analyzer implementations are available.
-  final superParametersAllowed =
-      VersionRange(min: Version.parse('2.17.0-0'), includeMin: true);
-
   group('parameters', () {
     late Library library;
 
@@ -373,7 +366,7 @@ class E extends D {
         </span>
       '''));
     });
-  }, skip: !superParametersAllowed.allows(platformVersion));
+  }, skip: superParametersAllowed);
 }
 
 extension on Library {

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -323,6 +323,34 @@ Matcher matchesCompressed(String text) => matches(RegExp(text.replaceAll(
       ' *',
     )));
 
+/// We can not use [ExperimentalFeature.releaseVersion] or even
+/// [ExperimentalFeature.experimentalReleaseVersion] as these are set to `null`
+/// even when partial analyzer implementations are available.
+bool get constructorTearoffsAllowed =>
+    VersionRange(min: Version.parse('2.15.0-0'), includeMin: true)
+        .allows(platformVersion);
+
+/// We can not use [ExperimentalFeature.releaseVersion] or even
+/// [ExperimentalFeature.experimentalReleaseVersion] as these are set to `null`
+/// even when partial analyzer implementations are available.
+bool get enhancedEnumsAllowed =>
+    VersionRange(min: Version.parse('2.17.0-0'), includeMin: true)
+        .allows(platformVersion);
+
+/// We can not use [ExperimentalFeature.releaseVersion] or even
+/// [ExperimentalFeature.experimentalReleaseVersion] as these are set to `null`
+/// even when partial analyzer implementations are available.
+bool get namedArgumentsAnywhereAllowed =>
+    VersionRange(min: Version.parse('2.17.0-0'), includeMin: true)
+        .allows(platformVersion);
+
+/// We can not use [ExperimentalFeature.releaseVersion] or even
+/// [ExperimentalFeature.experimentalReleaseVersion] as these are set to `null`
+/// even when partial analyzer implementations are available.
+bool get superParametersAllowed =>
+    VersionRange(min: Version.parse('2.17.0-0'), includeMin: true)
+        .allows(platformVersion);
+
 extension ModelElementIterableExtensions<T extends ModelElement>
     on Iterable<T> {
   T named(String name) => firstWhere((e) => e.name == name);


### PR DESCRIPTION
A few test cases are moved to option_tests, so they can stop relying on testing/.

parameter_test is moved to MemoryTestProvider. This makes the test faster while letting us define the test data per test case. Much cleaner.