### PR TITLE
Improve index.json generation with fewer casts, fewer lists

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -17,10 +17,10 @@ class GeneratorFrontEnd implements Generator {
 
   @override
   Future<void> generate(PackageGraph? packageGraph, FileWriter writer) async {
-    var indexElements = <Indexable>[];
-    if (packageGraph != null) {
-      _generateDocs(packageGraph, writer, indexElements);
-    }
+    var indexElements = packageGraph == null
+        ? <Indexable>[]
+        : _generateDocs(packageGraph, writer);
+
     await _generatorBackend.generateAdditionalFiles(writer);
 
     var categories = indexElements
@@ -33,11 +33,11 @@ class GeneratorFrontEnd implements Generator {
 
   /// Traverses the package graph and generates documentation for all contained
   /// elements.
-  void _generateDocs(PackageGraph packageGraph, FileWriter writer,
-      List<Indexable> indexAccumulator) {
+  List<Indexable> _generateDocs(PackageGraph packageGraph, FileWriter writer) {
     _generatorBackend.generatePackage(
         writer, packageGraph, packageGraph.defaultPackage);
 
+    var indexAccumulator = <Indexable>[];
     for (var package in packageGraph.localPackages) {
       for (var category in filterNonDocumented(package.categories)) {
         logInfo('Generating docs for category ${category.name} from '
@@ -283,6 +283,7 @@ class GeneratorFrontEnd implements Generator {
         }
       }
     }
+    return indexAccumulator;
   }
 }
 

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -10,79 +10,58 @@ import 'package:dartdoc/src/model/enclosed_element.dart';
 import 'package:dartdoc/src/model/indexable.dart';
 import 'package:dartdoc/src/model/model_element.dart';
 
-/// Convenience function to generate category JSON since different generators
-/// will likely want the same content for this.
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
-  // ignore: omit_local_variable_types
-  final List<Map<String, Object?>> indexItems =
-      categories.map((Categorization categorization) {
-    final data = <String, Object?>{
-      'name': categorization.name,
-      'qualifiedName': categorization.fullyQualifiedName,
-      'href': categorization.href,
-      'type': categorization.kind,
-    };
-
-    if (categorization.hasCategoryNames) {
-      data['categories'] = categorization.categoryNames;
-    }
-    if (categorization.hasSubCategoryNames) {
-      data['subcategories'] = categorization.subCategoryNames;
-    }
-    if (categorization.hasImage) {
-      data['image'] = categorization.image;
-    }
-    if (categorization.hasSamples) {
-      data['samples'] = categorization.samples;
-    }
-    return data;
-  }).sorted(_sortElementRepresentations);
+  final indexItems = [
+    for (final categorization in categories.sorted(_sortElementRepresentations))
+      <String, Object?>{
+        'name': categorization.name,
+        'qualifiedName': categorization.fullyQualifiedName,
+        'href': categorization.href,
+        'type': categorization.kind,
+        if (categorization.hasCategoryNames)
+          'categories': categorization.categoryNames,
+        if (categorization.hasSubCategoryNames)
+          'subcategories': categorization.subCategoryNames,
+        if (categorization.hasImage) 'image': categorization.image,
+        if (categorization.hasSamples) 'samples': categorization.samples,
+      }
+  ];
 
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
 
-  return encoder.convert(indexItems);
+  return encoder.convert(indexItems.toList());
 }
 
-/// Convenience function to generate search index JSON since different
-/// generators will likely want the same content for this.
 String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
-  final indexItems = indexedElements.map((Indexable indexable) {
-    final data = <String, Object?>{
-      'name': indexable.name,
-      'qualifiedName': indexable.fullyQualifiedName,
-      'href': indexable.href,
-      'type': indexable.kind,
-      'overriddenDepth': indexable.overriddenDepth,
-    };
-    if (indexable is ModelElement) {
-      data['packageName'] = indexable.package?.name;
-    }
-    if (indexable is EnclosedElement) {
-      final ee = indexable as EnclosedElement;
-      data['enclosedBy'] = <String, Object?>{
-        'name': ee.enclosingElement!.name,
-        'type': ee.enclosingElement!.kind
-      };
-
-      data['qualifiedName'] = indexable.fullyQualifiedName;
-    }
-    return data;
-  }).sorted(_sortElementRepresentations);
+  final indexItems = [
+    for (final indexable in indexedElements.sorted(_sortElementRepresentations))
+      <String, Object?>{
+        'name': indexable.name,
+        'qualifiedName': indexable.fullyQualifiedName,
+        'href': indexable.href,
+        'type': indexable.kind,
+        'overriddenDepth': indexable.overriddenDepth,
+        if (indexable is ModelElement) 'packageName': indexable.package?.name,
+        if (indexable is EnclosedElement)
+          'enclosedBy': {
+            'name': indexable.enclosingElement!.name,
+            'type': indexable.enclosingElement!.kind
+          },
+      }
+  ];
 
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
 
-  return encoder.convert(indexItems);
+  return encoder.convert(indexItems.toList());
 }
 
-int _sortElementRepresentations(
-    Map<String, Object?> a, Map<String, Object?> b) {
-  final value = compareNatural(
-      a['qualifiedName'] as String, b['qualifiedName'] as String);
+int _sortElementRepresentations(Indexable a, Indexable b) {
+  final value = compareNatural(a.fullyQualifiedName, b.fullyQualifiedName);
   if (value == 0) {
-    return compareNatural(a['type'] as String, b['type'] as String);
+    return compareNatural(a.kind, b.kind);
   }
   return value;
 }

--- a/lib/src/model/enclosed_element.dart
+++ b/lib/src/model/enclosed_element.dart
@@ -7,6 +7,6 @@ import 'package:dartdoc/src/model/model.dart';
 /// An element that is enclosed by some other element.
 ///
 /// Libraries are not enclosed.
-abstract class EnclosedElement {
+abstract class EnclosedElement implements Indexable {
   ModelElement? get enclosingElement;
 }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -58,11 +58,9 @@ Iterable<T> filterHasCanonical<T extends ModelElement>(
   return maybeHasCanonicalItems.where((me) => me.canonicalModelElement != null);
 }
 
-/// Remove elements that aren't documented.
-Iterable<T> filterNonDocumented<T extends Documentable>(
-    Iterable<T> maybeDocumentedItems) {
-  return maybeDocumentedItems.where((me) => me.isDocumented);
-}
+/// Selects [items] which are documented.
+Iterable<T> filterNonDocumented<T extends Documentable>(Iterable<T> items) =>
+    items.where((me) => me.isDocumented);
 
 /// Returns an iterable containing only public elements from [privacyItems].
 Iterable<T> filterNonPublic<T extends Privacy>(Iterable<T> privacyItems) {


### PR DESCRIPTION
* Do not pass a return argument to `_generateDocs`
* Using map literal if-elements is easier to read and should reduce re-allocations
* Perform sorting on original objects which cuts out a ton of casts