### PR TITLE
Tidy potentially applicable extensions

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -238,12 +238,12 @@ String renderClass(_i1.ClassTemplateData context0) {
       buffer.write('''
 **Available Extensions**
 ''');
-      var context5 = context2.potentiallyApplicableExtensions;
-      if (context5 != null) {
+      var context5 = context2.potentiallyApplicableExtensionsSorted;
+      for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
 - ''');
-        buffer.write(context2.linkedName);
+        buffer.write(context6.linkedName);
       }
     }
     buffer.write('\n\n');
@@ -257,10 +257,10 @@ String renderClass(_i1.ClassTemplateData context0) {
     buffer.write('''
 ## Properties
 ''');
-    var context6 = context2.publicInstanceFieldsSorted;
-    for (var context7 in context6) {
+    var context7 = context2.publicInstanceFieldsSorted;
+    for (var context8 in context7) {
       buffer.writeln();
-      buffer.write(_renderClass_partial_property_10(context7));
+      buffer.write(_renderClass_partial_property_10(context8));
       buffer.writeln();
     }
   }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -4867,14 +4867,11 @@ class _Renderer_ExtensionTarget extends RendererBase<ExtensionTarget> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Extension>'),
-                  isNullValue: (CT_ c) =>
-                      c.potentiallyApplicableExtensions == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
+                          c, remainingNames, 'List<Extension>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.potentiallyApplicableExtensions, ast,
-                        r.template, sink,
-                        parent: r, getters: _invisibleGetters['Iterable']!);
+                    return c.potentiallyApplicableExtensions.map((e) =>
+                        _render_Extension(e, ast, r.template, sink, parent: r));
                   },
                 ),
                 'potentiallyApplicableExtensionsSorted': Property(

--- a/lib/src/model/extension_target.dart
+++ b/lib/src/model/extension_target.dart
@@ -11,25 +11,25 @@ mixin ExtensionTarget on ModelElement {
   bool get hasModifiers;
 
   bool get hasPotentiallyApplicableExtensions =>
-      potentiallyApplicableExtensions!.isNotEmpty;
+      potentiallyApplicableExtensionsSorted.isNotEmpty;
 
-  List<Extension>? _potentiallyApplicableExtensions;
-
-  /// The set of potentiallyApplicableExtensions, for display in templates.
+  /// The sorted list of potentially applicable extensions, for display in
+  /// templates.
   ///
   /// This is defined as those extensions where an instantiation of the type
   /// defined by [element] can exist where this extension applies, not including
   /// any extension that applies to every type.
-  Iterable<Extension>? get potentiallyApplicableExtensions {
-    _potentiallyApplicableExtensions ??= packageGraph.documentedExtensions
-        .where((e) => !e.alwaysApplies)
-        .where((e) => e.couldApplyTo(this))
-        .toList(growable: false);
-    return _potentiallyApplicableExtensions;
-  }
+  @Deprecated('Use potentiallyApplicableExtensionsSorted')
+  late final List<Extension> potentiallyApplicableExtensions = packageGraph
+      .documentedExtensions
+      .where((e) => !e.alwaysApplies)
+      .where((e) => e.couldApplyTo(this))
+      .toList(growable: false)
+    ..sort(byName);
 
   ElementType get modelType;
 
   List<Extension> get potentiallyApplicableExtensionsSorted =>
-      potentiallyApplicableExtensions!.toList()..sort(byName);
+      // ignore: deprecated_member_use_from_same_package
+      potentiallyApplicableExtensions;
 }

--- a/lib/templates/md/class.md
+++ b/lib/templates/md/class.md
@@ -27,9 +27,9 @@
 {{#hasPotentiallyApplicableExtensions}}
 **Available Extensions**
 
-{{#potentiallyApplicableExtensions}}
+{{#potentiallyApplicableExtensionsSorted}}
 - {{{linkedName}}}
-{{/potentiallyApplicableExtensions}}
+{{/potentiallyApplicableExtensionsSorted}}
 {{/hasPotentiallyApplicableExtensions}}
 
 {{ >annotations }}

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3010,15 +3010,15 @@ void main() {
     });
 
     test('classes know about applicableExtensions', () {
-      expect(apple.potentiallyApplicableExtensions, orderedEquals([ext]));
-      expect(string.potentiallyApplicableExtensions,
+      expect(apple.potentiallyApplicableExtensionsSorted, orderedEquals([ext]));
+      expect(string.potentiallyApplicableExtensionsSorted,
           isNot(contains(documentOnceReexportOne)));
-      expect(string.potentiallyApplicableExtensions,
+      expect(string.potentiallyApplicableExtensionsSorted,
           contains(documentOnceReexportTwo));
-      expect(baseTest.potentiallyApplicableExtensions, isEmpty);
-      expect(anotherExtended.potentiallyApplicableExtensions,
+      expect(baseTest.potentiallyApplicableExtensionsSorted, isEmpty);
+      expect(anotherExtended.potentiallyApplicableExtensionsSorted,
           orderedEquals([uphill]));
-      expect(bigAnotherExtended.potentiallyApplicableExtensions,
+      expect(bigAnotherExtended.potentiallyApplicableExtensionsSorted,
           orderedEquals([uphill]));
     });
 
@@ -3090,10 +3090,10 @@ void main() {
     });
 
     test('type parameters and bounds work with applicableExtensions', () {
-      expect(
-          superMegaTron.potentiallyApplicableExtensions, orderedEquals([leg]));
-      expect(
-          megaTron.potentiallyApplicableExtensions, orderedEquals([arm, leg]));
+      expect(superMegaTron.potentiallyApplicableExtensionsSorted,
+          orderedEquals([leg]));
+      expect(megaTron.potentiallyApplicableExtensionsSorted,
+          orderedEquals([arm, leg]));
     });
 
     test('documentation links do not crash in base cases', () {


### PR DESCRIPTION
Deprecate `potentiallyApplicableExtensions` in favor of `potentiallyApplicableExtensionsSorted`. These methods are only used for displaying extensions, and the order they're found in the package graph is unlikely to have any meaning for the users.

Also make it all non-nullable, late, final.