### PR TITLE
fix exception for empty dartdoc_options.yaml file

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -990,10 +990,14 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
             .pathContext
             .join(dir.path, 'dartdoc_options.yaml'));
         if (dartdocOptionsFile.exists) {
-          yamlData = _YamlFileData(
-              loadYaml(dartdocOptionsFile.readAsStringSync()),
-              resourceProvider.pathContext.canonicalize(dir.path));
-          break;
+          final yaml = loadYaml(dartdocOptionsFile.readAsStringSync());
+          // [loadYaml()] will return null for empty (or all comment) yaml files,
+          // so we must check for that case.
+          if (yaml != null) {
+            yamlData = _YamlFileData(
+                yaml, resourceProvider.pathContext.canonicalize(dir.path));
+            break;
+          }
         }
       }
     }

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -996,8 +996,8 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
           if (yaml != null) {
             yamlData = _YamlFileData(
                 yaml, resourceProvider.pathContext.canonicalize(dir.path));
-            break;
           }
+          break;
         }
       }
     }


### PR DESCRIPTION
This PR fixes an exception that is thrown when dartdoc encounters an empty (or all comments) dartdoc_options.yaml file.

I discovered this bug when I commented all the lines of a dartdoc_options.yaml file and ran dartdoc.  An exception was thrown because the return value of loadYaml() on the 'empty' yaml file was null and this was passed directly to _YamlFileData() constructor which throws an exception because it doesn't accept null values.

When an empty file is found it is now just treated like it didn't exists in the first place.