### PR TITLE
Drop version back to 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 5.1.1
-* Fixed the `{@youtube}` directive to respect the provided width and height.
-
 ## 5.1.0
 * Support new enhanced enums feature.
 * Removed superfluous `[...]` links. (#2928)
@@ -12,6 +9,7 @@
 * Mustachio: Remove parameters which are unused in AOT renderers. (#2943)
 * Mustachio: Deduplicate AOT partial renderers. (#2978)
 * Mustachio: Allow whitespace after section and partial delimiters. (#2964)
+* Fixed the `{@youtube}` directive to respect the provided width and height. (#3030)
 
 ## 5.0.1
 * Add support for new VM service message. (#2931)

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v5.1.1/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v5.1.0/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.1';
+const packageVersion = '5.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `dart run grinder build` after updating.
-version: 5.1.1
+version: 5.1.0
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
In https://github.com/dart-lang/dartdoc/pull/3030 I had incorrectly assumed that dartdoc v5.1.0 has already been released and because of that I bumped the version to 5.1.1. However, as it turns out, v5.1.0 has not been released yet: https://pub.dev/packages/dartdoc/versions

This change drops the pubspec version back to v5.1.0 to release the change in https://github.com/dart-lang/dartdoc/pull/3030 as part of that version as there is no need to bump the version until 5.1.0 is released. 