### PR TITLE
Include docs.dart.js in published code

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -16,7 +16,6 @@ test_data/
 testing/
 pubspec.lock
 
-*.dart.js
 *.iml
 *.ipr
 *.iws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.1
+* Include `lib/resources/docs.dart.js`
+
 ## 5.1.0
 * Support new enhanced enums feature.
 * Removed superfluous `[...]` links. (#2928)

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v5.1.0/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v5.1.1/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0';
+const packageVersion = '5.1.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `dart run grinder build` after updating.
-version: 5.1.0
+version: 5.1.1
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
Fixes #3039 

Bumps dartdoc to 5.1.1.