### PR TITLE
Linkify enum names; tidy up

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3283,14 +3283,31 @@ String _deduplicated_lib_templates_html__constant_html(
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
-  buffer.write('''" class="constant">
-  <span class="name ''');
-  if (context0.isDeprecated == true) {
-    buffer.write('''deprecated''');
+  buffer.write('''" class="constant">''');
+  if (context0.isEnumValue == true) {
+    buffer.writeln();
+    buffer.write('''
+    <span class="name ''');
+    if (context0.isDeprecated == true) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context0.name);
+    buffer.write('''</span>''');
   }
-  buffer.write('''">''');
-  buffer.write(context0.linkedName);
-  buffer.write('''</span>
+  if (context0.isEnumValue != true) {
+    buffer.writeln();
+    buffer.write('''
+    <span class="name ''');
+    if (context0.isDeprecated == true) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context0.linkedName);
+    buffer.write('''</span>''');
+  }
+  buffer.writeln();
+  buffer.write('''
   <span class="signature">&#8594; const ''');
   buffer.write(context0.modelType.linkedName);
   buffer.write('''</span>
@@ -4463,14 +4480,31 @@ String
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="constant">
-  <span class="name ''');
-  if (context1.isDeprecated == true) {
-    buffer.write('''deprecated''');
+  buffer.write('''" class="constant">''');
+  if (context1.isEnumValue == true) {
+    buffer.writeln();
+    buffer.write('''
+    <span class="name ''');
+    if (context1.isDeprecated == true) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context1.name);
+    buffer.write('''</span>''');
   }
-  buffer.write('''">''');
-  buffer.write(context1.linkedName);
-  buffer.write('''</span>
+  if (context1.isEnumValue != true) {
+    buffer.writeln();
+    buffer.write('''
+    <span class="name ''');
+    if (context1.isDeprecated == true) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context1.linkedName);
+    buffer.write('''</span>''');
+  }
+  buffer.writeln();
+  buffer.write('''
   <span class="signature">&#8594; const ''');
   buffer.write(context1.modelType.linkedName);
   buffer.write('''</span>

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -10468,6 +10468,13 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isDocumented == true,
                 ),
+                'isEnumValue': Property(
+                  getValue: (CT_ c) => c.isEnumValue,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isEnumValue == true,
+                ),
                 'isExecutable': Property(
                   getValue: (CT_ c) => c.isExecutable,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -52,12 +52,10 @@ class Enum extends InheritingContainer
 /// Enum's value fields are virtual, so we do a little work to create usable
 /// entries for the docs.
 class EnumField extends Field {
-  int? index;
+  final int index;
 
-  EnumField(FieldElement element, Library library, PackageGraph packageGraph,
-      Accessor? getter, Accessor? setter)
-      : super(element, library, packageGraph, getter as ContainerAccessor?,
-            setter as ContainerAccessor?);
+  @override
+  bool get isEnumValue => true;
 
   EnumField.forConstant(this.index, FieldElement element, Library library,
       PackageGraph packageGraph, Accessor? getter)
@@ -88,16 +86,13 @@ class EnumField extends Field {
   }
 
   @override
-  String get linkedName => name;
+  String get linkedName => _fieldRenderer.renderLinkedName(this);
 
   @override
   bool get isCanonical {
     if (name == 'index') return false;
     // If this is something inherited from Object, e.g. hashCode, let the
     // normal rules apply.
-    if (index == null) {
-      return super.isCanonical;
-    }
     // TODO(jcollins-g): We don't actually document this as a separate entity;
     //                   do that or change this to false and deal with the
     //                   consequences.

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -185,7 +185,12 @@ abstract class ModelElement extends Canonicalization
             throw StateError(
                 'Enum $e (${e.runtimeType}) does not have a constant value.');
           }
-          var index = constantValue.getField('index')!.toIntValue();
+          var constantIndex = constantValue.getField('index');
+          if (constantIndex == null) {
+            throw StateError(
+                'Enum $e (${e.runtimeType}) does not have a constant value.');
+          }
+          var index = constantIndex.toIntValue()!;
           newModelElement =
               EnumField.forConstant(index, e, library, packageGraph, getter);
         } else if (e.enclosingElement is ExtensionElement) {
@@ -761,6 +766,9 @@ abstract class ModelElement extends Canonicalization
 
   @override
   bool get isDocumented => isCanonical && isPublic;
+
+  /// Whether this element is an enum value.
+  bool get isEnumValue => false;
 
   bool get isExecutable => element is ExecutableElement;
 

--- a/lib/src/render/enum_field_renderer.dart
+++ b/lib/src/render/enum_field_renderer.dart
@@ -6,6 +6,8 @@ import 'package:dartdoc/src/model/enum.dart';
 
 abstract class EnumFieldRenderer {
   String renderValue(EnumField field);
+
+  String renderLinkedName(EnumField field);
 }
 
 class EnumFieldRendererHtml implements EnumFieldRenderer {
@@ -19,6 +21,12 @@ class EnumFieldRendererHtml implements EnumFieldRenderer {
       return 'const ${field.enclosingElement.name}(${field.index})';
     }
   }
+
+  @override
+  String renderLinkedName(EnumField field) {
+    var cssClass = field.isDeprecated ? ' class="deprecated"' : '';
+    return '<a$cssClass href="${field.href}#${field.htmlId}">${field.name}</a>';
+  }
 }
 
 class EnumFieldRendererMd implements EnumFieldRenderer {
@@ -31,5 +39,13 @@ class EnumFieldRendererMd implements EnumFieldRenderer {
     } else {
       return 'const ${field.enclosingElement.name}(${field.index})';
     }
+  }
+
+  @override
+  String renderLinkedName(EnumField field) {
+    if (field.isDeprecated) {
+      return '[~~${field.name}~~](${field.href})';
+    }
+    return '[${field.name}](${field.href})';
   }
 }

--- a/lib/templates/html/_constant.html
+++ b/lib/templates/html/_constant.html
@@ -1,11 +1,16 @@
-<dt id="{{htmlId}}" class="constant">
-  <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{ linkedName }}}</span>
+<dt id="{{ htmlId }}" class="constant">
+  {{ #isEnumValue }}
+    <span class="name {{ #isDeprecated }}deprecated{{ /isDeprecated }}">{{{ name }}}</span>
+  {{ /isEnumValue }}
+  {{ ^isEnumValue }}
+    <span class="name {{ #isDeprecated }}deprecated{{ /isDeprecated }}">{{{ linkedName }}}</span>
+  {{ /isEnumValue }}
   <span class="signature">&#8594; const {{{ modelType.linkedName }}}</span>
-  {{>categorization}}
+  {{ >categorization }}
 </dt>
 <dd>
   {{{ oneLineDoc }}}
-  {{>features}}
+  {{ >features }}
   <div>
     <span class="signature"><code>{{{ constantValueTruncated }}}</code></span>
   </div>

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -183,11 +183,11 @@ class C {}
           equals(eEnum.characterLocation.toString()));
     });
 
-    test('value does not link anywhere', () async {
+    test('value links to its anchor', () async {
       var library = await bootPackageWithLibrary('enum E { one, two, three }');
       var oneValue =
           library.enums.named('E').publicEnumValues.named('one') as EnumField;
-      expect(oneValue.linkedName, 'one');
+      expect(oneValue.linkedName, '<a href="$linkPrefix/E.html#one">one</a>');
       expect(oneValue.constantValue,
           equals(EnumFieldRendererHtml().renderValue(oneValue)));
     });

--- a/test/templates/enum_test.dart
+++ b/test/templates/enum_test.dart
@@ -176,25 +176,24 @@ enum EnumWithDefaultConstructor { four, five, six }
           ]));
     });
 
-    test('enum sidebar contains default constructors', () async {
-      expect(
-          enumWithDefaultConstructorLines,
-          containsAllInOrder([
-            matches('<div id="dartdoc-sidebar-right"'),
-            matches(
-                '<a href="../lib/EnumWithDefaultConstructor.html#constructors">Constructors</a>'),
-            matches(
-                '<a href="../lib/EnumWithDefaultConstructor/EnumWithDefaultConstructor.html">EnumWithDefaultConstructor</a>'),
-          ]));
-    });
-
-    test('enum sidebar contains explicit constructors', () async {
+    test('enum page contains values', () async {
       expect(
           eLines,
           containsAllInOrder([
-            matches('<div id="dartdoc-sidebar-right"'),
-            matches('<a href="../lib/E.html#constructors">Constructors</a>'),
-            matches('<a href="../lib/E/E.named.html">named</a>'),
+            matches('<h2>Values</h2>'),
+            matches('<span class="name ">one</span>'),
+            matches('<p>Doc comment for <a href="../lib/E.html">one</a>.</p>'),
+            matches(
+                r'<span class="signature"><code>E&lt;int&gt;.named\(1\)</code></span>'),
+          ]));
+    });
+
+    test('enum page contains values with deprecated annotation', () async {
+      expect(
+          eLines,
+          containsAllInOrder([
+            matches('<h2>Values</h2>'),
+            matches('<span class="name deprecated">two</span>'),
           ]));
     });
 
@@ -300,27 +299,6 @@ enum EnumWithDefaultConstructor { four, five, six }
           ]));
     });
 
-    test('enum page contains values', () async {
-      expect(
-          eLines,
-          containsAllInOrder([
-            matches('<h2>Values</h2>'),
-            matches('<span class="name ">one</span>'),
-            matches('<p>Doc comment for <a href="../lib/E.html">one</a>.</p>'),
-            matches(
-                r'<span class="signature"><code>E&lt;int&gt;.named\(1\)</code></span>'),
-          ]));
-    });
-
-    test('enum page contains values with deprecated annotation', () async {
-      expect(
-          eLines,
-          containsAllInOrder([
-            matches('<h2>Values</h2>'),
-            matches('<span class="name deprecated">two</span>'),
-          ]));
-    });
-
     test('enum page contains (static) constants', () async {
       expect(
           eLines,
@@ -341,14 +319,35 @@ enum EnumWithDefaultConstructor { four, five, six }
           ]));
     });
 
+    test('enum sidebar contains default constructors', () async {
+      expect(
+          enumWithDefaultConstructorLines,
+          containsAllInOrder([
+            matches('<div id="dartdoc-sidebar-right"'),
+            matches(
+                '<a href="../lib/EnumWithDefaultConstructor.html#constructors">Constructors</a>'),
+            matches(
+                '<a href="../lib/EnumWithDefaultConstructor/EnumWithDefaultConstructor.html">EnumWithDefaultConstructor</a>'),
+          ]));
+    });
+
+    test('enum sidebar contains explicit constructors', () async {
+      expect(
+          eLines,
+          containsAllInOrder([
+            matches('<div id="dartdoc-sidebar-right"'),
+            matches('<a href="../lib/E.html#constructors">Constructors</a>'),
+            matches('<a href="../lib/E/E.named.html">named</a>'),
+          ]));
+    });
+
     test('enum sidebar contains values', () async {
       expect(
           eLines,
           containsAllInOrder([
             matches('<div id="dartdoc-sidebar-right"'),
             matches('<a href="../lib/E.html#values">Values</a>'),
-            // TODO(srawlins): Linkify this.
-            matches('<li>one</li>'),
+            matches('<li><a href="../lib/E.html#one">one</a></li>'),
           ]));
     });
 


### PR DESCRIPTION
Enum values don't get their own page, but we can link to their anchor on the Enum container page.

* Remove unused EnumField constructor
* Make EnumField.index final and non-nullable
* Add isEnumValue to discriminate whether the element should link to itself in the page body (for enum values, they shouldn't)