### PR TITLE
Enum constructors

### DIFF
--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -172,9 +172,9 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
 
   @override
   void generateConstructor(FileWriter writer, PackageGraph packageGraph,
-      Library lib, Class clazz, Constructor constructor) {
-    var data = ConstructorTemplateData(options, packageGraph, lib, clazz,
-        constructor, sidebarForContainer.getRenderFor);
+      Library lib, Constructable constructable, Constructor constructor) {
+    var data = ConstructorTemplateData(options, packageGraph, lib,
+        constructable, constructor, sidebarForContainer.getRenderFor);
     var content = templates.renderConstructor(data);
     write(writer, constructor.filePath, data, content);
   }

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -234,6 +234,14 @@ class GeneratorFrontEnd implements Generator {
                 writer, packageGraph, lib, enum_, constant);
           }
 
+          for (var constructor in filterNonDocumented(enum_.constructors)) {
+            if (!constructor.isCanonical) continue;
+
+            indexAccumulator.add(constructor);
+            _generatorBackend.generateConstructor(
+                writer, packageGraph, lib, enum_, constructor);
+          }
+
           for (var property in filterNonDocumented(enum_.instanceFields)) {
             indexAccumulator.add(property);
             _generatorBackend.generateConstant(
@@ -309,7 +317,7 @@ abstract class GeneratorBackend {
 
   /// Emit documentation content for the [constructor].
   void generateConstructor(FileWriter writer, PackageGraph graph,
-      Library library, Class clazz, Constructor constructor);
+      Library library, Constructable constructable, Constructor constructor);
 
   /// Emit documentation content for the [field].
   void generateConstant(FileWriter writer, PackageGraph graph, Library library,

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -301,7 +301,7 @@ class ConstructorTemplateData extends TemplateData<Constructor>
         TemplateDataWithContainer<Constructor> {
   @override
   final Library library;
-  final Class clazz;
+  final Constructable constructable;
   final Constructor constructor;
   final ContainerSidebar _sidebarForContainer;
 
@@ -309,7 +309,7 @@ class ConstructorTemplateData extends TemplateData<Constructor>
       TemplateOptions htmlOptions,
       PackageGraph packageGraph,
       this.library,
-      this.clazz,
+      this.constructable,
       this.constructor,
       this._sidebarForContainer)
       : super(htmlOptions, packageGraph);
@@ -317,7 +317,7 @@ class ConstructorTemplateData extends TemplateData<Constructor>
   String get sidebarForContainer => _sidebarForContainer(container, this);
 
   @override
-  Container get container => clazz;
+  Container get container => constructable;
   @override
   Constructor get self => constructor;
   @override
@@ -326,18 +326,18 @@ class ConstructorTemplateData extends TemplateData<Constructor>
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
   @override
-  List<Container> get navLinksWithGenerics => [clazz];
+  List<Container> get navLinksWithGenerics => [constructable];
   @override
   @override
   String get htmlBase => '../../';
   @override
-  String get title => '${constructor.name} constructor - ${clazz.name} class - '
+  String get title =>
+      '${constructor.name} constructor - ${constructable.name} - '
       '${library.name} library - Dart API';
   @override
   String get metaDescription =>
-      'API docs for the ${constructor.name} constructor from the '
-      '$clazz class from the ${library.name} library, '
-      'for the Dart programming language.';
+      'API docs for the ${constructor.name} constructor from $constructable '
+      'from the ${library.name} library, for the Dart programming language.';
 }
 
 class EnumTemplateData extends InheritingContainerTemplateData<Enum> {

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -2821,8 +2821,33 @@ String _renderClass_partial_documentation_4(_i10.Class context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
 String _renderClass_partial_super_chain_5(_i10.Class context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderClass_partial_interfaces_6(_i10.Class context1) =>
-    _deduplicated_lib_templates_html__interfaces_html(context1);
+String _renderClass_partial_interfaces_6(_i10.Class context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+<dt>Implemented types</dt>
+<dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </ul>
+</dd>''');
+  }
+
+  return buffer.toString();
+}
+
 String _renderClass_partial_constructors_7(_i10.Class context1) =>
     _deduplicated_lib_templates_html__constructors_html(context1);
 String _renderClass_partial_property_8(_i11.Field context2) =>
@@ -3369,8 +3394,33 @@ String _renderEnum_partial_documentation_4(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
 String _renderEnum_partial_super_chain_5(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderEnum_partial_interfaces_6(_i13.Enum context1) =>
-    _deduplicated_lib_templates_html__interfaces_html(context1);
+String _renderEnum_partial_interfaces_6(_i13.Enum context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+<dt>Implemented types</dt>
+<dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </ul>
+</dd>''');
+  }
+
+  return buffer.toString();
+}
+
 String _renderEnum_partial_constructors_7(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__constructors_html(context1);
 String _renderEnum_partial_constant_8(_i11.Field context2) =>
@@ -5590,8 +5640,33 @@ String _renderMixin_partial_documentation_4(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
 String _renderMixin_partial_super_chain_5(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderMixin_partial_interfaces_6(_i16.Mixin context1) =>
-    _deduplicated_lib_templates_html__interfaces_html(context1);
+String _renderMixin_partial_interfaces_6(_i16.Mixin context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+<dt>Implemented types</dt>
+<dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </ul>
+</dd>''');
+  }
+
+  return buffer.toString();
+}
+
 String _renderMixin_partial_property_7(_i11.Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
 String _renderMixin_partial_instance_methods_8(_i16.Mixin context1) =>
@@ -7226,7 +7301,7 @@ String _deduplicated_lib_templates_html__feature_set_html(
 }
 
 String _deduplicated_lib_templates_html__super_chain_html(
-    _i20.TypeImplementing context0) {
+    _i20.InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -7260,36 +7335,8 @@ String _deduplicated_lib_templates_html__super_chain_html(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__interfaces_html(
-    _i20.TypeImplementing context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicInterfaces == true) {
-    buffer.writeln();
-    buffer.write('''
-<dt>Implemented types</dt>
-<dd>
-    <ul class="comma-separated ''');
-    buffer.writeEscaped(context0.relationshipsClass);
-    buffer.write('''">''');
-    var context1 = context0.publicInterfaces;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''
-        <li>''');
-      buffer.write(context2.linkedName);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''
-    </ul>
-</dd>''');
-  }
-
-  return buffer.toString();
-}
-
 String _deduplicated_lib_templates_html__constructors_html(
-    _i20.TypeImplementing context0) {
+    _i20.InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicConstructors == true) {
     buffer.writeln();

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -387,49 +387,8 @@ String renderClass(_i1.ClassTemplateData context0) {
       </dl>
     </section>''');
   }
-  buffer.writeln();
-  if (context2.hasPublicConstructors == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">''');
-    var context11 = context2.publicConstructorsSorted;
-    for (var context12 in context11) {
-      buffer.writeln();
-      buffer.write('''
-        <dt id="''');
-      buffer.writeEscaped(context12.htmlId);
-      buffer.write('''" class="callable">
-          <span class="name">''');
-      buffer.write(context12.linkedName);
-      buffer.write('''</span><span class="signature">(''');
-      buffer.write(context12.linkedParams);
-      buffer.write(''')</span>
-        </dt>
-        <dd>
-          ''');
-      buffer.write(context12.oneLineDoc);
-      if (context12.isConst == true) {
-        buffer.writeln();
-        buffer.write('''
-          <div class="constructor-modifier features">const</div>''');
-      }
-      if (context12.isFactory == true) {
-        buffer.writeln();
-        buffer.write('''
-          <div class="constructor-modifier features">factory</div>''');
-      }
-      buffer.writeln();
-      buffer.write('''
-        </dd>''');
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
+  buffer.write('\n\n    ');
+  buffer.write(_renderClass_partial_constructors_7(context2));
   buffer.writeln();
   if (context2.hasPublicInstanceFields == true) {
     buffer.writeln();
@@ -442,10 +401,10 @@ String renderClass(_i1.ClassTemplateData context0) {
       <h2>Properties</h2>
 
       <dl class="properties">''');
-    var context13 = context2.publicInstanceFieldsSorted;
-    for (var context14 in context13) {
+    var context11 = context2.publicInstanceFieldsSorted;
+    for (var context12 in context11) {
       buffer.write('\n        ');
-      buffer.write(_renderClass_partial_property_7(context14));
+      buffer.write(_renderClass_partial_property_8(context12));
     }
     buffer.writeln();
     buffer.write('''
@@ -453,15 +412,15 @@ String renderClass(_i1.ClassTemplateData context0) {
     </section>''');
   }
   buffer.write('\n\n    ');
-  buffer.write(_renderClass_partial_instance_methods_8(context2));
+  buffer.write(_renderClass_partial_instance_methods_9(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_instance_operators_9(context2));
+  buffer.write(_renderClass_partial_instance_operators_10(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_static_properties_10(context2));
+  buffer.write(_renderClass_partial_static_properties_11(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_static_methods_11(context2));
+  buffer.write(_renderClass_partial_static_methods_12(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_static_constants_12(context2));
+  buffer.write(_renderClass_partial_static_constants_13(context2));
   buffer.writeln();
   buffer.write('''
 
@@ -469,7 +428,7 @@ String renderClass(_i1.ClassTemplateData context0) {
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderClass_partial_search_sidebar_13(context0));
+  buffer.write(_renderClass_partial_search_sidebar_14(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -491,7 +450,7 @@ String renderClass(_i1.ClassTemplateData context0) {
   </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderClass_partial_footer_14(context0));
+  buffer.write(_renderClass_partial_footer_15(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -656,6 +615,8 @@ String renderEnum(_i1.EnumTemplateData context0) {
       </dl>
     </section>''');
   }
+  buffer.write('\n\n    ');
+  buffer.write(_renderEnum_partial_constructors_7(context2));
   buffer.writeln();
   if (context2.hasPublicEnumValues == true) {
     buffer.writeln();
@@ -667,7 +628,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context5 = context2.publicEnumValuesSorted;
     for (var context6 in context5) {
       buffer.write('\n          ');
-      buffer.write(_renderEnum_partial_constant_7(context6));
+      buffer.write(_renderEnum_partial_constant_8(context6));
     }
     buffer.writeln();
     buffer.write('''
@@ -693,7 +654,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.write('\n        ');
-      buffer.write(_renderEnum_partial_property_8(context8));
+      buffer.write(_renderEnum_partial_property_9(context8));
     }
     buffer.writeln();
     buffer.write('''
@@ -701,22 +662,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
     </section>''');
   }
   buffer.write('\n\n    ');
-  buffer.write(_renderEnum_partial_instance_methods_9(context2));
+  buffer.write(_renderEnum_partial_instance_methods_10(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_instance_operators_10(context2));
+  buffer.write(_renderEnum_partial_instance_operators_11(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_static_properties_11(context2));
+  buffer.write(_renderEnum_partial_static_properties_12(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_static_methods_12(context2));
+  buffer.write(_renderEnum_partial_static_methods_13(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_static_constants_13(context2));
+  buffer.write(_renderEnum_partial_static_constants_14(context2));
   buffer.writeln();
   buffer.write('''
   </div><!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderEnum_partial_search_sidebar_14(context0));
+  buffer.write(_renderEnum_partial_search_sidebar_15(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -738,7 +699,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
   </div><!-- /.sidebar-offcanvas -->
 
 ''');
-  buffer.write(_renderEnum_partial_footer_15(context0));
+  buffer.write(_renderEnum_partial_footer_16(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -2403,23 +2364,50 @@ String _renderClass_partial_documentation_4(_i10.Class context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
 String _renderClass_partial_super_chain_5(_i10.Class context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderClass_partial_interfaces_6(_i10.Class context1) =>
-    _deduplicated_lib_templates_html__interfaces_html(context1);
-String _renderClass_partial_property_7(_i11.Field context2) =>
+String _renderClass_partial_interfaces_6(_i10.Class context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+<dt>Implemented types</dt>
+<dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </ul>
+</dd>''');
+  }
+
+  return buffer.toString();
+}
+
+String _renderClass_partial_constructors_7(_i10.Class context1) =>
+    _deduplicated_lib_templates_html__constructors_html(context1);
+String _renderClass_partial_property_8(_i11.Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderClass_partial_instance_methods_8(_i10.Class context1) =>
+String _renderClass_partial_instance_methods_9(_i10.Class context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderClass_partial_instance_operators_9(_i10.Class context1) =>
+String _renderClass_partial_instance_operators_10(_i10.Class context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderClass_partial_static_properties_10(_i10.Class context1) =>
+String _renderClass_partial_static_properties_11(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderClass_partial_static_methods_11(_i10.Class context1) =>
+String _renderClass_partial_static_methods_12(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderClass_partial_static_constants_12(_i10.Class context1) =>
+String _renderClass_partial_static_constants_13(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderClass_partial_search_sidebar_13(_i1.ClassTemplateData context0) =>
+String _renderClass_partial_search_sidebar_14(_i1.ClassTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderClass_partial_footer_14(_i1.ClassTemplateData context0) =>
+String _renderClass_partial_footer_15(_i1.ClassTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
 String _renderConstructor_partial_head_0(
         _i1.ConstructorTemplateData context0) =>
@@ -2450,25 +2438,52 @@ String _renderEnum_partial_documentation_4(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
 String _renderEnum_partial_super_chain_5(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderEnum_partial_interfaces_6(_i13.Enum context1) =>
-    _deduplicated_lib_templates_html__interfaces_html(context1);
-String _renderEnum_partial_constant_7(_i11.Field context2) =>
+String _renderEnum_partial_interfaces_6(_i13.Enum context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+<dt>Implemented types</dt>
+<dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </ul>
+</dd>''');
+  }
+
+  return buffer.toString();
+}
+
+String _renderEnum_partial_constructors_7(_i13.Enum context1) =>
+    _deduplicated_lib_templates_html__constructors_html(context1);
+String _renderEnum_partial_constant_8(_i11.Field context2) =>
     _deduplicated_lib_templates_html__constant_html(context2);
-String _renderEnum_partial_property_8(_i11.Field context2) =>
+String _renderEnum_partial_property_9(_i11.Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderEnum_partial_instance_methods_9(_i13.Enum context1) =>
+String _renderEnum_partial_instance_methods_10(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderEnum_partial_instance_operators_10(_i13.Enum context1) =>
+String _renderEnum_partial_instance_operators_11(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderEnum_partial_static_properties_11(_i13.Enum context1) =>
+String _renderEnum_partial_static_properties_12(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderEnum_partial_static_methods_12(_i13.Enum context1) =>
+String _renderEnum_partial_static_methods_13(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderEnum_partial_static_constants_13(_i13.Enum context1) =>
+String _renderEnum_partial_static_constants_14(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderEnum_partial_search_sidebar_14(_i1.EnumTemplateData context0) =>
+String _renderEnum_partial_search_sidebar_15(_i1.EnumTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderEnum_partial_footer_15(_i1.EnumTemplateData context0) =>
+String _renderEnum_partial_footer_16(_i1.EnumTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
 String _renderError_partial_head_0(_i1.PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
@@ -2736,8 +2751,33 @@ String _renderMixin_partial_documentation_4(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
 String _renderMixin_partial_super_chain_5(_i16.Mixin context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderMixin_partial_interfaces_6(_i16.Mixin context1) =>
-    _deduplicated_lib_templates_html__interfaces_html(context1);
+String _renderMixin_partial_interfaces_6(_i16.Mixin context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+<dt>Implemented types</dt>
+<dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context1.relationshipsClass);
+    buffer.write('''">''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context3.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </ul>
+</dd>''');
+  }
+
+  return buffer.toString();
+}
+
 String _renderMixin_partial_property_7(_i11.Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
 String _renderMixin_partial_instance_methods_8(_i16.Mixin context1) =>
@@ -3841,7 +3881,7 @@ String _deduplicated_lib_templates_html__feature_set_html(
 }
 
 String _deduplicated_lib_templates_html__super_chain_html(
-    _i20.TypeImplementing context0) {
+    _i20.InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -3875,29 +3915,50 @@ String _deduplicated_lib_templates_html__super_chain_html(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__interfaces_html(
-    _i20.TypeImplementing context0) {
+String _deduplicated_lib_templates_html__constructors_html(
+    _i20.InheritingContainer context0) {
   final buffer = StringBuffer();
-  if (context0.hasPublicInterfaces == true) {
+  if (context0.hasPublicConstructors == true) {
     buffer.writeln();
     buffer.write('''
-<dt>Implemented types</dt>
-<dd>
-    <ul class="comma-separated ''');
-    buffer.writeEscaped(context0.relationshipsClass);
-    buffer.write('''">''');
-    var context1 = context0.publicInterfaces;
+  <section class="summary offset-anchor" id="constructors">
+    <h2>Constructors</h2>
+
+    <dl class="constructor-summary-list">''');
+    var context1 = context0.publicConstructorsSorted;
     for (var context2 in context1) {
       buffer.writeln();
       buffer.write('''
-        <li>''');
+        <dt id="''');
+      buffer.writeEscaped(context2.htmlId);
+      buffer.write('''" class="callable">
+          <span class="name">''');
       buffer.write(context2.linkedName);
-      buffer.write('''</li>''');
+      buffer.write('''</span><span class="signature">(''');
+      buffer.write(context2.linkedParams);
+      buffer.write(''')</span>
+        </dt>
+        <dd>
+          ''');
+      buffer.write(context2.oneLineDoc);
+      if (context2.isConst == true) {
+        buffer.writeln();
+        buffer.write('''
+            <div class="constructor-modifier features">const</div>''');
+      }
+      if (context2.isFactory == true) {
+        buffer.writeln();
+        buffer.write('''
+            <div class="constructor-modifier features">factory</div>''');
+      }
+      buffer.writeln();
+      buffer.write('''
+        </dd>''');
     }
     buffer.writeln();
     buffer.write('''
-    </ul>
-</dd>''');
+    </dl>
+  </section>''');
   }
 
   return buffer.toString();

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -387,49 +387,8 @@ String renderClass(_i1.ClassTemplateData context0) {
       </dl>
     </section>''');
   }
-  buffer.writeln();
-  if (context2.hasPublicConstructors == true) {
-    buffer.writeln();
-    buffer.write('''
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">''');
-    var context11 = context2.publicConstructorsSorted;
-    for (var context12 in context11) {
-      buffer.writeln();
-      buffer.write('''
-        <dt id="''');
-      buffer.writeEscaped(context12.htmlId);
-      buffer.write('''" class="callable">
-          <span class="name">''');
-      buffer.write(context12.linkedName);
-      buffer.write('''</span><span class="signature">(''');
-      buffer.write(context12.linkedParams);
-      buffer.write(''')</span>
-        </dt>
-        <dd>
-          ''');
-      buffer.write(context12.oneLineDoc);
-      if (context12.isConst == true) {
-        buffer.writeln();
-        buffer.write('''
-          <div class="constructor-modifier features">const</div>''');
-      }
-      if (context12.isFactory == true) {
-        buffer.writeln();
-        buffer.write('''
-          <div class="constructor-modifier features">factory</div>''');
-      }
-      buffer.writeln();
-      buffer.write('''
-        </dd>''');
-    }
-    buffer.writeln();
-    buffer.write('''
-      </dl>
-    </section>''');
-  }
+  buffer.write('\n\n    ');
+  buffer.write(_renderClass_partial_constructors_7(context2));
   buffer.writeln();
   if (context2.hasPublicInstanceFields == true) {
     buffer.writeln();
@@ -442,10 +401,10 @@ String renderClass(_i1.ClassTemplateData context0) {
       <h2>Properties</h2>
 
       <dl class="properties">''');
-    var context13 = context2.publicInstanceFieldsSorted;
-    for (var context14 in context13) {
+    var context11 = context2.publicInstanceFieldsSorted;
+    for (var context12 in context11) {
       buffer.write('\n        ');
-      buffer.write(_renderClass_partial_property_7(context14));
+      buffer.write(_renderClass_partial_property_8(context12));
     }
     buffer.writeln();
     buffer.write('''
@@ -453,15 +412,15 @@ String renderClass(_i1.ClassTemplateData context0) {
     </section>''');
   }
   buffer.write('\n\n    ');
-  buffer.write(_renderClass_partial_instance_methods_8(context2));
+  buffer.write(_renderClass_partial_instance_methods_9(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_instance_operators_9(context2));
+  buffer.write(_renderClass_partial_instance_operators_10(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_static_properties_10(context2));
+  buffer.write(_renderClass_partial_static_properties_11(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_static_methods_11(context2));
+  buffer.write(_renderClass_partial_static_methods_12(context2));
   buffer.write('\n    ');
-  buffer.write(_renderClass_partial_static_constants_12(context2));
+  buffer.write(_renderClass_partial_static_constants_13(context2));
   buffer.writeln();
   buffer.write('''
 
@@ -469,7 +428,7 @@ String renderClass(_i1.ClassTemplateData context0) {
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderClass_partial_search_sidebar_13(context0));
+  buffer.write(_renderClass_partial_search_sidebar_14(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -491,7 +450,7 @@ String renderClass(_i1.ClassTemplateData context0) {
   </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderClass_partial_footer_14(context0));
+  buffer.write(_renderClass_partial_footer_15(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -656,6 +615,8 @@ String renderEnum(_i1.EnumTemplateData context0) {
       </dl>
     </section>''');
   }
+  buffer.write('\n\n    ');
+  buffer.write(_renderEnum_partial_constructors_7(context2));
   buffer.writeln();
   if (context2.hasPublicEnumValues == true) {
     buffer.writeln();
@@ -667,7 +628,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context5 = context2.publicEnumValuesSorted;
     for (var context6 in context5) {
       buffer.write('\n          ');
-      buffer.write(_renderEnum_partial_constant_7(context6));
+      buffer.write(_renderEnum_partial_constant_8(context6));
     }
     buffer.writeln();
     buffer.write('''
@@ -693,7 +654,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.write('\n        ');
-      buffer.write(_renderEnum_partial_property_8(context8));
+      buffer.write(_renderEnum_partial_property_9(context8));
     }
     buffer.writeln();
     buffer.write('''
@@ -701,22 +662,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
     </section>''');
   }
   buffer.write('\n\n    ');
-  buffer.write(_renderEnum_partial_instance_methods_9(context2));
+  buffer.write(_renderEnum_partial_instance_methods_10(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_instance_operators_10(context2));
+  buffer.write(_renderEnum_partial_instance_operators_11(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_static_properties_11(context2));
+  buffer.write(_renderEnum_partial_static_properties_12(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_static_methods_12(context2));
+  buffer.write(_renderEnum_partial_static_methods_13(context2));
   buffer.write('\n    ');
-  buffer.write(_renderEnum_partial_static_constants_13(context2));
+  buffer.write(_renderEnum_partial_static_constants_14(context2));
   buffer.writeln();
   buffer.write('''
   </div><!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderEnum_partial_search_sidebar_14(context0));
+  buffer.write(_renderEnum_partial_search_sidebar_15(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -738,7 +699,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
   </div><!-- /.sidebar-offcanvas -->
 
 ''');
-  buffer.write(_renderEnum_partial_footer_15(context0));
+  buffer.write(_renderEnum_partial_footer_16(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -2862,19 +2823,21 @@ String _renderClass_partial_super_chain_5(_i10.Class context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
 String _renderClass_partial_interfaces_6(_i10.Class context1) =>
     _deduplicated_lib_templates_html__interfaces_html(context1);
-String _renderClass_partial_property_7(_i11.Field context2) =>
+String _renderClass_partial_constructors_7(_i10.Class context1) =>
+    _deduplicated_lib_templates_html__constructors_html(context1);
+String _renderClass_partial_property_8(_i11.Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderClass_partial_instance_methods_8(_i10.Class context1) =>
+String _renderClass_partial_instance_methods_9(_i10.Class context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderClass_partial_instance_operators_9(_i10.Class context1) =>
+String _renderClass_partial_instance_operators_10(_i10.Class context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderClass_partial_static_properties_10(_i10.Class context1) =>
+String _renderClass_partial_static_properties_11(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderClass_partial_static_methods_11(_i10.Class context1) =>
+String _renderClass_partial_static_methods_12(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderClass_partial_static_constants_12(_i10.Class context1) =>
+String _renderClass_partial_static_constants_13(_i10.Class context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderClass_partial_search_sidebar_13(_i1.ClassTemplateData context0) {
+String _renderClass_partial_search_sidebar_14(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -2933,7 +2896,7 @@ String _renderClass_partial_search_sidebar_13(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderClass_partial_footer_14(_i1.ClassTemplateData context0) {
+String _renderClass_partial_footer_15(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -3408,21 +3371,23 @@ String _renderEnum_partial_super_chain_5(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
 String _renderEnum_partial_interfaces_6(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__interfaces_html(context1);
-String _renderEnum_partial_constant_7(_i11.Field context2) =>
+String _renderEnum_partial_constructors_7(_i13.Enum context1) =>
+    _deduplicated_lib_templates_html__constructors_html(context1);
+String _renderEnum_partial_constant_8(_i11.Field context2) =>
     _deduplicated_lib_templates_html__constant_html(context2);
-String _renderEnum_partial_property_8(_i11.Field context2) =>
+String _renderEnum_partial_property_9(_i11.Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderEnum_partial_instance_methods_9(_i13.Enum context1) =>
+String _renderEnum_partial_instance_methods_10(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderEnum_partial_instance_operators_10(_i13.Enum context1) =>
+String _renderEnum_partial_instance_operators_11(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderEnum_partial_static_properties_11(_i13.Enum context1) =>
+String _renderEnum_partial_static_properties_12(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderEnum_partial_static_methods_12(_i13.Enum context1) =>
+String _renderEnum_partial_static_methods_13(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderEnum_partial_static_constants_13(_i13.Enum context1) =>
+String _renderEnum_partial_static_constants_14(_i13.Enum context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderEnum_partial_search_sidebar_14(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_search_sidebar_15(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<header id="header-search-sidebar" class="hidden-l">
   <form class="search-sidebar" role="search">
@@ -3481,7 +3446,7 @@ String _renderEnum_partial_search_sidebar_14(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_footer_15(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_footer_16(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -7318,6 +7283,55 @@ String _deduplicated_lib_templates_html__interfaces_html(
     buffer.write('''
     </ul>
 </dd>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated_lib_templates_html__constructors_html(
+    _i20.TypeImplementing context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicConstructors == true) {
+    buffer.writeln();
+    buffer.write('''
+  <section class="summary offset-anchor" id="constructors">
+    <h2>Constructors</h2>
+
+    <dl class="constructor-summary-list">''');
+    var context1 = context0.publicConstructorsSorted;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''
+        <dt id="''');
+      buffer.writeEscaped(context2.htmlId);
+      buffer.write('''" class="callable">
+          <span class="name">''');
+      buffer.write(context2.linkedName);
+      buffer.write('''</span><span class="signature">(''');
+      buffer.write(context2.linkedParams);
+      buffer.write(''')</span>
+        </dt>
+        <dd>
+          ''');
+      buffer.write(context2.oneLineDoc);
+      if (context2.isConst == true) {
+        buffer.writeln();
+        buffer.write('''
+            <div class="constructor-modifier features">const</div>''');
+      }
+      if (context2.isFactory == true) {
+        buffer.writeln();
+        buffer.write('''
+            <div class="constructor-modifier features">factory</div>''');
+      }
+      buffer.writeln();
+      buffer.write('''
+        </dd>''');
+    }
+    buffer.writeln();
+    buffer.write('''
+    </dl>
+  </section>''');
   }
 
   return buffer.toString();

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -1112,8 +1112,25 @@ String _renderClass_partial_documentation_4(_i9.Class context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
 String _renderClass_partial_super_chain_5(_i9.Class context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderClass_partial_interfaces_6(_i9.Class context1) =>
-    _deduplicated_lib_templates_md__interfaces_md(context1);
+String _renderClass_partial_interfaces_6(_i9.Class context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+**Implemented types**
+''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
 String _renderClass_partial_constructors_7(_i9.Class context1) =>
     _deduplicated_lib_templates_md__constructors_md(context1);
 String _renderClass_partial_property_8(_i10.Field context2) =>
@@ -1183,8 +1200,25 @@ String _renderEnum_partial_documentation_3(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
 String _renderEnum_partial_super_chain_4(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderEnum_partial_interfaces_5(_i12.Enum context1) =>
-    _deduplicated_lib_templates_md__interfaces_md(context1);
+String _renderEnum_partial_interfaces_5(_i12.Enum context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+**Implemented types**
+''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
 String _renderEnum_partial_constructors_6(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__constructors_md(context1);
 String _renderEnum_partial_constant_7(_i10.Field context2) =>
@@ -1480,8 +1514,25 @@ String _renderMixin_partial_documentation_4(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
 String _renderMixin_partial_super_chain_5(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderMixin_partial_interfaces_6(_i15.Mixin context1) =>
-    _deduplicated_lib_templates_md__interfaces_md(context1);
+String _renderMixin_partial_interfaces_6(_i15.Mixin context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+**Implemented types**
+''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
 String _renderMixin_partial_property_7(_i10.Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
 String _renderMixin_partial_instance_methods_8(_i15.Mixin context1) =>
@@ -2112,7 +2163,7 @@ String _deduplicated_lib_templates_md__feature_set_md(
 }
 
 String _deduplicated_lib_templates_md__super_chain_md(
-    _i19.TypeImplementing context0) {
+    _i19.InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -2137,28 +2188,8 @@ String _deduplicated_lib_templates_md__super_chain_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__interfaces_md(
-    _i19.TypeImplementing context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicInterfaces == true) {
-    buffer.writeln();
-    buffer.write('''
-**Implemented types**
-''');
-    var context1 = context0.publicInterfaces;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''
-- ''');
-      buffer.write(context2.linkedName);
-    }
-  }
-
-  return buffer.toString();
-}
-
 String _deduplicated_lib_templates_md__constructors_md(
-    _i19.TypeImplementing context0) {
+    _i19.InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicConstructors == true) {
     buffer.writeln();

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -271,58 +271,33 @@ String renderClass(_i1.ClassTemplateData context0) {
       }
     }
   }
-  buffer.writeln();
-  if (context2.hasPublicConstructors == true) {
-    buffer.writeln();
-    buffer.write('''
-## Constructors
-''');
-    var context10 = context2.publicConstructorsSorted;
-    for (var context11 in context10) {
-      buffer.writeln();
-      buffer.write(context11.linkedName);
-      buffer.write(''' (''');
-      buffer.write(context11.linkedParams);
-      buffer.write(''')
-
-''');
-      buffer.write(context11.oneLineDoc);
-      buffer.write('  ');
-      if (context11.isConst == true) {
-        buffer.write('''_const_''');
-      }
-      buffer.write(' ');
-      if (context11.isFactory == true) {
-        buffer.write('''_factory_''');
-      }
-      buffer.writeln();
-    }
-  }
+  buffer.write('\n\n');
+  buffer.write(_renderClass_partial_constructors_7(context2));
   buffer.writeln();
   if (context2.hasPublicInstanceFields == true) {
     buffer.writeln();
     buffer.write('''
 ## Properties
 ''');
-    var context12 = context2.publicInstanceFieldsSorted;
-    for (var context13 in context12) {
+    var context10 = context2.publicInstanceFieldsSorted;
+    for (var context11 in context10) {
       buffer.writeln();
-      buffer.write(_renderClass_partial_property_7(context13));
+      buffer.write(_renderClass_partial_property_8(context11));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_instance_methods_8(context2));
+  buffer.write(_renderClass_partial_instance_methods_9(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_instance_operators_9(context2));
+  buffer.write(_renderClass_partial_instance_operators_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_properties_10(context2));
+  buffer.write(_renderClass_partial_static_properties_11(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_methods_11(context2));
+  buffer.write(_renderClass_partial_static_methods_12(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_constants_12(context2));
+  buffer.write(_renderClass_partial_static_constants_13(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_footer_13(context0));
+  buffer.write(_renderClass_partial_footer_14(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -418,6 +393,8 @@ String renderEnum(_i1.EnumTemplateData context0) {
       }
     }
   }
+  buffer.write('\n\n');
+  buffer.write(_renderEnum_partial_constructors_6(context2));
   buffer.writeln();
   if (context2.hasPublicConstantFields == true) {
     buffer.writeln();
@@ -427,7 +404,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context5 = context2.publicConstantFieldsSorted;
     for (var context6 in context5) {
       buffer.writeln();
-      buffer.write(_renderEnum_partial_constant_6(context6));
+      buffer.write(_renderEnum_partial_constant_7(context6));
       buffer.writeln();
     }
   }
@@ -440,22 +417,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(_renderEnum_partial_property_7(context8));
+      buffer.write(_renderEnum_partial_property_8(context8));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_instance_methods_8(context2));
+  buffer.write(_renderEnum_partial_instance_methods_9(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_instance_operators_9(context2));
+  buffer.write(_renderEnum_partial_instance_operators_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_properties_10(context2));
+  buffer.write(_renderEnum_partial_static_properties_11(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_methods_11(context2));
+  buffer.write(_renderEnum_partial_static_methods_12(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_constants_12(context2));
+  buffer.write(_renderEnum_partial_static_constants_13(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_footer_13(context0));
+  buffer.write(_renderEnum_partial_footer_14(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -1114,21 +1091,40 @@ String _renderClass_partial_documentation_4(_i9.Class context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
 String _renderClass_partial_super_chain_5(_i9.Class context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderClass_partial_interfaces_6(_i9.Class context1) =>
-    _deduplicated_lib_templates_md__interfaces_md(context1);
-String _renderClass_partial_property_7(_i10.Field context2) =>
+String _renderClass_partial_interfaces_6(_i9.Class context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+**Implemented types**
+''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
+String _renderClass_partial_constructors_7(_i9.Class context1) =>
+    _deduplicated_lib_templates_md__constructors_md(context1);
+String _renderClass_partial_property_8(_i10.Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderClass_partial_instance_methods_8(_i9.Class context1) =>
+String _renderClass_partial_instance_methods_9(_i9.Class context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderClass_partial_instance_operators_9(_i9.Class context1) =>
+String _renderClass_partial_instance_operators_10(_i9.Class context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderClass_partial_static_properties_10(_i9.Class context1) =>
+String _renderClass_partial_static_properties_11(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderClass_partial_static_methods_11(_i9.Class context1) =>
+String _renderClass_partial_static_methods_12(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderClass_partial_static_constants_12(_i9.Class context1) =>
+String _renderClass_partial_static_constants_13(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderClass_partial_footer_13(_i1.ClassTemplateData context0) =>
+String _renderClass_partial_footer_14(_i1.ClassTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
 String _renderConstructor_partial_head_0(
         _i1.ConstructorTemplateData context0) =>
@@ -1154,23 +1150,42 @@ String _renderEnum_partial_documentation_3(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
 String _renderEnum_partial_super_chain_4(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderEnum_partial_interfaces_5(_i12.Enum context1) =>
-    _deduplicated_lib_templates_md__interfaces_md(context1);
-String _renderEnum_partial_constant_6(_i10.Field context2) =>
+String _renderEnum_partial_interfaces_5(_i12.Enum context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+**Implemented types**
+''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
+String _renderEnum_partial_constructors_6(_i12.Enum context1) =>
+    _deduplicated_lib_templates_md__constructors_md(context1);
+String _renderEnum_partial_constant_7(_i10.Field context2) =>
     _deduplicated_lib_templates_md__constant_md(context2);
-String _renderEnum_partial_property_7(_i10.Field context2) =>
+String _renderEnum_partial_property_8(_i10.Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderEnum_partial_instance_methods_8(_i12.Enum context1) =>
+String _renderEnum_partial_instance_methods_9(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderEnum_partial_instance_operators_9(_i12.Enum context1) =>
+String _renderEnum_partial_instance_operators_10(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderEnum_partial_static_properties_10(_i12.Enum context1) =>
+String _renderEnum_partial_static_properties_11(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderEnum_partial_static_methods_11(_i12.Enum context1) =>
+String _renderEnum_partial_static_methods_12(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderEnum_partial_static_constants_12(_i12.Enum context1) =>
+String _renderEnum_partial_static_constants_13(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderEnum_partial_footer_13(_i1.EnumTemplateData context0) =>
+String _renderEnum_partial_footer_14(_i1.EnumTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
 String _renderExtension_partial_head_0<T extends _i2.Extension>(
         _i1.ExtensionTemplateData<T> context0) =>
@@ -1359,8 +1374,25 @@ String _renderMixin_partial_documentation_4(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
 String _renderMixin_partial_super_chain_5(_i15.Mixin context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderMixin_partial_interfaces_6(_i15.Mixin context1) =>
-    _deduplicated_lib_templates_md__interfaces_md(context1);
+String _renderMixin_partial_interfaces_6(_i15.Mixin context1) {
+  final buffer = StringBuffer();
+  if (context1.hasPublicInterfaces == true) {
+    buffer.writeln();
+    buffer.write('''
+**Implemented types**
+''');
+    var context2 = context1.publicInterfaces;
+    for (var context3 in context2) {
+      buffer.writeln();
+      buffer.write('''
+- ''');
+      buffer.write(context3.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
 String _renderMixin_partial_property_7(_i10.Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
 String _renderMixin_partial_instance_methods_8(_i15.Mixin context1) =>
@@ -1957,7 +1989,7 @@ String _deduplicated_lib_templates_md__feature_set_md(
 }
 
 String _deduplicated_lib_templates_md__super_chain_md(
-    _i19.TypeImplementing context0) {
+    _i19.InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -1982,20 +2014,33 @@ String _deduplicated_lib_templates_md__super_chain_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__interfaces_md(
-    _i19.TypeImplementing context0) {
+String _deduplicated_lib_templates_md__constructors_md(
+    _i19.InheritingContainer context0) {
   final buffer = StringBuffer();
-  if (context0.hasPublicInterfaces == true) {
+  if (context0.hasPublicConstructors == true) {
     buffer.writeln();
     buffer.write('''
-**Implemented types**
+## Constructors
 ''');
-    var context1 = context0.publicInterfaces;
+    var context1 = context0.publicConstructorsSorted;
     for (var context2 in context1) {
       buffer.writeln();
-      buffer.write('''
-- ''');
       buffer.write(context2.linkedName);
+      buffer.write(''' (''');
+      buffer.write(context2.linkedParams);
+      buffer.write(''')
+
+''');
+      buffer.write(context2.oneLineDoc);
+      buffer.write('  ');
+      if (context2.isConst == true) {
+        buffer.write('''_const_''');
+      }
+      buffer.write(' ');
+      if (context2.isFactory == true) {
+        buffer.write('''_factory_''');
+      }
+      buffer.writeln();
     }
   }
 

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -271,58 +271,33 @@ String renderClass(_i1.ClassTemplateData context0) {
       }
     }
   }
-  buffer.writeln();
-  if (context2.hasPublicConstructors == true) {
-    buffer.writeln();
-    buffer.write('''
-## Constructors
-''');
-    var context10 = context2.publicConstructorsSorted;
-    for (var context11 in context10) {
-      buffer.writeln();
-      buffer.write(context11.linkedName);
-      buffer.write(''' (''');
-      buffer.write(context11.linkedParams);
-      buffer.write(''')
-
-''');
-      buffer.write(context11.oneLineDoc);
-      buffer.write('  ');
-      if (context11.isConst == true) {
-        buffer.write('''_const_''');
-      }
-      buffer.write(' ');
-      if (context11.isFactory == true) {
-        buffer.write('''_factory_''');
-      }
-      buffer.writeln();
-    }
-  }
+  buffer.write('\n\n');
+  buffer.write(_renderClass_partial_constructors_7(context2));
   buffer.writeln();
   if (context2.hasPublicInstanceFields == true) {
     buffer.writeln();
     buffer.write('''
 ## Properties
 ''');
-    var context12 = context2.publicInstanceFieldsSorted;
-    for (var context13 in context12) {
+    var context10 = context2.publicInstanceFieldsSorted;
+    for (var context11 in context10) {
       buffer.writeln();
-      buffer.write(_renderClass_partial_property_7(context13));
+      buffer.write(_renderClass_partial_property_8(context11));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_instance_methods_8(context2));
+  buffer.write(_renderClass_partial_instance_methods_9(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_instance_operators_9(context2));
+  buffer.write(_renderClass_partial_instance_operators_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_properties_10(context2));
+  buffer.write(_renderClass_partial_static_properties_11(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_methods_11(context2));
+  buffer.write(_renderClass_partial_static_methods_12(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_static_constants_12(context2));
+  buffer.write(_renderClass_partial_static_constants_13(context2));
   buffer.write('\n\n');
-  buffer.write(_renderClass_partial_footer_13(context0));
+  buffer.write(_renderClass_partial_footer_14(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -418,6 +393,8 @@ String renderEnum(_i1.EnumTemplateData context0) {
       }
     }
   }
+  buffer.write('\n\n');
+  buffer.write(_renderEnum_partial_constructors_6(context2));
   buffer.writeln();
   if (context2.hasPublicConstantFields == true) {
     buffer.writeln();
@@ -427,7 +404,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context5 = context2.publicConstantFieldsSorted;
     for (var context6 in context5) {
       buffer.writeln();
-      buffer.write(_renderEnum_partial_constant_6(context6));
+      buffer.write(_renderEnum_partial_constant_7(context6));
       buffer.writeln();
     }
   }
@@ -440,22 +417,22 @@ String renderEnum(_i1.EnumTemplateData context0) {
     var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(_renderEnum_partial_property_7(context8));
+      buffer.write(_renderEnum_partial_property_8(context8));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_instance_methods_8(context2));
+  buffer.write(_renderEnum_partial_instance_methods_9(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_instance_operators_9(context2));
+  buffer.write(_renderEnum_partial_instance_operators_10(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_properties_10(context2));
+  buffer.write(_renderEnum_partial_static_properties_11(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_methods_11(context2));
+  buffer.write(_renderEnum_partial_static_methods_12(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_static_constants_12(context2));
+  buffer.write(_renderEnum_partial_static_constants_13(context2));
   buffer.write('\n\n');
-  buffer.write(_renderEnum_partial_footer_13(context0));
+  buffer.write(_renderEnum_partial_footer_14(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -1137,19 +1114,21 @@ String _renderClass_partial_super_chain_5(_i9.Class context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
 String _renderClass_partial_interfaces_6(_i9.Class context1) =>
     _deduplicated_lib_templates_md__interfaces_md(context1);
-String _renderClass_partial_property_7(_i10.Field context2) =>
+String _renderClass_partial_constructors_7(_i9.Class context1) =>
+    _deduplicated_lib_templates_md__constructors_md(context1);
+String _renderClass_partial_property_8(_i10.Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderClass_partial_instance_methods_8(_i9.Class context1) =>
+String _renderClass_partial_instance_methods_9(_i9.Class context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderClass_partial_instance_operators_9(_i9.Class context1) =>
+String _renderClass_partial_instance_operators_10(_i9.Class context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderClass_partial_static_properties_10(_i9.Class context1) =>
+String _renderClass_partial_static_properties_11(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderClass_partial_static_methods_11(_i9.Class context1) =>
+String _renderClass_partial_static_methods_12(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderClass_partial_static_constants_12(_i9.Class context1) =>
+String _renderClass_partial_static_constants_13(_i9.Class context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderClass_partial_footer_13(_i1.ClassTemplateData context0) {
+String _renderClass_partial_footer_14(_i1.ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -1206,21 +1185,23 @@ String _renderEnum_partial_super_chain_4(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
 String _renderEnum_partial_interfaces_5(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__interfaces_md(context1);
-String _renderEnum_partial_constant_6(_i10.Field context2) =>
+String _renderEnum_partial_constructors_6(_i12.Enum context1) =>
+    _deduplicated_lib_templates_md__constructors_md(context1);
+String _renderEnum_partial_constant_7(_i10.Field context2) =>
     _deduplicated_lib_templates_md__constant_md(context2);
-String _renderEnum_partial_property_7(_i10.Field context2) =>
+String _renderEnum_partial_property_8(_i10.Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderEnum_partial_instance_methods_8(_i12.Enum context1) =>
+String _renderEnum_partial_instance_methods_9(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderEnum_partial_instance_operators_9(_i12.Enum context1) =>
+String _renderEnum_partial_instance_operators_10(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderEnum_partial_static_properties_10(_i12.Enum context1) =>
+String _renderEnum_partial_static_properties_11(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderEnum_partial_static_methods_11(_i12.Enum context1) =>
+String _renderEnum_partial_static_methods_12(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderEnum_partial_static_constants_12(_i12.Enum context1) =>
+String _renderEnum_partial_static_constants_13(_i12.Enum context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderEnum_partial_footer_13(_i1.EnumTemplateData context0) {
+String _renderEnum_partial_footer_14(_i1.EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -2170,6 +2151,39 @@ String _deduplicated_lib_templates_md__interfaces_md(
       buffer.write('''
 - ''');
       buffer.write(context2.linkedName);
+    }
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated_lib_templates_md__constructors_md(
+    _i19.TypeImplementing context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicConstructors == true) {
+    buffer.writeln();
+    buffer.write('''
+## Constructors
+''');
+    var context1 = context0.publicConstructorsSorted;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write(context2.linkedName);
+      buffer.write(''' (''');
+      buffer.write(context2.linkedParams);
+      buffer.write(''')
+
+''');
+      buffer.write(context2.oneLineDoc);
+      buffer.write('  ');
+      if (context2.isConst == true) {
+        buffer.write('''_const_''');
+      }
+      buffer.write(' ');
+      if (context2.isFactory == true) {
+        buffer.write('''_factory_''');
+      }
+      buffer.writeln();
     }
   }
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1741,19 +1741,6 @@ class _Renderer_Class extends RendererBase<Class> {
                         parent: r);
                   },
                 ),
-                'extraReferenceChildren': Property(
-                  getValue: (CT_ c) => c.extraReferenceChildren,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Iterable<MapEntry<String, CommentReferable>>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.extraReferenceChildren.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['MapEntry']!));
-                  },
-                ),
                 'fileName': Property(
                   getValue: (CT_ c) => c.fileName,
                   renderVariable:
@@ -2019,30 +2006,6 @@ class _Renderer_CommentReferable extends RendererBase<CommentReferable> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                'definingCommentReferable': Property(
-                  getValue: (CT_ c) => c.definingCommentReferable,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_CommentReferable.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as CommentReferable,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(
-                        c.definingCommentReferable, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']!);
-                  },
-                ),
                 'href': Property(
                   getValue: (CT_ c) => c.href,
                   renderVariable:
@@ -2220,19 +2183,6 @@ class _Renderer_Constructable extends RendererBase<Constructable> {
                         parent: r);
                   },
                 ),
-                'extraReferenceChildren': Property(
-                  getValue: (CT_ c) => c.extraReferenceChildren,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Iterable<MapEntry<String, CommentReferable>>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.extraReferenceChildren.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['MapEntry']!));
-                  },
-                ),
                 'hasPublicConstructors': Property(
                   getValue: (CT_ c) => c.hasPublicConstructors,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -2245,7 +2195,7 @@ class _Renderer_Constructable extends RendererBase<Constructable> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Constructor>'),
+                          c, remainingNames, 'List<Constructor>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicConstructorsSorted.map((e) =>
@@ -3035,19 +2985,6 @@ class _Renderer_Container extends RendererBase<Container> {
                         parent: r);
                   },
                 ),
-                'extraReferenceChildren': Property(
-                  getValue: (CT_ c) => c.extraReferenceChildren,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Iterable<MapEntry<String, CommentReferable>>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.extraReferenceChildren.map((e) => renderSimple(
-                        e, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['MapEntry']!));
-                  },
-                ),
                 'hasInstanceFields': Property(
                   getValue: (CT_ c) => c.hasInstanceFields,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -3793,30 +3730,6 @@ class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
           CT_,
           () => {
                 ..._Renderer_ElementType.propertyMap<CT_>(),
-                'definingCommentReferable': Property(
-                  getValue: (CT_ c) => c.definingCommentReferable,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_CommentReferable.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as CommentReferable,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(
-                        c.definingCommentReferable, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']!);
-                  },
-                ),
                 'element': Property(
                   getValue: (CT_ c) => c.element,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -4605,7 +4518,21 @@ class _Renderer_Enum extends RendererBase<Enum> {
           CT_,
           () => {
                 ..._Renderer_InheritingContainer.propertyMap<CT_>(),
+                ..._Renderer_Constructable.propertyMap<CT_>(),
                 ..._Renderer_TypeImplementing.propertyMap<CT_>(),
+                'allModelElements': Property(
+                  getValue: (CT_ c) => c.allModelElements,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'List<ModelElement>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.allModelElements.map((e) => _render_ModelElement(
+                        e, ast, r.template, sink,
+                        parent: r));
+                  },
+                ),
                 'hasPublicEnumValues': Property(
                   getValue: (CT_ c) => c.hasPublicEnumValues,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -10105,30 +10032,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         getters: _invisibleGetters['DartdocOptionContext']!);
                   },
                 ),
-                'definingCommentReferable': Property(
-                  getValue: (CT_ c) => c.definingCommentReferable,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_CommentReferable.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as CommentReferable,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(
-                        c.definingCommentReferable, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CommentReferable']!);
-                  },
-                ),
                 'definingLibrary': Property(
                   getValue: (CT_ c) => c.definingLibrary,
                   renderVariable:
@@ -12346,7 +12249,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -12562,7 +12465,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -16607,7 +16510,6 @@ const _invisibleGetters = {
     'runtimeType',
     'values'
   },
-  'MapEntry': {'hashCode', 'key', 'runtimeType', 'value'},
   'Member': {
     'context',
     'declaration',

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2598,8 +2598,8 @@ class _Renderer_ConstructorTemplateData
           CT_,
           () => {
                 ..._Renderer_TemplateData.propertyMap<Constructor, CT_>(),
-                'clazz': Property(
-                  getValue: (CT_ c) => c.clazz,
+                'constructable': Property(
+                  getValue: (CT_ c) => c.constructable,
                   renderVariable:
                       (CT_ c, Property<CT_> self, List<String> remainingNames) {
                     if (remainingNames.isEmpty) {
@@ -2607,16 +2607,18 @@ class _Renderer_ConstructorTemplateData
                     }
                     var name = remainingNames.first;
                     var nextProperty =
-                        _Renderer_Class.propertyMap().getValue(name);
+                        _Renderer_Constructable.propertyMap().getValue(name);
                     return nextProperty.renderVariable(
-                        self.getValue(c) as Class,
+                        self.getValue(c) as Constructable,
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
                   isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_Class(c.clazz, ast, r.template, sink, parent: r);
+                    renderSimple(c.constructable, ast, r.template, sink,
+                        parent: r,
+                        getters: _invisibleGetters['Constructable']!);
                   },
                 ),
                 'constructor': Property(
@@ -16086,6 +16088,15 @@ const _invisibleGetters = {
     'topLevelVariables',
     'typeAliases',
     'types'
+  },
+  'Constructable': {
+    'constructors',
+    'defaultConstructor',
+    'extraReferenceChildren',
+    'hasPublicConstructors',
+    'publicConstructors',
+    'publicConstructorsSorted',
+    'unnamedConstructor'
   },
   'ConstructorElement': {
     'declaration',

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -22,8 +22,6 @@ class Class extends InheritingContainer
   }
 
   @override
-  // TODO(srawlins): Figure out what we elsewhere in dartdoc.
-  // ignore: overridden_fields
   late final List<ModelElement> allModelElements = [
     ...super.allModelElements,
     ...constructors,
@@ -93,11 +91,9 @@ class Class extends InheritingContainer
     ...interfaces.expandInheritanceChain,
   ];
 
-  Iterable<Field>? _instanceFields;
-
   @override
-  Iterable<Field> get instanceFields =>
-      _instanceFields ??= allFields.where((f) => !f.isStatic);
+  late final Iterable<Field> instanceFields =
+      allFields.where((f) => !f.isStatic);
 
   @override
   bool get publicInheritedInstanceFields =>

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -5,8 +5,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 
-import 'comment_referable.dart';
-
 /// A [Container] defined with a `class` declaration in Dart.
 ///
 /// Members follow similar naming rules to [Container], with the following
@@ -101,39 +99,6 @@ class Class extends InheritingContainer
 
   @override
   Iterable<Field> get constantFields => allFields.where((f) => f.isConst);
-
-  static Iterable<MapEntry<String, CommentReferable>> _constructorGenerator(
-      Iterable<Constructor> source) sync* {
-    for (var constructor in source) {
-      yield MapEntry(constructor.referenceName, constructor);
-      yield MapEntry(
-          '${constructor.enclosingElement.referenceName}.${constructor.referenceName}',
-          constructor);
-      if (constructor.isDefaultConstructor) {
-        yield MapEntry('new', constructor);
-      }
-    }
-  }
-
-  @override
-  Iterable<MapEntry<String, CommentReferable>>
-      get extraReferenceChildren sync* {
-    yield* _constructorGenerator(constructors);
-    // TODO(jcollins-g): wean important users off of relying on static method
-    // inheritance (dart-lang/dartdoc#2698)
-    for (var container
-        in publicSuperChain.map((t) => t.modelElement).whereType<Container>()) {
-      for (var modelElement in [
-        ...container.staticFields,
-        ...container.staticMethods,
-      ]) {
-        yield MapEntry(modelElement.referenceName, modelElement);
-      }
-      if (container is Class) {
-        yield* _constructorGenerator(container.constructors);
-      }
-    }
-  }
 
   @override
   String get relationshipsClass => 'clazz-relationships';

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -30,9 +30,8 @@ class Constructor extends ModelElement
   ConstructorElement? get element => super.element as ConstructorElement?;
 
   @override
-  // TODO(jcollins-g): Revisit this when dart-lang/sdk#31517 is implemented.
   List<TypeParameter> get typeParameters =>
-      (enclosingElement as Class).typeParameters;
+      (enclosingElement as Constructable).typeParameters;
 
   @override
   ModelElement get enclosingElement =>
@@ -60,16 +59,15 @@ class Constructor extends ModelElement
   bool get isUnnamedConstructor => name == enclosingElement.name;
 
   bool get isDefaultConstructor =>
-      name == '${enclosingElement.name}.new' || isUnnamedConstructor;
+      isUnnamedConstructor || name == '${enclosingElement.name}.new';
 
   bool get isFactory => element!.isFactory;
 
   @override
   String get kind => 'constructor';
 
-  Callable? _modelType;
-  Callable get modelType => (_modelType ??=
-      modelBuilder.typeFrom(element!.type, library!) as Callable?)!;
+  late final Callable modelType =
+      modelBuilder.typeFrom(element!.type, library!) as Callable;
 
   @override
   late final String name = () {

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -252,6 +252,7 @@ abstract class Container extends ModelElement
 
   /// For subclasses to add items after the main pass but before the
   /// parameter-global.
+  @visibleForOverriding
   Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren => [];
 
   @override

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -253,7 +253,7 @@ abstract class Container extends ModelElement
   /// For subclasses to add items after the main pass but before the
   /// parameter-global.
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren => [];
+  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren;
 
   @override
   @mustCallSuper

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
@@ -55,7 +56,10 @@ class EnumField extends Field {
             element, library, packageGraph, getter as ContainerAccessor?, null);
 
   @override
-  String get constantValueBase => _fieldRenderer.renderValue(this);
+  String get constantValueBase =>
+      element!.library!.featureSet.isEnabled(Feature.enhanced_enums)
+          ? super.constantValueBase
+          : _fieldRenderer.renderValue(this);
 
   @override
   List<DocumentationComment> get documentationFrom {

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -7,9 +7,15 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:dartdoc/src/render/enum_field_renderer.dart';
 
-class Enum extends InheritingContainer with TypeImplementing {
+class Enum extends InheritingContainer with Constructable, TypeImplementing {
   Enum(ClassElement element, Library? library, PackageGraph packageGraph)
       : super(element, library, packageGraph);
+
+  @override
+  late final List<ModelElement> allModelElements = [
+    ...super.allModelElements,
+    ...constructors,
+  ];
 
   @override
   late final List<InheritingContainer?> inheritanceChain = [

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -7,6 +7,7 @@ import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/extension_target.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:meta/meta.dart';
 
 /// Extension methods
 class Extension extends Container implements EnclosedElement {
@@ -109,4 +110,8 @@ class Extension extends Container implements EnclosedElement {
       ...super.referenceChildren,
     };
   }
+
+  @override
+  @visibleForOverriding
+  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren => [];
 }

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -77,11 +77,6 @@ mixin GetterSetterCombo on ModelElement {
         '${targetClass.linkedName}.${target.linkedName}');
   }
 
-  String _buildConstantValueBase() {
-    var result = constantInitializer?.toString() ?? '';
-    return const HtmlEscape(HtmlEscapeMode.unknown).convert(result);
-  }
-
   @override
   CharacterLocation? get characterLocation {
     if (enclosingElement is Enum) {
@@ -107,10 +102,9 @@ mixin GetterSetterCombo on ModelElement {
 
   String get constantValueTruncated =>
       linkifyConstantValue(truncateString(constantValueBase, 200));
-  String? _constantValueBase;
 
-  String get constantValueBase =>
-      _constantValueBase ??= _buildConstantValueBase();
+  late final String constantValueBase = const HtmlEscape(HtmlEscapeMode.unknown)
+      .convert(constantInitializer?.toString() ?? '');
 
   late final bool hasPublicGetter = hasGetter && getter!.isPublic;
 

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -57,6 +57,7 @@ mixin Constructable on InheritingContainer {
   }
 
   @override
+  @visibleForOverriding
   Iterable<MapEntry<String, CommentReferable>>
       get extraReferenceChildren sync* {
     yield* _constructorGenerator(constructors);
@@ -70,7 +71,7 @@ mixin Constructable on InheritingContainer {
       ]) {
         yield MapEntry(modelElement.referenceName, modelElement);
       }
-      if (container is Class) {
+      if (container is Constructable) {
         yield* _constructorGenerator(container.constructors);
       }
     }

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -31,28 +31,17 @@ mixin Constructable on InheritingContainer {
   Iterable<Constructor> get publicConstructors =>
       model_utils.filterNonPublic(constructors);
 
-  List<Constructor>? _publicConstructorsSorted;
-
   @override
-  Iterable<Constructor> get publicConstructorsSorted =>
-      _publicConstructorsSorted ??= publicConstructors.toList()..sort(byName);
+  late final List<Constructor> publicConstructorsSorted =
+      publicConstructors.toList()..sort(byName);
 
-  Constructor? _unnamedConstructor;
-  Constructor? get unnamedConstructor {
-    _unnamedConstructor ??=
-        constructors.firstWhereOrNull((c) => c.isUnnamedConstructor);
-    return _unnamedConstructor;
-  }
-
-  Constructor? _defaultConstructor;
+  late final Constructor? unnamedConstructor =
+      constructors.firstWhereOrNull((c) => c.isUnnamedConstructor);
 
   /// With constructor tearoffs, this is no longer equivalent to the unnamed
   /// constructor and assumptions based on that are incorrect.
-  Constructor? get defaultConstructor {
-    _defaultConstructor ??= unnamedConstructor ??
-        constructors.firstWhere((c) => c.isDefaultConstructor);
-    return _defaultConstructor;
-  }
+  late final Constructor? defaultConstructor = unnamedConstructor ??
+      constructors.firstWhere((c) => c.isDefaultConstructor);
 
   static Iterable<MapEntry<String, CommentReferable>> _constructorGenerator(
       Iterable<Constructor> source) sync* {
@@ -90,14 +79,10 @@ mixin Constructable on InheritingContainer {
 
 /// Add the ability to support mixed-in types to an [InheritingContainer].
 mixin MixedInTypes on InheritingContainer {
-  List<DefinedElementType>? _mixedInTypes;
-
-  List<DefinedElementType> get mixedInTypes =>
-      _mixedInTypes ??
-      [
-        ...element!.mixins.map<DefinedElementType>(
-            (f) => modelBuilder.typeFrom(f, library) as DefinedElementType)
-      ];
+  late final List<DefinedElementType> mixedInTypes = [
+    ...element!.mixins
+        .map((f) => modelBuilder.typeFrom(f, library) as DefinedElementType)
+  ];
 
   bool get hasPublicMixedInTypes => publicMixedInTypes.isNotEmpty;
 
@@ -242,11 +227,13 @@ abstract class InheritingContainer extends Container
   bool get publicInheritedInstanceOperators =>
       publicInstanceOperators.every((f) => f.isInherited);
 
-  @override
-  late final List<ModelElement> allModelElements = [
+  late final List<ModelElement> _allModelElements = [
     ...super.allModelElements,
     ...typeParameters,
   ];
+
+  @override
+  List<ModelElement> get allModelElements => _allModelElements;
 
   /// Returns the [InheritingContainer] with the library in which [element] is defined.
   InheritingContainer get definingContainer =>

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -5,9 +5,11 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
+import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:dartdoc/src/special_elements.dart';
+import 'package:meta/meta.dart';
 
 /// Implements the Dart 2.1 "mixin" style of mixin declarations.
 class Mixin extends InheritingContainer with TypeImplementing {
@@ -58,6 +60,10 @@ class Mixin extends InheritingContainer with TypeImplementing {
     // implement them even when they aren't mentioned.
     ...interfaces.expandInheritanceChain,
   ];
+
+  @override
+  @visibleForOverriding
+  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren => [];
 
   @override
   String get relationshipsClass => 'mixin-relationships';

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -415,6 +415,7 @@ abstract class ModelElement extends Canonicalization
     if (enclosingElement is Class && !(enclosingElement as Class).isPublic) {
       return false;
     }
+    // TODO(srawlins): Er, mixin? enum?
     if (enclosingElement is Extension &&
         !(enclosingElement as Extension).isPublic) {
       return false;
@@ -496,7 +497,10 @@ abstract class ModelElement extends Canonicalization
   // or null if there isn't one.
   late final ModelElement? canonicalModelElement = () {
     Container? preferredClass;
-    if (enclosingElement is Class || enclosingElement is Extension) {
+    // TODO(srawlins): Add mixin.
+    if (enclosingElement is Class ||
+        enclosingElement is Enum ||
+        enclosingElement is Extension) {
       preferredClass = enclosingElement as Container?;
     }
     return packageGraph.findCanonicalModelElementFor(element,

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -783,8 +783,9 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       var iKey = Tuple2<Element, Library?>(e, lib);
       var key =
           Tuple4<Element, Library?, Class?, ModelElement?>(e, lib, null, null);
-      var keyWithClass = Tuple4<Element, Library?, Class?, ModelElement?>(
-          e, lib, preferredClass as Class?, null);
+      var keyWithClass =
+          Tuple4<Element, Library?, InheritingContainer?, ModelElement?>(
+              e, lib, preferredClass as InheritingContainer?, null);
       var constructedWithKey = allConstructedModelElements[key];
       if (constructedWithKey != null) {
         candidates.add(constructedWithKey);
@@ -801,7 +802,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       }
 
       var canonicalClass = findCanonicalModelElementFor(e.enclosingElement);
-      if (canonicalClass is Class) {
+      if (canonicalClass is InheritingContainer) {
         candidates.addAll(canonicalClass.allCanonicalModelElements.where((m) {
           return m.element == e;
         }));
@@ -824,7 +825,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
         // Search for matches inside our superchain.
         var superChain = preferredClass.superChain
             .map((et) => et.modelElement)
-            .cast<Class>()
+            .cast<InheritingContainer>()
             .toList();
         superChain.add(preferredClass);
         matches.removeWhere((me) =>

--- a/lib/templates/html/_constructors.html
+++ b/lib/templates/html/_constructors.html
@@ -1,0 +1,22 @@
+{{ #hasPublicConstructors }}
+  <section class="summary offset-anchor" id="constructors">
+    <h2>Constructors</h2>
+
+    <dl class="constructor-summary-list">
+      {{ #publicConstructorsSorted }}
+        <dt id="{{htmlId}}" class="callable">
+          <span class="name">{{{ linkedName }}}</span><span class="signature">({{{ linkedParams }}})</span>
+        </dt>
+        <dd>
+          {{{ oneLineDoc }}}
+          {{ #isConst }}
+            <div class="constructor-modifier features">const</div>
+          {{ /isConst }}
+          {{ #isFactory }}
+            <div class="constructor-modifier features">factory</div>
+          {{ /isFactory }}
+        </dd>
+      {{ /publicConstructorsSorted }}
+    </dl>
+  </section>
+{{ /hasPublicConstructors }}

--- a/lib/templates/html/class.html
+++ b/lib/templates/html/class.html
@@ -53,28 +53,7 @@
     </section>
     {{/hasModifiers}}
 
-    {{#hasPublicConstructors}}
-    <section class="summary offset-anchor" id="constructors">
-      <h2>Constructors</h2>
-
-      <dl class="constructor-summary-list">
-        {{#publicConstructorsSorted}}
-        <dt id="{{htmlId}}" class="callable">
-          <span class="name">{{{linkedName}}}</span><span class="signature">({{{ linkedParams }}})</span>
-        </dt>
-        <dd>
-          {{{ oneLineDoc }}}
-          {{#isConst}}
-          <div class="constructor-modifier features">const</div>
-          {{/isConst}}
-          {{#isFactory}}
-          <div class="constructor-modifier features">factory</div>
-          {{/isFactory}}
-        </dd>
-        {{/publicConstructorsSorted}}
-      </dl>
-    </section>
-    {{/hasPublicConstructors}}
+    {{ >constructors }}
 
     {{#hasPublicInstanceFields}}
     <section class="summary offset-anchor{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}" id="instance-properties">

--- a/lib/templates/html/enum.html
+++ b/lib/templates/html/enum.html
@@ -30,6 +30,8 @@
     </section>
     {{ /hasModifiers }}
 
+    {{ >constructors }}
+
     {{ #hasPublicEnumValues }}
     <section class="summary offset-anchor" id="constants">
       <h2>Values</h2>

--- a/lib/templates/md/_constructors.md
+++ b/lib/templates/md/_constructors.md
@@ -1,0 +1,11 @@
+{{ #hasPublicConstructors }}
+## Constructors
+
+{{ #publicConstructorsSorted }}
+{{{ linkedName }}} ({{{ linkedParams }}})
+
+{{{ oneLineDoc }}}  {{ !two spaces intentional }}
+{{ #isConst }}_const_{{ /isConst }} {{ #isFactory }}_factory_{{ /isFactory }}
+
+{{ /publicConstructorsSorted }}
+{{ /hasPublicConstructors }}

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -48,17 +48,7 @@
 {{/hasAnnotations}}
 {{/hasModifiers}}
 
-{{#hasPublicConstructors}}
-## Constructors
-
-{{#publicConstructorsSorted}}
-{{{linkedName}}} ({{{ linkedParams }}})
-
-{{{ oneLineDoc }}}  {{!two spaces intentional}}
-{{#isConst}}_const_{{/isConst}} {{#isFactory}}_factory_{{/isFactory}}
-
-{{/publicConstructorsSorted}}
-{{/hasPublicConstructors}}
+{{ >constructors }}
 
 {{#hasPublicInstanceFields}}
 ## Properties

--- a/lib/templates/md/enum.md
+++ b/lib/templates/md/enum.md
@@ -23,6 +23,8 @@
 {{ /hasAnnotations }}
 {{ /hasModifiers }}
 
+{{ >constructors }}
+
 {{ #hasPublicConstantFields }}
 ## Constants
 

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -388,6 +388,47 @@ enum E {
       expect(method1.documentationComment, '/// Doc comment.');
     });
 
+    test("an enhanced enum's constructors are documented", () async {
+      var library = await bootPackageWithLibrary('''
+enum E {
+  one.named(1),
+  two.named(2);
+
+  final int x;
+
+  /// A named constructor.
+  const E.named(this.x);
+}
+''');
+      print(library.enums.named('E').constructors);
+      var namedConstructor =
+          library.enums.named('E').constructors.named('E.named');
+
+      expect(namedConstructor.isFactory, false);
+      expect(namedConstructor.fullyQualifiedName, 'enums.E.named');
+      expect(namedConstructor.nameWithGenerics, 'E.named');
+      expect(namedConstructor.documentationComment, '/// A named constructor.');
+    });
+    test("has an 'index' getter which can be referenced", () async {
+      var library = await bootPackageWithLibrary('''
+enum E {
+  one.named(1),
+  two.named(2);
+
+  const E.named(int x);
+}
+
+/// Reference to [E.named].
+class C {}
+''');
+      var cClass = library.classes.named('C');
+      expect(
+        cClass.documentationAsHtml,
+        '<p>Reference to '
+        '<a href="https://api.dart.dev/stable/2.16.0/dart-core/Enum/index.html">E.index</a>.</p>',
+      );
+    });
+
     // TODO(srawlins): Add rendering tests.
     // * Add tests for rendered supertypes HTML.
     // * Add tests for rendered mixins HTML.
@@ -396,7 +437,6 @@ enum E {
     // * Add tests for rendered getters, setters.
     // * Add tests for rendered field pages.
     // * Add tests for rendered generic enum values.
-    // * Add tests for rendered constructors.
 
     // TODO(srawlins): Add referencing tests (`/// [Enum.method]` etc.)
     // * Add tests for referencing enum static methods, static fields.

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -406,7 +406,36 @@ enum E {
       expect(namedConstructor.nameWithGenerics, 'E.named');
       expect(namedConstructor.documentationComment, '/// A named constructor.');
     });
-    test("has an 'index' getter which can be referenced", () async {
+
+    test("an enhanced enum's value has a constant value implementation",
+        () async {
+      var library = await bootPackageWithLibrary('''
+enum E {
+  one.named(1),
+  two.named(2);
+
+  final int x;
+
+  /// A named constructor.
+  const E.named(this.x);
+}
+
+enum F { one, two }
+''');
+      var eOneValue = library.enums.named('E').constantFields.named('one');
+      expect(eOneValue.constantValueTruncated, 'E.named(1)');
+
+      var eTwoValue = library.enums.named('E').constantFields.named('two');
+      expect(eTwoValue.constantValueTruncated, 'E.named(2)');
+
+      var fOneValue = library.enums.named('F').constantFields.named('one');
+      expect(fOneValue.constantValueTruncated, 'F()');
+
+      var fTwoValue = library.enums.named('F').constantFields.named('two');
+      expect(fTwoValue.constantValueTruncated, 'F()');
+    });
+
+    test('has a named constructor which can be referenced', () async {
       var library = await bootPackageWithLibrary('''
 enum E {
   one.named(1),

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -118,7 +118,7 @@ class C {}
       expect(
         cClass.documentationAsHtml,
         '<p>Reference to '
-        '<a href="%%__HTMLBASE_dartdoc_internal__%%enums/E/values-constant.html">E.values</a>.</p>',
+        '<a href="$linkPrefix/E/values-constant.html">E.values</a>.</p>',
       );
     });
 
@@ -130,10 +130,8 @@ enum E { one, two, three }
 class C {}
 ''');
       var cClass = library.classes.named('C');
-      expect(
-          cClass.documentationAsHtml,
-          '<p>Reference to '
-          '<a href="%%__HTMLBASE_dartdoc_internal__%%enums/E.html">E.one</a>.</p>');
+      expect(cClass.documentationAsHtml,
+          '<p>Reference to <a href="$linkPrefix/E.html">E.one</a>.</p>');
     });
 
     test("has an 'index' getter which can be referenced", () async {
@@ -400,7 +398,6 @@ enum E {
   const E.named(this.x);
 }
 ''');
-      print(library.enums.named('E').constructors);
       var namedConstructor =
           library.enums.named('E').constructors.named('E.named');
 
@@ -424,8 +421,7 @@ class C {}
       var cClass = library.classes.named('C');
       expect(
         cClass.documentationAsHtml,
-        '<p>Reference to '
-        '<a href="https://api.dart.dev/stable/2.16.0/dart-core/Enum/index.html">E.index</a>.</p>',
+        '<p>Reference to <a href="$linkPrefix/E/E.named.html">E.named</a>.</p>',
       );
     });
 
@@ -441,6 +437,5 @@ class C {}
     // TODO(srawlins): Add referencing tests (`/// [Enum.method]` etc.)
     // * Add tests for referencing enum static methods, static fields.
     // * Add tests for referencing enum getters, setters, operators, methods.
-    // * Add tests for referencing constructors.
   }, skip: !enhancedEnumsAllowed);
 }

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -152,11 +152,16 @@ import '${p.basename(_sourceUri.path)}';
   /// is a "valid" property.
   ///
   /// A "valid" property is a public, instance getter with an interface type
-  /// return type. Getters annotated with @internal, @protected, or
-  /// @visibleForTesting are not valid.
+  /// return type. Getters annotated with `@internal`, `@protected`,
+  ///  `@visibleForOverriding`, or `@visibleForTesting` are not valid.
   void _addPropertyToProcess(PropertyAccessorElement property) {
     if (property.isPrivate || property.isStatic || property.isSetter) return;
-    if (property.hasProtected || property.hasVisibleForTesting) return;
+    if (property.hasInternal ||
+        property.hasProtected ||
+        property.hasVisibleForOverriding ||
+        property.hasVisibleForTesting) {
+      return;
+    }
     var type = _relevantTypeFrom(property.type.returnType);
     if (type == null) return;
 
@@ -311,7 +316,8 @@ import '${p.basename(_sourceUri.path)}';
     }
   }
 
-  /// Returns whether [element] or any of its supertypes are "visible" to Mustache.
+  /// Returns whether [element] or any of its supertypes are "visible" to
+  /// Mustache.
   bool _isVisibleToMustache(ClassElement element) {
     if (_allVisibleElements.contains(element)) {
       return true;
@@ -468,7 +474,12 @@ class ${renderer._rendererClassName}${renderer._typeParametersString}
     }
 
     if (property.isPrivate || property.isStatic || property.isSetter) return;
-    if (property.hasProtected || property.hasVisibleForTesting) return;
+    if (property.hasInternal ||
+        property.hasProtected ||
+        property.hasVisibleForOverriding ||
+        property.hasVisibleForTesting) {
+      return;
+    }
     _buffer.writeln("'${property.name}': Property(");
     _buffer
         .writeln('getValue: ($_contextTypeVariable c) => c.${property.name},');


### PR DESCRIPTION
This adds support for enhanced enum constructors. A few small refactors are done in Container. Made `Container.extraReferenceChildren` abstract, so each class must intentionally declare some implementation.

Enum constructors are displayed, have good info, and can be referenced.