### PR TITLE
Move source-manipulating code from model_utils to model_node

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -9941,7 +9941,7 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
                           c, remainingNames, 'CompilationUnitElement'),
-                  isNullValue: (CT_ c) => c.compilationUnitElement == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     renderSimple(

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -671,18 +671,19 @@ abstract class ModelElement extends Canonicalization
 
   @override
   late final CharacterLocation? characterLocation = () {
-    var lineInfo = compilationUnitElement!.lineInfo;
-    assert(element!.nameOffset >= 0,
+    final lineInfo = compilationUnitElement.lineInfo;
+    late final element = this.element!;
+    assert(element.nameOffset >= 0,
         'Invalid location data for element: $fullyQualifiedName');
-    var nameOffset = element!.nameOffset;
+    var nameOffset = element.nameOffset;
     if (nameOffset >= 0) {
       return lineInfo.getLocation(nameOffset);
     }
     return null;
   }();
 
-  CompilationUnitElement? get compilationUnitElement =>
-      element!.thisOrAncestorOfType<CompilationUnitElement>();
+  CompilationUnitElement get compilationUnitElement =>
+      element!.thisOrAncestorOfType<CompilationUnitElement>()!;
 
   bool get hasAnnotations => annotations.isNotEmpty;
 

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/comment_references/model_comment_reference.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
+import 'package:meta/meta.dart';
 
 /// Stripped down information derived from [AstNode] containing only information
 /// needed for Dartdoc.  Drops link to the [AstNode] after construction.
@@ -20,13 +23,13 @@ class ModelNode {
   factory ModelNode(
       AstNode? sourceNode, Element element, ResourceProvider resourceProvider) {
     var commentRefs = _commentRefsFor(sourceNode, resourceProvider);
-    // Get a node higher up the syntax tree that includes the semicolon.
-    // In this case, it is either a [FieldDeclaration] or
-    // [TopLevelVariableDeclaration]. (#2401)
     if (sourceNode == null) {
       return ModelNode._(element, resourceProvider, commentRefs,
           sourceEnd: -1, sourceOffset: -1);
     } else {
+      // Get a node higher up the syntax tree that includes the semicolon.
+      // In this case, it is either a [FieldDeclaration] or
+      // [TopLevelVariableDeclaration]. (#2401)
       if (sourceNode is VariableDeclaration) {
         sourceNode = sourceNode.parent!.parent!;
         assert(sourceNode is FieldDeclaration ||
@@ -56,28 +59,94 @@ class ModelNode {
     return const [];
   }
 
-  late final String sourceCode = () {
-    if (_sourceEnd < 0 || _sourceOffset < 0) {
-      return '';
-    }
+  bool get _isSynthetic => _sourceEnd < 0 || _sourceOffset < 0;
 
-    var contents = model_utils.getFileContentsFor(element, resourceProvider);
-    // Find the start of the line, so that we can line up all of the indents.
-    var i = _sourceOffset;
+  /// The text of the source code of this node, stripped of the leading
+  /// indentation, and stripped of the doc comments.
+  late final String sourceCode = _isSynthetic
+      ? ''
+      : model_utils
+          .getFileContentsFor(element, resourceProvider)
+          .substringFromLineStart(_sourceOffset, _sourceEnd)
+          .stripIndent
+          .stripDocComments
+          .trim();
+}
+
+@visibleForTesting
+extension SourceStringExtensions on String {
+  String substringFromLineStart(int offset, int endOffset) {
+    var lineStartOffset = startOfLineWithOffset(offset);
+    return substring(lineStartOffset, endOffset);
+  }
+
+  // Finds the start of the line which contains the character at [offset].
+  int startOfLineWithOffset(int offset) {
+    var i = offset;
+    // Walk backwards until we find the previous line's EOL character.
     while (i > 0) {
       i -= 1;
-      if (contents[i] == '\n' || contents[i] == '\r') {
+      if (this[i] == '\n' || this[i] == '\r') {
         i += 1;
         break;
       }
     }
+    return i;
+  }
 
-    // Trim the common indent from the source snippet.
-    var source = contents.substring(i, _sourceEnd);
+  /// Strips leading doc comments from the given source code.
+  String get stripDocComments {
+    var remainder = trimLeft();
+    var lineComments = remainder.startsWith(_tripleSlash) ||
+        remainder.startsWith(_escapedTripleSlash);
+    var blockComments = remainder.startsWith(_slashStarStar) ||
+        remainder.startsWith(_escapedSlashStarStar);
 
-    source = model_utils.stripIndentFromSource(source);
-    source = model_utils.stripDartdocCommentsFromSource(source);
+    return split('\n').where((String line) {
+      if (lineComments) {
+        if (line.startsWith(_tripleSlash) ||
+            line.startsWith(_escapedTripleSlash)) {
+          return false;
+        }
+        lineComments = false;
+        return true;
+      } else if (blockComments) {
+        if (line.contains(_starSlash) || line.contains(_escapedStarSlash)) {
+          blockComments = false;
+          return false;
+        }
+        if (line.startsWith(_slashStarStar) ||
+            line.startsWith(_escapedSlashStarStar)) {
+          return false;
+        }
+        return false;
+      }
 
-    return source.trim();
-  }();
+      return true;
+    }).join('\n');
+  }
+
+  /// Strips the common indent from the given source fragment.
+  String get stripIndent {
+    var remainder = trimLeft();
+    var indent = substring(0, length - remainder.length);
+    return split('\n').map((line) {
+      line = line.trimRight();
+      return line.startsWith(indent) ? line.substring(indent.length) : line;
+    }).join('\n');
+  }
 }
+
+const HtmlEscape _escape = HtmlEscape();
+
+const String _tripleSlash = '///';
+
+final String _escapedTripleSlash = _escape.convert(_tripleSlash);
+
+const String _slashStarStar = '/**';
+
+final String _escapedSlashStarStar = _escape.convert(_slashStarStar);
+
+const String _starSlash = '*/';
+
+final String _escapedStarSlash = _escape.convert(_starSlash);

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -4,7 +4,6 @@
 
 library dartdoc.model_utils;
 
-import 'dart:convert';
 import 'dart:io' show Platform;
 
 import 'package:analyzer/dart/element/element.dart';
@@ -125,59 +124,3 @@ bool hasPrivateName(Element e) {
 }
 
 bool hasPublicName(Element e) => !hasPrivateName(e);
-
-/// Strip leading dartdoc comments from the given source code.
-String stripDartdocCommentsFromSource(String source) {
-  var remainder = source.trimLeft();
-  var lineComments = remainder.startsWith(_tripleSlash) ||
-      remainder.startsWith(_escapedTripleSlash);
-  var blockComments = remainder.startsWith(_slashStarStar) ||
-      remainder.startsWith(_escapedSlashStarStar);
-
-  return source.split('\n').where((String line) {
-    if (lineComments) {
-      if (line.startsWith(_tripleSlash) ||
-          line.startsWith(_escapedTripleSlash)) {
-        return false;
-      }
-      lineComments = false;
-      return true;
-    } else if (blockComments) {
-      if (line.contains(_starSlash) || line.contains(_escapedStarSlash)) {
-        blockComments = false;
-        return false;
-      }
-      if (line.startsWith(_slashStarStar) ||
-          line.startsWith(_escapedSlashStarStar)) {
-        return false;
-      }
-      return false;
-    }
-
-    return true;
-  }).join('\n');
-}
-
-const HtmlEscape _escape = HtmlEscape();
-
-const String _tripleSlash = '///';
-
-final String _escapedTripleSlash = _escape.convert(_tripleSlash);
-
-const String _slashStarStar = '/**';
-
-final String _escapedSlashStarStar = _escape.convert(_slashStarStar);
-
-const String _starSlash = '*/';
-
-final String _escapedStarSlash = _escape.convert(_starSlash);
-
-/// Strip the common indent from the given source fragment.
-String stripIndentFromSource(String source) {
-  var remainder = source.trimLeft();
-  var indent = source.substring(0, source.length - remainder.length);
-  return source.split('\n').map((line) {
-    line = line.trimRight();
-    return line.startsWith(indent) ? line.substring(indent.length) : line;
-  }).join('\n');
-}

--- a/test/model_node_test.dart
+++ b/test/model_node_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartdoc/src/model/model_node.dart' show SourceStringExtensions;
+import 'package:test/test.dart';
+
+void main() {
+  group('model_utils stripIndentFromSource', () {
+    test('no indent', () {
+      expect(
+        'void foo() {\n  print(1);\n}\n'.stripIndent,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+
+    test('same indent', () {
+      expect(
+        '  void foo() {\n    print(1);\n  }\n'.stripIndent,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+
+    test('odd indent', () {
+      expect(
+        '   void foo() {\n     print(1);\n   }\n'.stripIndent,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+  });
+
+  group('model_utils stripDartdocCommentsFromSource', () {
+    test('no comments', () {
+      expect(
+        'void foo() {\n  print(1);\n}\n'.stripDocComments,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+
+    test('line comments', () {
+      expect(
+        '/// foo comment\nvoid foo() {\n  print(1);\n}\n'.stripDocComments,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+
+    test('block comments 1', () {
+      expect(
+        '/** foo comment */\nvoid foo() {\n  print(1);\n}\n'.stripDocComments,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+
+    test('block comments 2', () {
+      expect(
+        '/**\n * foo comment\n */\nvoid foo() {\n  print(1);\n}\n'
+            .stripDocComments,
+        'void foo() {\n  print(1);\n}\n',
+      );
+    });
+  });
+}

--- a/test/model_utils_test.dart
+++ b/test/model_utils_test.dart
@@ -23,49 +23,4 @@ void main() {
       expect(matchGlobs([r'C:\a\b\*'], r'D:\a\b\d', isWindows: true), isFalse);
     });
   });
-
-  group('model_utils stripIndentFromSource', () {
-    test('no indent', () {
-      expect(stripIndentFromSource('void foo() {\n  print(1);\n}\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-
-    test('same indent', () {
-      expect(stripIndentFromSource('  void foo() {\n    print(1);\n  }\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-
-    test('odd indent', () {
-      expect(stripIndentFromSource('   void foo() {\n     print(1);\n   }\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-  });
-
-  group('model_utils stripDartdocCommentsFromSource', () {
-    test('no comments', () {
-      expect(stripDartdocCommentsFromSource('void foo() {\n  print(1);\n}\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-
-    test('line comments', () {
-      expect(
-          stripDartdocCommentsFromSource(
-              '/// foo comment\nvoid foo() {\n  print(1);\n}\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-
-    test('block comments 1', () {
-      expect(
-          stripDartdocCommentsFromSource(
-              '/** foo comment */\nvoid foo() {\n  print(1);\n}\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-
-    test('block comments 2', () {
-      expect(
-          stripDartdocCommentsFromSource(
-              '/**\n * foo comment\n */\nvoid foo() {\n  print(1);\n}\n'),
-          'void foo() {\n  print(1);\n}\n');
-    });
-  });
 }


### PR DESCRIPTION
The `sourceCode` getter is `late final` with a long complex initializer closure. These spook me, so I was able to refactor by bringing some helpers from model_utils.dart into model_node.dart as extension methods on String.

I also made ModelElement.compilationUnitElement non-nullable.

Tests were moved, but no test cases were added, removed, or changed.