### PR TITLE
Remove MatchingLinkResult.warn; unused

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -246,14 +246,12 @@ md.Node _makeLinkNode(String codeRef, Warnable warnable) {
     // else this would be linkedElement.linkedName, but link bodies are slightly
     // different for doc references, so fall out.
   } else {
-    if (result.warn) {
-      // Avoid claiming documentation is inherited when it comes from the
-      // current element.
-      warnable.warn(PackageWarning.unresolvedDocReference,
-          message: codeRef,
-          referredFrom:
-              warnable.documentationIsLocal ? [] : warnable.documentationFrom);
-    }
+    // Avoid claiming documentation is inherited when it comes from the
+    // current element.
+    warnable.warn(PackageWarning.unresolvedDocReference,
+        message: codeRef,
+        referredFrom:
+            warnable.documentationIsLocal ? [] : warnable.documentationFrom);
   }
 
   return md.Element.text('code', textContent);

--- a/lib/src/matching_link_result.dart
+++ b/lib/src/matching_link_result.dart
@@ -7,22 +7,20 @@ import 'package:dartdoc/src/model/model.dart';
 
 class MatchingLinkResult {
   final CommentReferable? commentReferable;
-  final bool warn;
 
-  MatchingLinkResult(this.commentReferable, {this.warn = true});
-
-  @override
-  bool operator ==(Object other) {
-    return other is MatchingLinkResult &&
-        commentReferable == other.commentReferable &&
-        warn == other.warn;
-  }
+  MatchingLinkResult(this.commentReferable);
 
   @override
-  int get hashCode => Object.hash(commentReferable, warn);
+  bool operator ==(Object other) =>
+      other is MatchingLinkResult && commentReferable == other.commentReferable;
+
+  @override
+  int get hashCode => commentReferable.hashCode;
 
   @override
   String toString() {
-    return 'element: [${commentReferable is Constructor ? 'new ' : ''}${commentReferable?.fullyQualifiedName}] warn: $warn';
+    // TODO(srawlins): Scrap the 'new' keyword?
+    final newKeyword = commentReferable is Constructor ? 'new ' : '';
+    return 'element: [$newKeyword${commentReferable?.fullyQualifiedName}]';
   }
 }

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -309,7 +309,7 @@ MatchingLinkResult definingLinkResult(MatchingLinkResult originalResult) {
 
   if (definingReferable != null &&
       definingReferable != originalResult.commentReferable) {
-    return MatchingLinkResult(definingReferable, warn: originalResult.warn);
+    return MatchingLinkResult(definingReferable);
   }
   return originalResult;
 }


### PR DESCRIPTION
By default it is always true, and an argument is never passed to the constructor.