### PR TITLE
Allow Parameter.enclosingElement to be nullable

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -12462,11 +12462,11 @@ class _Renderer_Parameter extends RendererBase<Parameter> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => false,
+                  isNullValue: (CT_ c) => c.enclosingElement == null,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_ModelElement(
-                        c.enclosingElement, ast, r.template, sink,
+                        c.enclosingElement!, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -104,9 +104,10 @@ class Parameter extends ModelElement implements EnclosedElement {
   }
 
   @override
-  Iterable<CommentReferable> get referenceParents => [
-        if (enclosingElement != null) enclosingElement!,
-      ];
+  Iterable<CommentReferable> get referenceParents {
+    final enclosingElement = this.enclosingElement;
+    return [if (enclosingElement != null) enclosingElement];
+  }
 
   @override
   ParameterElement? get element => super.element as ParameterElement?;

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -20,8 +20,12 @@ class Parameter extends ModelElement implements EnclosedElement {
   }
 
   @override
-  ModelElement get enclosingElement =>
-      modelBuilder.from(element!.enclosingElement!, library!);
+  ModelElement? get enclosingElement {
+    final enclosingElement = element!.enclosingElement;
+    return enclosingElement == null
+        ? null
+        : modelBuilder.from(enclosingElement, library!);
+  }
 
   bool get hasDefaultValue {
     return element!.defaultValueCode != null &&
@@ -100,7 +104,10 @@ class Parameter extends ModelElement implements EnclosedElement {
   }
 
   @override
-  Iterable<CommentReferable> get referenceParents => [enclosingElement];
+  Iterable<CommentReferable> get referenceParents => [
+        if (enclosingElement != null) enclosingElement!,
+      ];
+
   @override
   ParameterElement? get element => super.element as ParameterElement?;
 


### PR DESCRIPTION
dquery 2.0.0+2 appears to have a ParameterElement with an `enclosingElement` of `null`. Other than that I have not been able to reproduce...