### PR TITLE
Move annotation tests out of end-to-end test

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -318,11 +318,11 @@ abstract class DefinedElementType extends ElementType {
     }
   }();
 
-  /// The instantiated to bounds type of this type is a subtype of
-  /// [t].
+  /// Returns whether the instantiated-to-bounds type of this type is a subtype
+  /// of [type].
   @override
-  bool isSubtypeOf(ElementType t) =>
-      library.typeSystem.isSubtypeOf(instantiatedType, t.instantiatedType);
+  bool isSubtypeOf(ElementType type) =>
+      library.typeSystem.isSubtypeOf(instantiatedType, type.instantiatedType);
 
   /// Returns true if at least one supertype (including via mixins and
   /// interfaces) is equivalent to or a subtype of [this] when

--- a/lib/src/model/feature.dart
+++ b/lib/src/model/feature.dart
@@ -21,7 +21,7 @@ class ElementFeatureNotFoundError extends Error {
 }
 
 /// A "feature" includes both explicit annotations in code (e.g. `deprecated`)
-/// as well as others added by the documentation system (`read-write`);
+/// as well as others added by the documentation system (`read-write`).
 class Feature implements Privacy {
   final String _name;
 

--- a/lib/src/model/model_object_builder.dart
+++ b/lib/src/model/model_object_builder.dart
@@ -43,7 +43,7 @@ class ModelObjectBuilderImpl extends ModelObjectBuilder
   ModelObjectBuilderImpl(this.packageGraph);
 }
 
-/// Default implementation of the ModelBuilderInterface, requiring a
+/// Default implementation of [ModelBuilderInterface], requiring a
 /// [PackageGraph].
 mixin ModelBuilder implements ModelBuilderInterface {
   PackageGraph get packageGraph;

--- a/test/annotation_test.dart
+++ b/test/annotation_test.dart
@@ -1,0 +1,176 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
+import 'package:dartdoc/src/package_meta.dart';
+import 'package:test/test.dart';
+
+import 'src/test_descriptor_utils.dart' as d;
+import 'src/utils.dart';
+
+void main() {
+  const libraryName = 'annotations';
+
+  const dartCoreUrlPrefix = 'https://api.dart.dev/stable/2.16.0/dart-core';
+
+  late PackageMetaProvider packageMetaProvider;
+  late MemoryResourceProvider resourceProvider;
+  late FakePackageConfigProvider packageConfigProvider;
+  late String packagePath;
+
+  setUp(() async {
+    packageMetaProvider = testPackageMetaProvider;
+    resourceProvider =
+        packageMetaProvider.resourceProvider as MemoryResourceProvider;
+
+    packagePath = await d.createPackage(
+      libraryName,
+      pubspec: '''
+name: annotations
+version: 0.0.1
+environment:
+  sdk: '>=2.15.0 <3.0.0'
+''',
+      resourceProvider: resourceProvider,
+    );
+
+    packageConfigProvider =
+        getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
+    packageConfigProvider.addPackageToConfigFor(
+        packagePath, libraryName, Uri.file('$packagePath/'));
+  });
+
+  Future<Library> bootPackageWithLibrary(String libraryContent) async {
+    await d.dir('lib', [
+      d.file('lib.dart', '''
+library $libraryName;
+
+$libraryContent
+'''),
+    ]).createInMemory(resourceProvider, packagePath);
+
+    var packageGraph = await bootBasicPackage(
+      packagePath,
+      packageMetaProvider,
+      packageConfigProvider,
+    );
+    return packageGraph.libraries.named(libraryName);
+  }
+
+  test('deprecated constant is linked', () async {
+    var library = await bootPackageWithLibrary('''
+@deprecated
+int value = 0;
+''');
+    var valueVariable = library.properties.named('value');
+    expect(valueVariable.hasAnnotations, true);
+    var annotation = valueVariable.annotations.single;
+    expect(
+      annotation.linkedName,
+      '<a href="$dartCoreUrlPrefix/deprecated-constant.html">deprecated</a>',
+    );
+    expect(
+      annotation.linkedNameWithParameters,
+      '@<a href="$dartCoreUrlPrefix/deprecated-constant.html">deprecated</a>',
+    );
+  });
+
+  test('Deprecated() constructor call is linked', () async {
+    var library = await bootPackageWithLibrary('''
+@Deprecated('text')
+int value = 0;
+''');
+    var valueVariable = library.properties.named('value');
+    expect(valueVariable.hasAnnotations, true);
+    var annotation = valueVariable.annotations.single;
+    expect(
+      annotation.linkedName,
+      '<a href="$dartCoreUrlPrefix/Deprecated-class.html">Deprecated</a>',
+    );
+    expect(
+      annotation.linkedNameWithParameters,
+      '@<a href="$dartCoreUrlPrefix/Deprecated-class.html">Deprecated</a>'
+      '(&#39;text&#39;)',
+    );
+  });
+
+  test('locally declared constant is linked', () async {
+    var library = await bootPackageWithLibrary('''
+class MyAnnotation {
+  const MyAnnotation();
+}
+
+const myAnnotation = MyAnnotation();
+
+@myAnnotation
+int value = 0;
+''');
+    var valueVariable = library.properties.named('value');
+    expect(valueVariable.hasAnnotations, true);
+    var annotation = valueVariable.annotations.single;
+    expect(
+      annotation.linkedName,
+      '<a href="${htmlBasePlaceholder}annotations/myAnnotation-constant.html">'
+      'myAnnotation</a>',
+    );
+    expect(
+      annotation.linkedNameWithParameters,
+      '@<a href="${htmlBasePlaceholder}annotations/myAnnotation-constant.html">'
+      'myAnnotation</a>',
+    );
+  });
+
+  test('locally declared constructor call is linked', () async {
+    var library = await bootPackageWithLibrary('''
+class MyAnnotation {
+  const MyAnnotation(bool b);
+}
+
+@MyAnnotation(true)
+int value = 0;
+''');
+    var valueVariable = library.properties.named('value');
+    expect(valueVariable.hasAnnotations, true);
+    var annotation = valueVariable.annotations.single;
+    expect(
+      annotation.linkedName,
+      '<a href="${htmlBasePlaceholder}annotations/MyAnnotation-class.html">'
+      'MyAnnotation</a>',
+    );
+    expect(
+      annotation.linkedNameWithParameters,
+      '@<a href="${htmlBasePlaceholder}annotations/MyAnnotation-class.html">'
+      'MyAnnotation</a>(true)',
+    );
+  });
+
+  test('generic constructor call is linked', () async {
+    var library = await bootPackageWithLibrary('''
+class Ann<T> {
+  final T f;
+  const Ann(this.f);
+}
+
+@Ann(true)
+int value = 0;
+''');
+    var valueVariable = library.properties.named('value');
+    expect(valueVariable.hasAnnotations, true);
+    var annotation = valueVariable.annotations.single;
+    expect(
+      annotation.linkedName,
+      '<a href="${htmlBasePlaceholder}annotations/Ann-class.html">Ann</a>'
+      '<span class="signature">&lt;<wbr><span class="type-parameter">'
+      '<a href="$dartCoreUrlPrefix/bool-class.html">bool</a></span>&gt;</span>',
+    );
+    expect(
+      annotation.linkedNameWithParameters,
+      '@<a href="${htmlBasePlaceholder}annotations/Ann-class.html">Ann</a>'
+      '<span class="signature">&lt;<wbr><span class="type-parameter">'
+      '<a href="$dartCoreUrlPrefix/bool-class.html">bool</a></span>&gt;</span>(true)',
+    );
+  });
+}

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2041,7 +2041,7 @@ void main() {
     });
 
     test('correctly finds all the classes', () {
-      expect(classes, hasLength(38));
+      expect(classes, hasLength(37));
     });
 
     test('abstract', () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4896,58 +4896,6 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
   });
 
-  group('Annotations', () {
-    late final Class forAnnotation, dog;
-    late final Method ctr;
-    setUpAll(() {
-      forAnnotation =
-          exLibrary.classes.firstWhere((c) => c.name == 'HasAnnotation');
-      dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
-      ctr = dog.staticMethods.firstWhere((c) => c.name == 'createDog');
-    });
-
-    test('is not null', () => expect(forAnnotation, isNotNull));
-
-    test('has annotations', () => expect(forAnnotation.hasAnnotations, true));
-
-    test('has one annotation',
-        () => expect(forAnnotation.annotations, hasLength(1)));
-
-    test('has the right annotation and is escaped', () {
-      expect(
-          forAnnotation.annotations.first.linkedNameWithParameters,
-          equals(
-              '@<a href="${htmlBasePlaceholder}ex/ForAnnotation-class.html">ForAnnotation</a>'
-              '(&#39;my value&#39;)'));
-    });
-
-    test('methods has the right annotation', () {
-      var m = dog.instanceMethods.singleWhere((m) => m.name == 'getClassA');
-      expect(m.hasAnnotations, isTrue);
-      expect(
-          m.annotations.first.linkedNameWithParameters,
-          equals(
-              '@<a href="${htmlBasePlaceholder}ex/deprecated-constant.html">deprecated</a>'));
-    });
-
-    test('constructor annotations have the right link and are escaped', () {
-      expect(
-          ctr.annotations.first.linkedNameWithParameters,
-          equals(
-              '@<a href="${htmlBasePlaceholder}ex/Deprecated-class.html">Deprecated</a>'
-              '(&quot;Internal use&quot;)'));
-    });
-
-    test('const annotations have the right link and are escaped', () {
-      var createDog2 =
-          dog.staticMethods.firstWhere((c) => c.name == 'createDog2');
-      expect(
-          createDog2.annotations.first.linkedNameWithParameters,
-          equals(
-              '@<a href="${htmlBasePlaceholder}ex/deprecated-constant.html">deprecated</a>'));
-    });
-  });
-
   group('Source Code HTML', () {
     Class EscapableProperties;
     late final Field implicitGetterExplicitSetter, explicitGetterImplicitSetter;

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2041,7 +2041,7 @@ void main() {
     });
 
     test('correctly finds all the classes', () {
-      expect(classes, hasLength(39));
+      expect(classes, hasLength(38));
     });
 
     test('abstract', () {

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -410,16 +410,6 @@ class Dog implements Cat, E {
     return arg;
   }
 
-  @Deprecated("Internal use")
-  static Dog createDog(String s) {
-    return Dog.deprecatedCreate(s);
-  }
-
-  @deprecated
-  static Dog createDog2(String s) {
-    return Dog.deprecatedCreate(s);
-  }
-
   @override
   void abstractMethod() {}
 }
@@ -429,14 +419,6 @@ abstract class E {}
 class F<T extends String> extends Dog with _PrivateAbstractClass {
   void methodWithGenericParam([List<Apple>? msgs]) {}
 }
-
-class ForAnnotation {
-  final String value;
-  const ForAnnotation(this.value);
-}
-
-@ForAnnotation('my value')
-class HasAnnotation {}
 
 /// A class
 class Klass {


### PR DESCRIPTION
This also improves test coverage by adding tests for generic metadata.