### PR TITLE
Deprecate linkedParamsNoMetadataOrNames

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -805,6 +805,7 @@ abstract class ModelElement extends Canonicalization
   String? get linkedParamsNoMetadata =>
       _parameterRenderer.renderLinkedParams(parameters, showMetadata: false);
 
+  @Deprecated('Unused, will be removed')
   String get linkedParamsNoMetadataOrNames => _parameterRenderer
       .renderLinkedParams(parameters, showMetadata: false, showNames: false);
 


### PR DESCRIPTION
This is unused, and adds complexity to the Parameter renderer code; it represents the only type than names are not printed.