### PR TITLE
Remove Material Icons and replace usages of it with Material Symbols

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -81,7 +81,7 @@
   display: none;
 }
 
-.material-symbols-outlined {
+#theme-button .material-symbols-outlined {
   padding-top: 6px;
   color: var(--main-icon-color);
 }
@@ -606,11 +606,8 @@ h1 .feature {
 
 .source-link {
   padding: 18px 4px;
-  vertical-align: middle;
-}
-
-.source-link .material-icons {
   font-size: 18px;
+  vertical-align: middle;
 }
 
 @media (max-width: 840px) {

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3056,7 +3056,6 @@ String _deduplicated_lib_templates_html__head_html(
   buffer.write('''
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />
   ''');
   buffer.writeln();
@@ -3931,7 +3930,8 @@ String _deduplicated_lib_templates_html__source_link_html(
     buffer.write('''
   <div id="external-links" class="btn-group"><a title="View source code" class="source-link" href="''');
     buffer.write(context0.sourceHref);
-    buffer.write('''"><i class="material-icons">description</i></a></div>''');
+    buffer.write(
+        '''"><span class="material-symbols-outlined">description</span></a></div>''');
   }
   buffer.writeln();
 

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3056,7 +3056,7 @@ String _deduplicated_lib_templates_html__head_html(
   buffer.write('''
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   ''');
   buffer.writeln();
   buffer.write('''

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -23,7 +23,6 @@
   {{! TODO(jdkoren): unwrap ^useBaseHref sections when the option is removed.}}
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />
   {{! **Update versions for static assets when changed to force browsers to refresh them.** }}
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/github.css?v1">

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -23,7 +23,7 @@
   {{! TODO(jdkoren): unwrap ^useBaseHref sections when the option is removed.}}
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   {{! **Update versions for static assets when changed to force browsers to refresh them.** }}
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/github.css?v1">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/styles.css?v1">

--- a/lib/templates/html/_source_link.html
+++ b/lib/templates/html/_source_link.html
@@ -1,3 +1,3 @@
 {{#hasSourceHref}}
-  <div id="external-links" class="btn-group"><a title="View source code" class="source-link" href="{{{sourceHref}}}"><i class="material-icons">description</i></a></div>
+  <div id="external-links" class="btn-group"><a title="View source code" class="source-link" href="{{{sourceHref}}}"><span class="material-symbols-outlined">description</span></a></div>
 {{/hasSourceHref}}

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -160,7 +160,7 @@ void main() {
             anonymousOutput.readAsStringSync(),
             contains(r'<a title="View source code" class="source-link" '
                 'href="https://github.com/dart-lang/dartdoc/blob/master/testing/test_package/lib/anonymous_library.dart#L1">'
-                '<i class="material-icons">description</i></a>'));
+                '<i class="material-symbols-outlined">description</i></a>'));
       });
     });
 

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -160,7 +160,7 @@ void main() {
             anonymousOutput.readAsStringSync(),
             contains(r'<a title="View source code" class="source-link" '
                 'href="https://github.com/dart-lang/dartdoc/blob/master/testing/test_package/lib/anonymous_library.dart#L1">'
-                '<i class="material-symbols-outlined">description</i></a>'));
+                '<span class="material-symbols-outlined">description</span></a>'));
       });
     });
 


### PR DESCRIPTION
As the dark theme implementation added Material Symbols which is an expanded/updated version of Material Icons, it likely doesn't make sense to keep Material Icons around anymore. This PR removes the old font and migrates dartdoc's only usage to use Material Symbols instead.

This could be **potentially breaking** for downstream users if they use Material icons elsewhere. They can re-add the font or migrate their usage to Material Symbols.

Migrated source code symbol (compare with [live dart:async docs](https://api.dart.dev/stable/2.18.0/dart-async/dart-async-library.html)):
<img width="500" alt="dart:async page with new source code symbol" src="https://user-images.githubusercontent.com/18372958/187319981-9a98da9c-0325-4f9c-8b05-0925dbd726f7.png">

\cc @klr981 