### PR TITLE
Simplify some fields and getters in Package

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1266,8 +1266,8 @@ class DartdocOptionContext extends DartdocOptionContextBase
   late final Set<String> exclude =
       Set.of(optionSet['exclude'].valueAt(context));
 
-  List<String> get excludePackages =>
-      optionSet['excludePackages'].valueAt(context);
+  Set<String> get _excludePackages =>
+      {...optionSet['excludePackages'].valueAt(context)};
 
   String? get flutterRoot => optionSet['flutterRoot'].valueAt(context);
 
@@ -1331,8 +1331,7 @@ class DartdocOptionContext extends DartdocOptionContextBase
   bool isLibraryExcluded(String name) =>
       exclude.any((pattern) => name == pattern);
 
-  bool isPackageExcluded(String name) =>
-      excludePackages.any((pattern) => name == pattern);
+  bool isPackageExcluded(String name) => _excludePackages.contains(name);
 
   bool get showStats => optionSet['showStats'].valueAt(context);
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -15810,7 +15810,6 @@ const _invisibleGetters = {
     'examplePathPrefix',
     'exclude',
     'excludeFooterVersion',
-    'excludePackages',
     'flutterRoot',
     'format',
     'hashCode',


### PR DESCRIPTION
* Make `excludePackages` private.
* Rename private fields `_name`, `_packageGraph`, and `_packageMeta` to be public; they had public getters; so there is nothing wrong with making them final and public.
* Make `packagePath` a final field as it is used a lot and involves a calculation.
* Make `isPublic`, `_isExcluded` and `_isLocalPublicByDefault`, `fileType` into getters instead of late final; cheaper this way