### PR TITLE
Simplify category initializiation

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -962,15 +962,13 @@ String _renderCategory_partial_packages_9(_i1.CategoryTemplateData context0) {
       buffer.write('''</li>''');
     }
     var context16 = context13.defaultCategory;
-    if (context16 != null) {
-      var context17 = context16.publicLibrariesSorted;
-      for (var context18 in context17) {
-        buffer.writeln();
-        buffer.write('''
+    var context17 = context16.publicLibrariesSorted;
+    for (var context18 in context17) {
+      buffer.writeln();
+      buffer.write('''
       <li>''');
-        buffer.write(context18.linkedName);
-        buffer.write('''</li>''');
-      }
+      buffer.write(context18.linkedName);
+      buffer.write('''</li>''');
     }
     var context19 = context13.categoriesWithPublicLibraries;
     for (var context20 in context19) {
@@ -3980,15 +3978,13 @@ String _renderError_partial_packages_2(_i1.PackageTemplateData context0) {
       buffer.write('''</li>''');
     }
     var context16 = context13.defaultCategory;
-    if (context16 != null) {
-      var context17 = context16.publicLibrariesSorted;
-      for (var context18 in context17) {
-        buffer.writeln();
-        buffer.write('''
+    var context17 = context16.publicLibrariesSorted;
+    for (var context18 in context17) {
+      buffer.writeln();
+      buffer.write('''
       <li>''');
-        buffer.write(context18.linkedName);
-        buffer.write('''</li>''');
-      }
+      buffer.write(context18.linkedName);
+      buffer.write('''</li>''');
     }
     var context19 = context13.categoriesWithPublicLibraries;
     for (var context20 in context19) {
@@ -5462,12 +5458,10 @@ String renderIndex(_i1.PackageTemplateData context0) {
     buffer.write('''
         <dl>''');
     var context4 = context3.defaultCategory;
-    if (context4 != null) {
-      var context5 = context4.publicLibrariesSorted;
-      for (var context6 in context5) {
-        buffer.write('\n          ');
-        buffer.write(_renderIndex_partial_library_2(context6));
-      }
+    var context5 = context4.publicLibrariesSorted;
+    for (var context6 in context5) {
+      buffer.write('\n          ');
+      buffer.write(_renderIndex_partial_library_2(context6));
     }
     var context7 = context3.categoriesWithPublicLibraries;
     for (var context8 in context7) {
@@ -5812,15 +5806,13 @@ String _renderIndex_partial_packages_4(_i1.PackageTemplateData context0) {
       buffer.write('''</li>''');
     }
     var context16 = context13.defaultCategory;
-    if (context16 != null) {
-      var context17 = context16.publicLibrariesSorted;
-      for (var context18 in context17) {
-        buffer.writeln();
-        buffer.write('''
+    var context17 = context16.publicLibrariesSorted;
+    for (var context18 in context17) {
+      buffer.writeln();
+      buffer.write('''
       <li>''');
-        buffer.write(context18.linkedName);
-        buffer.write('''</li>''');
-      }
+      buffer.write(context18.linkedName);
+      buffer.write('''</li>''');
     }
     var context19 = context13.categoriesWithPublicLibraries;
     for (var context20 in context19) {
@@ -6898,15 +6890,13 @@ String _renderLibrary_partial_packages_12(_i1.LibraryTemplateData context0) {
       buffer.write('''</li>''');
     }
     var context16 = context13.defaultCategory;
-    if (context16 != null) {
-      var context17 = context16.publicLibrariesSorted;
-      for (var context18 in context17) {
-        buffer.writeln();
-        buffer.write('''
+    var context17 = context16.publicLibrariesSorted;
+    for (var context18 in context17) {
+      buffer.writeln();
+      buffer.write('''
       <li>''');
-        buffer.write(context18.linkedName);
-        buffer.write('''</li>''');
-      }
+      buffer.write(context18.linkedName);
+      buffer.write('''</li>''');
     }
     var context19 = context13.categoriesWithPublicLibraries;
     for (var context20 in context19) {

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -2463,12 +2463,10 @@ String renderIndex(_i1.PackageTemplateData context0) {
     }
     buffer.writeln();
     var context4 = context3.defaultCategory;
-    if (context4 != null) {
-      var context5 = context4.publicLibrariesSorted;
-      for (var context6 in context5) {
-        buffer.writeln();
-        buffer.write(_renderIndex_partial_library_2(context6));
-      }
+    var context5 = context4.publicLibrariesSorted;
+    for (var context6 in context5) {
+      buffer.writeln();
+      buffer.write(_renderIndex_partial_library_2(context6));
     }
     buffer.writeln();
     var context7 = context3.categoriesWithPublicLibraries;

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1051,7 +1051,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
+                          c, remainingNames, 'List<TopLevelVariable>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.constants.map((e) => _render_TopLevelVariable(
@@ -1171,7 +1171,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Enum>'),
+                          c, remainingNames, 'List<Enum>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.enums.map((e) =>
@@ -1195,7 +1195,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Extension>'),
+                          c, remainingNames, 'List<Extension>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.extensions.map((e) =>
@@ -1251,7 +1251,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ModelFunction>'),
+                          c, remainingNames, 'List<ModelFunction>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.functions.map((e) => _render_ModelFunction(
@@ -1342,7 +1342,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Mixin>'),
+                          c, remainingNames, 'List<Mixin>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.mixins.map((e) =>
@@ -1410,7 +1410,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
+                          c, remainingNames, 'List<TopLevelVariable>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.properties.map((e) => _render_TopLevelVariable(
@@ -1471,7 +1471,7 @@ class _Renderer_Category extends RendererBase<Category> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Typedef>'),
+                          c, remainingNames, 'List<Typedef>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.typedefs.map((e) =>
@@ -7855,19 +7855,6 @@ class _Renderer_Library extends RendererBase<Library> {
                 ..._Renderer_ModelElement.propertyMap<CT_>(),
                 ..._Renderer_Categorization.propertyMap<CT_>(),
                 ..._Renderer_TopLevelContainer.propertyMap<CT_>(),
-                'allCanonicalModelElements': Property(
-                  getValue: (CT_ c) => c.allCanonicalModelElements,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ModelElement>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.allCanonicalModelElements.map((e) =>
-                        _render_ModelElement(e, ast, r.template, sink,
-                            parent: r));
-                  },
-                ),
                 'allClasses': Property(
                   getValue: (CT_ c) => c.allClasses,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -8458,13 +8445,6 @@ class _Renderer_Library extends RendererBase<Library> {
       return null;
     }
   }
-}
-
-void _render_LibraryContainer(LibraryContainer context, List<MustachioNode> ast,
-    Template template, StringSink sink,
-    {RendererBase<Object>? parent}) {
-  var renderer = _Renderer_LibraryContainer(context, parent, template, sink);
-  renderer.renderBlock(ast);
 }
 
 class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
@@ -11698,17 +11678,16 @@ class _Renderer_Package extends RendererBase<Package> {
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_LibraryContainer.propertyMap().getValue(name);
+                        _Renderer_Category.propertyMap().getValue(name);
                     return nextProperty.renderVariable(
-                        self.getValue(c) as LibraryContainer,
+                        self.getValue(c) as Category,
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.defaultCategory == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_LibraryContainer(
-                        c.defaultCategory!, ast, r.template, sink,
+                    _render_Category(c.defaultCategory, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -12,8 +12,7 @@ import 'package:dartdoc/src/model/model_object_builder.dart';
 import 'package:dartdoc/src/render/category_renderer.dart';
 import 'package:dartdoc/src/warnings.dart';
 
-/// A category is a subcategory of a package, containing libraries tagged
-/// with a @category identifier.
+/// A subcategory of a package, containing elements tagged with `{@category}`.
 class Category extends Nameable
     with
         Warnable,
@@ -26,7 +25,7 @@ class Category extends Nameable
         Indexable,
         ModelBuilder
     implements Documentable {
-  /// All libraries in [libraries] must come from [package].
+  /// All libraries in [libraries] must come from [_package].
   final Package _package;
 
   @override
@@ -38,8 +37,6 @@ class Category extends Nameable
 
   @override
   DartdocOptionContext get config => _config;
-
-  final Set<Categorization> _allItems = {};
 
   final List<Class> _classes = [];
   final List<Extension> _extensions = [];
@@ -53,35 +50,11 @@ class Category extends Nameable
 
   Category(this._name, this._package, this._config);
 
-  void addItem(Categorization c) {
-    if (_allItems.contains(c)) return;
-    _allItems.add(c);
-    if (c is Library) {
-      libraries.add(c);
-    } else if (c is Mixin) {
-      _mixins.add(c);
-    } else if (c is Enum) {
-      _enums.add(c);
-    } else if (c is Class) {
-      if (c.isErrorOrException) {
-        _exceptions.add(c);
-      } else {
-        _classes.add(c);
-      }
-    } else if (c is TopLevelVariable) {
-      if (c.isConst) {
-        _constants.add(c);
-      } else {
-        _properties.add(c);
-      }
-    } else if (c is ModelFunction) {
-      _functions.add(c);
-    } else if (c is Typedef) {
-      _typedefs.add(c);
-    } else if (c is Extension) {
-      _extensions.add(c);
+  void addClass(Class class_) {
+    if (class_.isErrorOrException) {
+      _exceptions.add(class_);
     } else {
-      throw UnimplementedError('Unrecognized element: $c (${c.runtimeType})');
+      _classes.add(class_);
     }
   }
 
@@ -161,28 +134,28 @@ class Category extends Nameable
   Iterable<Class> get classes => _classes;
 
   @override
-  Iterable<TopLevelVariable> get constants => _constants;
+  List<TopLevelVariable> get constants => _constants;
 
   @override
-  Iterable<Enum> get enums => _enums;
+  List<Enum> get enums => _enums;
 
   @override
   Iterable<Class> get exceptions => _exceptions;
 
   @override
-  Iterable<Extension> get extensions => _extensions;
+  List<Extension> get extensions => _extensions;
 
   @override
-  Iterable<ModelFunction> get functions => _functions;
+  List<ModelFunction> get functions => _functions;
 
   @override
-  Iterable<Mixin> get mixins => _mixins;
+  List<Mixin> get mixins => _mixins;
 
   @override
-  Iterable<TopLevelVariable> get properties => _properties;
+  List<TopLevelVariable> get properties => _properties;
 
   @override
-  Iterable<Typedef> get typedefs => _typedefs;
+  List<Typedef> get typedefs => _typedefs;
 
   CategoryRenderer get _categoryRenderer =>
       packageGraph.rendererFactory.categoryRenderer;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -426,6 +426,8 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
     return name;
   }
 
+  /// A mapping of all [Element]s in this library to the [ModelElement]s which
+  /// represent them in dartdoc.
   late final HashMap<Element, Set<ModelElement>> modelElementsMap = () {
     var modelElements = HashMap<Element, Set<ModelElement>>();
     for (var modelElement in <ModelElement>[
@@ -433,18 +435,10 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
       ...library.functions,
       ...library.properties,
       ...library.typedefs,
-      ...library.extensions.expand((e) {
-        return [e, ...e.allModelElements];
-      }),
-      ...library.allClasses.expand((c) {
-        return [c, ...c.allModelElements];
-      }),
-      ...library.enums.expand((e) {
-        return [e, ...e.allModelElements];
-      }),
-      ...library.mixins.expand((m) {
-        return [m, ...m.allModelElements];
-      }),
+      ...library.extensions.expand((e) => [e, ...e.allModelElements]),
+      ...library.allClasses.expand((c) => [c, ...c.allModelElements]),
+      ...library.enums.expand((e) => [e, ...e.allModelElements]),
+      ...library.mixins.expand((m) => [m, ...m.allModelElements]),
     ]) {
       modelElements
           .putIfAbsent(modelElement.element!, () => {})
@@ -457,9 +451,6 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   Iterable<ModelElement> get allModelElements => [
         for (var modelElements in modelElementsMap.values) ...modelElements,
       ];
-
-  late final Iterable<ModelElement> allCanonicalModelElements =
-      allModelElements.where((e) => e.isCanonical).toList(growable: false);
 
   @override
   late final Map<String, CommentReferable> referenceChildren = () {

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -86,6 +86,11 @@ class PubPackageBuilder implements PackageBuilder {
     runtimeStats.startPerfTask('initializePackageGraph');
     await newGraph.initializePackageGraph();
     runtimeStats.endPerfTask();
+
+    runtimeStats.startPerfTask('initializeCategories');
+    newGraph.initializeCategories();
+    runtimeStats.endPerfTask();
+
     return newGraph;
   }
 

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -160,6 +160,13 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     yield config.tools.runner.wait();
   }
 
+  /// Initializes the category mappings in all [packages].
+  void initializeCategories() {
+    for (var package in packages) {
+      package.initializeCategories();
+    }
+  }
+
   // Many ModelElements have the same ModelNode; don't build/cache this data more
   // than once for them.
   final Map<Element, ModelNode> _modelNodes = {};

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -798,7 +798,7 @@ void main() {
     test('Verify that libraries without categories get handled', () {
       expect(
           packageGraph
-              .localPackages.first.defaultCategory!.publicLibraries.length,
+              .localPackages.first.defaultCategory.publicLibraries.length,
           // Only 5 libraries have categories, the rest belong in default.
           equals(kTestPackagePublicLibraries - 5));
     });


### PR DESCRIPTION
I'm becoming _less_ of a fan of `late final` with a big ole initializer that depends on other `late final` fields. It can feel like a house of cards. This PR largely moves lazy actions to be intentional and more intelligent.

* Add PackageGraph.initializeCategories and Package.initializeCategories. These are called after building the package graph, so that canonicalization is known.
* Move a Package's default category into its own field; several code points which accessed Package.nameToCategory tease out the default category, so it makes more sense just to keep it separate.
* Remove Library.allCanonicalModelElements. This was used in only one place, when building a package's categories. It likely consumed a fair amount of memory, and was totally unnecessary.
* Add elements to a Category by their known static type. The previous Category.addItem used a private Set to improve performance of collapsing all elements into one known type, then `if/else`-ing `is` checks to separate them back into different static types. Removing this Set should also relieve memory pressure.