### PR TITLE
Deprecate some unused elements in PackageMeta

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,8 @@ analyzer:
     unused_import: warning
     unused_shown_name: warning
   language:
+    # TODO(srawlins) Enable strict-casts.
+    # strict-casts: true
     strict-raw-types: true
     strict-inference: true
   exclude:

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1485,7 +1485,6 @@ List<DartdocOption> createDartdocOptions(
             if (inSdkVal != null) return inSdkVal;
           }
           var hostedAt = packageMeta.hostedAt;
-          // ignore: unnecessary_null_comparison
           if (hostedAt != null) {
             Map<String, String> hostMap = option.parent['hosted'].valueAt(dir);
             var hostedAtVal = hostMap[hostedAt];

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -128,22 +128,26 @@ abstract class PackageMeta {
 
   String get name;
 
-  /// null if not a hosted pub package.  If set, the hostname
-  /// that the package is hosted at -- usually 'pub.dartlang.org'.
+  /// The hostname that the package is hosted at -- usually 'pub.dartlang.org',
+  /// or `null` if not a hosted pub package.
   String? get hostedAt;
 
   String get version;
 
+  @Deprecated('This getter will be removed.')
   String get description;
 
   String get homepage;
 
+  @Deprecated('This getter will be removed.')
   String get repository;
 
   File? getReadmeContents();
 
+  @Deprecated('This method will be removed.')
   File? getLicenseContents();
 
+  @Deprecated('This method will be removed.')
   File? getChangelogContents();
 
   /// Returns true if we are a valid package, valid enough to generate docs.
@@ -341,28 +345,29 @@ class _FilePackageMeta extends PubPackageMeta {
   bool get isSdk => false;
 
   @override
-  String get name => _pubspec['name'] ?? '';
+  String get name => _pubspec.getOptionalString('name') ?? '';
 
   @override
-  String get version => _pubspec['version'] ?? '0.0.0-unknown';
+  String get version =>
+      _pubspec.getOptionalString('version') ?? '0.0.0-unknown';
 
   @override
-  String get description => _pubspec['description'] ?? '';
+  String get description => _pubspec.getOptionalString('description') ?? '';
 
   @override
-  String get homepage => _pubspec['homepage'] ?? '';
+  String get homepage => _pubspec.getOptionalString('homepage') ?? '';
 
   @override
-  String get repository => _pubspec['repository'] ?? '';
+  String get repository => _pubspec.getOptionalString('repository') ?? '';
 
   @override
   bool get requiresFlutter =>
       _environment?.containsKey('flutter') == true ||
       _dependencies?.containsKey('flutter') == true;
 
-  YamlMap? get _environment => _pubspec['environment'];
+  YamlMap? get _environment => _pubspec.getOptionalMap('environment');
 
-  YamlMap? get _dependencies => _pubspec['environment'];
+  YamlMap? get _dependencies => _pubspec.getOptionalMap('dependencies');
 
   @override
   File? getReadmeContents() =>
@@ -466,4 +471,13 @@ class _SdkMeta extends PubPackageMeta {
 @visibleForTesting
 void clearPackageMetaCache() {
   _packageMetaCache.clear();
+}
+
+/// Extensions for a Map of YAML data, like a pubspec.
+extension on Map<dynamic, dynamic> {
+  /// Gets the value for [key], casting to a nullable [YamlMap].
+  YamlMap? getOptionalMap(dynamic key) => this[key] as YamlMap?;
+
+  /// Gets the value for [key], casting to a nullable [String].
+  String? getOptionalString(dynamic key) => this[key] as String?;
 }

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -50,12 +50,14 @@ void main() {
 
     test('has a description', () {
       expect(
+          // ignore: deprecated_member_use_from_same_package
           p.description,
           equals(
               'A non-interactive HTML documentation generator for Dart source code.'));
     });
 
     test('has a repository', () {
+      // ignore: deprecated_member_use_from_same_package
       expect(p.repository, equals('https://github.com/dart-lang/dartdoc'));
     });
 
@@ -74,17 +76,21 @@ void main() {
     });
 
     test('has a license', () {
+      // ignore: deprecated_member_use_from_same_package
       expect(p.getLicenseContents(), isNotNull);
       expect(
           resourceProvider
+              // ignore: deprecated_member_use_from_same_package
               .readAsMalformedAllowedStringSync(p.getLicenseContents()!),
           contains('Copyright 2014, the Dart project authors.'));
     });
 
     test('has a changelog', () {
+      // ignore: deprecated_member_use_from_same_package
       expect(p.getChangelogContents(), isNotNull);
       expect(
           resourceProvider
+              // ignore: deprecated_member_use_from_same_package
               .readAsMalformedAllowedStringSync(p.getChangelogContents()!),
           contains('## 0.2.2'));
     });
@@ -110,6 +116,7 @@ void main() {
 
     test('has a description', () {
       expect(
+          // ignore: deprecated_member_use_from_same_package
           p.description,
           equals(
               'The Dart SDK is a set of tools and libraries for the Dart programming language.'));
@@ -128,6 +135,7 @@ void main() {
     });
 
     test('does not have a license', () {
+      // ignore: deprecated_member_use_from_same_package
       expect(p.getLicenseContents(), isNull);
     });
   });


### PR DESCRIPTION
Also tidy up some "implicit dynamic" casts in PackageMeta.

These were found when investigating briefly the `implicit-casts: true` mode.