### PR TITLE
inline the used package:charcode constants

### DIFF
--- a/lib/src/charcode.dart
+++ b/lib/src/charcode.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Character `.`.
+const int $dot = 0x2E;
+
+/// Space character.
+const int $space = 0x20;
+
+/// "Horizontal Tab" control character, common name.
+const int $tab = 0x09;
+
+/// "Line feed" control character.
+const int $lf = 0x0A;
+
+/// "Carriage return" control character.
+const int $cr = 0x0D;
+
+/// Character `>`.
+const int $gt = 0x3E;
+
+/// Character `<`.
+const int $lt = 0x3C;
+
+/// Character `(`.
+const int $lparen = 0x28;
+
+/// Character `)`.
+const int $rparen = 0x29;
+
+/// Character `\`.
+const int $backslash = 0x5C;
+
+/// Character `?`.
+const int $question = 0x3F;
+
+/// Character `!`.
+const int $exclamation = 0x21;
+
+/// Character `{`.
+const int $lbrace = 0x7B;
+
+/// Character `}`.
+const int $rbrace = 0x7D;
+
+/// Character `#`.
+const int $hash = 0x23;
+
+/// Character `^`.
+const int $caret = 0x5E;
+
+/// Character `/`.
+const int $slash = 0x2F;
+
+/// Character `_`.
+const int $underscore = 0x5F;
+
+/// Character `$`.
+const int $dollar = 0x24;
+
+/// Character `a`.
+const int $a = 0x61;
+
+/// Character `z`.
+const int $z = 0x7A;
+
+/// Character `A`.
+const int $A = 0x41;
+
+/// Character `Z`.
+const int $Z = 0x5A;
+
+/// Character `0`.
+const int $0 = 0x30;
+
+/// Character `9`.
+const int $9 = 0x39;

--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -1,10 +1,10 @@
 // Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-//
 
-import 'package:charcode/charcode.dart';
 import 'package:meta/meta.dart';
+
+import '../charcode.dart';
 
 const _operatorKeyword = 'operator';
 const Map<String, String> operatorNames = {

--- a/lib/src/mustachio/parser.dart
+++ b/lib/src/mustachio/parser.dart
@@ -5,9 +5,10 @@
 // See the Mustachio README at tool/mustachio/README.md for high-level
 // documentation.
 
-import 'package:charcode/charcode.dart';
 import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
+
+import '../charcode.dart';
 
 /// A [Mustache](https://mustache.github.io/mustache.5.html) parser for use by a
 /// generated Mustachio renderer.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,14 +10,13 @@ environment:
 dependencies:
   analyzer: ^3.4.0
   args: ^2.3.0
-  charcode: ^1.3.1
   cli_util: ^0.3.5
   collection: ^1.15.0
   crypto: ^3.0.1
   glob: ^2.0.1
   html: ^0.15.0
   logging: ^1.0.2
-  markdown: ">=4.0.0 <6.0.0"
+  markdown: ^5.0.0
   meta: ^1.7.0
   package_config: ^2.0.2
   path: ^1.8.0


### PR DESCRIPTION
- Similar to https://github.com/dart-lang/markdown/pull/423, this PR in-lines the portions of package:charcode that dartdoc uses.
- This also revs the dep on package:markdown; that's not a critical aspect of this PR, but we will need to resolve against the latest `markdown` in order to not pull in `charcode` transitively.
