### PR TITLE
Tidy CommentReferable and MarkdownProcessor

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -184,7 +184,10 @@ MatchingLinkResult _getMatchingLinkElement(
     String referenceText, Warnable element) {
   var commentReference = ModelCommentReference.synthetic(referenceText);
 
+  // A filter to be used by [CommentReferable.referenceBy].
   bool Function(CommentReferable?) filter;
+
+  // An "allow tree" filter to be used by [CommentReferable.referenceBy].
   bool Function(CommentReferable?) allowTree;
 
   // Constructor references are pretty ambiguous by nature since they can be
@@ -194,11 +197,11 @@ MatchingLinkResult _getMatchingLinkElement(
   // Maybe clean this up with inspiration from constructor tear-off syntax?
   if (commentReference.allowUnnamedConstructor) {
     allowTree = (_) => true;
-    // Neither reject, nor require, a default constructor in the event
-    // the comment reference structure implies one.  (We can not require it
-    // in case a library name is the same as a member class name and the class
-    // is the intended lookup).   For example, [FooClass.FooClass] structurally
-    // "looks like" a default constructor, so we should allow it here.
+    // Neither reject, nor require, a unnamed constructor in the event the
+    // comment reference structure implies one.  (We can not require it in case
+    // a library name is the same as a member class name and the class is the
+    // intended lookup).  For example, '[FooClass.FooClass]' structurally
+    // "looks like" an unnamed constructor, so we should allow it here.
     filter = commentReference.hasCallableHint ? _requireCallable : (_) => true;
   } else if (commentReference.hasConstructorHint &&
       commentReference.hasCallableHint) {

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -110,8 +110,11 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
       result = result.enclosingCombo;
     }
     if (result.enclosingElement is Container) {
-      assert(false,
-          '[Container] member detected, support not implemented for analyzer scope inside containers');
+      assert(
+        false,
+        '[Container] member detected, support not implemented for analyzer '
+        'scope inside containers',
+      );
       return null;
     }
     if (!allowTree(result)) return null;

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -155,7 +155,7 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   /// This allows us to deal with libraries that may have separators in them.
   /// [referenceBy] stops at the first one found.
   Iterable<_ReferenceChildrenLookup> _childLookups(List<String> reference) =>
-      reference.mapIndexed((int index, name) => _ReferenceChildrenLookup(
+      reference.skip(1).mapIndexed((index, name) => _ReferenceChildrenLookup(
             reference.sublist(0, index).join('.'),
             reference.sublist(index),
           ));

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -11,6 +11,7 @@ import 'dart:core';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
+import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/accessor.dart';
 import 'package:dartdoc/src/model/container.dart';
 import 'package:dartdoc/src/model/library.dart';
@@ -18,63 +19,18 @@ import 'package:dartdoc/src/model/model_object_builder.dart';
 import 'package:dartdoc/src/model/nameable.dart';
 import 'package:meta/meta.dart';
 
-class ReferenceChildrenLookup {
+@Deprecated('Public access to this class is deprecated')
+typedef ReferenceChildrenLookup = _ReferenceChildrenLookup;
+
+class _ReferenceChildrenLookup {
   final String lookup;
   final List<String> remaining;
 
-  ReferenceChildrenLookup(this.lookup, this.remaining);
+  _ReferenceChildrenLookup(this.lookup, this.remaining);
 
   @override
   String toString() =>
       '$lookup ($lookup${remaining.isNotEmpty ? ".${remaining.join(".")}" : ''})';
-}
-
-extension on Scope {
-  /// Prefer the getter for a bundled lookup if both exist.
-  Element? lookupPreferGetter(String id) {
-    var result = lookup(id);
-    return result.getter ?? result.setter;
-  }
-}
-
-/// A set of utility methods for helping build
-/// [CommentReferable.referenceChildren] out of collections of other
-/// [CommentReferable]s.
-extension CommentReferableEntryGenerators on Iterable<CommentReferable> {
-  /// Creates ordinary references except if there is a conflict with
-  /// [referable], it will generate a [MapEntry] using [referable]'s
-  /// [CommentReferable.referenceName] as a prefix for the conflicting item.
-  Iterable<MapEntry<String, CommentReferable>> explicitOnCollisionWith(
-          CommentReferable referable) =>
-      map((r) {
-        if (r.referenceName == referable.referenceName) {
-          return MapEntry('${referable.referenceName}.${r.referenceName}', r);
-        }
-        return MapEntry(r.referenceName, r);
-      });
-
-  /// Just generate entries from this iterable.
-  Iterable<MapEntry<String, CommentReferable>> generateEntries() =>
-      map((r) => MapEntry(r.referenceName, r));
-
-  /// Return all values not of this type.
-  Iterable<CommentReferable> whereNotType<T>() sync* {
-    for (var r in this) {
-      if (r is! T) yield r;
-    }
-  }
-}
-
-/// A set of utility methods to add entries to
-/// [CommentReferable.referenceChildren].
-extension CommentReferableEntryBuilder on Map<String, CommentReferable> {
-  /// Like [Map.putIfAbsent] except works on an iterable of entries.
-  void addEntriesIfAbsent(
-      Iterable<MapEntry<String, CommentReferable>> entries) {
-    for (var entry in entries) {
-      if (!containsKey(entry.key)) this[entry.key] = entry.value;
-    }
-  }
 }
 
 /// Support comment reference lookups on a Nameable object.
@@ -106,7 +62,7 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
       return null;
     }
 
-    for (var referenceLookup in childLookups(reference)) {
+    for (var referenceLookup in _childLookups(reference)) {
       if (scope != null) {
         var result = _lookupViaScope(referenceLookup,
             filter: filter, allowTree: allowTree);
@@ -141,7 +97,7 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   /// [CommentReferable], but you still want to have an implementation of
   /// [scope].
   CommentReferable? _lookupViaScope(
-    ReferenceChildrenLookup referenceLookup, {
+    _ReferenceChildrenLookup referenceLookup, {
     required bool Function(CommentReferable?) filter,
     required bool Function(CommentReferable?) allowTree,
   }) {
@@ -162,10 +118,10 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   }
 
   /// Given a [result] found in an implementation of [lookupViaScope] or
-  /// [ReferenceChildrenLookup], recurse through children, skipping over
+  /// [_ReferenceChildrenLookup], recurse through children, skipping over
   /// results that do not match the filter.
   CommentReferable? _recurseChildrenAndFilter(
-    ReferenceChildrenLookup referenceLookup,
+    _ReferenceChildrenLookup referenceLookup,
     CommentReferable result, {
     required bool Function(CommentReferable?) filter,
     required bool Function(CommentReferable?) allowTree,
@@ -188,18 +144,21 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
     return returnValue;
   }
 
+  @Deprecated('Public access to this method is deprecated')
+  // ignore: library_private_types_in_public_api
+  Iterable<_ReferenceChildrenLookup> childLookups(List<String> reference) =>
+      _childLookups(reference);
+
   /// A list of lookups that should be attempted on children based on
-  /// [reference].  This allows us to deal with libraries that may have
-  /// separators in them. [referenceBy] stops at the first one found.
-  // TODO(jcollins-g): Convert to generator after dart-lang/sdk#46419
-  Iterable<ReferenceChildrenLookup> childLookups(List<String> reference) {
-    var retval = <ReferenceChildrenLookup>[];
-    for (var index = 1; index <= reference.length; index++) {
-      retval.add(ReferenceChildrenLookup(
-          reference.sublist(0, index).join('.'), reference.sublist(index)));
-    }
-    return retval;
-  }
+  /// [reference].
+  ///
+  /// This allows us to deal with libraries that may have separators in them.
+  /// [referenceBy] stops at the first one found.
+  Iterable<_ReferenceChildrenLookup> _childLookups(List<String> reference) =>
+      reference.mapIndexed((int index, name) => _ReferenceChildrenLookup(
+            reference.sublist(0, index).join('.'),
+            reference.sublist(index),
+          ));
 
   /// Map of [referenceName] to the elements that are a member of [this], but
   /// not this model element itself.  Can be cached.
@@ -234,4 +193,52 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   /// For testing / comparison only, get the comment referable from where this
   /// [ElementType] was defined.  Override where an [Element] is available.
   CommentReferable get definingCommentReferable => this;
+}
+
+extension on Scope {
+  /// Prefer the getter for a bundled lookup if both exist.
+  Element? lookupPreferGetter(String id) {
+    var result = lookup(id);
+    return result.getter ?? result.setter;
+  }
+}
+
+/// A set of utility methods for helping build
+/// [CommentReferable.referenceChildren] out of collections of other
+/// [CommentReferable]s.
+extension CommentReferableEntryGenerators on Iterable<CommentReferable> {
+  /// Creates reference entries for this Iterable.
+  ///
+  /// If there is a conflict with [referable], the included [MapEntry] uses
+  /// [referable]'s [CommentReferable.referenceName] as a prefix.
+  Iterable<MapEntry<String, CommentReferable>> explicitOnCollisionWith(
+          CommentReferable referable) =>
+      map((r) {
+        if (r.referenceName == referable.referenceName) {
+          return MapEntry('${referable.referenceName}.${r.referenceName}', r);
+        }
+        return MapEntry(r.referenceName, r);
+      });
+
+  /// Generates entries from this Iterable.
+  Iterable<MapEntry<String, CommentReferable>> generateEntries() =>
+      map((r) => MapEntry(r.referenceName, r));
+
+  /// Returns all values not of this type.
+  List<CommentReferable> whereNotType<T>() => [
+        for (var referable in this)
+          if (referable is! T) referable,
+      ];
+}
+
+/// A set of utility methods to add entries to
+/// [CommentReferable.referenceChildren].
+extension CommentReferableEntryBuilder on Map<String, CommentReferable> {
+  /// Like [Map.putIfAbsent] except works on an iterable of entries.
+  void addEntriesIfAbsent(
+      Iterable<MapEntry<String, CommentReferable>> entries) {
+    for (var entry in entries) {
+      if (!containsKey(entry.key)) this[entry.key] = entry.value;
+    }
+  }
 }

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -11,7 +11,6 @@ import 'dart:core';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
-import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/accessor.dart';
 import 'package:dartdoc/src/model/container.dart';
 import 'package:dartdoc/src/model/library.dart';
@@ -154,11 +153,14 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   ///
   /// This allows us to deal with libraries that may have separators in them.
   /// [referenceBy] stops at the first one found.
-  Iterable<_ReferenceChildrenLookup> _childLookups(List<String> reference) =>
-      reference.skip(1).mapIndexed((index, name) => _ReferenceChildrenLookup(
-            reference.sublist(0, index).join('.'),
-            reference.sublist(index),
-          ));
+  Iterable<_ReferenceChildrenLookup> _childLookups(List<String> reference) {
+    var retval = <_ReferenceChildrenLookup>[];
+    for (var index = 1; index <= reference.length; index++) {
+      retval.add(_ReferenceChildrenLookup(
+          reference.sublist(0, index).join('.'), reference.sublist(index)));
+    }
+    return retval;
+  }
 
   /// Map of [referenceName] to the elements that are a member of [this], but
   /// not this model element itself.  Can be cached.

--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -57,22 +57,25 @@ mixin CommentReferable implements Nameable, ModelBuilderInterface {
   }) {
     parentOverrides ??= referenceParents;
     if (reference.isEmpty) {
-      if (tryParents == false) return this;
-      return null;
+      return tryParents ? null : this;
     }
 
     for (var referenceLookup in _childLookups(reference)) {
       if (scope != null) {
         var result = _lookupViaScope(referenceLookup,
             filter: filter, allowTree: allowTree);
-        if (result != null) return result;
+        if (result != null) {
+          return result;
+        }
       }
       final referenceChildren = this.referenceChildren;
       final childrenResult = referenceChildren[referenceLookup.lookup];
       if (childrenResult != null) {
         var result = _recurseChildrenAndFilter(referenceLookup, childrenResult,
             allowTree: allowTree, filter: filter);
-        if (result != null) return result;
+        if (result != null) {
+          return result;
+        }
       }
     }
     // If we can't find it in children, try searching parents if allowed.

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -18,7 +18,7 @@ class Documentation {
   String? get asHtml {
     if (_asHtml == null) {
       assert(_asOneLiner == null || _element.isCanonical);
-      _renderDocumentation(true);
+      _renderDocumentation(processFullText: true);
     }
     return _asHtml;
   }
@@ -28,25 +28,25 @@ class Documentation {
   String? get asOneLiner {
     if (_asOneLiner == null) {
       assert(_asHtml == null);
-      _renderDocumentation(_element.isCanonical);
+      _renderDocumentation(processFullText: _element.isCanonical);
     }
     return _asOneLiner;
   }
 
-  void _renderDocumentation(bool processFullDocs) {
-    var parseResult = _parseDocumentation(processFullDocs);
+  void _renderDocumentation({required bool processFullText}) {
+    var parseResult = _parseDocumentation(processFullText: processFullText);
 
     var renderResult = _renderer.render(parseResult,
-        processFullDocs: processFullDocs,
+        processFullDocs: processFullText,
         sanitizeHtml: _element.config.sanitizeHtml);
 
-    if (processFullDocs) {
+    if (processFullText) {
       _asHtml = renderResult.asHtml;
     }
     _asOneLiner ??= renderResult.asOneLiner;
   }
 
-  List<md.Node> _parseDocumentation(bool processFullDocs) {
+  List<md.Node> _parseDocumentation({required bool processFullText}) {
     final text = _element.documentation;
     if (text == null || text.isEmpty) {
       return const [];
@@ -55,7 +55,7 @@ class Documentation {
         text, _element as Warnable);
     var document =
         MarkdownDocument.withElementLinkResolver(_element as Warnable);
-    return document.parseMarkdownText(text, processFullDocs);
+    return document.parseMarkdownText(text, processFullText: processFullText);
   }
 
   DocumentationRenderer get _renderer =>

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -315,7 +315,7 @@ MatchingLinkResult definingLinkResult(MatchingLinkResult originalResult) {
 }
 
 MatchingLinkResult referenceLookup(Warnable element, String codeRef) =>
-    definingLinkResult(getMatchingLinkElement(element, codeRef));
+    definingLinkResult(getMatchingLinkElement(codeRef, element));
 
 /// Returns a matcher which compresses consecutive whitespace in [text] into a
 /// single space.


### PR DESCRIPTION
Lots of nits:

* In comments, capitalize Markdown and HTML.
* Variables with acronyms should be camelcase, like `nonHtml`.
* Turn some comments into doc comments.
* Deprecate public access to `allBeforeFirstNewline`, `allAfterLastNewline`, `findFreeHangingGenericsPositions`, `ReferenceChildrenLookup`, `childLookups`
* Use trailing commas in some long parameter lists an argument lists
* Make all positional `processFullText` named, as they are bool.
* Move all extensions to the bottom of `comment_referable.dart`, which is now quite idiomatic.