### PR TITLE
Fix two styling issues relating to constructors

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -373,10 +373,6 @@ dl dt.callable .name {
   width: auto;
 }
 
-.parameter {
-  white-space: nowrap;
-}
-
 .type-parameter {
   white-space: nowrap;
 }
@@ -390,6 +386,7 @@ dl dt.callable .name {
   display: table-cell;
   margin-left: 10px;
   list-style-type: none;
+  padding-inline-start: unset;
 }
 
 .signature {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/2408
Before | After
--- | ---
<img width="627" alt="Screen Shot 2022-05-21 at 18 29 04" src="https://user-images.githubusercontent.com/6655696/169660805-3c99afbf-82fa-4877-9831-69e920385067.png"> | <img width="627" alt="Screen Shot 2022-05-21 at 18 28 49" src="https://user-images.githubusercontent.com/6655696/169660809-d3ef6435-48b7-4c47-adfd-996a470fca2d.png">

Fixes https://github.com/dart-lang/dartdoc/issues/3043

Before | After
--- | ---
<img width="627" alt="Screen Shot 2022-05-21 at 18 03 01" src="https://user-images.githubusercontent.com/6655696/169660816-9216660f-c942-4e93-b96c-3ca33a46f0b0.png"> |  <img width="627" alt="Screen Shot 2022-05-21 at 18 02 54" src="https://user-images.githubusercontent.com/6655696/169660819-c9364bb1-7565-4592-bdcd-c9fb09102e10.png">

 
Style change only, needs new tests @devoncarew?