### PR TITLE
Simplify some code in dartdoc_options.dart

### DIFF
--- a/lib/options.dart
+++ b/lib/options.dart
@@ -106,12 +106,12 @@ DartdocProgramOptionContext? parseOptions(
     exitCode = 64;
     return null;
   }
-  if (optionRoot['help'].valueAtCurrent()) {
+  if (optionRoot['help'].valueAtCurrent() as bool) {
     _printHelp(optionRoot.argParser);
     exitCode = 0;
     return null;
   }
-  if (optionRoot['version'].valueAtCurrent()) {
+  if (optionRoot['version'].valueAtCurrent() as bool) {
     _printVersion(optionRoot.argParser);
     exitCode = 0;
     return null;

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -303,16 +303,16 @@ class _OptionValueWithContext<T> {
   ///
   /// Throws [UnsupportedError] if [T] isn't a [String] or [List<String>].
   T get resolvedValue {
+    final value = this.value;
     if (value is List<String>) {
-      return (value as List<String>)
+      return value
           .map((v) => pathContext.canonicalizeWithTilde(v))
           .cast<String>()
           .toList() as T;
     } else if (value is String) {
-      return pathContext.canonicalizeWithTilde(value as String) as T;
+      return pathContext.canonicalizeWithTilde(value) as T;
     } else if (value is Map<String, String>) {
-      return (value as Map<String, String>)
-          .map<String, String>((String key, String value) {
+      return value.map<String, String>((String key, String value) {
         return MapEntry(key, pathContext.canonicalizeWithTilde(value));
       }) as T;
     } else {
@@ -496,7 +496,7 @@ abstract class DartdocOption<T extends Object?> {
 
   /// Calls [valueAt] with the working directory at the start of the program.
   // TODO(jcollins-g): use of dynamic.  https://github.com/dart-lang/dartdoc/issues/2814
-  dynamic valueAtCurrent() => valueAt(_directoryCurrent);
+  Object? valueAtCurrent() => valueAt(_directoryCurrent);
 
   late final Folder _directoryCurrent =
       resourceProvider.getFolder(_directoryCurrentPath);
@@ -805,15 +805,11 @@ class DartdocOptionArgFile<T> extends DartdocOption<T>
     }
   }
 
-  /// Try to find an explicit argument setting this value, but if not, fall back
-  /// to files finally, the default.
+  /// Try to find an explicit argument setting this value, and fall back first
+  /// to files, then to the default.
   @override
-  T? valueAt(Folder dir) {
-    var value = _valueAtFromArgs();
-    value ??= _valueAtFromFiles(dir);
-    value ??= defaultsTo;
-    return value;
-  }
+  T? valueAt(Folder dir) =>
+      _valueAtFromArgs() ?? _valueAtFromFiles(dir) ?? defaultsTo;
 }
 
 class DartdocOptionFileOnly<T> extends DartdocOption<T>
@@ -866,10 +862,9 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
 
   /// Searches for a value in configuration files relative to [dir], and if not
   /// found, returns [defaultsTo].
-  T? valueAt(Folder dir) {
-    return _valueAtFromFiles(dir) ?? defaultsTo;
-  }
+  T? valueAt(Folder dir) => _valueAtFromFiles(dir) ?? defaultsTo;
 
+  /// The backing store for [_valueAtFromFiles].
   final Map<String, T?> __valueAtFromFiles = {};
 
   // The value of this option from files will not change unless files are
@@ -990,8 +985,8 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
             .join(dir.path, 'dartdoc_options.yaml'));
         if (dartdocOptionsFile.exists) {
           final yaml = loadYaml(dartdocOptionsFile.readAsStringSync());
-          // [loadYaml()] will return null for empty (or all comment) yaml files,
-          // so we must check for that case.
+          // [loadYaml] will return `null` for empty (or all comment) YAML
+          // files, so we must check for that case.
           if (yaml != null) {
             yamlData = _YamlFileData(
                 yaml, resourceProvider.pathContext.canonicalize(dir.path));


### PR DESCRIPTION
* Save a field to a local to allow for promotion.
* Return `Object?` instead of `dynamic` for type safety.
* Simplify functions.
* Correct comments.