### PR TITLE
Move test skip above test body

### DIFF
--- a/test/constant_values_test.dart
+++ b/test/constant_values_test.dart
@@ -182,9 +182,9 @@ const aTearOffUnnamedConstructorArgsTypedef = Ft<String>.new;
       expect(aTearOffUnnamedConstructorArgsTypedef.constantValue,
           equals('Ft&lt;String&gt;.new'));
     });
-  }, skip: !constructorTearoffsAllowed);
+  });
 
-  group('named-arguments-anywhere', () {
+  group('named-arguments-anywhere', skip: !namedArgumentsAnywhereAllowed, () {
     const placeholder = '%%__HTMLBASE_dartdoc_internal__%%';
     const libraryName = 'constant_values';
     const linkPrefix = '$placeholder$libraryName';
@@ -251,5 +251,5 @@ const r = C(c: 1, d: 2, 3, 4);
       expect(rConst.constantValue,
           equals('<a href="$linkPrefix/C/C.html">C</a>(c: 1, d: 2, 3, 4)'));
     });
-  }, skip: !namedArgumentsAnywhereAllowed);
+  });
 }

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -165,7 +165,8 @@ void main() {
     });
 
     test('generate docs for ${p.basename(_testPackageBadDir.path)} fails',
-        () async {
+        skip: 'Blocked on getting analysis errors with correct interpretation '
+            'from analysis_options', () async {
       var dartdoc = await buildDartdoc([], _testPackageBadDir, tempDir);
 
       try {
@@ -174,9 +175,7 @@ void main() {
       } catch (e) {
         expect(e is DartdocFailure, isTrue);
       }
-    },
-        skip: 'Blocked on getting analysis errors with correct interpretation '
-            'from analysis_options');
+    });
 
     test('generate docs for package with embedder yaml', () async {
       var dartdoc = await buildDartdoc([], _testSkyEnginePackage, tempDir);

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -212,7 +212,7 @@ void main() {
         expect(referenceLookup(A, 'new'), equals(MatchingLinkResult(null)));
         expect(referenceLookup(At, 'new'), equals(MatchingLinkResult(null)));
       });
-    }, skip: !utils.constructorTearoffsAllowed);
+    });
   });
 
   group('HTML is sanitized when enabled', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -160,15 +160,16 @@ void main() {
     });
 
     test(
-        'Verify annotations and their type arguments render on type parameters for typedefs',
-        () {
+        'Verify annotations and their type arguments render on type parameters '
+        'for typedefs',
+        skip: 'dart-lang/sdk#46064', () {
       expect((F.aliasedType as FunctionType).typeFormals.first.metadata,
           isNotEmpty);
       expect((F.aliasedType as FunctionType).parameters.first.metadata,
           isNotEmpty);
       // TODO(jcollins-g): add rendering verification once we have data from
       // analyzer.
-    }, skip: 'dart-lang/sdk#46064');
+    });
 
     test('Verify type arguments on annotations renders, including parameters',
         () {
@@ -260,14 +261,15 @@ void main() {
           g.modelType.parameters.last.modelType as Aliased, equals('T3'));
     });
 
-    test('typedef references to special types work', () {
+    test('typedef references to special types work',
+        skip: 'dart-lang/sdk#45291', () {
       var a = generalizedTypedefs.properties.firstWhere((p) => p.name == 'a');
       var b = C2.allFields.firstWhere((f) => f.name == 'b');
       var f = C.allFields.firstWhere((f) => f.name == 'f');
       expectAliasedTypeName(a.modelType as Aliased, equals('T0'));
       expectAliasedTypeName(b.modelType as Aliased, equals('T0'));
       expectAliasedTypeName(f.modelType as Aliased, equals('T0'));
-    }, skip: 'dart-lang/sdk#45291');
+    });
 
     test('basic non-function typedefs work', () {
       expectTypedefs(T0, 'void', []);
@@ -1410,12 +1412,15 @@ void main() {
                 '<a href="${htmlBasePlaceholder}fake/BaseForDocComments/operator_get.html">operator []</a> '));
       });
 
-      test('operator [] reference outside of a class works', () {
+      test('operator [] reference outside of a class works',
+          skip: 'https://github.com/dart-lang/dartdoc/issues/1285', () {
         expect(
-            docsAsHtml,
-            contains(
-                '<a href="${htmlBasePlaceholder}fake/SpecialList/operator_get.html">SpecialList.operator []</a> '));
-      }, skip: 'https://github.com/dart-lang/dartdoc/issues/1285');
+          docsAsHtml,
+          contains(
+              '<a href="${htmlBasePlaceholder}fake/SpecialList/operator_get.html">'
+              'SpecialList.operator []</a> '),
+        );
+      });
 
       test('adds <code> tag to a class from the SDK', () {
         expect(docsAsHtml, contains('<code>String</code>'));

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -250,7 +250,7 @@ enum E {
     });
   });
 
-  group('an enhanced enum', () {
+  group('an enhanced enum', skip: !enhancedEnumsAllowed, () {
     const placeholder = '%%__HTMLBASE_dartdoc_internal__%%';
     const linkPrefix = '$placeholder$libraryName';
 
@@ -652,5 +652,5 @@ class C {}
         '<p>Reference to <a href="$linkPrefix/E/f.html">E.f</a>.</p>',
       );
     });
-  }, skip: !enhancedEnumsAllowed);
+  });
 }

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -160,7 +160,7 @@ class C {
     });
   });
 
-  group('super-parameters', () {
+  group('super-parameters', skip: !superParametersAllowed, () {
     late Library library;
 
     // It is expensive (~10s) to compute a package graph, even skipping
@@ -366,7 +366,7 @@ class E extends D {
         </span>
       '''));
     });
-  }, skip: !superParametersAllowed);
+  });
 }
 
 extension on Library {

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -327,13 +327,6 @@ Matcher matchesCompressed(String text) => matches(RegExp(text.replaceAll(
 /// We can not use [ExperimentalFeature.releaseVersion] or even
 /// [ExperimentalFeature.experimentalReleaseVersion] as these are set to `null`
 /// even when partial analyzer implementations are available.
-bool get constructorTearoffsAllowed =>
-    VersionRange(min: Version.parse('2.15.0-0'), includeMin: true)
-        .allows(platformVersion);
-
-/// We can not use [ExperimentalFeature.releaseVersion] or even
-/// [ExperimentalFeature.experimentalReleaseVersion] as these are set to `null`
-/// even when partial analyzer implementations are available.
 bool get enhancedEnumsAllowed =>
     VersionRange(min: Version.parse('2.17.0-0'), includeMin: true)
         .allows(platformVersion);

--- a/test/templates/enum_test.dart
+++ b/test/templates/enum_test.dart
@@ -61,7 +61,7 @@ void main() async {
     );
   }
 
-  group('enhanced enums', () {
+  group('enhanced enums', skip: !enhancedEnumsAllowed, () {
     setUpAll(() async {
       packageMetaProvider = testPackageMetaProvider;
       resourceProvider =
@@ -420,5 +420,5 @@ enum EnumWithDefaultConstructor { four, five, six }
     // TODO(srawlins): Add rendering tests.
     // * Add tests for rendered supertype (Enum) HTML.
     // * Add tests for rendered field pages.
-  }, skip: !enhancedEnumsAllowed);
+  });
 }


### PR DESCRIPTION
It's much nicer to have the `skip` argument _above_ the test/group body, rather than a million miles away.

I also removed all skips for pre-constructor tear-offs, as those landed back in 2.15.0