### PR TITLE
Remove dead field commentRefs, which is always empty

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -715,19 +715,6 @@ class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
                         parent: r);
                   },
                 ),
-                'commentRefs': Property(
-                  getValue: (CT_ c) => c.commentRefs,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Map<String, ModelCommentReference>'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.commentRefs, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Map']!);
-                  },
-                ),
                 'isCanonical': Property(
                   getValue: (CT_ c) => c.isCanonical,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -1017,19 +1004,6 @@ class _Renderer_Category extends RendererBase<Category> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.classes.map((e) =>
                         _render_Class(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'commentRefs': Property(
-                  getValue: (CT_ c) => c.commentRefs,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Map<String, ModelCommentReference>'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.commentRefs, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Map']!);
                   },
                 ),
                 'config': Property(
@@ -10043,19 +10017,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         getters: _invisibleGetters['CharacterLocation']!);
                   },
                 ),
-                'commentRefs': Property(
-                  getValue: (CT_ c) => c.commentRefs,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Map<String, ModelCommentReference>'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.commentRefs, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Map']!);
-                  },
-                ),
                 'compilationUnitElement': Property(
                   getValue: (CT_ c) => c.compilationUnitElement,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -11610,19 +11571,6 @@ class _Renderer_Package extends RendererBase<Package> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.categoriesWithPublicLibraries.map((e) =>
                         _render_Category(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'commentRefs': Property(
-                  getValue: (CT_ c) => c.commentRefs,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'Map<String, ModelCommentReference>'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.commentRefs, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Map']!);
                   },
                 ),
                 'config': Property(
@@ -16290,13 +16238,7 @@ const _invisibleGetters = {
     'validateLinks'
   },
   'DocumentLocation': {'hashCode', 'index', 'runtimeType'},
-  'Documentation': {
-    'asHtml',
-    'asOneLiner',
-    'commentRefs',
-    'hashCode',
-    'runtimeType'
-  },
+  'Documentation': {'asHtml', 'asOneLiner', 'hashCode', 'runtimeType'},
   'DocumentationComment': {
     'documentationAsHtml',
     'documentationComment',

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -183,8 +183,7 @@ bool _requireConstructor(CommentReferable? referable) =>
 /// Implements _getMatchingLinkElement via [CommentReferable.referenceBy].
 MatchingLinkResult _getMatchingLinkElementCommentReferable(
     String codeRef, Warnable warnable) {
-  var commentReference =
-      warnable.commentRefs[codeRef] ?? ModelCommentReference.synthetic(codeRef);
+  var commentReference = ModelCommentReference.synthetic(codeRef);
 
   bool Function(CommentReferable?) filter;
   bool Function(CommentReferable?) allowTree;

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 /// Classes extending this class have canonicalization support in Dartdoc.
@@ -10,13 +9,6 @@ abstract class Canonicalization implements Locatable, Documentable {
   bool get isCanonical;
 
   Library? get canonicalLibrary;
-
-  /// A map of [ModelCommentReference.codeRef] to [ModelCommentReference].
-  /// This map deduplicates comment references as all identical reference
-  /// strings inside a single documentation comment will point to the same
-  /// place, so it should not be used to count exactly how many references
-  /// there are.
-  Map<String, ModelCommentReference> get commentRefs;
 
   /// Pieces of the location, split to remove 'package:' and slashes.
   Set<String> get locationPieces;

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
-import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -167,9 +166,4 @@ class Category extends Nameable
   @override
   // TODO: implement referenceParents
   Iterable<CommentReferable> get referenceParents => [];
-
-  @override
-  // Categories are not analyzed by the analyzer, so they can't have
-  // comment references.
-  Map<String, ModelCommentReference> get commentRefs => {};
 }

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/documentation_renderer.dart';
@@ -33,8 +32,6 @@ class Documentation {
     }
     return _asOneLiner;
   }
-
-  Map<String, ModelCommentReference>? get commentRefs => _element.commentRefs;
 
   void _renderDocumentation(bool processFullDocs) {
     var parseResult = _parseDocumentation(processFullDocs);

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -14,7 +14,6 @@ import 'package:analyzer/source/line_info.dart';
 import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member, ParameterMember;
 import 'package:collection/collection.dart';
-import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/annotation.dart';
@@ -431,31 +430,6 @@ abstract class ModelElement extends Canonicalization
       return false;
     }
     return utils.hasPublicName(element!) && !hasNodoc;
-  }();
-
-  @override
-  late final Map<String, ModelCommentReference> commentRefs = () {
-    var commentRefsBuilder = <String, ModelCommentReference>{};
-    for (var from in documentationFrom) {
-      if (from is ModelElement) {
-        var checkReferences = [from];
-        if (from is Accessor) {
-          checkReferences.add(from.enclosingCombo);
-        }
-        for (var e in checkReferences) {
-          // Some elements don't have modelNodes or aren't traversed by
-          // the element visitor, or both.
-          assert(e is Parameter || e.modelNode != null);
-          var nodeCommentRefs = e.modelNode?.commentRefs;
-          if (nodeCommentRefs != null && nodeCommentRefs.isNotEmpty) {
-            for (var r in nodeCommentRefs) {
-              commentRefsBuilder[r.codeRef];
-            }
-          }
-        }
-      }
-    }
-    return commentRefsBuilder;
   }();
 
   @override

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -417,11 +416,6 @@ class Package extends LibraryContainer
   Iterable<CommentReferable> get referenceParents => [packageGraph];
 
   p.Context get _pathContext => _packageGraph.resourceProvider.pathContext;
-
-  @override
-  // Packages are not interpreted by the analyzer in such a way to generate
-  // [CommentReference] nodes, so this is always empty.
-  Map<String, ModelCommentReference> get commentRefs => {};
 
   @override
   String get referenceName => 'package:$name';


### PR DESCRIPTION
I don't know why this code is dead, or what difference it used to make. In any case, it's dead now. See the innermost line in `lib/src/model/model_element.dart`, which in itself is a dead statement. Strange.