### PR TITLE
Refactor Documentation.asHtml and asOneLiner

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3791,11 +3791,10 @@ class _Renderer_Documentable extends RendererBase<Documentable> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.documentationAsHtml == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(
-                        c.documentationAsHtml!, ast, r.template, sink,
+                    _render_String(c.documentationAsHtml, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -3929,11 +3928,10 @@ class _Renderer_DocumentationComment
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.documentationAsHtml == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(
-                        c.documentationAsHtml!, ast, r.template, sink,
+                    _render_String(c.documentationAsHtml, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -6349,10 +6347,10 @@ class _Renderer_GetterSetterCombo extends RendererBase<GetterSetterCombo> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.oneLineDoc == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.oneLineDoc!, ast, r.template, sink,
+                    _render_String(c.oneLineDoc, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -8600,11 +8598,10 @@ class _Renderer_MarkdownFileDocumentation
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.documentationAsHtml == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(
-                        c.documentationAsHtml!, ast, r.template, sink,
+                    _render_String(c.documentationAsHtml, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -8697,10 +8694,10 @@ class _Renderer_MarkdownFileDocumentation
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.oneLineDoc == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.oneLineDoc!, ast, r.template, sink,
+                    _render_String(c.oneLineDoc, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -10454,10 +10451,10 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.oneLineDoc == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.oneLineDoc!, ast, r.template, sink,
+                    _render_String(c.oneLineDoc, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -11378,11 +11375,10 @@ class _Renderer_Package extends RendererBase<Package> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.documentationAsHtml == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(
-                        c.documentationAsHtml!, ast, r.template, sink,
+                    _render_String(c.documentationAsHtml, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -13,7 +13,7 @@ import 'model.dart';
 abstract class Documentable extends Nameable {
   String? get documentation;
 
-  String? get documentationAsHtml;
+  String get documentationAsHtml;
 
   bool get hasDocumentation;
 
@@ -43,16 +43,10 @@ enum DocumentLocation {
 mixin MarkdownFileDocumentation implements Documentable, Canonicalization {
   DocumentLocation get documentedWhere;
 
-  Documentation? __documentation;
-
-  Documentation? get _documentation {
-    if (__documentation != null) return __documentation;
-    __documentation = Documentation.forElement(this);
-    return __documentation;
-  }
+  late final Documentation _documentation = Documentation.forElement(this);
 
   @override
-  String? get documentationAsHtml => _documentation!.asHtml;
+  String get documentationAsHtml => _documentation.asHtml;
 
   @override
   String get documentation {
@@ -70,7 +64,7 @@ mixin MarkdownFileDocumentation implements Documentable, Canonicalization {
   bool get isDocumented;
 
   @override
-  String? get oneLineDoc => __documentation!.asOneLiner;
+  String get oneLineDoc => _documentation.asOneLiner;
 
   File? get documentationFile;
 

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -64,7 +64,7 @@ mixin DocumentationComment
       }();
 
   @override
-  late final String? documentationAsHtml =
+  late final String documentationAsHtml =
       _injectHtmlFragments(elementDocumentation.asHtml);
 
   late final Documentation elementDocumentation =
@@ -908,10 +908,10 @@ mixin DocumentationComment
   ///
   /// And the HTML fragment will not have been processed or changed by Markdown,
   /// but just injected verbatim.
-  String? _injectHtmlFragments(String? rawDocs) {
+  String _injectHtmlFragments(String rawDocs) {
     if (!config.injectHtml) return rawDocs;
 
-    return rawDocs!.replaceAllMapped(_htmlInjectRegExp, (match) {
+    return rawDocs.replaceAllMapped(_htmlInjectRegExp, (match) {
       var fragment = packageGraph.getHtmlFragment(match[1]);
       if (fragment == null) {
         warn(PackageWarning.unknownHtmlFragment, message: match[1]);

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -99,7 +99,7 @@ class EnumField extends Field {
   }
 
   @override
-  String? get oneLineDoc => documentationAsHtml;
+  String get oneLineDoc => documentationAsHtml;
 
   @override
   Inheritable? get overriddenElement => null;

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -138,15 +138,15 @@ mixin GetterSetterCombo on ModelElement {
       setter!.hasDocumentation);
 
   @override
-  late final String? oneLineDoc = () {
+  late final String oneLineDoc = () {
     if (!hasAccessorsWithDocs) {
       return super.oneLineDoc;
     } else {
       var buffer = StringBuffer();
-      if (hasPublicGetter && getter!.oneLineDoc!.isNotEmpty) {
+      if (hasPublicGetter && getter!.oneLineDoc.isNotEmpty) {
         buffer.write(getter!.oneLineDoc);
       }
-      if (hasPublicSetter && setter!.oneLineDoc!.isNotEmpty) {
+      if (hasPublicSetter && setter!.oneLineDoc.isNotEmpty) {
         buffer.write(getterSetterBothAvailable ? '' : setter!.oneLineDoc);
       }
       return buffer.toString();

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -812,7 +812,7 @@ abstract class ModelElement extends Canonicalization
   String get name => element.name!;
 
   @override
-  String? get oneLineDoc => elementDocumentation.asOneLiner;
+  String get oneLineDoc => elementDocumentation.asOneLiner;
 
   Member? get originalMember => _originalMember;
 

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -115,8 +115,7 @@ class Package extends LibraryContainer
   bool get hasCategories => categories.isNotEmpty;
 
   @override
-  late final String? documentationAsHtml =
-      Documentation.forElement(this).asHtml;
+  late final String documentationAsHtml = Documentation.forElement(this).asHtml;
 
   @override
   late final String? documentation = () {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1298,7 +1298,7 @@ void main() {
       setUpAll(() {
         DocumentWithATable = fakeLibrary.classes
             .firstWhere((cls) => cls.name == 'DocumentWithATable');
-        docsAsHtml = DocumentWithATable.documentationAsHtml!;
+        docsAsHtml = DocumentWithATable.documentationAsHtml;
       });
 
       test('Verify table appearance', () {
@@ -1322,7 +1322,7 @@ void main() {
       test('Verify there is no emoji support', () {
         var tpvar = fakeLibrary.constants
             .firstWhere((t) => t.name == 'hasMarkdownInDoc');
-        var tpvarDocsAsHtml = tpvar.documentationAsHtml!;
+        var tpvarDocsAsHtml = tpvar.documentationAsHtml;
         expect(tpvarDocsAsHtml, contains('3ffe:2a00:100:7031::1'));
       });
     });
@@ -1347,7 +1347,7 @@ void main() {
       late final String docsAsHtml;
 
       setUpAll(() {
-        docsAsHtml = doAwesomeStuff.documentationAsHtml!;
+        docsAsHtml = doAwesomeStuff.documentationAsHtml;
       });
 
       test('Verify links to inherited members inside class', () {
@@ -1616,7 +1616,7 @@ void main() {
 
     test('single ref to class', () {
       expect(
-          B.documentationAsHtml!,
+          B.documentationAsHtml,
           contains(
               '<p>Extends class <a href="${htmlBasePlaceholder}ex/Apple-class.html">Apple</a>, use <a href="${htmlBasePlaceholder}ex/Apple/Apple.html">new Apple</a> or <a href="${htmlBasePlaceholder}ex/Apple/Apple.fromString.html">new Apple.fromString</a></p>'));
     });
@@ -1744,7 +1744,7 @@ void main() {
       var powers = superAwesomeClass.instanceFields
           .firstWhere((p) => p.name == 'powers');
       Iterable<Match> matches =
-          RegExp('In the super class').allMatches(powers.documentationAsHtml!);
+          RegExp('In the super class').allMatches(powers.documentationAsHtml);
       expect(matches, hasLength(1));
     });
   });


### PR DESCRIPTION
This code was written in a way that sort of collided with null safety, or perhaps with lateness.

Multiple late fields can be initialized by one of two entrypoints, and one of them conditionally. A bit rough. But by setting some simple (if crude) private bool fields, we can make more explicit the coupling between the two fields.

This should be a no-op, except that many fields get to be non-nullable (🎉 ).

CC @Levi-Lesches 