### PR TITLE
Refactor renderers

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -832,9 +832,9 @@ abstract class ModelElement extends Canonicalization
   late final List<Parameter> allParameters = () {
     var recursedParameters = <Parameter>{};
     var newParameters = <Parameter>{};
-    if (this is GetterSetterCombo &&
-        (this as GetterSetterCombo).setter != null) {
-      newParameters.addAll((this as GetterSetterCombo).setter!.parameters);
+    final self = this;
+    if (self is GetterSetterCombo && self.setter != null) {
+      newParameters.addAll(self.setter!.parameters);
     } else {
       if (isCallable) newParameters.addAll(parameters);
     }

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -16,11 +16,50 @@ abstract class ElementTypeRenderer<T extends ElementType> {
       elementType.nullabilitySuffix.isEmpty
           ? inner
           : '($inner${elementType.nullabilitySuffix})';
+
+  @Deprecated('Append nullability suffix to StringBuilder')
   String wrapNullability(T elementType, String inner) =>
       '$inner${elementType.nullabilitySuffix}';
 }
 
-// Html implementations
+// HTML implementations.
+
+abstract class ElementTypeRendererHtml<T extends ElementType>
+    extends ElementTypeRenderer<T> {
+  const ElementTypeRendererHtml();
+
+  String _renderLinkedName(
+      T elementType, String name, Iterable<ElementType> typeArguments) {
+    var buffer = StringBuffer()..write(name);
+    if (typeArguments.isNotEmpty &&
+        !typeArguments.every((t) => t.name == 'dynamic')) {
+      buffer
+        ..write('<span class="signature">')
+        ..write('&lt;<wbr><span class="type-parameter">')
+        ..writeAll(typeArguments.map((t) => t.linkedName),
+            '</span>, <span class="type-parameter">')
+        ..write('</span>&gt;')
+        ..write('</span>');
+    }
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
+  }
+
+  String _renderNameWithGenerics(
+      T elementType, String name, Iterable<ElementType> typeArguments) {
+    var buffer = StringBuffer()..write(name);
+    if (typeArguments.isNotEmpty &&
+        !typeArguments.every((t) => t.name == 'dynamic')) {
+      buffer
+        ..write('&lt;<wbr><span class="type-parameter">')
+        ..writeAll(typeArguments.map((t) => t.nameWithGenerics),
+            '</span>, <span class="type-parameter">')
+        ..write('</span>&gt;');
+    }
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
+  }
+}
 
 class FunctionTypeElementTypeRendererHtml
     extends ElementTypeRenderer<FunctionTypeElementType> {
@@ -28,136 +67,94 @@ class FunctionTypeElementTypeRendererHtml
 
   @override
   String renderLinkedName(FunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.returnType.linkedName);
-    buf.write(' ');
-    buf.write(elementType.nameWithGenerics);
-    buf.write('<span class="signature">(');
-    buf.write(const ParameterRendererHtml()
-        .renderLinkedParams(elementType.parameters));
-    buf.write(')</span>');
-    return wrapNullabilityParens(elementType, buf.toString());
+    var buffer = StringBuffer()
+      ..write(elementType.returnType.linkedName)
+      ..write(' ')
+      ..write(elementType.nameWithGenerics)
+      ..write('<span class="signature">(')
+      ..write(const ParameterRendererHtml()
+          .renderLinkedParams(elementType.parameters))
+      ..write(')</span>');
+    return wrapNullabilityParens(elementType, buffer.toString());
   }
 
   @override
   String renderNameWithGenerics(FunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.name);
+    var buffer = StringBuffer()..write(elementType.name);
     if (elementType.typeFormals.isNotEmpty) {
       if (!elementType.typeFormals.every((t) => t.name == 'dynamic')) {
-        buf.write('&lt;<wbr><span class="type-parameter">');
-        buf.writeAll(elementType.typeFormals.map((t) => t.name),
-            '</span>, <span class="type-parameter">');
-        buf.write('</span>&gt;');
+        buffer
+          ..write('&lt;<wbr><span class="type-parameter">')
+          ..writeAll(elementType.typeFormals.map((t) => t.name),
+              '</span>, <span class="type-parameter">')
+          ..write('</span>&gt;');
       }
     }
-    return wrapNullability(elementType, buf.toString());
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
   }
 }
 
 class ParameterizedElementTypeRendererHtml
-    extends ElementTypeRenderer<ParameterizedElementType> {
+    extends ElementTypeRendererHtml<ParameterizedElementType> {
   const ParameterizedElementTypeRendererHtml();
 
   @override
-  String renderLinkedName(ParameterizedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.modelElement.linkedName);
-    if (elementType.typeArguments.isNotEmpty &&
-        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('<span class="signature">');
-      buf.write('&lt;<wbr><span class="type-parameter">');
-      buf.writeAll(elementType.typeArguments.map((t) => t.linkedName),
-          '</span>, <span class="type-parameter">');
-      buf.write('</span>&gt;');
-      buf.write('</span>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderLinkedName(ParameterizedElementType elementType) =>
+      _renderLinkedName(
+        elementType,
+        elementType.modelElement.linkedName,
+        elementType.typeArguments,
+      );
 
   @override
-  String renderNameWithGenerics(ParameterizedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.modelElement.name);
-    if (elementType.typeArguments.isNotEmpty &&
-        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;<wbr><span class="type-parameter">');
-      buf.writeAll(elementType.typeArguments.map((t) => t.nameWithGenerics),
-          '</span>, <span class="type-parameter">');
-      buf.write('</span>&gt;');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(ParameterizedElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.modelElement.name,
+        elementType.typeArguments,
+      );
 }
 
 class AliasedFunctionTypeElementTypeRendererHtml
-    extends ElementTypeRenderer<AliasedFunctionTypeElementType> {
+    extends ElementTypeRendererHtml<AliasedFunctionTypeElementType> {
   const AliasedFunctionTypeElementTypeRendererHtml();
 
   @override
-  String renderLinkedName(AliasedFunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.linkedName);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('<span class="signature">');
-      buf.write('&lt;<wbr><span class="type-parameter">');
-      buf.writeAll(elementType.aliasArguments.map((t) => t.linkedName),
-          '</span>, <span class="type-parameter">');
-      buf.write('</span>&gt;');
-      buf.write('</span>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderLinkedName(AliasedFunctionTypeElementType elementType) =>
+      _renderLinkedName(
+        elementType,
+        elementType.aliasElement.linkedName,
+        elementType.aliasArguments,
+      );
 
   @override
-  String renderNameWithGenerics(AliasedFunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.name);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;<wbr><span class="type-parameter">');
-      buf.writeAll(elementType.aliasArguments.map((t) => t.nameWithGenerics),
-          '</span>, <span class="type-parameter">');
-      buf.write('</span>&gt;');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(AliasedFunctionTypeElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.aliasElement.name,
+        elementType.aliasArguments,
+      );
 }
 
 class AliasedElementTypeRendererHtml
-    extends ElementTypeRenderer<AliasedElementType> {
+    extends ElementTypeRendererHtml<AliasedElementType> {
   const AliasedElementTypeRendererHtml();
 
   @override
-  String renderLinkedName(AliasedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.linkedName);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('<span class="signature">');
-      buf.write('&lt;<wbr><span class="type-parameter">');
-      buf.writeAll(elementType.aliasArguments.map((t) => t.linkedName),
-          '</span>, <span class="type-parameter">');
-      buf.write('</span>&gt;');
-      buf.write('</span>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderLinkedName(AliasedElementType elementType) => _renderLinkedName(
+        elementType,
+        elementType.aliasElement.linkedName,
+        elementType.aliasArguments,
+      );
 
   @override
-  String renderNameWithGenerics(AliasedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.name);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;<wbr><span class="type-parameter">');
-      buf.writeAll(elementType.aliasArguments.map((t) => t.nameWithGenerics),
-          '</span>, <span class="type-parameter">');
-      buf.write('</span>&gt;');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(AliasedElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.aliasElement.name,
+        elementType.aliasArguments,
+      );
 }
 
 class CallableElementTypeRendererHtml
@@ -166,34 +163,68 @@ class CallableElementTypeRendererHtml
 
   @override
   String renderLinkedName(CallableElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.nameWithGenerics);
-    buf.write('(');
-    buf.write(const ParameterRendererHtml()
-        .renderLinkedParams(elementType.modelElement.parameters,
-            showNames: false)
-        .trim());
-    buf.write(') → ');
-    buf.write(elementType.returnType.linkedName);
-    return wrapNullabilityParens(elementType, buf.toString());
+    var buffer = StringBuffer()
+      ..write(elementType.nameWithGenerics)
+      ..write('(')
+      ..write(const ParameterRendererHtml()
+          .renderLinkedParams(elementType.modelElement.parameters,
+              showNames: false)
+          .trim())
+      ..write(') → ')
+      ..write(elementType.returnType.linkedName);
+    return wrapNullabilityParens(elementType, buffer.toString());
   }
 
   @override
   String renderNameWithGenerics(CallableElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.name);
+    var buffer = StringBuffer()..write(elementType.name);
     if (elementType.typeArguments.isNotEmpty &&
         !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(
-          elementType.typeArguments.map((t) => t.nameWithGenerics), ', ');
-      buf.write('>');
+      buffer
+        ..write('&lt;')
+        ..writeAll(
+            elementType.typeArguments.map((t) => t.nameWithGenerics), ', ')
+        ..write('>');
     }
-    return wrapNullability(elementType, buf.toString());
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
   }
 }
 
-// Markdown implementations
+// Markdown implementations.
+
+abstract class ElementTypeRendererMd<T extends ElementType>
+    extends ElementTypeRenderer<T> {
+  const ElementTypeRendererMd();
+
+  String _renderLinkedName(
+      T elementType, String name, Iterable<ElementType> typeArguments) {
+    var buffer = StringBuffer()..write(name);
+    if (typeArguments.isNotEmpty &&
+        !typeArguments.every((t) => t.name == 'dynamic')) {
+      buffer
+        ..write('&lt;')
+        ..writeAll(typeArguments.map((t) => t.linkedName), ', ')
+        ..write('>');
+    }
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
+  }
+
+  String _renderNameWithGenerics(
+      T elementType, String name, Iterable<ElementType> typeArguments) {
+    var buffer = StringBuffer()..write(name);
+    if (typeArguments.isNotEmpty &&
+        !typeArguments.every((t) => t.name == 'dynamic')) {
+      buffer
+        ..write('&lt;')
+        ..writeAll(typeArguments.map((t) => t.nameWithGenerics), ', ')
+        ..write('>');
+    }
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
+  }
+}
 
 class FunctionTypeElementTypeRendererMd
     extends ElementTypeRenderer<FunctionTypeElementType> {
@@ -201,156 +232,115 @@ class FunctionTypeElementTypeRendererMd
 
   @override
   String renderLinkedName(FunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.returnType.linkedName);
-    buf.write(' ');
-    buf.write(elementType.nameWithGenerics);
-    buf.write('(');
-    buf.write(
-        const ParameterRendererMd().renderLinkedParams(elementType.parameters));
-    buf.write(')');
-    return wrapNullabilityParens(elementType, buf.toString());
+    var parameterRenderer = const ParameterRendererMd();
+    return wrapNullabilityParens(
+        elementType,
+        '${elementType.returnType.linkedName} '
+        '${elementType.nameWithGenerics}'
+        '('
+        '${parameterRenderer.renderLinkedParams(elementType.parameters)}'
+        ')');
   }
 
   @override
   String renderNameWithGenerics(FunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.name);
+    var buffer = StringBuffer()..write(elementType.name);
     if (elementType.typeFormals.isNotEmpty) {
       if (!elementType.typeFormals.every((t) => t.name == 'dynamic')) {
-        buf.write('&lt;');
-        buf.writeAll(elementType.typeFormals.map((t) => t.name), ', ');
-        buf.write('>');
+        buffer
+          ..write('&lt;')
+          ..writeAll(elementType.typeFormals.map((t) => t.name), ', ')
+          ..write('>');
       }
     }
-    return wrapNullabilityParens(elementType, buf.toString());
+    return wrapNullabilityParens(elementType, buffer.toString());
   }
 }
 
 class ParameterizedElementTypeRendererMd
-    extends ElementTypeRenderer<ParameterizedElementType> {
+    extends ElementTypeRendererMd<ParameterizedElementType> {
   const ParameterizedElementTypeRendererMd();
 
   @override
-  String renderLinkedName(ParameterizedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.modelElement.linkedName);
-    if (elementType.typeArguments.isNotEmpty &&
-        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(elementType.typeArguments.map((t) => t.linkedName), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderLinkedName(ParameterizedElementType elementType) =>
+      _renderLinkedName(
+        elementType,
+        elementType.modelElement.linkedName,
+        elementType.typeArguments,
+      );
 
   @override
-  String renderNameWithGenerics(ParameterizedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.modelElement.name);
-    if (elementType.typeArguments.isNotEmpty &&
-        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(
-          elementType.typeArguments.map((t) => t.nameWithGenerics), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(ParameterizedElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.modelElement.name,
+        elementType.typeArguments,
+      );
 }
 
 class AliasedElementTypeRendererMd
-    extends ElementTypeRenderer<AliasedElementType> {
+    extends ElementTypeRendererMd<AliasedElementType> {
   const AliasedElementTypeRendererMd();
 
   @override
-  String renderLinkedName(AliasedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.linkedName);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(elementType.aliasArguments.map((t) => t.linkedName), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderLinkedName(AliasedElementType elementType) => _renderLinkedName(
+        elementType,
+        elementType.aliasElement.linkedName,
+        elementType.aliasArguments,
+      );
 
   @override
-  String renderNameWithGenerics(AliasedElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.name);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(
-          elementType.aliasArguments.map((t) => t.nameWithGenerics), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(AliasedElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.aliasElement.name,
+        elementType.aliasArguments,
+      );
 }
 
 class AliasedFunctionTypeElementTypeRendererMd
-    extends ElementTypeRenderer<AliasedFunctionTypeElementType> {
+    extends ElementTypeRendererMd<AliasedFunctionTypeElementType> {
   const AliasedFunctionTypeElementTypeRendererMd();
 
   @override
-  String renderLinkedName(AliasedFunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.linkedName);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(elementType.aliasArguments.map((t) => t.linkedName), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderLinkedName(AliasedFunctionTypeElementType elementType) =>
+      _renderLinkedName(
+        elementType,
+        elementType.aliasElement.linkedName,
+        elementType.aliasArguments,
+      );
 
   @override
-  String renderNameWithGenerics(AliasedFunctionTypeElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.aliasElement.name);
-    if (elementType.aliasArguments.isNotEmpty &&
-        !elementType.aliasArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(
-          elementType.aliasArguments.map((t) => t.nameWithGenerics), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(AliasedFunctionTypeElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.aliasElement.name,
+        elementType.aliasArguments,
+      );
 }
 
 class CallableElementTypeRendererMd
-    extends ElementTypeRenderer<CallableElementType> {
+    extends ElementTypeRendererMd<CallableElementType> {
   const CallableElementTypeRendererMd();
 
   @override
   String renderLinkedName(CallableElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.nameWithGenerics);
-    buf.write('(');
-    buf.write(const ParameterRendererMd()
-        .renderLinkedParams(elementType.parameters, showNames: false)
-        .trim());
-    buf.write(') → ');
-    buf.write(elementType.returnType.linkedName);
-    return wrapNullabilityParens(elementType, buf.toString());
+    var buffer = StringBuffer()
+      ..write(elementType.nameWithGenerics)
+      ..write('(')
+      ..write(const ParameterRendererMd()
+          .renderLinkedParams(elementType.parameters, showNames: false)
+          .trim())
+      ..write(') → ')
+      ..write(elementType.returnType.linkedName);
+    return wrapNullabilityParens(elementType, buffer.toString());
   }
 
   @override
-  String renderNameWithGenerics(CallableElementType elementType) {
-    var buf = StringBuffer();
-    buf.write(elementType.name);
-    if (elementType.typeArguments.isNotEmpty &&
-        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buf.write('&lt;');
-      buf.writeAll(
-          elementType.typeArguments.map((t) => t.nameWithGenerics), ', ');
-      buf.write('>');
-    }
-    return wrapNullability(elementType, buf.toString());
-  }
+  String renderNameWithGenerics(CallableElementType elementType) =>
+      _renderNameWithGenerics(
+        elementType,
+        elementType.name,
+        elementType.typeArguments,
+      );
 }

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -337,10 +337,17 @@ class CallableElementTypeRendererMd
   }
 
   @override
-  String renderNameWithGenerics(CallableElementType elementType) =>
-      _renderNameWithGenerics(
-        elementType,
-        elementType.name,
-        elementType.typeArguments,
-      );
+  String renderNameWithGenerics(CallableElementType elementType) {
+    var buffer = StringBuffer()..write(elementType.name);
+    if (elementType.typeArguments.isNotEmpty &&
+        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
+      buffer
+        ..write('&lt;')
+        ..writeAll(
+            elementType.typeArguments.map((t) => t.nameWithGenerics), ', ')
+        ..write('>');
+    }
+    buffer.write(elementType.nullabilitySuffix);
+    return buffer.toString();
+  }
 }

--- a/lib/src/render/enum_field_renderer.dart
+++ b/lib/src/render/enum_field_renderer.dart
@@ -16,7 +16,9 @@ class EnumFieldRendererHtml implements EnumFieldRenderer {
   @override
   String renderValue(EnumField field) {
     if (field.name == 'values') {
-      return 'const List&lt;<wbr><span class="type-parameter">${field.enclosingElement.name}</span>&gt;';
+      return 'const List&lt;<wbr>'
+          '<span class="type-parameter">${field.enclosingElement.name}</span>'
+          '&gt;';
     } else {
       return 'const ${field.enclosingElement.name}(${field.index})';
     }

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -7,14 +7,14 @@ import 'dart:convert';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/parameter.dart';
 
-/// Render HTML in an extended vertical format using <ol> tag.
+/// Render HTML in an extended vertical format using an `<ol>` tag.
 class ParameterRendererHtmlList extends ParameterRendererHtml {
   const ParameterRendererHtmlList();
 
   @override
   String listItem(String item) => '<li>$item</li>\n';
   @override
-  // TODO(jcollins-g): consider comma separated lists and more advanced css.
+  // TODO(jcollins-g): consider comma separated lists and more advanced CSS.
   String orderedList(String listItems) =>
       '<ol class="parameter-list">$listItems</ol>\n';
 }
@@ -103,16 +103,16 @@ abstract class ParameterRenderer {
         parameters.where((Parameter p) => p.isOptionalPositional).toList();
     var namedParams = parameters.where((Parameter p) => p.isNamed).toList();
 
-    var output = StringBuffer();
+    var buffer = StringBuffer();
     if (positionalParams.isNotEmpty) {
-      _renderLinkedParameterSublist(positionalParams, output,
+      _renderLinkedParameterSublist(positionalParams, buffer,
           trailingComma:
               optionalPositionalParams.isNotEmpty || namedParams.isNotEmpty,
           showMetadata: showMetadata,
           showNames: showNames);
     }
     if (optionalPositionalParams.isNotEmpty) {
-      _renderLinkedParameterSublist(optionalPositionalParams, output,
+      _renderLinkedParameterSublist(optionalPositionalParams, buffer,
           trailingComma: namedParams.isNotEmpty,
           openBracket: '[',
           closeBracket: ']',
@@ -120,23 +120,25 @@ abstract class ParameterRenderer {
           showNames: showNames);
     }
     if (namedParams.isNotEmpty) {
-      _renderLinkedParameterSublist(namedParams, output,
+      _renderLinkedParameterSublist(namedParams, buffer,
           trailingComma: false,
           openBracket: '{',
           closeBracket: '}',
           showMetadata: showMetadata,
           showNames: showNames);
     }
-    return orderedList(output.toString());
+    return orderedList(buffer.toString());
   }
 
   void _renderLinkedParameterSublist(
-      List<Parameter> parameters, StringBuffer output,
-      {required bool trailingComma,
-      String openBracket = '',
-      String closeBracket = '',
-      bool showMetadata = true,
-      bool showNames = true}) {
+    List<Parameter> parameters,
+    StringBuffer buffer, {
+    required bool trailingComma,
+    String openBracket = '',
+    String closeBracket = '',
+    bool showMetadata = true,
+    bool showNames = true,
+  }) {
     for (var p in parameters) {
       var prefix = '';
       var suffix = '';
@@ -149,37 +151,39 @@ abstract class ParameterRenderer {
       } else {
         suffix += ', ';
       }
-      var renderedParam = _renderParam(p,
-          prefix: prefix,
-          suffix: suffix,
-          showMetadata: showMetadata,
-          showNames: showNames);
-      output.write(listItem(parameter(renderedParam, p.htmlId)));
+      var renderedParameter = _renderParameter(
+        p,
+        prefix: prefix,
+        suffix: suffix,
+        showMetadata: showMetadata,
+        showNames: showNames,
+      );
+      buffer.write(listItem(parameter(renderedParameter, p.htmlId)));
     }
   }
 
-  String _renderParam(
+  String _renderParameter(
     Parameter param, {
     required String prefix,
     required String suffix,
     bool showMetadata = true,
     bool showNames = true,
   }) {
-    var buf = StringBuffer();
-    buf.write(prefix);
+    var buffer = StringBuffer();
+    buffer.write(prefix);
     var paramModelType = param.modelType;
 
     if (showMetadata && param.hasAnnotations) {
       for (var a in param.annotations) {
-        buf.write(annotation(a.linkedNameWithParameters));
-        buf.write(' ');
+        buffer.write(annotation(a.linkedNameWithParameters));
+        buffer.write(' ');
       }
     }
     if (param.isRequiredNamed) {
-      buf.write('${required('required')} ');
+      buffer.write('${required('required')} ');
     }
     if (param.isCovariant) {
-      buf.write('${covariant('covariant')} ');
+      buffer.write('${covariant('covariant')} ');
     }
     if (paramModelType is Callable) {
       String returnTypeName;
@@ -188,47 +192,51 @@ abstract class ParameterRenderer {
       } else {
         returnTypeName = paramModelType.returnType.linkedName;
       }
-      buf.write(typeName(returnTypeName));
+      buffer.write(typeName(returnTypeName));
       if (showNames) {
-        buf.write(' ${parameterName(param.name)}');
+        buffer.write(' ${parameterName(param.name)}');
       } else {
-        buf.write(' ${parameterName(paramModelType.name)}');
+        buffer.write(' ${parameterName(paramModelType.name)}');
       }
       if (!paramModelType.isTypedef && paramModelType is DefinedElementType) {
-        buf.write('(');
-        buf.write(renderLinkedParams(
-            (paramModelType as DefinedElementType).modelElement.parameters,
-            showMetadata: showMetadata,
-            showNames: showNames));
-        buf.write(')');
-        buf.write(paramModelType.nullabilitySuffix);
+        buffer.write('(');
+        buffer.write(renderLinkedParams(
+          (paramModelType as DefinedElementType).modelElement.parameters,
+          showMetadata: showMetadata,
+          showNames: showNames,
+        ));
+        buffer.write(')');
+        buffer.write(paramModelType.nullabilitySuffix);
       }
       if (!paramModelType.isTypedef) {
-        buf.write('(');
-        buf.write(renderLinkedParams(paramModelType.parameters,
-            showMetadata: showMetadata, showNames: showNames));
-        buf.write(')');
-        buf.write(paramModelType.nullabilitySuffix);
+        buffer.write('(');
+        buffer.write(renderLinkedParams(
+          paramModelType.parameters,
+          showMetadata: showMetadata,
+          showNames: showNames,
+        ));
+        buffer.write(')');
+        buffer.write(paramModelType.nullabilitySuffix);
       }
     } else {
       var linkedTypeName = paramModelType.linkedName;
       if (linkedTypeName.isNotEmpty) {
-        buf.write(typeName(linkedTypeName));
+        buffer.write(typeName(linkedTypeName));
         if (showNames && param.name.isNotEmpty) {
-          buf.write(' ');
+          buffer.write(' ');
         }
       }
       if (showNames && param.name.isNotEmpty) {
-        buf.write(parameterName(param.name));
+        buffer.write(parameterName(param.name));
       }
     }
 
     if (param.hasDefaultValue) {
-      buf.write(' = ');
-      buf.write(defaultValue(param.defaultValue!));
+      buffer.write(' = ');
+      buffer.write(defaultValue(param.defaultValue!));
     }
 
-    buf.write(suffix);
-    return buf.toString();
+    buffer.write(suffix);
+    return buffer.toString();
   }
 }

--- a/lib/src/render/typedef_renderer.dart
+++ b/lib/src/render/typedef_renderer.dart
@@ -16,7 +16,7 @@ abstract class TypedefRenderer {
   String renderLinkedGenericParameters(Typedef typedef);
 }
 
-/// A HTML renderer for a [Typedef].
+/// An HTML renderer for a [Typedef].
 class TypedefRendererHtml extends TypedefRenderer {
   const TypedefRendererHtml();
 

--- a/test/element_type_test.dart
+++ b/test/element_type_test.dart
@@ -1,0 +1,163 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
+import 'package:dartdoc/src/package_meta.dart';
+import 'package:test/test.dart';
+
+import 'src/test_descriptor_utils.dart' as d;
+import 'src/utils.dart';
+
+void main() {
+  const libraryName = 'element_types';
+
+  late PackageMetaProvider packageMetaProvider;
+  late MemoryResourceProvider resourceProvider;
+  late FakePackageConfigProvider packageConfigProvider;
+  late String packagePath;
+
+  Future<void> setUpPackage(
+    String name, {
+    String? pubspec,
+    String? analysisOptions,
+  }) async {
+    packagePath = await d.createPackage(
+      name,
+      pubspec: pubspec,
+      analysisOptions: analysisOptions,
+      resourceProvider: resourceProvider,
+    );
+
+    packageConfigProvider =
+        getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
+    packageConfigProvider.addPackageToConfigFor(
+        packagePath, name, Uri.file('$packagePath/'));
+  }
+
+  Future<Library> bootPackageWithLibrary(String libraryContent) async {
+    await d.dir('lib', [
+      d.file('lib.dart', '''
+library $libraryName;
+
+$libraryContent
+'''),
+    ]).createInMemory(resourceProvider, packagePath);
+
+    var packageGraph = await bootBasicPackage(
+      packagePath,
+      packageMetaProvider,
+      packageConfigProvider,
+    );
+    return packageGraph.libraries.named(libraryName);
+  }
+
+  group('interface type', () {
+    const libraryName = 'element_types';
+    const placeholder = '%%__HTMLBASE_dartdoc_internal__%%';
+    const linkPrefix = '$placeholder$libraryName';
+
+    setUp(() async {
+      packageMetaProvider = testPackageMetaProvider;
+      resourceProvider =
+          packageMetaProvider.resourceProvider as MemoryResourceProvider;
+      await setUpPackage(libraryName);
+    });
+
+    test('simple class has rendered names', () async {
+      var library = await bootPackageWithLibrary('''
+class C {}
+void f(C p) {}
+''');
+      var fFunction = library.functions.named('f');
+      var parameterType = fFunction.allParameters.single.modelType;
+
+      expect(parameterType.linkedName,
+          equals('<a href="$linkPrefix/C-class.html">C</a>'));
+      expect(parameterType.nameWithGenerics, equals('C'));
+    });
+
+    test('simple nullable class has rendered names', () async {
+      var library = await bootPackageWithLibrary('''
+class C {}
+void f(C? p) {}
+''');
+      var fFunction = library.functions.named('f');
+      var parameterType = fFunction.allParameters.single.modelType;
+
+      expect(parameterType.linkedName,
+          equals('<a href="$linkPrefix/C-class.html">C</a>?'));
+      expect(parameterType.nameWithGenerics, equals('C?'));
+    });
+
+    test('generic class, instantiated with a simple type, has rendered names',
+        () async {
+      var library = await bootPackageWithLibrary('''
+class C<T> {}
+void f(C<int> p) {}
+''');
+      var fFunction = library.functions.named('f');
+      var parameterType = fFunction.allParameters.single.modelType;
+
+      expect(
+        parameterType.linkedName,
+        '<a href="$linkPrefix/C-class.html">C</a>'
+        '<span class="signature">&lt;<wbr>'
+        '<span class="type-parameter"><a href="https://api.dart.dev/stable/2.16.0/dart-core/int-class.html">int</a></span>&gt;</span>',
+      );
+      expect(
+        parameterType.nameWithGenerics,
+        equals('C&lt;<wbr><span class="type-parameter">int</span>&gt;'),
+      );
+    });
+
+    test(
+        'generic class, instantiated with a simple nullable type, has a linked '
+        'name', () async {
+      var library = await bootPackageWithLibrary('''
+class C<T> {}
+void f(C<int?> p) {}
+''');
+      var fFunction = library.functions.named('f');
+      var parameterType = fFunction.allParameters.single.modelType;
+
+      expect(
+        parameterType.linkedName,
+        '<a href="$linkPrefix/C-class.html">C</a>'
+        '<span class="signature">&lt;<wbr>'
+        '<span class="type-parameter">'
+        '<a href="https://api.dart.dev/stable/2.16.0/dart-core/int-class.html">int</a>?</span>&gt;</span>',
+      );
+    });
+
+    test('generic class, instantiated with a type variable, has a linked name',
+        () async {
+      var library = await bootPackageWithLibrary('''
+class C<T> {}
+void f<T>(C<T> p) {}
+''');
+      var fFunction = library.functions.named('f');
+      var parameterType = fFunction.allParameters.single.modelType;
+
+      expect(
+        parameterType.linkedName,
+        '<a href="$linkPrefix/C-class.html">C</a>'
+        '<span class="signature">&lt;<wbr>'
+        '<span class="type-parameter">T</span>&gt;</span>',
+      );
+    });
+
+    test('"dynamic" type has rendered names', () async {
+      var library = await bootPackageWithLibrary('''
+void f(dynamic p) {}
+''');
+      var fFunction = library.functions.named('f');
+      var parameterType = fFunction.allParameters.single.modelType;
+
+      expect(parameterType.linkedName, equals('dynamic'));
+      expect(parameterType.nameWithGenerics, equals('dynamic'));
+    });
+  });
+}

--- a/test/element_type_test.dart
+++ b/test/element_type_test.dart
@@ -5,17 +5,24 @@
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
-import 'package:dartdoc/src/package_meta.dart';
 import 'package:test/test.dart';
 
 import 'src/test_descriptor_utils.dart' as d;
 import 'src/utils.dart';
 
-void main() {
+void main() async {
   const libraryName = 'element_types';
+  const placeholder = '%%__HTMLBASE_dartdoc_internal__%%';
+  const linkPrefix = '$placeholder$libraryName';
 
-  late PackageMetaProvider packageMetaProvider;
-  late MemoryResourceProvider resourceProvider;
+  const intLink =
+      '<a href="https://api.dart.dev/stable/2.16.0/dart-core/int-class.html">int</a>';
+  const stringLink =
+      '<a href="https://api.dart.dev/stable/2.16.0/dart-core/String-class.html">String</a>';
+
+  final packageMetaProvider = testPackageMetaProvider;
+  final resourceProvider =
+      packageMetaProvider.resourceProvider as MemoryResourceProvider;
   late FakePackageConfigProvider packageConfigProvider;
   late String packagePath;
 
@@ -46,7 +53,7 @@ $libraryContent
 '''),
     ]).createInMemory(resourceProvider, packagePath);
 
-    var packageGraph = await bootBasicPackage(
+    final packageGraph = await bootBasicPackage(
       packagePath,
       packageMetaProvider,
       packageConfigProvider,
@@ -54,25 +61,16 @@ $libraryContent
     return packageGraph.libraries.named(libraryName);
   }
 
+  await setUpPackage(libraryName);
+
   group('interface type', () {
-    const libraryName = 'element_types';
-    const placeholder = '%%__HTMLBASE_dartdoc_internal__%%';
-    const linkPrefix = '$placeholder$libraryName';
-
-    setUp(() async {
-      packageMetaProvider = testPackageMetaProvider;
-      resourceProvider =
-          packageMetaProvider.resourceProvider as MemoryResourceProvider;
-      await setUpPackage(libraryName);
-    });
-
     test('simple class has rendered names', () async {
-      var library = await bootPackageWithLibrary('''
+      final library = await bootPackageWithLibrary('''
 class C {}
 void f(C p) {}
 ''');
-      var fFunction = library.functions.named('f');
-      var parameterType = fFunction.allParameters.single.modelType;
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
 
       expect(parameterType.linkedName,
           equals('<a href="$linkPrefix/C-class.html">C</a>'));
@@ -80,12 +78,12 @@ void f(C p) {}
     });
 
     test('simple nullable class has rendered names', () async {
-      var library = await bootPackageWithLibrary('''
+      final library = await bootPackageWithLibrary('''
 class C {}
 void f(C? p) {}
 ''');
-      var fFunction = library.functions.named('f');
-      var parameterType = fFunction.allParameters.single.modelType;
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
 
       expect(parameterType.linkedName,
           equals('<a href="$linkPrefix/C-class.html">C</a>?'));
@@ -94,18 +92,18 @@ void f(C? p) {}
 
     test('generic class, instantiated with a simple type, has rendered names',
         () async {
-      var library = await bootPackageWithLibrary('''
+      final library = await bootPackageWithLibrary('''
 class C<T> {}
 void f(C<int> p) {}
 ''');
-      var fFunction = library.functions.named('f');
-      var parameterType = fFunction.allParameters.single.modelType;
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
 
       expect(
         parameterType.linkedName,
         '<a href="$linkPrefix/C-class.html">C</a>'
         '<span class="signature">&lt;<wbr>'
-        '<span class="type-parameter"><a href="https://api.dart.dev/stable/2.16.0/dart-core/int-class.html">int</a></span>&gt;</span>',
+        '<span class="type-parameter">$intLink</span>&gt;</span>',
       );
       expect(
         parameterType.nameWithGenerics,
@@ -116,30 +114,29 @@ void f(C<int> p) {}
     test(
         'generic class, instantiated with a simple nullable type, has a linked '
         'name', () async {
-      var library = await bootPackageWithLibrary('''
+      final library = await bootPackageWithLibrary('''
 class C<T> {}
 void f(C<int?> p) {}
 ''');
-      var fFunction = library.functions.named('f');
-      var parameterType = fFunction.allParameters.single.modelType;
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
 
       expect(
         parameterType.linkedName,
         '<a href="$linkPrefix/C-class.html">C</a>'
         '<span class="signature">&lt;<wbr>'
-        '<span class="type-parameter">'
-        '<a href="https://api.dart.dev/stable/2.16.0/dart-core/int-class.html">int</a>?</span>&gt;</span>',
+        '<span class="type-parameter">$intLink?</span>&gt;</span>',
       );
     });
 
     test('generic class, instantiated with a type variable, has a linked name',
         () async {
-      var library = await bootPackageWithLibrary('''
+      final library = await bootPackageWithLibrary('''
 class C<T> {}
 void f<T>(C<T> p) {}
 ''');
-      var fFunction = library.functions.named('f');
-      var parameterType = fFunction.allParameters.single.modelType;
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
 
       expect(
         parameterType.linkedName,
@@ -148,16 +145,97 @@ void f<T>(C<T> p) {}
         '<span class="type-parameter">T</span>&gt;</span>',
       );
     });
+  });
 
+  group('function type', () {
+    test('simple function type has rendered names', () async {
+      final library = await bootPackageWithLibrary('''
+void f(int Function(String) p) {}
+''');
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
+
+      expect(
+        parameterType.linkedName,
+        '$intLink Function'
+        '<span class="signature">'
+        '(<span class="parameter" id="param-">'
+        '<span class="type-annotation">$stringLink</span>'
+        '</span>)</span>',
+      );
+      expect(parameterType.nameWithGenerics, equals('Function'));
+    });
+
+    test('nullable function type has rendered names', () async {
+      final library = await bootPackageWithLibrary('''
+void f(int Function(String)? p) {}
+''');
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
+
+      expect(
+        parameterType.linkedName,
+        // TODO(https://github.com/dart-lang/dartdoc/issues/2381): Fix.
+        '($intLink Function?'
+        '<span class="signature">'
+        '(<span class="parameter" id="param-">'
+        '<span class="type-annotation">$stringLink</span>'
+        '</span>)</span>?)',
+      );
+      expect(parameterType.nameWithGenerics, equals('Function?'));
+    });
+
+    test('generic function type has rendered names', () async {
+      final library = await bootPackageWithLibrary('''
+void f(int Function(String) p) {}
+''');
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
+
+      expect(
+        parameterType.linkedName,
+        '$intLink Function'
+        '<span class="signature">'
+        '(<span class="parameter" id="param-">'
+        '<span class="type-annotation">$stringLink</span>'
+        '</span>)</span>',
+      );
+      expect(parameterType.nameWithGenerics, equals('Function'));
+    });
+  });
+
+  group('other types', () {
     test('"dynamic" type has rendered names', () async {
-      var library = await bootPackageWithLibrary('''
+      final library = await bootPackageWithLibrary('''
 void f(dynamic p) {}
 ''');
-      var fFunction = library.functions.named('f');
-      var parameterType = fFunction.allParameters.single.modelType;
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
 
       expect(parameterType.linkedName, equals('dynamic'));
       expect(parameterType.nameWithGenerics, equals('dynamic'));
+    });
+
+    test('"Never" type has rendered names', () async {
+      final library = await bootPackageWithLibrary('''
+void f(Never p) {}
+''');
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
+
+      expect(parameterType.linkedName, equals('Never'));
+      expect(parameterType.nameWithGenerics, equals('Never'));
+    });
+
+    test('"void" type has rendered names', () async {
+      final library = await bootPackageWithLibrary('''
+void f(void p) {}
+''');
+      final fFunction = library.functions.named('f');
+      final parameterType = fFunction.parameters.single.modelType;
+
+      expect(parameterType.linkedName, equals('void'));
+      expect(parameterType.nameWithGenerics, equals('void'));
     });
   });
 }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -444,51 +444,25 @@ void main() {
     test('complex nullable elements are detected and rendered correctly', () {
       var complexNullableMembers = nullableElements.allClasses
           .firstWhere((c) => c.name == 'ComplexNullableMembers');
-      var aComplexType = complexNullableMembers.allFields
-          .firstWhere((f) => f.name == 'aComplexType');
-      var aComplexSetterOnlyType = complexNullableMembers.allFields
-          .firstWhere((f) => f.name == 'aComplexSetterOnlyType');
       expect(complexNullableMembers.isNullSafety, isTrue);
       expect(
           complexNullableMembers.nameWithGenerics,
           equals(
               'ComplexNullableMembers&lt;<wbr><span class="type-parameter">T extends String?</span>&gt;'));
-      expect(
-          aComplexType.modelType.linkedName,
-          equals(
-              'Map<span class="signature">&lt;<wbr><span class="type-parameter">T?</span>, <span class="type-parameter">String?</span>&gt;</span>'));
-      expect(
-          aComplexSetterOnlyType.modelType.linkedName,
-          equals(
-              'List<span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">T?</span>, <span class="type-parameter">String?</span>&gt;</span>?</span>&gt;</span>'));
     });
 
     test('simple nullable elements are detected and rendered correctly', () {
       var nullableMembers = nullableElements.allClasses
           .firstWhere((c) => c.name == 'NullableMembers');
-      var initialized =
-          nullableMembers.allFields.firstWhere((f) => f.name == 'initialized');
-      var nullableField = nullableMembers.allFields
-          .firstWhere((f) => f.name == 'nullableField');
       var methodWithNullables = nullableMembers.publicInstanceMethods
           .firstWhere((f) => f.name == 'methodWithNullables');
       var operatorStar = nullableMembers.publicInstanceOperators
           .firstWhere((f) => f.name == 'operator *');
       expect(nullableMembers.isNullSafety, isTrue);
       expect(
-          nullableField.modelType.linkedName,
-          equals(
-              'Iterable<span class="signature">&lt;<wbr><span class="type-parameter">BigInt</span>&gt;</span>?'));
-      expect(
           methodWithNullables.linkedParams,
           equals(
               '<span class="parameter" id="methodWithNullables-param-foo"><span class="type-annotation">String?</span> <span class="parameter-name">foo</span></span>'));
-      expect(
-          methodWithNullables.modelType.returnType.linkedName, equals('int?'));
-      expect(
-          initialized.modelType.linkedName,
-          equals(
-              'Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">Map</span>&gt;</span>?'));
       expect(
           operatorStar.linkedParams,
           equals(
@@ -1995,7 +1969,7 @@ void main() {
 
   group('Class', () {
     late final List<Class> classes;
-    late final Class Apple, B, Cat, Cool, Dog, F, Dep, SpecialList;
+    late final Class Apple, B, Cat, Dog, F, Dep, SpecialList;
     late final Class ExtendingClass, CatString;
 
     setUpAll(() {
@@ -2006,7 +1980,6 @@ void main() {
       Dog = classes.firstWhere((c) => c.name == 'Dog');
       F = classes.firstWhere((c) => c.name == 'F');
       Dep = classes.firstWhere((c) => c.name == 'Deprecated');
-      Cool = classes.firstWhere((c) => c.name == 'Cool');
       SpecialList =
           fakeLibrary.classes.firstWhere((c) => c.name == 'SpecialList');
       ExtendingClass =
@@ -2153,17 +2126,6 @@ void main() {
           equals('${htmlBasePlaceholder}ex/Deprecated/toString.html'));
       expect(Dep.instanceFields.firstWhere((m) => m.name == 'expires').href,
           equals('${htmlBasePlaceholder}ex/Deprecated/expires.html'));
-    });
-
-    test(
-        'exported class should have modelType.returnType.linkedName for the current library',
-        () {
-      var returnCool =
-          Cool.instanceMethods.firstWhere((m) => m.name == 'returnCool');
-      expect(
-          returnCool.modelType.returnType.linkedName,
-          equals(
-              '<a href="${htmlBasePlaceholder}fake/Cool-class.html">Cool</a>'));
     });
 
     test('F has a single instance method', () {
@@ -3199,7 +3161,6 @@ void main() {
     late final ModelFunction thisIsAsync;
     late final ModelFunction thisIsFutureOr;
     late final ModelFunction thisIsFutureOrNull;
-    late final ModelFunction thisIsFutureOrT;
     late final ModelFunction topLevelFunction;
     late final ModelFunction typeParamOfFutureOr;
     late final ModelFunction doAComplicatedThing;
@@ -3216,8 +3177,6 @@ void main() {
           fakeLibrary.functions.firstWhere((f) => f.name == 'thisIsFutureOr');
       thisIsFutureOrNull = fakeLibrary.functions
           .firstWhere((f) => f.name == 'thisIsFutureOrNull');
-      thisIsFutureOrT =
-          fakeLibrary.functions.firstWhere((f) => f.name == 'thisIsFutureOrT');
       topLevelFunction =
           fakeLibrary.functions.firstWhere((f) => f.name == 'topLevelFunction');
       typeParamOfFutureOr = fakeLibrary.functions
@@ -3261,7 +3220,6 @@ void main() {
 
     test('async function', () {
       expect(thisIsAsync.isAsynchronous, isTrue);
-      expect(thisIsAsync.modelType.returnType.linkedName, equals('dynamic'));
       expect(
           thisIsAsync.documentation,
           equals(
@@ -3274,24 +3232,14 @@ void main() {
 
     test('function returning FutureOr', () {
       expect(thisIsFutureOr.isAsynchronous, isFalse);
-      expect(
-          thisIsFutureOr.modelType.returnType.linkedName, equals('FutureOr'));
     });
 
     test('function returning FutureOr<Null>', () {
       expect(thisIsFutureOrNull.isAsynchronous, isFalse);
-      expect(
-          thisIsFutureOrNull.modelType.returnType.linkedName,
-          equals(
-              'FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">Null</span>&gt;</span>'));
     });
 
     test('function returning FutureOr<T>', () {
       expect(thisIsFutureOrNull.isAsynchronous, isFalse);
-      expect(
-          thisIsFutureOrT.modelType.returnType.linkedName,
-          equals(
-              'FutureOr<span class="signature">&lt;<wbr><span class="type-parameter">T</span>&gt;</span>?'));
     });
 
     test('function with a parameter having type FutureOr<Null>', () {
@@ -3393,15 +3341,6 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
               r'dynamic Function<span class="signature">\(<span class="parameter" id="(f-)?param-bar"><span class="type-annotation">int</span> <span class="parameter-name">bar</span>, </span><span class="parameter" id="(f-)?param-baz"><span class="type-annotation"><a href="%%__HTMLBASE_dartdoc_internal__%%fake/Cool-class.html">Cool</a></span> <span class="parameter-name">baz</span>, </span><span class="parameter" id="(f-)?param-macTruck"><span class="type-annotation">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span> <span class="parameter-name">macTruck</span></span>\)</span>')));
     });
 
-    test('parameterized type from field is correctly displayed', () {
-      var aField = TemplatedInterface.instanceFields
-          .singleWhere((f) => f.name == 'aField');
-      expect(
-          aField.modelType.linkedName,
-          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a>'
-          '<span class="signature">&lt;<wbr><span class="type-parameter">Stream<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span></span>&gt;</span>?');
-    });
-
     test('parameterized type from inherited field is correctly displayed', () {
       var aInheritedField = TemplatedInterface.inheritedFields
           .singleWhere((f) => f.name == 'aInheritedField');
@@ -3409,16 +3348,6 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
           aInheritedField.modelType.linkedName,
           '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a>'
           '<span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>?');
-    });
-
-    test(
-        'parameterized type for return value from explicit getter is correctly displayed',
-        () {
-      Accessor aGetter = TemplatedInterface.instanceFields
-          .singleWhere((f) => f.name == 'aGetter')
-          .getter!;
-      expect(aGetter.modelType.returnType.linkedName,
-          '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">Map<span class="signature">&lt;<wbr><span class="type-parameter">A</span>, <span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">String</span>&gt;</span></span>&gt;</span></span>&gt;</span>');
     });
 
     test(

--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -102,7 +102,6 @@ abstract class TemplatedInterface<A> implements ParameterizedClass<List<int>> {
   AnotherParameterizedClass<List<int>> aMethodInterface(A value);
   ParameterizedTypedef<List<String>> aTypedefReturningMethodInterface();
   AnotherParameterizedClass<Stream<List<int>>>? aField;
-  AnotherParameterizedClass<Map<A, List<String>>> get aGetter;
   set aSetter(AnotherParameterizedClass<List<bool>> thingToSet);
 }
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -310,10 +310,7 @@ typedef int LotsAndLotsOfParameters(so, many, parameters, it, should, wrap,
     when, converted, to, html, documentation);
 
 /// This class is cool!
-class Cool {
-  // ignore: body_might_complete_normally
-  Cool returnCool() {}
-}
+class Cool {}
 
 /// A map initialization making use of optional const.
 const Map<int, String> myMap = {1: "hello"};
@@ -816,9 +813,6 @@ FutureOr thisIsFutureOr() => null;
 
 /// Explicitly return a `FutureOr<Null>`.
 FutureOr<Null> thisIsFutureOrNull() => null;
-
-/// Explicitly return a `FutureOr<T>`.
-FutureOr<T>? thisIsFutureOrT<T>() => null;
 
 /// Has a parameter explicitly typed `FutureOr<Null>`.
 void paramOfFutureOrNull(FutureOr<Null> future) {}

--- a/testing/test_package/lib/features/nullable_elements.dart
+++ b/testing/test_package/lib/features/nullable_elements.dart
@@ -30,12 +30,7 @@ Never? almostNeverReturns() {}
 void some(int? nullable, String? parameters) {}
 
 class NullableMembers {
-  final Map<String, Map>? initialized;
-
-  /// Nullable constructor parameters.
-  NullableMembers(this.initialized);
-
-  Iterable<BigInt>? nullableField;
+  NullableMembers();
 
   operator *(NullableMembers? nullableOther) => this;
 
@@ -43,9 +38,5 @@ class NullableMembers {
 }
 
 class ComplexNullableMembers<T extends String?> {
-  Map<T?, String?> aComplexType = <T?, String?>{null: null};
-
-  void set aComplexSetterOnlyType(List<Map<T?, String?>?> value) => null;
-
   X? aMethod<X extends T?>(X? f) => null;
 }

--- a/testing/test_package/lib/src/shadowing_lib.dart
+++ b/testing/test_package/lib/src/shadowing_lib.dart
@@ -1,7 +1,5 @@
 library shadowing_lib;
 
-class ADuplicateClass {
-  bool get aGetter => true;
-}
+class ADuplicateClass {}
 
 class SomeMoreClassDeclaration {}


### PR DESCRIPTION
This is a big ball of... related... work. The two big pieces:

* Introduced two abstract classes, `ElementTypeRendererHtml` and `ElementTypeRendererMd`, which include a shared `_renderLinkedName` and `_renderNameWithGenerics` implementation. There was a lot of piecemeal HTML-string building which seemed fragile.
* Introduce unit tests for how various types get printed. This is needed in order to support record types. (I removed some duplicate test work from model_test.dart, which is an end-to-end test.)

Smaller work:

* `ModelElement.allParameters` - not even sure what this is for; it recursively walks parameter lists for function-typed parameters? Maybe it is just for referenceChildren, which is legit. Anyways, tidied.
* `ElementTypeRenderer.wrapNullability` - deprecated; more efficient to add to StringBuilder.
* Standardize on `StringBuffer` variables being named `buffer`, rather than `buf` or `output`. It was confusing to see different variable names.
* Standardize on variables being named `parameter` rather than sometimes `param`.
* Use cascades where possible.