### PR TITLE
remove the height constraint on the search box

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -889,7 +889,6 @@ button {
 .tt-query,
 .tt-hint {
   width: 200px;
-  height: 20px;
   padding: 2px 7px 1px 7px;
   line-height: 20px;
   outline: none;


### PR DESCRIPTION
- remove the height constraint on the search box

Before this, the text in the search box would be a bit compressed vertically; this allows the text to fit its desired height.

before:

<img width="231" alt="Screen Shot 2022-07-26 at 3 33 43 PM" src="https://user-images.githubusercontent.com/1269969/181123904-cb501b9d-3230-4e15-b908-6a29081e2778.png">

after:

<img width="224" alt="Screen Shot 2022-07-26 at 3 33 59 PM" src="https://user-images.githubusercontent.com/1269969/181123923-646d1e82-6335-4103-83d2-623e7316d77f.png">

cc @klr981