### PR TITLE
Create a .pubignore in order to skip testing files from publish check

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -13,7 +13,7 @@ lcov.info
 packages
 pub.dartlang.org/
 test_data/
-testing/**/doc
+testing/
 pubspec.lock
 
 *.dart.js


### PR DESCRIPTION
Some recent build of pub is failing the `pub publish --dry-run` check because of files in the testing/ directory: https://github.com/dart-lang/dartdoc/runs/5859985135?check_suite_focus=true