### PR TITLE
Use `toList(growable: false)` more

### DIFF
--- a/lib/src/comment_references/model_comment_reference.dart
+++ b/lib/src/comment_references/model_comment_reference.dart
@@ -34,7 +34,8 @@ abstract class ModelCommentReference {
 /// and [ResourceProvider] after construction.
 class _ModelCommentReferenceImpl implements ModelCommentReference {
   void _initAllowCache() {
-    var referencePieces = parsed.whereType<IdentifierNode>().toList();
+    final referencePieces =
+        parsed.whereType<IdentifierNode>().toList(growable: false);
     _allowUnnamedConstructor = false;
     _allowUnnamedConstructorParameter = false;
     if (referencePieces.length >= 2) {
@@ -51,7 +52,7 @@ class _ModelCommentReferenceImpl implements ModelCommentReference {
           }
         }
       }
-      // e.g. [C.new], which may be the unnamed constructor
+      // e.g. [C.new], which may be the unnamed constructor.
       if (referencePieces.isNotEmpty && referencePieces.last.text == 'new') {
         _allowUnnamedConstructor = true;
       }

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -184,8 +184,9 @@ class ToolConfiguration {
             if (compileArgs is String) {
               args = [toolMap[compileArgsTagName].toString()];
             } else if (compileArgs is YamlList) {
-              args =
-                  compileArgs.map<String>((node) => node.toString()).toList();
+              args = compileArgs
+                  .map<String>((node) => node.toString())
+                  .toList(growable: false);
             } else {
               throw DartdocOptionError(
                   'Tool compile arguments must be a list of strings. The tool '
@@ -307,7 +308,7 @@ class _OptionValueWithContext<T> {
       return (value as List<String>)
           .map((v) => pathContext.canonicalizeWithTilde(v))
           .cast<String>()
-          .toList() as T;
+          .toList(growable: false) as T;
     } else if (value is String) {
       return pathContext.canonicalizeWithTilde(value as String) as T;
     } else if (value is Map<String, String>) {

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -33,7 +33,7 @@ class GeneratorFrontEnd implements Generator {
     var categories = indexElements
         .whereType<Categorization>()
         .where((e) => e.hasCategorization)
-        .toList();
+        .toList(growable: false);
     _generatorBackend.generateCategoryJson(categories);
     _generatorBackend.generateSearchIndex(indexElements);
   }

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -31,7 +31,7 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
 
-  return encoder.convert(indexItems.toList());
+  return encoder.convert(indexItems.toList(growable: false));
 }
 
 String removeHtmlTags(String? input) {
@@ -69,7 +69,7 @@ String generateSearchIndexJson(
   final encoder =
       pretty ? const JsonEncoder.withIndent(' ') : const JsonEncoder();
 
-  return encoder.convert(indexItems.toList());
+  return encoder.convert(indexItems);
 }
 
 // Compares two elements, first by fully qualified name, then by kind.

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -352,7 +352,7 @@ class MarkdownDocument extends md.Document {
   /// if [processFullText] is `true`.
   List<md.Node> parseMarkdownText(String text,
       {required bool processFullText}) {
-    var lines = LineSplitter.split(text).toList();
+    var lines = LineSplitter.split(text).toList(growable: false);
     md.Node? firstNode;
     var nodes = <md.Node>[];
     // TODO(srawlins): Refactor this. I think with null safety, it is more clear

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -14,7 +14,8 @@ abstract class Canonicalization implements Locatable, Documentable {
   Set<String> get locationPieces;
 
   List<ScoredCandidate> scoreCanonicalCandidates(Iterable<Library> libraries) {
-    return libraries.map(_scoreElementWithLibrary).toList()..sort();
+    return libraries.map(_scoreElementWithLibrary).toList(growable: false)
+      ..sort();
   }
 
   ScoredCandidate _scoreElementWithLibrary(Library lib) {

--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -43,8 +43,8 @@ abstract class Categorization implements ModelElement {
       return '';
     });
 
-    _categoryNames = categorySet.toList()..sort();
-    _subCategoryNames = subCategorySet.toList()..sort();
+    _categoryNames = categorySet.toList(growable: false)..sort();
+    _subCategoryNames = subCategorySet.toList(growable: false)..sort();
     _image ??= '';
     _samples ??= '';
     return rawDocs;

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -73,7 +73,7 @@ abstract class Container extends ModelElement
       ];
 
   late final List<ModelElement> allCanonicalModelElements =
-      allModelElements.where((e) => e.isCanonical).toList();
+      allModelElements.where((e) => e.isCanonical).toList(growable: false);
 
   /// All methods, including operators and statics, declared as part of this
   /// [Container].
@@ -108,7 +108,7 @@ abstract class Container extends ModelElement
       model_utils.filterNonPublic(instanceMethods);
 
   late final List<Method> publicInstanceMethodsSorted =
-      publicInstanceMethods.toList()..sort();
+      publicInstanceMethods.toList(growable: false)..sort();
 
   @nonVirtual
   late final Iterable<Operator> declaredOperators =
@@ -128,7 +128,7 @@ abstract class Container extends ModelElement
       model_utils.filterNonPublic(instanceOperators);
 
   late final List<Operator> publicInstanceOperatorsSorted =
-      publicInstanceOperators.toList()..sort();
+      publicInstanceOperators.toList(growable: false)..sort();
 
   /// Fields fully declared in this [Container].
   Iterable<Field> get declaredFields;
@@ -147,7 +147,7 @@ abstract class Container extends ModelElement
   bool get hasPublicInstanceFields => publicInstanceFields.isNotEmpty;
 
   late final List<Field> publicInstanceFieldsSorted =
-      publicInstanceFields.toList()..sort(byName);
+      publicInstanceFields.toList(growable: false)..sort(byName);
 
   Iterable<Field> get constantFields => declaredFields.where((f) => f.isConst);
 
@@ -157,7 +157,7 @@ abstract class Container extends ModelElement
   bool get hasPublicConstantFields => publicConstantFields.isNotEmpty;
 
   late final List<Field> publicConstantFieldsSorted =
-      publicConstantFields.toList()..sort(byName);
+      publicConstantFields.toList(growable: false)..sort(byName);
 
   Iterable<Field> get publicEnumValues => [];
 
@@ -208,7 +208,7 @@ abstract class Container extends ModelElement
   bool get hasPublicStaticFields => publicStaticFieldsSorted.isNotEmpty;
 
   late final List<Field> publicStaticFieldsSorted =
-      model_utils.filterNonPublic(staticFields).toList()..sort();
+      model_utils.filterNonPublic(staticFields).toList(growable: false)..sort();
 
   Iterable<Field> get staticFields => declaredFields.where((f) => f.isStatic);
 
@@ -218,8 +218,10 @@ abstract class Container extends ModelElement
   bool get hasPublicVariableStaticFields =>
       publicVariableStaticFieldsSorted.isNotEmpty;
 
-  late final List<Field> publicVariableStaticFieldsSorted =
-      model_utils.filterNonPublic(variableStaticFields).toList()..sort();
+  late final List<Field> publicVariableStaticFieldsSorted = model_utils
+      .filterNonPublic(variableStaticFields)
+      .toList(growable: false)
+    ..sort();
 
   Iterable<Method> get staticMethods =>
       declaredMethods.where((m) => m.isStatic);
@@ -227,8 +229,10 @@ abstract class Container extends ModelElement
   bool get hasPublicStaticMethods =>
       model_utils.filterNonPublic(publicStaticMethodsSorted).isNotEmpty;
 
-  late final List<Method> publicStaticMethodsSorted =
-      model_utils.filterNonPublic(staticMethods).toList()..sort();
+  late final List<Method> publicStaticMethodsSorted = model_utils
+      .filterNonPublic(staticMethods)
+      .toList(growable: false)
+    ..sort();
 
   /// For subclasses to add items after the main pass but before the
   /// parameter-global.

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -258,7 +258,7 @@ mixin DocumentationComment
     var invocationIndex = 0;
     return await _replaceAllMappedAsync(rawDocs, _basicToolPattern,
         (basicMatch) async {
-      var args = _splitUpQuotedArgs(basicMatch[1]!).toList();
+      final args = _splitUpQuotedArgs(basicMatch[1]!);
       // Tool name must come first.
       if (args.isEmpty) {
         warn(PackageWarning.toolError,
@@ -268,8 +268,8 @@ mixin DocumentationComment
       // Count the number of invocations of tools in this dartdoc block,
       // so that tools can differentiate different blocks from each other.
       invocationIndex++;
-      return await config.tools.runner.run(args, content: basicMatch[2]!,
-          toolErrorCallback: (String message) async {
+      return await config.tools.runner.run(args.toList(),
+          content: basicMatch[2]!, toolErrorCallback: (String message) async {
         warn(PackageWarning.toolError, message: message);
       }, environment: _toolsEnvironment(invocationIndex: invocationIndex));
     });

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -28,7 +28,7 @@ mixin Constructable on InheritingContainer {
 
   @override
   late final List<Constructor> publicConstructorsSorted =
-      model_utils.filterNonPublic(constructors).toList()..sort();
+      model_utils.filterNonPublic(constructors).toList(growable: false)..sort();
 
   static Iterable<MapEntry<String, CommentReferable>> _constructorGenerator(
       Iterable<Constructor> source) sync* {
@@ -171,7 +171,8 @@ mixin TypeImplementing on InheritingContainer {
   List<InheritingContainer>? _publicImplementorsSorted;
 
   Iterable<InheritingContainer> get publicImplementorsSorted =>
-      _publicImplementorsSorted ??= publicImplementors.toList()..sort(byName);
+      _publicImplementorsSorted ??= publicImplementors.toList(growable: false)
+        ..sort(byName);
 }
 
 /// A [Container] that participates in inheritance in Dart.
@@ -354,7 +355,7 @@ abstract class InheritingContainer extends Container
           // Elements in the inheritance chain starting from [this.element]
           // down to, but not including, [Object].
           inheritanceChainElements ??=
-              inheritanceChain.map((c) => c!.element).toList();
+              inheritanceChain.map((c) => c!.element).toList(growable: false);
           // [packageGraph.specialClasses] is not available yet.
           bool isDartCoreObject(ClassElement e) =>
               e.name == 'Object' && e.library.name == 'dart.core';
@@ -379,7 +380,7 @@ abstract class InheritingContainer extends Container
         }
       }
 
-      __inheritedElements = combinedMap.values.toList();
+      __inheritedElements = combinedMap.values.toList(growable: false);
     }
     return __inheritedElements;
   }
@@ -419,7 +420,7 @@ abstract class InheritingContainer extends Container
     // Now we only have inherited accessors who aren't associated with
     // anything in cls._fields.
     for (var fieldName in accessorMap.keys) {
-      var elements = accessorMap[fieldName]!.toList();
+      var elements = accessorMap[fieldName]!.toList(growable: false);
       var getterElement = elements.firstWhereOrNull((e) => e.isGetter);
       var setterElement = elements.firstWhereOrNull((e) => e.isSetter);
       fields.add(_createSingleField(
@@ -519,7 +520,7 @@ abstract class InheritingContainer extends Container
     _typeParameters ??= element.typeParameters.map((f) {
       var lib = modelBuilder.fromElement(f.enclosingElement3!.library!);
       return modelBuilder.from(f, lib as Library) as TypeParameter;
-    }).toList();
+    }).toList(growable: false);
     return _typeParameters!;
   }
 

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -34,7 +34,7 @@ class Method extends ModelElement
   void _calcTypeParameters() {
     typeParameters = element.typeParameters.map((f) {
       return modelBuilder.from(f, library) as TypeParameter;
-    }).toList();
+    }).toList(growable: false);
   }
 
   @override

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -570,7 +570,7 @@ abstract class ModelElement extends Canonicalization
       topLevelElement = topLevelElement.enclosingElement3!;
     }
 
-    var candidateLibraries = thisAndExported
+    final candidateLibraries = thisAndExported
         .where((l) =>
             l.isPublic && l.package.documentedWhere != DocumentLocation.missing)
         .where((l) {
@@ -580,7 +580,7 @@ abstract class ModelElement extends Canonicalization
         lookup = lookup.variable;
       }
       return topLevelElement == lookup;
-    }).toList();
+    }).toList(growable: true);
 
     // Avoid claiming canonicalization for elements outside of this element's
     // defining package.
@@ -609,21 +609,22 @@ abstract class ModelElement extends Canonicalization
     // canonical.  Still warn if the heuristic isn't that confident.
     var scoredCandidates =
         warnable.scoreCanonicalCandidates(candidateLibraries);
-    candidateLibraries = scoredCandidates.map((s) => s.library).toList();
+    final librariesByScore = scoredCandidates.map((s) => s.library).toList();
     var secondHighestScore =
         scoredCandidates[scoredCandidates.length - 2].score;
     var highestScore = scoredCandidates.last.score;
     var confidence = highestScore - secondHighestScore;
+    final canonicalLibrary = librariesByScore.last;
 
     if (confidence < config.ambiguousReexportScorerMinConfidence) {
-      var libraryNames = candidateLibraries.map((l) => l.name);
-      var message = '$libraryNames -> ${candidateLibraries.last.name} '
+      var libraryNames = librariesByScore.map((l) => l.name);
+      var message = '$libraryNames -> ${canonicalLibrary.name} '
           '(confidence ${confidence.toStringAsPrecision(4)})';
       warnable.warn(PackageWarning.ambiguousReexport,
           message: message, extendedDebug: scoredCandidates.map((s) => '$s'));
     }
 
-    return candidateLibraries.last;
+    return canonicalLibrary;
   }
 
   @override
@@ -737,7 +738,7 @@ abstract class ModelElement extends Canonicalization
       var setterDeprecated = pie.setter?.metadata.any((a) => a.isDeprecated);
 
       var deprecatedValues =
-          [getterDeprecated, setterDeprecated].whereNotNull().toList();
+          [getterDeprecated, setterDeprecated].whereNotNull();
 
       // At least one of these should be non-null. Otherwise things are weird
       assert(deprecatedValues.isNotEmpty);
@@ -854,7 +855,7 @@ abstract class ModelElement extends Canonicalization
         }
       }
     }
-    return recursedParameters.toList();
+    return recursedParameters.toList(growable: false);
   }();
 
   @override

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -329,7 +329,7 @@ class Package extends LibraryContainer
   late final List<Category> categories = [
     defaultCategory,
     ...nameToCategory.values,
-  ].where((c) => c.name.isNotEmpty).toList()
+  ].where((c) => c.name.isNotEmpty).toList(growable: false)
     ..sort();
 
   Iterable<Category> get categoriesWithPublicLibraries =>
@@ -346,7 +346,8 @@ class Package extends LibraryContainer
   /// ordered by name.
   Iterable<Category> get documentedCategoriesSorted {
     if (config.categoryOrder.isNotEmpty) {
-      final documentedCategories = this.documentedCategories.toList();
+      final documentedCategories =
+          this.documentedCategories.toList(growable: false);
       return documentedCategories
         ..sort((a, b) {
           var aIndex = config.categoryOrder.indexOf(a.name);

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -53,49 +53,51 @@ abstract class TopLevelContainer implements Nameable {
   // TODO(jcollins-g):  Setting this type parameter to `Container` magically
   // fixes a number of type problems in the AOT compiler, but I am mystified as
   // to why that should be the case.
-  late final Iterable<Container> publicClassesSorted = publicClasses.toList()
-    ..sort();
+  late final Iterable<Container> publicClassesSorted =
+      publicClasses.toList(growable: false)..sort();
 
   Iterable<Extension> get publicExtensions =>
       model_utils.filterNonPublic(extensions);
 
   late final Iterable<Extension> publicExtensionsSorted =
-      publicExtensions.toList()..sort();
+      publicExtensions.toList(growable: false)..sort();
 
   Iterable<TopLevelVariable> get publicConstants =>
       model_utils.filterNonPublic(constants);
 
   Iterable<TopLevelVariable> get publicConstantsSorted =>
-      publicConstants.toList()..sort();
+      publicConstants.toList(growable: false)..sort();
 
   Iterable<Enum> get publicEnums => model_utils.filterNonPublic(enums);
 
-  late final Iterable<Enum> publicEnumsSorted = publicEnums.toList()..sort();
+  late final Iterable<Enum> publicEnumsSorted =
+      publicEnums.toList(growable: false)..sort();
 
   Iterable<Class> get _publicExceptions =>
       model_utils.filterNonPublic(exceptions);
 
-  late final Iterable<Class> publicExceptionsSorted = _publicExceptions.toList()
-    ..sort();
+  late final Iterable<Class> publicExceptionsSorted =
+      _publicExceptions.toList(growable: false)..sort();
 
   Iterable<ModelFunctionTyped> get publicFunctions =>
       model_utils.filterNonPublic(functions!);
 
   late final Iterable<ModelFunctionTyped> publicFunctionsSorted =
-      publicFunctions.toList()..sort();
+      publicFunctions.toList(growable: false)..sort();
 
   Iterable<Mixin> get publicMixins => model_utils.filterNonPublic(mixins);
 
-  late final Iterable<Mixin> publicMixinsSorted = publicMixins.toList()..sort();
+  late final Iterable<Mixin> publicMixinsSorted =
+      publicMixins.toList(growable: false)..sort();
 
   Iterable<TopLevelVariable> get publicProperties =>
       model_utils.filterNonPublic(properties);
 
   late final Iterable<TopLevelVariable> publicPropertiesSorted =
-      publicProperties.toList()..sort();
+      publicProperties.toList(growable: false)..sort();
 
   Iterable<Typedef> get publicTypedefs => model_utils.filterNonPublic(typedefs);
 
-  late final Iterable<Typedef> publicTypedefsSorted = publicTypedefs.toList()
-    ..sort();
+  late final Iterable<Typedef> publicTypedefsSorted =
+      publicTypedefs.toList(growable: false)..sort();
 }

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -62,7 +62,7 @@ abstract class Typedef extends ModelElement
   @override
   List<TypeParameter> get typeParameters => element.typeParameters
       .map((f) => modelBuilder.from(f, library) as TypeParameter)
-      .toList();
+      .toList(growable: false);
 
   TypedefRenderer get _renderer => packageGraph.rendererFactory.typedefRenderer;
 

--- a/lib/src/mustachio/renderer_base.dart
+++ b/lib/src/mustachio/renderer_base.dart
@@ -263,7 +263,7 @@ abstract class RendererBase<T extends Object?> {
         // An inverted section is rendered with the current context.
         renderBlock(node.children);
       } else if (!node.invert && renderedIterable.isNotEmpty) {
-        renderedIterable.toList();
+        renderedIterable.toList(growable: false);
       }
       // Otherwise, render nothing.
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -396,7 +396,7 @@ class _FilePackageMeta extends PubPackageMeta {
 }
 
 File? _locate(Folder dir, List<String> fileNames) {
-  var files = dir.getChildren().whereType<File>().toList();
+  var files = dir.getChildren().whereType<File>().toList(growable: false);
 
   for (var name in fileNames) {
     for (var f in files) {

--- a/lib/src/render/model_element_renderer.dart
+++ b/lib/src/render/model_element_renderer.dart
@@ -16,7 +16,8 @@ abstract class ModelElementRenderer {
       String uniqueId, int width, int height, Uri movieUrl, String overlayId);
 
   String renderFeatures(ModelElement modelElement) {
-    var allFeatures = modelElement.features.toList()..sort(byFeatureOrdering);
+    var allFeatures = modelElement.features.toList(growable: false)
+      ..sort(byFeatureOrdering);
     return allFeatures
         .map((f) =>
             '<span class="${f.cssClassName} ${f.linkedNameWithParameters}">${f.linkedNameWithParameters}</span>')

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -97,11 +97,14 @@ abstract class ParameterRenderer {
 
   String renderLinkedParams(List<Parameter> parameters,
       {bool showMetadata = true, bool showNames = true}) {
-    var positionalParams =
-        parameters.where((Parameter p) => p.isRequiredPositional).toList();
-    var optionalPositionalParams =
-        parameters.where((Parameter p) => p.isOptionalPositional).toList();
-    var namedParams = parameters.where((Parameter p) => p.isNamed).toList();
+    var positionalParams = parameters
+        .where((Parameter p) => p.isRequiredPositional)
+        .toList(growable: false);
+    var optionalPositionalParams = parameters
+        .where((Parameter p) => p.isOptionalPositional)
+        .toList(growable: false);
+    var namedParams =
+        parameters.where((Parameter p) => p.isNamed).toList(growable: false);
 
     var output = StringBuffer();
     if (positionalParams.isNotEmpty) {

--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -73,7 +73,7 @@ class ToolRunner {
       Map<String, String> environment,
       ToolErrorCallback toolErrorCallback) async {
     var isDartSetup = ToolDefinition.isDartExecutable(tool.setupCommand[0]);
-    var args = tool.setupCommand.toList();
+    var args = tool.setupCommand.toList(growable: true);
     String commandPath;
 
     if (isDartSetup) {

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -87,7 +87,7 @@ List<DartdocOption<Object?>> createPackageWarningOptions(
 String _warningsListHelpText(PackageWarningMode mode) {
   return (packageWarningDefinitions.values
           .where((d) => d.defaultWarningMode == mode)
-          .toList()
+          .toList(growable: false)
         ..sort())
       .map((d) => '   ${d.warningName}: ${d.shortHelp}')
       .join('\n');


### PR DESCRIPTION
I looked through every `toList()` call, for the ones which could be `growable: false`, and looked at Observatory's allocation profile, before and after, when documenting package:collection. Here are the result of 3 runs, excluding a 4th run outlier:

* Used MB: 444 (before) &xrarr; 411 (after) -- 7% reduction
* Allocated MB: 464 (before) &xrarr; 450 (after) -- 3% reduction
* _List instance MBs: 149 (before) &xrarr; 129 (after) -- 13% reduction
* _List instances: 868510 (before) &xrarr; 870317 (after) -- 0% reduction
* _GrowableList instance MBs: 15.1 (before) &xrarr; 13.3 (after) -- 12% reduction
* _GrowableList instances: 495092 (before) &xrarr; 435337 (after) -- 12% reduction

I can't super explain these. The reduction in _GrowableLists is expected. But why did the MBs of _List also shrink dramatically? 🤷 