### PR TITLE
Make theme toggle not text selectable and have pointer on hover

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -81,9 +81,11 @@
   display: none;
 }
 
-.material-symbols-outlined {
+#theme-button .material-symbols-outlined {
   padding-top: 6px;
   color: var(--main-icon-color);
+  user-select: none;
+  cursor: pointer;
 }
 
 /* for layout */
@@ -1059,7 +1061,7 @@ button {
   padding-right: 60px;
 }
 
-#theme-button.toggle {
+#theme-button {
   position: absolute;
   right: 30px;
 }


### PR DESCRIPTION
This prevents the theme toggle from being text selectable(which causes text selection to show up after clicking) as well as making the pointer cursor show up when hovering.

\cc @klr981 