### PR TITLE
Format mustache of sidebars

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1545,14 +1545,14 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicEnumValues == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title"><a href="''');
+        <li class="section-title"><a href="''');
       buffer.write(context1.href);
       buffer.write('''#values">Values</a></li>''');
       var context4 = context1.publicEnumValues;
       for (var context5 in context4) {
         buffer.writeln();
         buffer.write('''
-    <li>''');
+          <li>''');
         buffer.write(context5.linkedName);
         buffer.write('''</li>''');
       }
@@ -1563,20 +1563,20 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicInstanceFields == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title''');
+        <li class="section-title''');
       if (context1.publicInheritedInstanceFields == true) {
         buffer.write(''' inherited''');
       }
       buffer.write('''">
-      <a href="''');
+          <a href="''');
       buffer.write(context1.href);
       buffer.write('''#instance-properties">Properties</a>
-    </li>''');
+        </li>''');
       var context6 = context1.publicInstanceFieldsSorted;
       for (var context7 in context6) {
         buffer.writeln();
         buffer.write('''
-    <li''');
+          <li''');
         if (context7.isInherited == true) {
           buffer.write(''' class="inherited"''');
         }
@@ -1589,7 +1589,7 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicInstanceMethods == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title''');
+        <li class="section-title''');
       if (context1.publicInheritedInstanceMethods == true) {
         buffer.write(''' inherited''');
       }
@@ -1600,7 +1600,7 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
       for (var context9 in context8) {
         buffer.writeln();
         buffer.write('''
-    <li''');
+          <li''');
         if (context9.isInherited == true) {
           buffer.write(''' class="inherited"''');
         }
@@ -1613,7 +1613,7 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicInstanceOperators == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title''');
+        <li class="section-title''');
       if (context1.publicInheritedInstanceOperators == true) {
         buffer.write(''' inherited''');
       }
@@ -1624,7 +1624,7 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
       for (var context11 in context10) {
         buffer.writeln();
         buffer.write('''
-    <li''');
+          <li''');
         if (context11.isInherited == true) {
           buffer.write(''' class="inherited"''');
         }
@@ -1639,15 +1639,14 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicInstanceFields == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title"> <a href="''');
+        <li class="section-title"> <a href="''');
       buffer.write(context1.href);
-      buffer.write('''#instance-properties">Properties</a>
-    </li>''');
+      buffer.write('''#instance-properties">Properties</a></li>''');
       var context12 = context1.publicInstanceFieldsSorted;
       for (var context13 in context12) {
         buffer.writeln();
         buffer.write('''
-    <li>''');
+          <li>''');
         buffer.write(context13.linkedName);
         buffer.write('''</li>''');
       }
@@ -1656,14 +1655,14 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicInstanceMethods == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title"><a href="''');
+        <li class="section-title"><a href="''');
       buffer.write(context1.href);
       buffer.write('''#instance-methods">Methods</a></li>''');
       var context14 = context1.publicInstanceMethodsSorted;
       for (var context15 in context14) {
         buffer.writeln();
         buffer.write('''
-    <li>''');
+          <li>''');
         buffer.write(context15.linkedName);
         buffer.write('''</li>''');
       }
@@ -1672,14 +1671,14 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
     if (context1.hasPublicInstanceOperators == true) {
       buffer.writeln();
       buffer.write('''
-    <li class="section-title"><a href="''');
+        <li class="section-title"><a href="''');
       buffer.write(context1.href);
       buffer.write('''#operators">Operators</a></li>''');
       var context16 = context1.publicInstanceOperatorsSorted;
       for (var context17 in context16) {
         buffer.writeln();
         buffer.write('''
-    <li>''');
+          <li>''');
         buffer.write(context17.linkedName);
         buffer.write('''</li>''');
       }
@@ -1751,14 +1750,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicClasses == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#classes">Classes</a></li>''');
     var context2 = context1.publicClassesSorted;
     for (var context3 in context2) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context3.linkedName);
       buffer.write('''</li>''');
     }
@@ -1767,14 +1766,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicExtensions == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#extensions">Extensions</a></li>''');
     var context4 = context1.publicExtensionsSorted;
     for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context5.linkedName);
       buffer.write('''</li>''');
     }
@@ -1783,14 +1782,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicMixins == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#mixins">Mixins</a></li>''');
     var context6 = context1.publicMixinsSorted;
     for (var context7 in context6) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context7.linkedName);
       buffer.write('''</li>''');
     }
@@ -1799,14 +1798,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicConstants == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#constants">Constants</a></li>''');
     var context8 = context1.publicConstantsSorted;
     for (var context9 in context8) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context9.linkedName);
       buffer.write('''</li>''');
     }
@@ -1815,14 +1814,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicProperties == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#properties">Properties</a></li>''');
     var context10 = context1.publicPropertiesSorted;
     for (var context11 in context10) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context11.linkedName);
       buffer.write('''</li>''');
     }
@@ -1831,14 +1830,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicFunctions == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#functions">Functions</a></li>''');
     var context12 = context1.publicFunctionsSorted;
     for (var context13 in context12) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context13.linkedName);
       buffer.write('''</li>''');
     }
@@ -1847,14 +1846,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicEnums == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#enums">Enums</a></li>''');
     var context14 = context1.publicEnumsSorted;
     for (var context15 in context14) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context15.linkedName);
       buffer.write('''</li>''');
     }
@@ -1863,14 +1862,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicTypedefs == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#typedefs">Typedefs</a></li>''');
     var context16 = context1.publicTypedefsSorted;
     for (var context17 in context16) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context17.linkedName);
       buffer.write('''</li>''');
     }
@@ -1879,14 +1878,14 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   if (context1.hasPublicExceptions == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+      <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#exceptions">Exceptions</a></li>''');
     var context18 = context1.publicExceptionsSorted;
     for (var context19 in context18) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+        <li>''');
       buffer.write(context19.linkedName);
       buffer.write('''</li>''');
     }
@@ -2130,7 +2129,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context1.hasPublicLibraries == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#libraries">Libraries</a></li>''');
     var context2 = context0.self;
@@ -2138,7 +2137,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context4 in context3) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context4.linkedName);
       buffer.write('''</li>''');
     }
@@ -2148,7 +2147,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context5.hasPublicMixins == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#mixins">Mixins</a></li>''');
     var context6 = context0.self;
@@ -2156,7 +2155,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context8 in context7) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context8.linkedName);
       buffer.write('''</li>''');
     }
@@ -2166,7 +2165,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context9.hasPublicClasses == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#classes">Classes</a></li>''');
     var context10 = context0.self;
@@ -2174,7 +2173,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context12 in context11) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context12.linkedName);
       buffer.write('''</li>''');
     }
@@ -2184,7 +2183,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context13.hasPublicConstants == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#constants">Constants</a></li>''');
     var context14 = context0.self;
@@ -2192,7 +2191,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context16 in context15) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context16.linkedName);
       buffer.write('''</li>''');
     }
@@ -2202,7 +2201,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context17.hasPublicProperties == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#properties">Properties</a></li>''');
     var context18 = context0.self;
@@ -2210,7 +2209,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context20 in context19) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context20.linkedName);
       buffer.write('''</li>''');
     }
@@ -2220,7 +2219,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context21.hasPublicFunctions == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#functions">Functions</a></li>''');
     var context22 = context0.self;
@@ -2228,7 +2227,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context24 in context23) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context24.linkedName);
       buffer.write('''</li>''');
     }
@@ -2238,7 +2237,7 @@ String _renderCategory_partial_sidebar_for_category_11(
   if (context25.hasPublicEnums == true) {
     buffer.writeln();
     buffer.write('''
-  <li class="section-title"><a href="''');
+    <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
     buffer.write('''#enums">Enums</a></li>''');
     var context26 = context0.self;
@@ -2246,7 +2245,7 @@ String _renderCategory_partial_sidebar_for_category_11(
     for (var context28 in context27) {
       buffer.writeln();
       buffer.write('''
-  <li>''');
+      <li>''');
       buffer.write(context28.linkedName);
       buffer.write('''</li>''');
     }

--- a/lib/templates/html/_sidebar_for_category.html
+++ b/lib/templates/html/_sidebar_for_category.html
@@ -1,64 +1,64 @@
 <ol>
-  {{#self.hasPublicLibraries}}
-  <li class="section-title"><a href="{{{self.href}}}#libraries">Libraries</a></li>
-  {{#self.publicLibrariesSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicLibrariesSorted}}
-  {{/self.hasPublicLibraries}}
+  {{ #self.hasPublicLibraries }}
+    <li class="section-title"><a href="{{{ self.href }}}#libraries">Libraries</a></li>
+    {{ #self.publicLibrariesSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicLibrariesSorted }}
+  {{ /self.hasPublicLibraries }}
 
-  {{#self.hasPublicMixins}}
-  <li class="section-title"><a href="{{{self.href}}}#mixins">Mixins</a></li>
-  {{#self.publicMixinsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicMixinsSorted}}
-  {{/self.hasPublicMixins}}
+  {{ #self.hasPublicMixins }}
+    <li class="section-title"><a href="{{{ self.href }}}#mixins">Mixins</a></li>
+    {{ #self.publicMixinsSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicMixinsSorted }}
+  {{ /self.hasPublicMixins }}
 
-  {{#self.hasPublicClasses}}
-  <li class="section-title"><a href="{{{self.href}}}#classes">Classes</a></li>
-  {{#self.publicClassesSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicClassesSorted}}
-  {{/self.hasPublicClasses}}
+  {{ #self.hasPublicClasses }}
+    <li class="section-title"><a href="{{{ self.href }}}#classes">Classes</a></li>
+    {{ #self.publicClassesSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicClassesSorted }}
+  {{ /self.hasPublicClasses }}
 
-  {{#self.hasPublicConstants}}
-  <li class="section-title"><a href="{{{self.href}}}#constants">Constants</a></li>
-  {{#self.publicConstantsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicConstantsSorted}}
-  {{/self.hasPublicConstants}}
+  {{ #self.hasPublicConstants}}
+    <li class="section-title"><a href="{{{ self.href }}}#constants">Constants</a></li>
+    {{ #self.publicConstantsSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicConstantsSorted }}
+  {{ /self.hasPublicConstants }}
 
-  {{#self.hasPublicProperties}}
-  <li class="section-title"><a href="{{{self.href}}}#properties">Properties</a></li>
-  {{#self.publicPropertiesSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicPropertiesSorted}}
-  {{/self.hasPublicProperties}}
+  {{ #self.hasPublicProperties }}
+    <li class="section-title"><a href="{{{ self.href }}}#properties">Properties</a></li>
+    {{ #self.publicPropertiesSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicPropertiesSorted }}
+  {{ /self.hasPublicProperties }}
 
-  {{#self.hasPublicFunctions}}
-  <li class="section-title"><a href="{{{self.href}}}#functions">Functions</a></li>
-  {{#self.publicFunctionsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicFunctionsSorted}}
-  {{/self.hasPublicFunctions}}
+  {{ #self.hasPublicFunctions }}
+    <li class="section-title"><a href="{{{ self.href }}}#functions">Functions</a></li>
+    {{ #self.publicFunctionsSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicFunctionsSorted }}
+  {{ /self.hasPublicFunctions }}
 
-  {{#self.hasPublicEnums}}
-  <li class="section-title"><a href="{{{self.href}}}#enums">Enums</a></li>
-  {{#self.publicEnumsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/self.publicEnumsSorted}}
-  {{/self.hasPublicEnums}}
+  {{ #self.hasPublicEnums }}
+    <li class="section-title"><a href="{{{ self.href }}}#enums">Enums</a></li>
+    {{ #self.publicEnumsSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicEnumsSorted }}
+  {{ /self.hasPublicEnums }}
 
-  {{#self.hasPublicTypedefs}}
-  <li class="section-title"><a href="{{{self.href}}}#typedefs">Typedefs</a></li>
-  {{#self.publicTypedefsSorted}}
+  {{ #self.hasPublicTypedefs }}
+  <li class="section-title"><a href="{{{ self.href }}}#typedefs">Typedefs</a></li>
+  {{ #self.publicTypedefsSorted }}
   <li>{{{ linkedName }}}</li>
-  {{/self.publicTypedefsSorted}}
-  {{/self.hasPublicTypedefs}}
+  {{ /self.publicTypedefsSorted }}
+  {{ /self.hasPublicTypedefs }}
 
-  {{#self.hasPublicExceptions}}
-  <li class="section-title"><a href="{{{self.href}}}#exceptions">Exceptions</a></li>
-  {{#self.publicExceptionsSorted}}
+  {{ #self.hasPublicExceptions }}
+  <li class="section-title"><a href="{{{ self.href }}}#exceptions">Exceptions</a></li>
+  {{ #self.publicExceptionsSorted }}
   <li>{{{ linkedName }}}</li>
-  {{/self.publicExceptionsSorted}}
-  {{/self.hasPublicExceptions}}
+  {{ /self.publicExceptionsSorted }}
+  {{ /self.hasPublicExceptions }}
 </ol>

--- a/lib/templates/html/_sidebar_for_container.html
+++ b/lib/templates/html/_sidebar_for_container.html
@@ -1,5 +1,5 @@
 <ol>
-    {{#container}}
+  {{ #container }}
 
     {{ #isClassOrEnum }}
       {{ #hasPublicConstructors }}
@@ -11,62 +11,61 @@
     {{ /isClassOrEnum }}
 
     {{ #isEnum }}
-    {{ #hasPublicEnumValues }}
-    <li class="section-title"><a href="{{{ href }}}#values">Values</a></li>
-    {{ #publicEnumValues }}
-    <li>{{{ linkedName }}}</li>
-    {{ /publicEnumValues }}
-    {{ /hasPublicEnumValues }}
+      {{ #hasPublicEnumValues }}
+        <li class="section-title"><a href="{{{ href }}}#values">Values</a></li>
+        {{ #publicEnumValues }}
+          <li>{{{ linkedName }}}</li>
+        {{ /publicEnumValues }}
+      {{ /hasPublicEnumValues }}
     {{ /isEnum }}
 
-    {{#isClassOrEnum}}
-    {{#hasPublicInstanceFields}}
-    <li class="section-title{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}">
-      <a href="{{{href}}}#instance-properties">Properties</a>
-    </li>
-    {{#publicInstanceFieldsSorted}}
-    <li{{ #isInherited }} class="inherited"{{ /isInherited}}>{{{ linkedName }}}</li>
-    {{/publicInstanceFieldsSorted}}
-    {{/hasPublicInstanceFields}}
+    {{ #isClassOrEnum }}
+      {{ #hasPublicInstanceFields }}
+        <li class="section-title{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}">
+          <a href="{{{ href }}}#instance-properties">Properties</a>
+        </li>
+        {{ #publicInstanceFieldsSorted }}
+          <li{{ #isInherited }} class="inherited"{{ /isInherited }}>{{{ linkedName }}}</li>
+        {{ /publicInstanceFieldsSorted }}
+      {{ /hasPublicInstanceFields }}
 
-    {{#hasPublicInstanceMethods}}
-    <li class="section-title{{ #publicInheritedInstanceMethods }} inherited{{ /publicInheritedInstanceMethods }}"><a href="{{{href}}}#instance-methods">Methods</a></li>
-    {{#publicInstanceMethodsSorted}}
-    <li{{ #isInherited }} class="inherited"{{ /isInherited}}>{{{ linkedName }}}</li>
-    {{/publicInstanceMethodsSorted}}
-    {{/hasPublicInstanceMethods}}
+      {{ #hasPublicInstanceMethods }}
+        <li class="section-title{{ #publicInheritedInstanceMethods }} inherited{{ /publicInheritedInstanceMethods }}"><a href="{{{ href }}}#instance-methods">Methods</a></li>
+        {{ #publicInstanceMethodsSorted }}
+          <li{{ #isInherited }} class="inherited"{{ /isInherited }}>{{{ linkedName }}}</li>
+        {{ /publicInstanceMethodsSorted }}
+      {{ /hasPublicInstanceMethods }}
 
-    {{#hasPublicInstanceOperators}}
-    <li class="section-title{{ #publicInheritedInstanceOperators }} inherited{{ /publicInheritedInstanceOperators }}"><a href="{{{href}}}#operators">Operators</a></li>
-    {{#publicInstanceOperatorsSorted}}
-    <li{{ #isInherited }} class="inherited"{{ /isInherited}}>{{{ linkedName }}}</li>
-    {{/publicInstanceOperatorsSorted}}
-    {{/hasPublicInstanceOperators}}
-    {{/isClassOrEnum}}
+      {{ #hasPublicInstanceOperators }}
+        <li class="section-title{{ #publicInheritedInstanceOperators }} inherited{{ /publicInheritedInstanceOperators }}"><a href="{{{ href }}}#operators">Operators</a></li>
+        {{ #publicInstanceOperatorsSorted }}
+          <li{{ #isInherited }} class="inherited"{{ /isInherited }}>{{{ linkedName }}}</li>
+        {{ /publicInstanceOperatorsSorted }}
+      {{ /hasPublicInstanceOperators }}
+    {{ /isClassOrEnum }}
 
-    {{#isExtension}}
-    {{#hasPublicInstanceFields}}
-    <li class="section-title"> <a href="{{{href}}}#instance-properties">Properties</a>
-    </li>
-    {{#publicInstanceFieldsSorted}}
-    <li>{{{ linkedName }}}</li>
-    {{/publicInstanceFieldsSorted}}
-    {{/hasPublicInstanceFields}}
+    {{ #isExtension }}
+      {{ #hasPublicInstanceFields }}
+        <li class="section-title"> <a href="{{{ href }}}#instance-properties">Properties</a></li>
+        {{ #publicInstanceFieldsSorted }}
+          <li>{{{ linkedName }}}</li>
+        {{ /publicInstanceFieldsSorted }}
+      {{ /hasPublicInstanceFields }}
 
-    {{#hasPublicInstanceMethods}}
-    <li class="section-title"><a href="{{{href}}}#instance-methods">Methods</a></li>
-    {{#publicInstanceMethodsSorted}}
-    <li>{{{ linkedName }}}</li>
-    {{/publicInstanceMethodsSorted}}
-    {{/hasPublicInstanceMethods}}
+      {{ #hasPublicInstanceMethods }}
+        <li class="section-title"><a href="{{{ href }}}#instance-methods">Methods</a></li>
+        {{ #publicInstanceMethodsSorted }}
+          <li>{{{ linkedName }}}</li>
+        {{ /publicInstanceMethodsSorted }}
+      {{ /hasPublicInstanceMethods }}
 
-    {{#hasPublicInstanceOperators}}
-    <li class="section-title"><a href="{{{href}}}#operators">Operators</a></li>
-    {{#publicInstanceOperatorsSorted}}
-    <li>{{{ linkedName }}}</li>
-    {{/publicInstanceOperatorsSorted}}
-    {{/hasPublicInstanceOperators}}
-    {{/isExtension}}
+      {{ #hasPublicInstanceOperators }}
+        <li class="section-title"><a href="{{{ href }}}#operators">Operators</a></li>
+        {{ #publicInstanceOperatorsSorted }}
+          <li>{{{ linkedName }}}</li>
+        {{ /publicInstanceOperatorsSorted }}
+      {{ /hasPublicInstanceOperators }}
+    {{ /isExtension }}
 
     {{ #isClassOrEnumOrExtension }}
       {{ #hasPublicVariableStaticFields }}
@@ -90,5 +89,5 @@
         {{ /publicConstantFieldsSorted }}
       {{ /hasPublicConstantFields }}
     {{ /isClassOrEnumOrExtension }}
-    {{ /container }}
+  {{ /container }}
 </ol>

--- a/lib/templates/html/_sidebar_for_library.html
+++ b/lib/templates/html/_sidebar_for_library.html
@@ -1,66 +1,66 @@
 <ol>
-  {{#library}}
-  {{#hasPublicClasses}}
-  <li class="section-title"><a href="{{{href}}}#classes">Classes</a></li>
-  {{#publicClassesSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicClassesSorted}}
-  {{/hasPublicClasses}}
+  {{ #library }}
+    {{ #hasPublicClasses }}
+      <li class="section-title"><a href="{{{ href }}}#classes">Classes</a></li>
+      {{ #publicClassesSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicClassesSorted }}
+    {{ /hasPublicClasses }}
 
-  {{#hasPublicExtensions}}
-  <li class="section-title"><a href="{{{href}}}#extensions">Extensions</a></li>
-  {{#publicExtensionsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicExtensionsSorted}}
-  {{/hasPublicExtensions}}
+    {{ #hasPublicExtensions }}
+      <li class="section-title"><a href="{{{ href }}}#extensions">Extensions</a></li>
+      {{ #publicExtensionsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicExtensionsSorted }}
+    {{ /hasPublicExtensions }}
 
-  {{#hasPublicMixins}}
-  <li class="section-title"><a href="{{{href}}}#mixins">Mixins</a></li>
-  {{#publicMixinsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicMixinsSorted}}
-  {{/hasPublicMixins}}
+    {{ #hasPublicMixins }}
+      <li class="section-title"><a href="{{{ href }}}#mixins">Mixins</a></li>
+      {{ #publicMixinsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicMixinsSorted }}
+    {{ /hasPublicMixins }}
 
-  {{#hasPublicConstants}}
-  <li class="section-title"><a href="{{{href}}}#constants">Constants</a></li>
-  {{#publicConstantsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicConstantsSorted}}
-  {{/hasPublicConstants}}
+    {{ #hasPublicConstants }}
+      <li class="section-title"><a href="{{{ href }}}#constants">Constants</a></li>
+      {{ #publicConstantsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicConstantsSorted }}
+    {{ /hasPublicConstants }}
 
-  {{#hasPublicProperties}}
-  <li class="section-title"><a href="{{{href}}}#properties">Properties</a></li>
-  {{#publicPropertiesSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicPropertiesSorted}}
-  {{/hasPublicProperties}}
+    {{ #hasPublicProperties }}
+      <li class="section-title"><a href="{{{ href }}}#properties">Properties</a></li>
+      {{ #publicPropertiesSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicPropertiesSorted }}
+    {{ /hasPublicProperties }}
 
-  {{#hasPublicFunctions}}
-  <li class="section-title"><a href="{{{href}}}#functions">Functions</a></li>
-  {{#publicFunctionsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicFunctionsSorted}}
-  {{/hasPublicFunctions}}
+    {{ #hasPublicFunctions }}
+      <li class="section-title"><a href="{{{ href }}}#functions">Functions</a></li>
+      {{ #publicFunctionsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicFunctionsSorted }}
+    {{ /hasPublicFunctions }}
 
-  {{#hasPublicEnums}}
-  <li class="section-title"><a href="{{{href}}}#enums">Enums</a></li>
-  {{#publicEnumsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicEnumsSorted}}
-  {{/hasPublicEnums}}
+    {{ #hasPublicEnums }}
+      <li class="section-title"><a href="{{{ href }}}#enums">Enums</a></li>
+      {{ #publicEnumsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicEnumsSorted }}
+    {{ /hasPublicEnums }}
 
-  {{#hasPublicTypedefs}}
-  <li class="section-title"><a href="{{{href}}}#typedefs">Typedefs</a></li>
-  {{#publicTypedefsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicTypedefsSorted}}
-  {{/hasPublicTypedefs}}
+    {{ #hasPublicTypedefs }}
+      <li class="section-title"><a href="{{{ href }}}#typedefs">Typedefs</a></li>
+      {{ #publicTypedefsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicTypedefsSorted }}
+    {{ /hasPublicTypedefs }}
 
-  {{#hasPublicExceptions}}
-  <li class="section-title"><a href="{{{href}}}#exceptions">Exceptions</a></li>
-  {{#publicExceptionsSorted}}
-  <li>{{{ linkedName }}}</li>
-  {{/publicExceptionsSorted}}
-  {{/hasPublicExceptions}}
-  {{/library}}
+    {{ #hasPublicExceptions }}
+      <li class="section-title"><a href="{{{ href }}}#exceptions">Exceptions</a></li>
+      {{ #publicExceptionsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicExceptionsSorted }}
+    {{ /hasPublicExceptions }}
+  {{ /library }}
 </ol>


### PR DESCRIPTION
I'm formatting some of the mustache files before making a lot of changes to them. These are the sidebars.

* Indent as we enter sections.
* Insert one space between all mustache delimiters (`{{`, etc) and contained identifiers and directives (`foo`, `#foo`, `/foo`, etc)