### PR TITLE
Separate enum values from other enum constants

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -217,24 +217,37 @@ class GeneratorFrontEnd implements Generator {
           }
         }
 
-        for (var eNum in filterNonDocumented(lib.enums)) {
-          indexAccumulator.add(eNum);
-          _generatorBackend.generateEnum(writer, packageGraph, lib, eNum);
+        for (var enum_ in filterNonDocumented(lib.enums)) {
+          indexAccumulator.add(enum_);
+          _generatorBackend.generateEnum(writer, packageGraph, lib, enum_);
 
-          for (var property in filterNonDocumented(eNum.instanceFields)) {
+          for (var constant in filterNonDocumented(enum_.constantFields)) {
+            if (constant is EnumField) {
+              // Enum values don't get their own page; just any additional
+              // constants.
+              continue;
+            }
+            if (!constant.isCanonical) continue;
+
+            indexAccumulator.add(constant);
+            _generatorBackend.generateConstant(
+                writer, packageGraph, lib, enum_, constant);
+          }
+
+          for (var property in filterNonDocumented(enum_.instanceFields)) {
             indexAccumulator.add(property);
             _generatorBackend.generateConstant(
-                writer, packageGraph, lib, eNum, property);
+                writer, packageGraph, lib, enum_, property);
           }
-          for (var operator in filterNonDocumented(eNum.instanceOperators)) {
+          for (var operator in filterNonDocumented(enum_.instanceOperators)) {
             indexAccumulator.add(operator);
             _generatorBackend.generateMethod(
-                writer, packageGraph, lib, eNum, operator);
+                writer, packageGraph, lib, enum_, operator);
           }
-          for (var method in filterNonDocumented(eNum.instanceMethods)) {
+          for (var method in filterNonDocumented(enum_.instanceMethods)) {
             indexAccumulator.add(method);
             _generatorBackend.generateMethod(
-                writer, packageGraph, lib, eNum, method);
+                writer, packageGraph, lib, enum_, method);
           }
         }
 

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -456,44 +456,12 @@ String renderClass(_i1.ClassTemplateData context0) {
   buffer.write(_renderClass_partial_instance_methods_8(context2));
   buffer.write('\n    ');
   buffer.write(_renderClass_partial_instance_operators_9(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="static-properties">
-      <h2>Static Properties</h2>
-
-      <dl class="properties">''');
-    var context15 = context2.publicVariableStaticFieldsSorted;
-    for (var context16 in context15) {
-      buffer.write('\n        ');
-      buffer.write(_renderClass_partial_property_7(context16));
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
-  buffer.write('\n\n    ');
-  buffer.write(_renderClass_partial_static_methods_10(context2));
-  buffer.writeln();
-  if (context2.hasPublicConstantFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="constants">
-      <h2>Constants</h2>
-
-      <dl class="properties">''');
-    var context17 = context2.publicConstantFieldsSorted;
-    for (var context18 in context17) {
-      buffer.write('\n        ');
-      buffer.write(_renderClass_partial_constant_11(context18));
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
+  buffer.write('\n    ');
+  buffer.write(_renderClass_partial_static_properties_10(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderClass_partial_static_methods_11(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderClass_partial_static_constants_12(context2));
   buffer.writeln();
   buffer.write('''
 
@@ -501,7 +469,7 @@ String renderClass(_i1.ClassTemplateData context0) {
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderClass_partial_search_sidebar_12(context0));
+  buffer.write(_renderClass_partial_search_sidebar_13(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -523,7 +491,7 @@ String renderClass(_i1.ClassTemplateData context0) {
   </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderClass_partial_footer_13(context0));
+  buffer.write(_renderClass_partial_footer_14(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -689,16 +657,16 @@ String renderEnum(_i1.EnumTemplateData context0) {
     </section>''');
   }
   buffer.writeln();
-  if (context2.hasPublicConstantFields == true) {
+  if (context2.hasPublicEnumValues == true) {
     buffer.writeln();
     buffer.write('''
     <section class="summary offset-anchor" id="constants">
-      <h2>Constants</h2>
+      <h2>Values</h2>
 
       <dl class="properties">''');
-    var context5 = context2.publicConstantFieldsSorted;
+    var context5 = context2.publicEnumValuesSorted;
     for (var context6 in context5) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderEnum_partial_constant_7(context6));
     }
     buffer.writeln();
@@ -736,33 +704,19 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.write(_renderEnum_partial_instance_methods_9(context2));
   buffer.write('\n    ');
   buffer.write(_renderEnum_partial_instance_operators_10(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="static-properties">
-      <h2>Static Properties</h2>
-
-      <dl class="properties">''');
-    var context9 = context2.publicVariableStaticFieldsSorted;
-    for (var context10 in context9) {
-      buffer.write('\n        ');
-      buffer.write(_renderEnum_partial_property_8(context10));
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
-  buffer.write('\n\n    ');
-  buffer.write(_renderEnum_partial_static_methods_11(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderEnum_partial_static_properties_11(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderEnum_partial_static_methods_12(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderEnum_partial_static_constants_13(context2));
   buffer.writeln();
   buffer.write('''
   </div><!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderEnum_partial_search_sidebar_12(context0));
+  buffer.write(_renderEnum_partial_search_sidebar_14(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -784,7 +738,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
   </div><!-- /.sidebar-offcanvas -->
 
 ''');
-  buffer.write(_renderEnum_partial_footer_13(context0));
+  buffer.write(_renderEnum_partial_footer_15(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -904,44 +858,12 @@ String renderExtension<T extends _i2.Extension>(
   buffer.write(_renderExtension_partial_instance_methods_6(context2));
   buffer.write('\n    ');
   buffer.write(_renderExtension_partial_instance_operators_7(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="static-properties">
-        <h2>Static Properties</h2>
-
-        <dl class="properties">''');
-    var context6 = context2.publicVariableStaticFieldsSorted;
-    for (var context7 in context6) {
-      buffer.write('\n            ');
-      buffer.write(_renderExtension_partial_property_5(context7));
-    }
-    buffer.writeln();
-    buffer.write('''
-        </dl>
-    </section>''');
-  }
-  buffer.write('\n\n    ');
-  buffer.write(_renderExtension_partial_static_methods_8(context2));
-  buffer.writeln();
-  if (context2.hasPublicConstantFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="constants">
-        <h2>Constants</h2>
-
-        <dl class="properties">''');
-    var context8 = context2.publicConstantFieldsSorted;
-    for (var context9 in context8) {
-      buffer.write('\n            ');
-      buffer.write(_renderExtension_partial_constant_9(context9));
-    }
-    buffer.writeln();
-    buffer.write('''
-        </dl>
-    </section>''');
-  }
+  buffer.write('\n    ');
+  buffer.write(_renderExtension_partial_static_properties_8(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderExtension_partial_static_methods_9(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderExtension_partial_static_constants_10(context2));
   buffer.writeln();
   buffer.write('''
 
@@ -949,7 +871,7 @@ String renderExtension<T extends _i2.Extension>(
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderExtension_partial_search_sidebar_10(context0));
+  buffer.write(_renderExtension_partial_search_sidebar_11(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -971,7 +893,8 @@ String renderExtension<T extends _i2.Extension>(
 </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderExtension_partial_footer_11(context0));
+  buffer.write(_renderExtension_partial_footer_12(context0));
+  buffer.writeln();
   buffer.writeln();
 
   return buffer.toString();
@@ -1561,51 +1484,19 @@ String renderMixin(_i1.MixinTemplateData context0) {
   buffer.write(_renderMixin_partial_instance_methods_8(context2));
   buffer.write('\n    ');
   buffer.write(_renderMixin_partial_instance_operators_9(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="static-properties">
-      <h2>Static Properties</h2>
-
-      <dl class="properties">''');
-    var context11 = context2.publicVariableStaticFieldsSorted;
-    for (var context12 in context11) {
-      buffer.write('\n        ');
-      buffer.write(_renderMixin_partial_property_7(context12));
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
-  buffer.write('\n\n    ');
-  buffer.write(_renderMixin_partial_static_methods_10(context2));
-  buffer.writeln();
-  if (context2.hasPublicConstantFields == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="constants">
-      <h2>Constants</h2>
-
-      <dl class="properties">''');
-    var context13 = context2.publicConstantFieldsSorted;
-    for (var context14 in context13) {
-      buffer.write('\n        ');
-      buffer.write(_renderMixin_partial_constant_11(context14));
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
+  buffer.write('\n    ');
+  buffer.write(_renderMixin_partial_static_properties_10(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderMixin_partial_static_methods_11(context2));
+  buffer.write('\n    ');
+  buffer.write(_renderMixin_partial_static_constants_12(context2));
   buffer.writeln();
   buffer.write('''
   </div> <!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderMixin_partial_search_sidebar_12(context0));
+  buffer.write(_renderMixin_partial_search_sidebar_13(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -1627,7 +1518,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
   </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderMixin_partial_footer_13(context0));
+  buffer.write(_renderMixin_partial_footer_14(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -2977,11 +2868,13 @@ String _renderClass_partial_instance_methods_8(_i10.Class context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
 String _renderClass_partial_instance_operators_9(_i10.Class context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderClass_partial_static_methods_10(_i10.Class context1) =>
+String _renderClass_partial_static_properties_10(_i10.Class context1) =>
+    _deduplicated_lib_templates_html__static_properties_html(context1);
+String _renderClass_partial_static_methods_11(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderClass_partial_constant_11(_i11.Field context2) =>
-    _deduplicated_lib_templates_html__constant_html(context2);
-String _renderClass_partial_search_sidebar_12(_i1.ClassTemplateData context0) {
+String _renderClass_partial_static_constants_12(_i10.Class context1) =>
+    _deduplicated_lib_templates_html__static_constants_html(context1);
+String _renderClass_partial_search_sidebar_13(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -3040,7 +2933,7 @@ String _renderClass_partial_search_sidebar_12(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderClass_partial_footer_13(_i1.ClassTemplateData context0) {
+String _renderClass_partial_footer_14(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -3523,9 +3416,13 @@ String _renderEnum_partial_instance_methods_9(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
 String _renderEnum_partial_instance_operators_10(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderEnum_partial_static_methods_11(_i13.Enum context1) =>
+String _renderEnum_partial_static_properties_11(_i13.Enum context1) =>
+    _deduplicated_lib_templates_html__static_properties_html(context1);
+String _renderEnum_partial_static_methods_12(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderEnum_partial_search_sidebar_12(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_static_constants_13(_i13.Enum context1) =>
+    _deduplicated_lib_templates_html__static_constants_html(context1);
+String _renderEnum_partial_search_sidebar_14(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -3584,7 +3481,7 @@ String _renderEnum_partial_search_sidebar_12(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_footer_13(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_footer_15(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -4116,11 +4013,13 @@ String _renderExtension_partial_instance_methods_6(_i2.Extension context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
 String _renderExtension_partial_instance_operators_7(_i2.Extension context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderExtension_partial_static_methods_8(_i2.Extension context1) =>
+String _renderExtension_partial_static_properties_8(_i2.Extension context1) =>
+    _deduplicated_lib_templates_html__static_properties_html(context1);
+String _renderExtension_partial_static_methods_9(_i2.Extension context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderExtension_partial_constant_9(_i11.Field context2) =>
-    _deduplicated_lib_templates_html__constant_html(context2);
-String _renderExtension_partial_search_sidebar_10<T extends _i2.Extension>(
+String _renderExtension_partial_static_constants_10(_i2.Extension context1) =>
+    _deduplicated_lib_templates_html__static_constants_html(context1);
+String _renderExtension_partial_search_sidebar_11<T extends _i2.Extension>(
     _i1.ExtensionTemplateData<T> context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
@@ -4130,27 +4029,27 @@ String _renderExtension_partial_search_sidebar_10<T extends _i2.Extension>(
 </header>
 
 <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
+  var context2 = context0.navLinks;
+  for (var context3 in context2) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context2.href);
+    buffer.write(context3.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
+    buffer.writeEscaped(context3.name);
     buffer.write('''</a></li>''');
   }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
+  var context4 = context0.navLinksWithGenerics;
+  for (var context5 in context4) {
     buffer.writeln();
     buffer.write('''
   <li><a href="''');
-    buffer.write(context4.href);
+    buffer.write(context5.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters == true) {
+    buffer.writeEscaped(context5.name);
+    if (context5.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
+      buffer.write(context5.genericParameters);
       buffer.write('''</span>''');
     }
     buffer.write('''</a></li>''');
@@ -4180,7 +4079,7 @@ String _renderExtension_partial_search_sidebar_10<T extends _i2.Extension>(
   return buffer.toString();
 }
 
-String _renderExtension_partial_footer_11<T extends _i2.Extension>(
+String _renderExtension_partial_footer_12<T extends _i2.Extension>(
     _i1.ExtensionTemplateData<T> context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
@@ -5734,11 +5633,13 @@ String _renderMixin_partial_instance_methods_8(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
 String _renderMixin_partial_instance_operators_9(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderMixin_partial_static_methods_10(_i16.Mixin context1) =>
+String _renderMixin_partial_static_properties_10(_i16.Mixin context1) =>
+    _deduplicated_lib_templates_html__static_properties_html(context1);
+String _renderMixin_partial_static_methods_11(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderMixin_partial_constant_11(_i11.Field context2) =>
-    _deduplicated_lib_templates_html__constant_html(context2);
-String _renderMixin_partial_search_sidebar_12(_i1.MixinTemplateData context0) {
+String _renderMixin_partial_static_constants_12(_i16.Mixin context1) =>
+    _deduplicated_lib_templates_html__static_constants_html(context1);
+String _renderMixin_partial_search_sidebar_13(_i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -5797,7 +5698,7 @@ String _renderMixin_partial_search_sidebar_12(_i1.MixinTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderMixin_partial_footer_13(_i1.MixinTemplateData context0) {
+String _renderMixin_partial_footer_14(_i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -7648,6 +7549,106 @@ String
   return buffer.toString();
 }
 
+String _deduplicated_lib_templates_html__static_properties_html(
+    _i6.Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicVariableStaticFields == true) {
+    buffer.writeln();
+    buffer.write('''
+  <section class="summary offset-anchor" id="static-properties">
+    <h2>Static Properties</h2>
+
+    <dl class="properties">''');
+    var context1 = context0.publicVariableStaticFieldsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(
+          __deduplicated_lib_templates_html__static_properties_html_partial_property_0(
+              context2));
+    }
+    buffer.writeln();
+    buffer.write('''
+    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String
+    __deduplicated_lib_templates_html__static_properties_html_partial_property_0(
+        _i11.Field context1) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context1.htmlId);
+  buffer.write('''" class="property''');
+  if (context1.isInherited == true) {
+    buffer.write(''' inherited''');
+  }
+  buffer.write('''">
+  <span class="name">''');
+  buffer.write(context1.linkedName);
+  buffer.write('''</span>
+  <span class="signature">''');
+  buffer.write(context1.arrow);
+  buffer.write(' ');
+  buffer.write(context1.modelType.linkedName);
+  buffer.write('''</span> ''');
+  buffer.write(
+      ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_categorization_0(
+          context1));
+  buffer.writeln();
+  buffer.write('''
+</dt>
+<dd''');
+  if (context1.isInherited == true) {
+    buffer.write(''' class="inherited"''');
+  }
+  buffer.write('''>
+  ''');
+  buffer.write(context1.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(
+      ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_features_1(
+          context1));
+  buffer.writeln();
+  buffer.write('''
+</dd>
+''');
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_categorization_0(
+        _i11.Field context1) {
+  final buffer = StringBuffer();
+  if (context1.hasCategoryNames == true) {
+    var context2 = context1.displayedCategories;
+    for (var context3 in context2) {
+      buffer.write('\n    ');
+      buffer.write(context3!.categoryLabel);
+    }
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_features_1(
+        _i11.Field context1) {
+  final buffer = StringBuffer();
+  if (context1.hasFeatures == true) {
+    buffer.write('''<div class="features">''');
+    buffer.write(context1.featuresAsString);
+    buffer.write('''</div>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
 String _deduplicated_lib_templates_html__static_methods_html(
     _i6.Container context0) {
   final buffer = StringBuffer();
@@ -7744,6 +7745,107 @@ String
 String
     ___deduplicated_lib_templates_html__static_methods_html_partial_callable_0_partial_features_1(
         _i15.Method context1) {
+  final buffer = StringBuffer();
+  if (context1.hasFeatures == true) {
+    buffer.write('''<div class="features">''');
+    buffer.write(context1.featuresAsString);
+    buffer.write('''</div>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated_lib_templates_html__static_constants_html(
+    _i6.Container context0) {
+  final buffer = StringBuffer();
+  buffer.writeln();
+  if (context0.hasPublicConstantFields == true) {
+    buffer.writeln();
+    buffer.write('''
+  <section class="summary offset-anchor" id="constants">
+    <h2>Constants</h2>
+
+    <dl class="properties">''');
+    var context1 = context0.publicConstantFieldsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(
+          __deduplicated_lib_templates_html__static_constants_html_partial_constant_0(
+              context2));
+    }
+    buffer.writeln();
+    buffer.write('''
+    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String
+    __deduplicated_lib_templates_html__static_constants_html_partial_constant_0(
+        _i11.Field context1) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context1.htmlId);
+  buffer.write('''" class="constant">
+  <span class="name ''');
+  if (context1.isDeprecated == true) {
+    buffer.write('''deprecated''');
+  }
+  buffer.write('''">''');
+  buffer.write(context1.linkedName);
+  buffer.write('''</span>
+  <span class="signature">&#8594; const ''');
+  buffer.write(context1.modelType.linkedName);
+  buffer.write('''</span>
+  ''');
+  buffer.write(
+      ___deduplicated_lib_templates_html__static_constants_html_partial_constant_0_partial_categorization_0(
+          context1));
+  buffer.writeln();
+  buffer.write('''
+</dt>
+<dd>
+  ''');
+  buffer.write(context1.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(
+      ___deduplicated_lib_templates_html__static_constants_html_partial_constant_0_partial_features_1(
+          context1));
+  buffer.writeln();
+  buffer.write('''
+  <div>
+    <span class="signature"><code>''');
+  buffer.write(context1.constantValueTruncated);
+  buffer.write('''</code></span>
+  </div>
+</dd>
+''');
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_html__static_constants_html_partial_constant_0_partial_categorization_0(
+        _i11.Field context1) {
+  final buffer = StringBuffer();
+  if (context1.hasCategoryNames == true) {
+    var context2 = context1.displayedCategories;
+    for (var context3 in context2) {
+      buffer.write('\n    ');
+      buffer.write(context3!.categoryLabel);
+    }
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_html__static_constants_html_partial_constant_0_partial_features_1(
+        _i11.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -315,36 +315,14 @@ String renderClass(_i1.ClassTemplateData context0) {
   buffer.write(_renderClass_partial_instance_methods_8(context2));
   buffer.write('\n\n');
   buffer.write(_renderClass_partial_instance_operators_9(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Static Properties
-''');
-    var context14 = context2.publicVariableStaticFieldsSorted;
-    for (var context15 in context14) {
-      buffer.writeln();
-      buffer.write(_renderClass_partial_property_7(context15));
-      buffer.writeln();
-    }
-  }
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_methods_10(context2));
-  buffer.writeln();
-  if (context2.hasPublicConstantFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Constants
-''');
-    var context16 = context2.publicConstantFieldsSorted;
-    for (var context17 in context16) {
-      buffer.writeln();
-      buffer.write(_renderClass_partial_constant_11(context17));
-      buffer.writeln();
-    }
-  }
+  buffer.write(_renderClass_partial_static_properties_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_footer_12(context0));
+  buffer.write(_renderClass_partial_static_methods_11(context2));
+  buffer.write('\n\n');
+  buffer.write(_renderClass_partial_static_constants_12(context2));
+  buffer.write('\n\n');
+  buffer.write(_renderClass_partial_footer_13(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -470,23 +448,14 @@ String renderEnum(_i1.EnumTemplateData context0) {
   buffer.write(_renderEnum_partial_instance_methods_8(context2));
   buffer.write('\n\n');
   buffer.write(_renderEnum_partial_instance_operators_9(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Static Properties
-''');
-    var context9 = context2.publicVariableStaticFieldsSorted;
-    for (var context10 in context9) {
-      buffer.writeln();
-      buffer.write(_renderEnum_partial_property_7(context10));
-      buffer.writeln();
-    }
-  }
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_methods_10(context2));
+  buffer.write(_renderEnum_partial_static_properties_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_footer_11(context0));
+  buffer.write(_renderEnum_partial_static_methods_11(context2));
+  buffer.write('\n\n');
+  buffer.write(_renderEnum_partial_static_constants_12(context2));
+  buffer.write('\n\n');
+  buffer.write(_renderEnum_partial_footer_13(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -549,36 +518,14 @@ on ''');
   buffer.write(_renderExtension_partial_instance_methods_6(context3));
   buffer.write('\n\n');
   buffer.write(_renderExtension_partial_instance_operators_7(context3));
-  buffer.writeln();
-  if (context3.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Static Properties
-''');
-    var context6 = context3.publicVariableStaticFieldsSorted;
-    for (var context7 in context6) {
-      buffer.writeln();
-      buffer.write(_renderExtension_partial_property_5(context7));
-      buffer.writeln();
-    }
-  }
   buffer.write('\n\n');
-  buffer.write(_renderExtension_partial_static_methods_8(context3));
-  buffer.writeln();
-  if (context3.hasPublicConstantFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Constants
-''');
-    var context8 = context3.publicConstantFieldsSorted;
-    for (var context9 in context8) {
-      buffer.writeln();
-      buffer.write(_renderExtension_partial_constant_9(context9));
-      buffer.writeln();
-    }
-  }
+  buffer.write(_renderExtension_partial_static_properties_8(context3));
   buffer.write('\n\n');
-  buffer.write(_renderExtension_partial_footer_10(context0));
+  buffer.write(_renderExtension_partial_static_methods_9(context3));
+  buffer.write('\n\n');
+  buffer.write(_renderExtension_partial_static_constants_10(context3));
+  buffer.write('\n\n');
+  buffer.write(_renderExtension_partial_footer_11(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -954,36 +901,14 @@ String renderMixin(_i1.MixinTemplateData context0) {
   buffer.write(_renderMixin_partial_instance_methods_8(context2));
   buffer.write('\n\n');
   buffer.write(_renderMixin_partial_instance_operators_9(context2));
-  buffer.writeln();
-  if (context2.hasPublicVariableStaticFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Static Properties
-''');
-    var context11 = context2.publicVariableStaticFieldsSorted;
-    for (var context12 in context11) {
-      buffer.writeln();
-      buffer.write(_renderMixin_partial_property_7(context12));
-      buffer.writeln();
-    }
-  }
   buffer.write('\n\n');
-  buffer.write(_renderMixin_partial_static_methods_10(context2));
-  buffer.writeln();
-  if (context2.hasPublicConstantFields == true) {
-    buffer.writeln();
-    buffer.write('''
-## Constants
-''');
-    var context13 = context2.publicConstantFieldsSorted;
-    for (var context14 in context13) {
-      buffer.writeln();
-      buffer.write(_renderMixin_partial_constant_11(context14));
-      buffer.writeln();
-    }
-  }
+  buffer.write(_renderMixin_partial_static_properties_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderMixin_partial_footer_12(context0));
+  buffer.write(_renderMixin_partial_static_methods_11(context2));
+  buffer.write('\n\n');
+  buffer.write(_renderMixin_partial_static_constants_12(context2));
+  buffer.write('\n\n');
+  buffer.write(_renderMixin_partial_footer_13(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -1218,11 +1143,13 @@ String _renderClass_partial_instance_methods_8(_i9.Class context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
 String _renderClass_partial_instance_operators_9(_i9.Class context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderClass_partial_static_methods_10(_i9.Class context1) =>
+String _renderClass_partial_static_properties_10(_i9.Class context1) =>
+    _deduplicated_lib_templates_md__static_properties_md(context1);
+String _renderClass_partial_static_methods_11(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderClass_partial_constant_11(_i10.Field context2) =>
-    _deduplicated_lib_templates_md__constant_md(context2);
-String _renderClass_partial_footer_12(_i1.ClassTemplateData context0) {
+String _renderClass_partial_static_constants_12(_i9.Class context1) =>
+    _deduplicated_lib_templates_md__static_constants_md(context1);
+String _renderClass_partial_footer_13(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -1287,9 +1214,13 @@ String _renderEnum_partial_instance_methods_8(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
 String _renderEnum_partial_instance_operators_9(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderEnum_partial_static_methods_10(_i12.Enum context1) =>
+String _renderEnum_partial_static_properties_10(_i12.Enum context1) =>
+    _deduplicated_lib_templates_md__static_properties_md(context1);
+String _renderEnum_partial_static_methods_11(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderEnum_partial_footer_11(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_static_constants_12(_i12.Enum context1) =>
+    _deduplicated_lib_templates_md__static_constants_md(context1);
+String _renderEnum_partial_footer_13(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -1323,11 +1254,13 @@ String _renderExtension_partial_instance_methods_6(_i2.Extension context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
 String _renderExtension_partial_instance_operators_7(_i2.Extension context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderExtension_partial_static_methods_8(_i2.Extension context1) =>
+String _renderExtension_partial_static_properties_8(_i2.Extension context1) =>
+    _deduplicated_lib_templates_md__static_properties_md(context1);
+String _renderExtension_partial_static_methods_9(_i2.Extension context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderExtension_partial_constant_9(_i10.Field context2) =>
-    _deduplicated_lib_templates_md__constant_md(context2);
-String _renderExtension_partial_footer_10<T extends _i2.Extension>(
+String _renderExtension_partial_static_constants_10(_i2.Extension context1) =>
+    _deduplicated_lib_templates_md__static_constants_md(context1);
+String _renderExtension_partial_footer_11<T extends _i2.Extension>(
     _i1.ExtensionTemplateData<T> context0) {
   final buffer = StringBuffer();
   buffer.writeln();
@@ -1574,11 +1507,13 @@ String _renderMixin_partial_instance_methods_8(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
 String _renderMixin_partial_instance_operators_9(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderMixin_partial_static_methods_10(_i15.Mixin context1) =>
+String _renderMixin_partial_static_properties_10(_i15.Mixin context1) =>
+    _deduplicated_lib_templates_md__static_properties_md(context1);
+String _renderMixin_partial_static_methods_11(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderMixin_partial_constant_11(_i10.Field context2) =>
-    _deduplicated_lib_templates_md__constant_md(context2);
-String _renderMixin_partial_footer_12(_i1.MixinTemplateData context0) {
+String _renderMixin_partial_static_constants_12(_i15.Mixin context1) =>
+    _deduplicated_lib_templates_md__static_constants_md(context1);
+String _renderMixin_partial_footer_13(_i1.MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -2402,6 +2337,85 @@ String
   return buffer.toString();
 }
 
+String _deduplicated_lib_templates_md__static_properties_md(
+    _i5.Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicVariableStaticFields == true) {
+    buffer.writeln();
+    buffer.write('''
+## Static Properties
+''');
+    var context1 = context0.publicVariableStaticFieldsSorted;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write(
+          __deduplicated_lib_templates_md__static_properties_md_partial_property_0(
+              context2));
+      buffer.writeln();
+    }
+  }
+
+  return buffer.toString();
+}
+
+String __deduplicated_lib_templates_md__static_properties_md_partial_property_0(
+    _i10.Field context1) {
+  final buffer = StringBuffer();
+  buffer.write('''##### ''');
+  buffer.write(context1.linkedName);
+  buffer.write(' ');
+  buffer.write(context1.arrow);
+  buffer.write(' ');
+  buffer.write(context1.modelType.linkedName);
+  buffer.writeln();
+  buffer.write(
+      ___deduplicated_lib_templates_md__static_properties_md_partial_property_0_partial_categorization_0(
+          context1));
+  buffer.write('\n\n');
+  buffer.write(context1.oneLineDoc);
+  buffer.write('  ');
+  buffer.writeln();
+  buffer.write(
+      ___deduplicated_lib_templates_md__static_properties_md_partial_property_0_partial_features_1(
+          context1));
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_md__static_properties_md_partial_property_0_partial_categorization_0(
+        _i10.Field context1) {
+  final buffer = StringBuffer();
+  if (context1.hasCategoryNames == true) {
+    buffer.writeln();
+    buffer.write('''
+Categories:''');
+    var context2 = context1.displayedCategories;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write(context3!.categoryLabel);
+    }
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_md__static_properties_md_partial_property_0_partial_features_1(
+        _i10.Field context1) {
+  final buffer = StringBuffer();
+  if (context1.hasFeatures == true) {
+    buffer.write('''_''');
+    buffer.write(context1.featuresAsString);
+    buffer.write('''_''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
 String _deduplicated_lib_templates_md__static_methods_md(
     _i5.Container context0) {
   final buffer = StringBuffer();
@@ -2471,6 +2485,84 @@ Categories:''');
 String
     ___deduplicated_lib_templates_md__static_methods_md_partial_callable_0_partial_features_1(
         _i14.Method context1) {
+  final buffer = StringBuffer();
+  if (context1.hasFeatures == true) {
+    buffer.write('''_''');
+    buffer.write(context1.featuresAsString);
+    buffer.write('''_''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated_lib_templates_md__static_constants_md(
+    _i5.Container context0) {
+  final buffer = StringBuffer();
+  buffer.writeln();
+  if (context0.hasPublicConstantFields == true) {
+    buffer.writeln();
+    buffer.write('''
+## Constants
+''');
+    var context1 = context0.publicConstantFieldsSorted;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write(
+          __deduplicated_lib_templates_md__static_constants_md_partial_constant_0(
+              context2));
+      buffer.writeln();
+    }
+  }
+
+  return buffer.toString();
+}
+
+String __deduplicated_lib_templates_md__static_constants_md_partial_constant_0(
+    _i10.Field context1) {
+  final buffer = StringBuffer();
+  buffer.write('''##### ''');
+  buffer.write(context1.linkedName);
+  buffer.write(''' const ''');
+  buffer.write(context1.modelType.linkedName);
+  buffer.writeln();
+  buffer.write(
+      ___deduplicated_lib_templates_md__static_constants_md_partial_constant_0_partial_categorization_0(
+          context1));
+  buffer.write('\n\n');
+  buffer.write(context1.oneLineDoc);
+  buffer.write('  ');
+  buffer.writeln();
+  buffer.write(
+      ___deduplicated_lib_templates_md__static_constants_md_partial_constant_0_partial_features_1(
+          context1));
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_md__static_constants_md_partial_constant_0_partial_categorization_0(
+        _i10.Field context1) {
+  final buffer = StringBuffer();
+  if (context1.hasCategoryNames == true) {
+    buffer.writeln();
+    buffer.write('''
+Categories:''');
+    var context2 = context1.displayedCategories;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write(context3!.categoryLabel);
+    }
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String
+    ___deduplicated_lib_templates_md__static_constants_md_partial_constant_0_partial_features_1(
+        _i10.Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -4606,6 +4606,13 @@ class _Renderer_Enum extends RendererBase<Enum> {
           () => {
                 ..._Renderer_InheritingContainer.propertyMap<CT_>(),
                 ..._Renderer_TypeImplementing.propertyMap<CT_>(),
+                'hasPublicEnumValues': Property(
+                  getValue: (CT_ c) => c.hasPublicEnumValues,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.hasPublicEnumValues == true,
+                ),
                 'inheritanceChain': Property(
                   getValue: (CT_ c) => c.inheritanceChain,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -4638,6 +4645,18 @@ class _Renderer_Enum extends RendererBase<Enum> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.kind, ast, r.template, sink, parent: r);
+                  },
+                ),
+                'publicEnumValuesSorted': Property(
+                  getValue: (CT_ c) => c.publicEnumValuesSorted,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'Iterable<Field>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.publicEnumValuesSorted.map((e) =>
+                        _render_Field(e, ast, r.template, sink, parent: r));
                   },
                 ),
                 'relationshipsClass': Property(

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -163,8 +163,7 @@ abstract class Container extends ModelElement
 
   bool get hasPublicConstantFields => publicConstantFieldsSorted.isNotEmpty;
 
-  List<Field>? _publicConstantFieldsSorted;
-  List<Field> get publicConstantFieldsSorted => _publicConstantFieldsSorted ??=
+  late final List<Field> publicConstantFieldsSorted =
       publicConstantFields.toList()..sort(byName);
 
   Iterable<Accessor> get instanceAccessors =>

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:dartdoc/src/render/enum_field_renderer.dart';
 
 class Enum extends InheritingContainer with TypeImplementing {
@@ -23,6 +24,11 @@ class Enum extends InheritingContainer with TypeImplementing {
 
   @override
   String get relationshipsClass => 'eNum-relationships';
+
+  late final Iterable<Field> publicEnumValuesSorted =
+      model_utils.filterNonPublic(constantFields).whereType<EnumField>();
+
+  bool get hasPublicEnumValues => publicEnumValuesSorted.isNotEmpty;
 }
 
 /// A field specific to an enum's values.
@@ -49,17 +55,6 @@ class EnumField extends Field {
   List<DocumentationComment> get documentationFrom {
     if (name == 'values' || name == 'index') return [this];
     return super.documentationFrom;
-  }
-
-  @override
-  String get documentation {
-    if (name == 'values') {
-      return 'A constant List of the values in this enum, in order of their declaration.';
-    } else if (name == 'index') {
-      return 'The integer index of this enum.';
-    } else {
-      return super.documentation;
-    }
   }
 
   @override

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -44,6 +44,14 @@ class Field extends ModelElement
 
   @override
   String get documentation {
+    if (enclosingElement is Enum) {
+      if (name == 'values') {
+        return 'A constant List of the values in this enum, in order of their declaration.';
+      } else if (name == 'index') {
+        return 'The integer index of this enum.';
+      }
+    }
+
     // Verify that [hasSetter] and [hasGetthasPublicGetterNoSettererNoSetter]
     // are mutually exclusive, to prevent displaying more or less than one
     // summary.
@@ -51,7 +59,6 @@ class Field extends ModelElement
       assert((hasPublicSetter && !hasPublicGetterNoSetter) ||
           (!hasPublicSetter && hasPublicGetterNoSetter));
     }
-    //documentationFrom;
     return super.documentation;
   }
 

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -84,6 +84,13 @@ mixin GetterSetterCombo on ModelElement {
 
   @override
   CharacterLocation? get characterLocation {
+    if (enclosingElement is Enum) {
+      if (name == 'values') {
+        return null;
+      } else if (name == 'index') {
+        return null;
+      }
+    }
     // Handle all synthetic possibilities.  Ordinarily, warnings for
     // explicit setters/getters will be handled by those objects, but
     // if a warning comes up for an enclosing synthetic field we have to

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -186,10 +186,6 @@ abstract class ModelElement extends Canonicalization
         } else if (e.enclosingElement is ExtensionElement) {
           newModelElement = Field(e, library, packageGraph,
               getter as ContainerAccessor?, setter as ContainerAccessor?);
-        } // TODO(srawlins): Stop special casing enum fields.
-        else if (e.enclosingElement is ClassElement &&
-            (e.enclosingElement as ClassElement).isEnum) {
-          newModelElement = EnumField(e, library, packageGraph, getter, setter);
         } else {
           newModelElement = Field(e, library, packageGraph,
               getter as ContainerAccessor?, setter as ContainerAccessor?);

--- a/lib/templates/html/_static_constants.html
+++ b/lib/templates/html/_static_constants.html
@@ -1,0 +1,14 @@
+{{! All constants on classes, enums, extensions, and mixins are static, but the
+    file is named this way for organization purposes. }}
+
+{{ #hasPublicConstantFields }}
+  <section class="summary offset-anchor" id="constants">
+    <h2>Constants</h2>
+
+    <dl class="properties">
+      {{ #publicConstantFieldsSorted }}
+        {{ >constant }}
+      {{ /publicConstantFieldsSorted }}
+    </dl>
+  </section>
+{{ /hasPublicConstantFields }}

--- a/lib/templates/html/_static_properties.html
+++ b/lib/templates/html/_static_properties.html
@@ -1,0 +1,11 @@
+{{ #hasPublicVariableStaticFields }}
+  <section class="summary offset-anchor" id="static-properties">
+    <h2>Static Properties</h2>
+
+    <dl class="properties">
+      {{ #publicVariableStaticFieldsSorted }}
+        {{ >property }}
+      {{ /publicVariableStaticFieldsSorted }}
+    </dl>
+  </section>
+{{ /hasPublicVariableStaticFields }}

--- a/lib/templates/html/class.html
+++ b/lib/templates/html/class.html
@@ -90,32 +90,9 @@
 
     {{ >instance_methods }}
     {{ >instance_operators }}
-
-    {{#hasPublicVariableStaticFields}}
-    <section class="summary offset-anchor" id="static-properties">
-      <h2>Static Properties</h2>
-
-      <dl class="properties">
-        {{#publicVariableStaticFieldsSorted}}
-        {{>property}}
-        {{/publicVariableStaticFieldsSorted}}
-      </dl>
-    </section>
-    {{/hasPublicVariableStaticFields}}
-
+    {{ >static_properties }}
     {{ >static_methods }}
-
-    {{#hasPublicConstantFields}}
-    <section class="summary offset-anchor" id="constants">
-      <h2>Constants</h2>
-
-      <dl class="properties">
-        {{#publicConstantFieldsSorted}}
-        {{>constant}}
-        {{/publicConstantFieldsSorted}}
-      </dl>
-    </section>
-    {{/hasPublicConstantFields}}
+    {{ >static_constants }}
     {{/clazz}}
 
   </div> <!-- /.main-content -->

--- a/lib/templates/html/enum.html
+++ b/lib/templates/html/enum.html
@@ -30,17 +30,17 @@
     </section>
     {{ /hasModifiers }}
 
-    {{ #hasPublicConstantFields }}
+    {{ #hasPublicEnumValues }}
     <section class="summary offset-anchor" id="constants">
-      <h2>Constants</h2>
+      <h2>Values</h2>
 
       <dl class="properties">
-        {{ #publicConstantFieldsSorted }}
-        {{ >constant }}
-        {{ /publicConstantFieldsSorted }}
+        {{ #publicEnumValuesSorted }}
+          {{ >constant }}
+        {{ /publicEnumValuesSorted }}
       </dl>
     </section>
-    {{ /hasPublicConstantFields }}
+    {{ /hasPublicEnumValues }}
 
     {{ #hasPublicInstanceFields }}
     <section
@@ -61,20 +61,9 @@
 
     {{ >instance_methods }}
     {{ >instance_operators }}
-
-    {{ #hasPublicVariableStaticFields }}
-    <section class="summary offset-anchor" id="static-properties">
-      <h2>Static Properties</h2>
-
-      <dl class="properties">
-        {{ #publicVariableStaticFieldsSorted }}
-        {{ >property }}
-        {{ /publicVariableStaticFieldsSorted }}
-      </dl>
-    </section>
-    {{ /hasPublicVariableStaticFields }}
-
+    {{ >static_properties }}
     {{ >static_methods }}
+    {{ >static_constants }}
     {{ /eNum }}
   </div><!-- /.main-content -->
 

--- a/lib/templates/html/extension.html
+++ b/lib/templates/html/extension.html
@@ -34,33 +34,9 @@
 
     {{ >instance_methods }}
     {{ >instance_operators }}
-
-    {{#hasPublicVariableStaticFields}}
-    <section class="summary offset-anchor" id="static-properties">
-        <h2>Static Properties</h2>
-
-        <dl class="properties">
-            {{#publicVariableStaticFieldsSorted}}
-            {{>property}}
-            {{/publicVariableStaticFieldsSorted}}
-        </dl>
-    </section>
-    {{/hasPublicVariableStaticFields}}
-
+    {{ >static_properties }}
     {{ >static_methods }}
-
-    {{#hasPublicConstantFields}}
-    <section class="summary offset-anchor" id="constants">
-        <h2>Constants</h2>
-
-        <dl class="properties">
-            {{#publicConstantFieldsSorted}}
-            {{>constant}}
-            {{/publicConstantFieldsSorted}}
-        </dl>
-    </section>
-    {{/hasPublicConstantFields}}
-    {{/extension}}
+    {{ >static_constants }}
 
 </div> <!-- /.main-content -->
 

--- a/lib/templates/html/mixin.html
+++ b/lib/templates/html/mixin.html
@@ -60,32 +60,9 @@
 
     {{ >instance_methods }}
     {{ >instance_operators }}
-
-    {{#hasPublicVariableStaticFields}}
-    <section class="summary offset-anchor" id="static-properties">
-      <h2>Static Properties</h2>
-
-      <dl class="properties">
-        {{#publicVariableStaticFieldsSorted}}
-        {{>property}}
-        {{/publicVariableStaticFieldsSorted}}
-      </dl>
-    </section>
-    {{/hasPublicVariableStaticFields}}
-
+    {{ >static_properties }}
     {{ >static_methods }}
-
-    {{#hasPublicConstantFields}}
-    <section class="summary offset-anchor" id="constants">
-      <h2>Constants</h2>
-
-      <dl class="properties">
-        {{#publicConstantFieldsSorted}}
-        {{>constant}}
-        {{/publicConstantFieldsSorted}}
-      </dl>
-    </section>
-    {{/hasPublicConstantFields}}
+    {{ >static_constants }}
     {{/mixin}}
   </div> <!-- /.main-content -->
 

--- a/lib/templates/md/_static_constants.md
+++ b/lib/templates/md/_static_constants.md
@@ -1,0 +1,11 @@
+{{! All constants on classes, enums, extensions, and mixins are static, but the
+    file is named this way for organization purposes. }}
+
+{{ #hasPublicConstantFields }}
+## Constants
+
+{{ #publicConstantFieldsSorted }}
+{{ >constant }}
+
+{{ /publicConstantFieldsSorted }}
+{{ /hasPublicConstantFields }}

--- a/lib/templates/md/_static_properties.md
+++ b/lib/templates/md/_static_properties.md
@@ -1,0 +1,8 @@
+{{ #hasPublicVariableStaticFields }}
+## Static Properties
+
+{{ #publicVariableStaticFieldsSorted }}
+{{ >property }}
+
+{{ /publicVariableStaticFieldsSorted }}
+{{ /hasPublicVariableStaticFields }}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -73,25 +73,11 @@
 
 {{ >instance_operators }}
 
-{{#hasPublicVariableStaticFields}}
-## Static Properties
-
-{{#publicVariableStaticFieldsSorted}}
-{{>property}}
-
-{{/publicVariableStaticFieldsSorted}}
-{{/hasPublicVariableStaticFields}}
+{{ >static_properties }}
 
 {{ >static_methods }}
 
-{{#hasPublicConstantFields}}
-## Constants
-
-{{#publicConstantFieldsSorted}}
-{{>constant}}
-
-{{/publicConstantFieldsSorted}}
-{{/hasPublicConstantFields}}
+{{ >static_constants }}
 {{/clazz}}
 
 {{>footer}}

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -45,16 +45,11 @@
 
 {{ >instance_operators }}
 
-{{ #hasPublicVariableStaticFields }}
-## Static Properties
-
-{{ #publicVariableStaticFieldsSorted }}
-{{ >property }}
-
-{{ /publicVariableStaticFieldsSorted }}
-{{ /hasPublicVariableStaticFields }}
+{{ >static_properties }}
 
 {{ >static_methods }}
+
+{{ >static_constants }}
 {{ /eNum }}
 
 {{ >footer }}

--- a/lib/templates/md/extension.md
+++ b/lib/templates/md/extension.md
@@ -26,25 +26,11 @@ on {{#extendedType}}{{{linkedName}}}{{/extendedType}}
 
 {{ >instance_operators }}
 
-{{#hasPublicVariableStaticFields}}
-## Static Properties
-
-{{#publicVariableStaticFieldsSorted}}
-{{>property}}
-
-{{/publicVariableStaticFieldsSorted}}
-{{/hasPublicVariableStaticFields}}
+{{ >static_properties }}
 
 {{ >static_methods }}
 
-{{#hasPublicConstantFields}}
-## Constants
-
-{{#publicConstantFieldsSorted}}
-{{>constant}}
-
-{{/publicConstantFieldsSorted}}
-{{/hasPublicConstantFields}}
+{{ >static_constants }}
 {{/extension}}
 
 {{>footer}}

--- a/lib/templates/md/mixin.md
+++ b/lib/templates/md/mixin.md
@@ -53,25 +53,11 @@
 
 {{ >instance_operators }}
 
-{{#hasPublicVariableStaticFields}}
-## Static Properties
-
-{{#publicVariableStaticFieldsSorted}}
-{{>property}}
-
-{{/publicVariableStaticFieldsSorted}}
-{{/hasPublicVariableStaticFields}}
+{{ >static_properties }}
 
 {{ >static_methods }}
 
-{{#hasPublicConstantFields}}
-## Constants
-
-{{#publicConstantFieldsSorted}}
-{{>constant}}
-
-{{/publicConstantFieldsSorted}}
-{{/hasPublicConstantFields}}
+{{ >static_constants }}
 {{/mixin}}
 
 {{>footer}}

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4089,6 +4089,9 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
       var macrosFromAccessors =
           fakeLibrary.enums.firstWhere((e) => e.name == 'MacrosFromAccessors');
       for (var a in macrosFromAccessors.allFields.expand(_expandAccessors)) {
+        if (a.name == 'values') {
+          continue;
+        }
         expectValidLocation(a.characterLocation!);
       }
     });

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -103,11 +103,52 @@ $libraryContent
 
     test("has a (synthetic) 'values' constant", () async {
       var library = await bootPackageWithLibrary('enum E { one, two, three }');
-      var valuesField =
-          library.enums.named('E').constantFields.named('values') as EnumField;
-      expect(valuesField.constantValue,
-          equals(EnumFieldRendererHtml().renderValue(valuesField)));
+      var valuesField = library.enums.named('E').constantFields.named('values');
       expect(valuesField.documentation, startsWith('A constant List'));
+    });
+
+    test("has a 'values' constant which can be referenced", () async {
+      var library = await bootPackageWithLibrary('''
+enum E { one, two, three }
+
+/// Reference to [E.values].
+class C {}
+''');
+      var cClass = library.classes.named('C');
+      expect(
+        cClass.documentationAsHtml,
+        '<p>Reference to '
+        '<a href="%%__HTMLBASE_dartdoc_internal__%%enums/E/values-constant.html">E.values</a>.</p>',
+      );
+    });
+
+    test('has a value which can be referenced', () async {
+      var library = await bootPackageWithLibrary('''
+enum E { one, two, three }
+
+/// Reference to [E.one].
+class C {}
+''');
+      var cClass = library.classes.named('C');
+      expect(
+          cClass.documentationAsHtml,
+          '<p>Reference to '
+          '<a href="%%__HTMLBASE_dartdoc_internal__%%enums/E.html">E.one</a>.</p>');
+    });
+
+    test("has an 'index' getter which can be referenced", () async {
+      var library = await bootPackageWithLibrary('''
+enum E { one, two, three }
+
+/// Reference to [E.index].
+class C {}
+''');
+      var cClass = library.classes.named('C');
+      expect(
+        cClass.documentationAsHtml,
+        '<p>Reference to '
+        '<a href="https://api.dart.dev/stable/2.16.0/dart-core/Enum/index.html">E.index</a>.</p>',
+      );
     });
 
     test("has an 'index' getter, which is linked", () async {
@@ -117,7 +158,7 @@ $libraryContent
       expect(eEnum.instanceFields.map((f) => f.name), contains('index'));
       expect(
         eEnum.instanceFields.named('index').linkedName,
-        '<a href="https://api.dart.dev/stable/2.9.0/dart-core/Enum/index.html">index</a>',
+        '<a href="https://api.dart.dev/stable/2.16.0/dart-core/Enum/index.html">index</a>',
       );
     });
 
@@ -348,19 +389,17 @@ enum E {
     });
 
     // TODO(srawlins): Add rendering tests.
-    // * Fix interfaces test.
     // * Add tests for rendered supertypes HTML.
-    // * Add tests for rendered interfaces HTML.
     // * Add tests for rendered mixins HTML.
-    // * Add tests for rendered static members.
+    // * Add tests for rendered static methods, static fields.
     // * Add tests for rendered fields.
-    // * Add tests for rendered getters, setters, operators.
+    // * Add tests for rendered getters, setters.
     // * Add tests for rendered field pages.
     // * Add tests for rendered generic enum values.
     // * Add tests for rendered constructors.
 
     // TODO(srawlins): Add referencing tests (`/// [Enum.method]` etc.)
-    // * Add tests for referencing enum static members.
+    // * Add tests for referencing enum static methods, static fields.
     // * Add tests for referencing enum getters, setters, operators, methods.
     // * Add tests for referencing constructors.
   }, skip: !enhancedEnumsAllowed);

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -158,7 +158,7 @@ PackageMetaProvider get testPackageMetaProvider {
 ///
 /// Included is a "version" file and an "api_readme.md" file.
 void writeMockSdkFiles(Folder sdkFolder) {
-  sdkFolder.getChildAssumingFile('version').writeAsStringSync('2.9.0');
+  sdkFolder.getChildAssumingFile('version').writeAsStringSync('2.16.0');
   sdkFolder.getChildAssumingFile('api_readme.md').writeAsStringSync(
       'Welcome to the [Dart](https://dart.dev/) API reference documentation');
 

--- a/test/templates/enum_test.dart
+++ b/test/templates/enum_test.dart
@@ -86,7 +86,10 @@ analyzer:
 class C<T> {}
 
 enum E<T> implements C<T> {
-  one, two, three;
+  /// Doc comment for [one].
+  one,
+
+  two, three;
 
   /// A method.
   void m1() {}
@@ -96,6 +99,9 @@ enum E<T> implements C<T> {
 
   /// A static method.
   static void s1() {}
+
+  /// A constant.
+  static const c1 = 1;
 }
 '''),
         ],
@@ -130,12 +136,12 @@ enum E<T> implements C<T> {
       );
     });
 
-    test('enum page contains the values constant', () async {
+    test("enum page contains the 'values' constant", () async {
       expect(
           eLines,
           containsAllInOrder([
             matches('<h2>Constants</h2>'),
-            matches('<span class="name ">values</span>'),
+            matches('<a href="../lib/E/values-constant.html">values</a>'),
             matches(
                 'A constant List of the values in this enum, in order of their declaration.'),
           ]));
@@ -177,6 +183,26 @@ enum E<T> implements C<T> {
             matches('<h2>Static Methods</h2>'),
             matches('<a href="../lib/E/s1.html">s1</a>'),
             matches('A static method.'),
+          ]));
+    });
+
+    test('enum page contains values', () async {
+      expect(
+          eLines,
+          containsAllInOrder([
+            matches('<h2>Values</h2>'),
+            matches('<span class="name ">one</span>'),
+            matches('<p>Doc comment for <a href="../lib/E.html">one</a>.</p>'),
+          ]));
+    });
+
+    test('enum page contains (static) constants', () async {
+      expect(
+          eLines,
+          containsAllInOrder([
+            matches('<h2>Constants</h2>'),
+            matches('<a href="../lib/E/c1-constant.html">c1</a>'),
+            matches('A constant.'),
           ]));
     });
 

--- a/testing/test_package_custom_templates/templates/_sidebar_for_enum.html
+++ b/testing/test_package_custom_templates/templates/_sidebar_for_enum.html
@@ -1,11 +1,11 @@
 <ol>
   {{#eNum}}
-  {{#hasPublicConstantFields}}
-  <li class="section-title"><a href="{{{href}}}#constants">Constants</a></li>
-  {{#publicConstantFieldsSorted}}
-  <li>{{{linkedName}}}</li>
-  {{/publicConstantFieldsSorted}}
-  {{/hasPublicConstantFields}}
+  {{ #hasPublicEnumValues }}
+  <li class="section-title"><a href="{{{href}}}#values">Values</a></li>
+  {{ #publicEnumValuesSorted }}
+  <li>{{{ linkedName }}}</li>
+  {{ /publicEnumValuesSorted }}
+  {{ /hasPublicEnumValues }}
 
   {{#hasPublicConstructors}}
   <li class="section-title"><a href="{{{href}}}#constructors">Constructors</a></li>
@@ -50,5 +50,12 @@
   <li>{{{ linkedName }}}</li>
   {{/publicStaticMethodsSorted}}
   {{/hasPublicStaticMethods}}
-  {{/eNum}}
+
+  {{ #hasPublicConstantFields }}
+  <li class="section-title"><a href="{{{ href }}}#constants">Constants</a></li>
+  {{ #publicConstantFieldsSorted }}
+  <li>{{{ linkedName }}}</li>
+  {{ /publicConstantFieldsSorted }}
+  {{ /hasPublicConstantFields }}
+  {{ /eNum }}
 </ol>


### PR DESCRIPTION
* Generate a page for each enum's `values` constant.
* Generate a page for enums' other constants.
* Late final'ize publicConstantFieldsSorted.
* Add publicEnumValuesSorted, separate from other constants.
* Move static property rendering and (static) constant rendering into partials.
* Test rendering of static enum constants.
* Move enum non-value constants in enum's sidebar.