### PR TITLE
Update analyzer to v3.4.0 + fix warnings/deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.1.0-dev
 * Removed superfluous `[...]` links. (#2928)
+* Move to analyzer 3.4.0.
 
 ## 5.0.1
 * Add support for new VM service message. (#2931)

--- a/lib/src/dartdoc.dart
+++ b/lib/src/dartdoc.dart
@@ -91,7 +91,7 @@ class DartdocFileWriter implements FileWriter {
   File _getFile(String outFile) {
     var file = resourceProvider
         .getFile(resourceProvider.pathContext.join(_outputDir, outFile));
-    var parent = file.parent2;
+    var parent = file.parent;
     if (!parent.exists) {
       parent.create();
     }

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1200,7 +1200,7 @@ class DartdocOptionContext extends DartdocOptionContextBase
       ResourceProvider resourceProvider)
       : context = resourceProvider.getFolder(resourceProvider.pathContext
             .canonicalize(contextLocation is File
-                ? contextLocation.parent2.path
+                ? contextLocation.parent.path
                 : contextLocation.path));
 
   /// Build a DartdocOptionContext via the 'inputDir' command line option.

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -16482,7 +16482,12 @@ const _invisibleGetters = {
     'modificationStamp',
     'runtimeType'
   },
-  'FunctionElement': {'hashCode', 'isEntryPoint', 'runtimeType'},
+  'FunctionElement': {
+    'hashCode',
+    'isDartCoreIdentical',
+    'isEntryPoint',
+    'runtimeType'
+  },
   'FunctionType': {
     'hashCode',
     'namedParameterTypes',

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -695,11 +695,9 @@ abstract class ModelElement extends Canonicalization
     var lineInfo = compilationUnitElement!.lineInfo;
     assert(element!.nameOffset >= 0,
         'Invalid location data for element: $fullyQualifiedName');
-    assert(lineInfo != null,
-        'No lineInfo data available for element: $fullyQualifiedName');
     var nameOffset = element!.nameOffset;
     if (nameOffset >= 0) {
-      return lineInfo?.getLocation(nameOffset);
+      return lineInfo.getLocation(nameOffset);
     }
     return null;
   }();

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -947,7 +947,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       // might not be where the element was defined, which is what's important
       // for nodoc's semantics.  Looking up the defining element just to pull
       // a context is again, slow.
-      var globs = config.optionSet['nodoc'].valueAt(file.parent2);
+      var globs = config.optionSet['nodoc'].valueAt(file.parent);
       return utils.matchGlobs(globs, fullName);
     });
   }

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -79,7 +79,7 @@ class Template {
       partialResolver = (String path) async {
         var partialPath = pathContext.isAbsolute(path)
             ? path
-            : pathContext.join(file.parent2.path, path);
+            : pathContext.join(file.parent.path, path);
         var partialFile =
             file.provider.getFile(pathContext.normalize(partialPath));
         return partialFile;

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -40,8 +40,8 @@ final PackageMetaProvider pubPackageMetaProvider = PackageMetaProvider(
     PhysicalResourceProvider.INSTANCE
         .getFile(PhysicalResourceProvider.INSTANCE.pathContext
             .absolute(Platform.resolvedExecutable))
-        .parent2
-        .parent2,
+        .parent
+        .parent,
     messageForMissingPackageMeta: PubPackageMeta.messageForMissingPackageMeta);
 
 /// Sets the supported way of constructing [PackageMeta] objects.
@@ -215,14 +215,14 @@ abstract class PubPackageMeta extends PackageMeta {
         resourceProvider
             .getFile(resourceProvider.pathContext
                 .canonicalize(libraryElement.source.fullName))
-            .parent2,
+            .parent,
         resourceProvider);
   }
 
   static PackageMeta? fromFilename(
       String filename, ResourceProvider resourceProvider) {
     return PubPackageMeta.fromDir(
-        resourceProvider.getFile(filename).parent2, resourceProvider);
+        resourceProvider.getFile(filename).parent, resourceProvider);
   }
 
   /// This factory is guaranteed to return the same object for any given
@@ -321,11 +321,11 @@ class _FilePackageMeta extends PubPackageMeta {
     // a pub library to do this.
     // People could have a pub cache at root with Windows drive mappings.
     if (pathContext.split(pathContext.canonicalize(dir.path)).length >= 3) {
-      var pubCacheRoot = dir.parent2.parent2.parent2.path;
+      var pubCacheRoot = dir.parent.parent.parent.path;
       // Check for directory structure too close to root.
-      if (pubCacheRoot != dir.parent2.parent2.path) {
-        var hosted = pathContext.canonicalize(dir.parent2.parent2.path);
-        var hostname = pathContext.canonicalize(dir.parent2.path);
+      if (pubCacheRoot != dir.parent.parent.path) {
+        var hosted = pathContext.canonicalize(dir.parent.parent.path);
+        var hostname = pathContext.canonicalize(dir.parent.path);
         if (pathContext.basename(hosted) == 'hosted' &&
             resourceProvider
                 .getFolder(pathContext.join(pubCacheRoot, '_temp'))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: ^3.3.0
+  analyzer: ^3.4.0
   args: ^2.3.0
   charcode: ^1.3.1
   cli_util: ^0.3.5


### PR DESCRIPTION
I recently landed changes in `package:analyzer` that made `lineInfo` non-nullable in a few places. Since then, when running some tests from source in the SDK repo I see repeated warnings printed because dartdoc uses `?` in places that are no longer required.

I believe the fix is to upgrade the `analyzer` package here (and then update the `dartdoc` package in the SDK).

The tests all pass locally (running `dart pub global run grinder test`), although I'm not sure whether whether forcing consumers of this package onto this version is reasonable yet. If not, perhaps some `// ignore`'s could be added for the `?.lineInfo` calls in the meantime?