### PR TITLE
Better documentation in generator/; make a few things private

### DIFF
--- a/lib/src/dartdoc.dart
+++ b/lib/src/dartdoc.dart
@@ -133,7 +133,7 @@ class Dartdoc {
   ) {
     return Dartdoc._(
       config,
-      initEmptyGenerator(config),
+      initEmptyGenerator(),
       packageBuilder,
     );
   }

--- a/lib/src/generator/dartdoc_generator_backend.dart
+++ b/lib/src/generator/dartdoc_generator_backend.dart
@@ -15,7 +15,7 @@ import 'package:dartdoc/src/version.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:path/path.dart' as p show Context;
 
-/// Configuration options for the Dartdoc's default backend.
+/// Configuration options for Dartdoc's default backend.
 class DartdocGeneratorBackendOptions implements TemplateOptions {
   @override
   final String? relCanonicalPrefix;
@@ -60,31 +60,32 @@ class SidebarGenerator<T extends TemplateData> {
 
   SidebarGenerator(this.renderFunction);
 
-  // Retrieve the render for a specific key, or generate it using the given
-  // template data if you need.
+  /// Retrieves the render for a specific [key], or generates it using the given
+  /// [templateData] if needed.
   String getRenderFor(Documentable key, T templateData) {
     return _renderCache[key] ??= renderFunction(templateData);
   }
 }
 
-/// Base GeneratorBackend for Dartdoc's supported formats.
+/// Base [GeneratorBackend] for Dartdoc's supported formats.
 abstract class DartdocGeneratorBackend implements GeneratorBackend {
   final DartdocGeneratorBackendOptions options;
   final Templates templates;
   final SidebarGenerator<TemplateDataWithLibrary<Documentable>>
-      sidebarForLibrary;
+      _sidebarForLibrary;
   final SidebarGenerator<TemplateDataWithContainer<Documentable>>
-      sidebarForContainer;
+      _sidebarForContainer;
   final ResourceProvider resourceProvider;
   final p.Context _pathContext;
 
   DartdocGeneratorBackend(this.options, this.templates, this.resourceProvider)
-      : sidebarForLibrary = SidebarGenerator(templates.renderSidebarForLibrary),
-        sidebarForContainer =
+      : _sidebarForLibrary =
+            SidebarGenerator(templates.renderSidebarForLibrary),
+        _sidebarForContainer =
             SidebarGenerator(templates.renderSidebarForContainer),
         _pathContext = resourceProvider.pathContext;
 
-  /// Helper method to bind template data and emit the content to the writer.
+  /// Binds template data and emits the content to the [writer].
   void write(
       FileWriter writer, String filename, TemplateData data, String content) {
     if (!options.useBaseHref) {
@@ -133,7 +134,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateClass(
       FileWriter writer, PackageGraph packageGraph, Library lib, Class clazz) {
     var data = ClassTemplateData(options, packageGraph, lib, clazz,
-        sidebarForLibrary.getRenderFor, sidebarForContainer.getRenderFor);
+        _sidebarForLibrary.getRenderFor, _sidebarForContainer.getRenderFor);
     var content = templates.renderClass(data);
     write(writer, clazz.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenClassFileCount');
@@ -148,7 +149,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateConstructor(FileWriter writer, PackageGraph packageGraph,
       Library lib, Constructable constructable, Constructor constructor) {
     var data = ConstructorTemplateData(options, packageGraph, lib,
-        constructable, constructor, sidebarForContainer.getRenderFor);
+        constructable, constructor, _sidebarForContainer.getRenderFor);
     var content = templates.renderConstructor(data);
     write(writer, constructor.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenConstructorFileCount');
@@ -158,7 +159,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateEnum(
       FileWriter writer, PackageGraph packageGraph, Library lib, Enum eNum) {
     var data = EnumTemplateData(options, packageGraph, lib, eNum,
-        sidebarForLibrary.getRenderFor, sidebarForContainer.getRenderFor);
+        _sidebarForLibrary.getRenderFor, _sidebarForContainer.getRenderFor);
     var content = templates.renderEnum(data);
     write(writer, eNum.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenEnumFileCount');
@@ -168,7 +169,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateExtension(FileWriter writer, PackageGraph packageGraph,
       Library lib, Extension extension) {
     var data = ExtensionTemplateData(options, packageGraph, lib, extension,
-        sidebarForLibrary.getRenderFor, sidebarForContainer.getRenderFor);
+        _sidebarForLibrary.getRenderFor, _sidebarForContainer.getRenderFor);
     var content = templates.renderExtension(data);
     write(writer, extension.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenExtensionFileCount');
@@ -178,7 +179,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateFunction(FileWriter writer, PackageGraph packageGraph,
       Library lib, ModelFunction function) {
     var data = FunctionTemplateData(
-        options, packageGraph, lib, function, sidebarForLibrary.getRenderFor);
+        options, packageGraph, lib, function, _sidebarForLibrary.getRenderFor);
     var content = templates.renderFunction(data);
     write(writer, function.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenFunctionFileCount');
@@ -188,7 +189,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateLibrary(
       FileWriter writer, PackageGraph packageGraph, Library lib) {
     var data = LibraryTemplateData(
-        options, packageGraph, lib, sidebarForLibrary.getRenderFor);
+        options, packageGraph, lib, _sidebarForLibrary.getRenderFor);
     var content = templates.renderLibrary(data);
     write(writer, lib.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenLibraryFileCount');
@@ -198,7 +199,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateMethod(FileWriter writer, PackageGraph packageGraph, Library lib,
       Container clazz, Method method) {
     var data = MethodTemplateData(options, packageGraph, lib, clazz, method,
-        sidebarForContainer.getRenderFor);
+        _sidebarForContainer.getRenderFor);
     var content = templates.renderMethod(data);
     write(writer, method.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenMethodFileCount');
@@ -208,7 +209,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateMixin(
       FileWriter writer, PackageGraph packageGraph, Library lib, Mixin mixin) {
     var data = MixinTemplateData(options, packageGraph, lib, mixin,
-        sidebarForLibrary.getRenderFor, sidebarForContainer.getRenderFor);
+        _sidebarForLibrary.getRenderFor, _sidebarForContainer.getRenderFor);
     var content = templates.renderMixin(data);
     write(writer, mixin.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenMixinFileCount');
@@ -226,7 +227,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateProperty(FileWriter writer, PackageGraph packageGraph,
       Library lib, Container clazz, Field property) {
     var data = PropertyTemplateData(options, packageGraph, lib, clazz, property,
-        sidebarForContainer.getRenderFor);
+        _sidebarForContainer.getRenderFor);
     var content = templates.renderProperty(data);
     write(writer, property.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenPropertyFileCount');
@@ -241,7 +242,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateTopLevelProperty(FileWriter writer, PackageGraph packageGraph,
       Library lib, TopLevelVariable property) {
     var data = TopLevelPropertyTemplateData(
-        options, packageGraph, lib, property, sidebarForLibrary.getRenderFor);
+        options, packageGraph, lib, property, _sidebarForLibrary.getRenderFor);
     var content = templates.renderTopLevelProperty(data);
     write(writer, property.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenTopLevelPropertyFileCount');
@@ -251,7 +252,7 @@ abstract class DartdocGeneratorBackend implements GeneratorBackend {
   void generateTypeDef(FileWriter writer, PackageGraph packageGraph,
       Library lib, Typedef typeDef) {
     var data = TypedefTemplateData(
-        options, packageGraph, lib, typeDef, sidebarForLibrary.getRenderFor);
+        options, packageGraph, lib, typeDef, _sidebarForLibrary.getRenderFor);
     var content = templates.renderTypedef(data);
     write(writer, typeDef.filePath, data, content);
     runtimeStats.incrementAccumulator('writtenTypedefFileCount');

--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -1,14 +1,13 @@
 library dartdoc.empty_generator;
 
-import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 
-/// A generator that does not generate files, but does traverse the [PackageGraph]
-/// and access [ModelElement.documentationAsHtml] for every element as though
-/// it were.
+/// A generator that does not generate files, but does traverse the
+/// [PackageGraph] and access [ModelElement.documentationAsHtml] for every
+/// element as though it were.
 class EmptyGenerator extends Generator {
   @override
   Future<void> generate(PackageGraph packageGraph, FileWriter writer) {
@@ -28,6 +27,6 @@ class EmptyGenerator extends Generator {
   }
 }
 
-Generator initEmptyGenerator(DartdocOptionContext config) {
+Generator initEmptyGenerator() {
   return EmptyGenerator();
 }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -33,12 +33,11 @@ abstract class FileWriter {
   });
 }
 
-/// An abstract class that defines a generator that generates documentation for
-/// a given package.
+/// A generator generates documentation for a given package.
 ///
-/// Generators can generate documentation in different formats: html, json etc.
+/// Generators can generate documentation in different formats: HTML, JSON, etc.
 abstract class Generator {
-  /// Generate the documentation for the given package using the specified
+  /// Generates the documentation for the given package using the specified
   /// writer. Completes the returned future when done.
   Future<void> generate(PackageGraph packageGraph, FileWriter writer);
 }

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -9,7 +9,7 @@ import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/runtime_stats.dart';
 import 'package:dartdoc/src/warnings.dart';
 
-/// [Generator] that delegates rendering to a [GeneratorBackend] and delegates
+/// A [Generator] that delegates rendering to a [GeneratorBackend] and delegates
 /// file creation to a [FileWriter].
 class GeneratorFrontEnd implements Generator {
   final GeneratorBackend _generatorBackend;
@@ -32,7 +32,7 @@ class GeneratorFrontEnd implements Generator {
     _generatorBackend.generateSearchIndex(writer, indexElements);
   }
 
-  /// Traverses the package graph and generates documentation for all contained
+  /// Traverses the [packageGraph] and generates documentation for all contained
   /// elements.
   List<Indexable> _generateDocs(PackageGraph packageGraph, FileWriter writer) {
     runtimeStats.resetAccumulators({
@@ -303,71 +303,73 @@ class GeneratorFrontEnd implements Generator {
   }
 }
 
+/// An interface for classes which are responsible for outputing the generated
+/// documentation.
 abstract class GeneratorBackend {
-  /// Emit json describing the [categories] defined by the package.
+  /// Emits JSON describing the [categories] defined by the package.
   void generateCategoryJson(FileWriter writer, List<Categorization> categories);
 
-  /// Emit json catalog of [indexedElements] for use with a search index.
+  /// Emits a JSON catalog of [indexedElements] for use with a search index.
   void generateSearchIndex(FileWriter writer, List<Indexable> indexedElements);
 
-  /// Emit documentation content for the [package].
+  /// Emits documentation content for the [package].
   void generatePackage(FileWriter writer, PackageGraph graph, Package package);
 
-  /// Emit documentation content for the [category].
+  /// Emits documentation content for the [category].
   void generateCategory(
       FileWriter writer, PackageGraph graph, Category category);
 
-  /// Emit documentation content for the [library].
+  /// Emits documentation content for the [library].
   void generateLibrary(FileWriter writer, PackageGraph graph, Library library);
 
-  /// Emit documentation content for the [clazz].
+  /// Emits documentation content for the [clazz].
   void generateClass(
       FileWriter writer, PackageGraph graph, Library library, Class clazz);
 
-  /// Emit documentation content for the [eNum].
+  /// Emits documentation content for the [eNum].
   void generateEnum(
       FileWriter writer, PackageGraph graph, Library library, Enum eNum);
 
-  /// Emit documentation content for the [mixin].
+  /// Emits documentation content for the [mixin].
   void generateMixin(
       FileWriter writer, PackageGraph graph, Library library, Mixin mixin);
 
-  /// Emit documentation content for the [constructor].
+  /// Emits documentation content for the [constructor].
   void generateConstructor(FileWriter writer, PackageGraph graph,
       Library library, Constructable constructable, Constructor constructor);
 
-  /// Emit documentation content for the [field].
+  /// Emits documentation content for the [field].
   void generateConstant(FileWriter writer, PackageGraph graph, Library library,
       Container clazz, Field field);
 
-  /// Emit documentation content for the [field].
+  /// Emits documentation content for the [field].
   void generateProperty(FileWriter writer, PackageGraph graph, Library library,
       Container clazz, Field field);
 
-  /// Emit documentation content for the [method].
+  /// Emits documentation content for the [method].
   void generateMethod(FileWriter writer, PackageGraph graph, Library library,
       Container clazz, Method method);
 
-  /// Emit documentation content for the [extension].
+  /// Emits documentation content for the [extension].
   void generateExtension(FileWriter writer, PackageGraph graph, Library library,
       Extension extension);
 
-  /// Emit documentation content for the [function].
+  /// Emits documentation content for the [function].
   void generateFunction(FileWriter writer, PackageGraph graph, Library library,
       ModelFunction function);
 
-  /// Emit documentation content for the [constant].
+  /// Emits documentation content for the [constant].
   void generateTopLevelConstant(FileWriter writer, PackageGraph graph,
       Library library, TopLevelVariable constant);
 
-  /// Emit documentation content for the [property].
+  /// Emits documentation content for the [property].
   void generateTopLevelProperty(FileWriter writer, PackageGraph graph,
       Library library, TopLevelVariable property);
 
-  /// Emit documentation content for the [typedef].
+  /// Emits documentation content for the [typedef].
   void generateTypeDef(
       FileWriter writer, PackageGraph graph, Library library, Typedef typedef);
 
-  /// Emit files not specific to a Dart language element.
+  /// Emits files not specific to a Dart language element (like a favicon, etc).
   Future<void> generateAdditionalFiles(FileWriter writer);
 }

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -12,7 +12,8 @@ import 'package:dartdoc/src/model/model_element.dart';
 
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   final indexItems = [
-    for (final categorization in categories.sorted(_sortElementRepresentations))
+    for (final categorization
+        in categories.sorted(_compareElementRepresentations))
       <String, Object?>{
         'name': categorization.name,
         'qualifiedName': categorization.fullyQualifiedName,
@@ -36,7 +37,8 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
 String generateSearchIndexJson(
     Iterable<Indexable> indexedElements, bool pretty) {
   final indexItems = [
-    for (final indexable in indexedElements.sorted(_sortElementRepresentations))
+    for (final indexable
+        in indexedElements.sorted(_compareElementRepresentations))
       <String, Object?>{
         'name': indexable.name,
         'qualifiedName': indexable.fullyQualifiedName,
@@ -58,7 +60,8 @@ String generateSearchIndexJson(
   return encoder.convert(indexItems.toList());
 }
 
-int _sortElementRepresentations(Indexable a, Indexable b) {
+// Compares two elements, first by fully qualified name, then by kind.
+int _compareElementRepresentations(Indexable a, Indexable b) {
   final value = compareNatural(a.fullyQualifiedName, b.fullyQualifiedName);
   if (value == 0) {
     return compareNatural(a.kind, b.kind);

--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -14,12 +14,13 @@ import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/src/generator/templates.dart';
 import 'package:dartdoc/src/model/package.dart';
 import 'package:dartdoc/src/model/package_graph.dart';
+import 'package:meta/meta.dart';
 
 /// Creates a [Generator] with an [HtmlGeneratorBackend] backend.
 ///
 /// [forceRuntimeTemplates] should only be given [true] during tests.
 Future<Generator> initHtmlGenerator(DartdocGeneratorOptionContext context,
-    {bool forceRuntimeTemplates = false}) async {
+    {@visibleForTesting bool forceRuntimeTemplates = false}) async {
   var templates = await Templates.fromContext(context,
       forceRuntimeTemplates: forceRuntimeTemplates);
   var options = DartdocGeneratorBackendOptions.fromContext(context);
@@ -28,7 +29,7 @@ Future<Generator> initHtmlGenerator(DartdocGeneratorOptionContext context,
   return GeneratorFrontEnd(backend);
 }
 
-/// Generator backend for html output.
+/// Generator backend for HTML output.
 class HtmlGeneratorBackend extends DartdocGeneratorBackend {
   HtmlGeneratorBackend(super.options, super.templates, super.resourceProvider);
 

--- a/lib/src/generator/markdown_generator.dart
+++ b/lib/src/generator/markdown_generator.dart
@@ -10,12 +10,13 @@ import 'package:dartdoc/src/generator/template_data.dart';
 import 'package:dartdoc/src/generator/templates.dart';
 import 'package:dartdoc/src/model/package.dart';
 import 'package:dartdoc/src/model/package_graph.dart';
+import 'package:meta/meta.dart';
 
 /// Creates a [Generator] with an [MarkdownGeneratorBackend] backend.
 ///
 /// [forceRuntimeTemplates] should only be given [true] during tests.
 Future<Generator> initMarkdownGenerator(DartdocGeneratorOptionContext context,
-    {bool forceRuntimeTemplates = false}) async {
+    {@visibleForTesting bool forceRuntimeTemplates = false}) async {
   var templates = await Templates.fromContext(context);
   var options = DartdocGeneratorBackendOptions.fromContext(context);
   var backend =
@@ -23,7 +24,7 @@ Future<Generator> initMarkdownGenerator(DartdocGeneratorOptionContext context,
   return GeneratorFrontEnd(backend);
 }
 
-/// Generator backend for markdown output.
+/// Generator backend for Markdown output.
 class MarkdownGeneratorBackend extends DartdocGeneratorBackend {
   MarkdownGeneratorBackend(
       super.options, super.templates, super.resourceProvider);

--- a/lib/src/generator/resource_loader.dart
+++ b/lib/src/generator/resource_loader.dart
@@ -37,7 +37,7 @@ extension ResourceLoader on ResourceProvider {
     return getFolder(uri.toFilePath());
   }
 
-  /// Helper function for resolving to a non-relative, non-package URI.
+  /// Resolves a non-relative, non-package URI.
   @visibleForTesting
   Future<Uri> resolveResourceUri(Uri uri) async {
     if (uri.scheme == 'package') {

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -8,6 +8,8 @@ typedef ContainerSidebar = String Function(
     Container, TemplateDataWithContainer);
 typedef LibrarySidebar = String Function(Library, TemplateDataWithLibrary);
 
+/// Shared options for [TemplateData] classes, which can be referenced across
+/// template files.
 abstract class TemplateOptions {
   String? get relCanonicalPrefix;
   String get toolVersion;
@@ -75,6 +77,8 @@ abstract class TemplateDataBase {
   }
 }
 
+/// A grab bag of data for a template that an element of type [T] can be
+/// rendered into.
 abstract class TemplateData<T extends Documentable> extends TemplateDataBase {
   TemplateData(super.htmlOptions, super.packageGraph);
 

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -2,6 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// Renderer annotations direct the Mustachio code generators to generate render
+// functions. These are generated into:
+//
+// * templates.aot_renderers_for_html.dart
+// * templates.aot_renderers_for_markdown.dart
+// * templates.runtime_renderers.dart
+//
+// See tool/mustachio/README.md for details.
+
 @Renderer(#renderCategory, Context<CategoryTemplateData>(), 'category',
     visibleTypes: _visibleTypes)
 @Renderer(#renderClass, Context<ClassTemplateData>(), 'class')
@@ -45,6 +54,11 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/mustachio/annotations.dart';
 import 'package:dartdoc/src/mustachio/renderer_base.dart';
 
+/// The set of types which are visible to the Mustachio renderers.
+///
+/// These are the types whose fields are referenced in templates. The set
+/// only needs to be specified on one `@Renderer` annotation; above, they are
+/// only referenced in the first.
 const _visibleTypes = {
   Annotation,
   Callable,
@@ -71,7 +85,7 @@ const _visibleTypes = {
   TypeParameter,
 };
 
-/// The collection of [Template] objects
+/// The collection of [Template] objects.
 abstract class Templates {
   String renderCategory(CategoryTemplateData context);
   String renderClass<T extends Class>(ClassTemplateData context);
@@ -119,6 +133,8 @@ abstract class Templates {
   }
 }
 
+/// The [Templates] implementation which uses the render functions generated
+/// from the default Dartdoc HTML templates.
 class HtmlAotTemplates implements Templates {
   @override
   String renderCategory(CategoryTemplateData context) =>
@@ -187,6 +203,8 @@ class HtmlAotTemplates implements Templates {
       aot_renderers_for_html.renderTypedef(context);
 }
 
+/// The [Templates] implementation which uses the render functions generated
+/// from the default Dartdoc Markdown templates.
 class MarkdownAotTemplates implements Templates {
   @override
   String renderCategory(CategoryTemplateData context) =>

--- a/lib/src/runtime_stats.dart
+++ b/lib/src/runtime_stats.dart
@@ -75,7 +75,10 @@ class _RuntimeStats {
   }
 }
 
-/// TODO(jcollins-g): re-write to something that isn't process-global?
+/// Statistics that get populated as the package graph is built up (like a count
+/// of all comment references) and as files are written (like the number of
+/// class files that are written).
+// TODO(jcollins-g): re-write to something that isn't process-global?
 final runtimeStats = _RuntimeStats();
 
 class _PerfTask {


### PR DESCRIPTION
* Improve (or add) docs to a lot of elements. In particular:
  * [Do format comments like sentences](https://dart.dev/guides/language/effective-dart/documentation#do-format-comments-like-sentences)
  * [Prefer starting function or method comments with third-person verbs](https://dart.dev/guides/language/effective-dart/documentation#prefer-starting-function-or-method-comments-with-third-person-verbs)
* Remove unused parameter from `initEmptyGenerator`
* Mark `initHtmlGeneratedForceRuntimeTemplates` as `@visibleForTesting`