### PR TITLE
Remove ModelElement.allParameters

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -9624,18 +9624,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                 ..._Renderer_FeatureSet.propertyMap<CT_>(),
                 ..._Renderer_DocumentationComment.propertyMap<CT_>(),
                 ..._Renderer_ModelBuilder.propertyMap<CT_>(),
-                'allParameters': Property(
-                  getValue: (CT_ c) => c.allParameters,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'List<Parameter>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.allParameters.map((e) =>
-                        _render_Parameter(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'annotations': Property(
                   getValue: (CT_ c) => c.annotations,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -110,11 +110,9 @@ class Constructor extends ModelElement
       }
     }
 
-    var parameterElements = allParameters.map((param) {
-      var paramElement = dereferenceParameter(param.element);
-      return paramElement == null
-          ? param
-          : modelBuilder.fromElement(paramElement);
+    var parameterElements = parameters.map((parameter) {
+      var element = dereferenceParameter(parameter.element);
+      return element == null ? parameter : modelBuilder.fromElement(element);
     });
     return {
       for (var element in parameterElements) element.referenceName: element,

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -136,7 +136,7 @@ class Method extends ModelElement
     return _referenceChildren ??= <String, CommentReferable>{
       ...modelType.returnType.typeArguments.explicitOnCollisionWith(this),
       ...modelType.typeArguments.explicitOnCollisionWith(this),
-      ...allParameters.explicitOnCollisionWith(this),
+      ...parameters.explicitOnCollisionWith(this),
       ...typeParameters.explicitOnCollisionWith(this),
     };
   }

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -15,7 +15,6 @@ import 'package:analyzer/src/dart/element/member.dart'
     show ExecutableMember, Member, ParameterMember;
 import 'package:collection/collection.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
-import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/annotation.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/feature.dart';
@@ -827,36 +826,6 @@ abstract class ModelElement extends Canonicalization
   Package get package => library.package;
 
   bool get isPublicAndPackageDocumented => isPublic && package.isDocumented;
-
-  // TODO(jcollins-g): This is in the wrong place.  Move parts to
-  // [GetterSetterCombo], elsewhere as appropriate?
-  late final List<Parameter> allParameters = () {
-    var recursedParameters = <Parameter>{};
-    var newParameters = <Parameter>{};
-    final self = this;
-    if (self is GetterSetterCombo && self.setter != null) {
-      newParameters.addAll(self.setter!.parameters);
-    } else {
-      if (isCallable) newParameters.addAll(parameters);
-    }
-    // TODO(jcollins-g): This part probably belongs in [ElementType].
-    while (newParameters.isNotEmpty) {
-      recursedParameters.addAll(newParameters);
-      newParameters.clear();
-      for (var p in recursedParameters) {
-        var parameterModelType = p.modelType;
-        if (parameterModelType is Callable) {
-          newParameters.addAll(parameterModelType.parameters
-              .where((pm) => !recursedParameters.contains(pm)));
-        }
-        if (parameterModelType is AliasedElementType) {
-          newParameters.addAll(parameterModelType.aliasedParameters
-              .where((pm) => !recursedParameters.contains(pm)));
-        }
-      }
-    }
-    return recursedParameters.toList(growable: false);
-  }();
 
   @override
   p.Context get pathContext => packageGraph.resourceProvider.pathContext;

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -341,8 +341,8 @@ void main() {
 
     test('method parameters with required', () {
       var m1 = b.instanceMethods.firstWhere((m) => m.name == 'm1');
-      var p1 = m1.allParameters.firstWhere((p) => p.name == 'p1');
-      var p2 = m1.allParameters.firstWhere((p) => p.name == 'p2');
+      var p1 = m1.parameters.firstWhere((p) => p.name == 'p1');
+      var p2 = m1.parameters.firstWhere((p) => p.name == 'p2');
       expect(p1.isRequiredNamed, isTrue);
       expect(p2.isRequiredNamed, isFalse);
       expect(p2.isNamed, isTrue);
@@ -362,8 +362,8 @@ void main() {
 
     test('verify no regression on ordinary optionals', () {
       var m2 = b.instanceMethods.firstWhere((m) => m.name == 'm2');
-      var sometimes = m2.allParameters.firstWhere((p) => p.name == 'sometimes');
-      var optionals = m2.allParameters.firstWhere((p) => p.name == 'optionals');
+      var sometimes = m2.parameters.firstWhere((p) => p.name == 'sometimes');
+      var optionals = m2.parameters.firstWhere((p) => p.name == 'optionals');
       expect(sometimes.isRequiredNamed, isFalse);
       expect(sometimes.isRequiredPositional, isTrue);
       expect(sometimes.isOptionalPositional, isFalse);
@@ -383,8 +383,8 @@ void main() {
 
     test('anonymous callback parameters are correctly marked as nullable', () {
       var m3 = c.instanceMethods.firstWhere((m) => m.name == 'm3');
-      var listen = m3.allParameters.firstWhere((p) => p.name == 'listen');
-      var onDone = m3.allParameters.firstWhere((p) => p.name == 'onDone');
+      var listen = m3.parameters.firstWhere((p) => p.name == 'listen');
+      var onDone = m3.parameters.firstWhere((p) => p.name == 'onDone');
       expect(listen.isRequiredPositional, isTrue);
       expect(onDone.isNamed, isTrue);
 
@@ -2559,7 +2559,7 @@ void main() {
             (c) => c.name == 'BaseForDocComments.aNonDefaultConstructor');
         defaultConstructor = baseForDocComments.constructors
             .firstWhere((c) => c.name == 'BaseForDocComments');
-        somethingShadowyParameter = defaultConstructor.allParameters
+        somethingShadowyParameter = defaultConstructor.parameters
             .firstWhere((p) => p.name == 'somethingShadowy');
         initializeMe = baseForDocComments.allFields
             .firstWhere((f) => f.name == 'initializeMe');
@@ -2623,14 +2623,14 @@ void main() {
         factoryConstructorThingsDefault = FactoryConstructorThings.constructors
             .firstWhere((c) => c.name == 'FactoryConstructorThings');
 
-        aName = anotherName.allParameters.firstWhere((p) => p.name == 'aName');
-        anotherNameParameter = anotherName.allParameters
-            .firstWhere((p) => p.name == 'anotherName');
-        anotherDifferentName = anotherName.allParameters
+        aName = anotherName.parameters.firstWhere((p) => p.name == 'aName');
+        anotherNameParameter =
+            anotherName.parameters.firstWhere((p) => p.name == 'anotherName');
+        anotherDifferentName = anotherName.parameters
             .firstWhere((p) => p.name == 'anotherDifferentName');
-        differentName = anotherName.allParameters
-            .firstWhere((p) => p.name == 'differentName');
-        redHerring = anotherConstructor.allParameters
+        differentName =
+            anotherName.parameters.firstWhere((p) => p.name == 'differentName');
+        redHerring = anotherConstructor.parameters
             .firstWhere((p) => p.name == 'redHerring');
 
         aNameField = FactoryConstructorThings.allFields
@@ -2643,7 +2643,7 @@ void main() {
         aMethod = FactoryConstructorThings.instanceMethods
             .firstWhere((m) => m.name == 'aMethod');
         yetAnotherName =
-            aMethod.allParameters.firstWhere((p) => p.name == 'yetAnotherName');
+            aMethod.parameters.firstWhere((p) => p.name == 'yetAnotherName');
       });
 
       group('Parameter references work properly', () {
@@ -3366,7 +3366,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
       Accessor aInheritedSetter = TemplatedInterface.inheritedFields
           .singleWhere((f) => f.name == 'aInheritedSetter')
           .setter!;
-      expect(aInheritedSetter.allParameters.first.modelType.linkedName,
+      expect(aInheritedSetter.parameters.first.modelType.linkedName,
           '<a href="${htmlBasePlaceholder}ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');
       expect(aInheritedSetter.enclosingCombo.modelType.linkedName,
           '<a href="%%__HTMLBASE_dartdoc_internal__%%ex/AnotherParameterizedClass-class.html">AnotherParameterizedClass</a><span class="signature">&lt;<wbr><span class="type-parameter">List<span class="signature">&lt;<wbr><span class="type-parameter">int</span>&gt;</span></span>&gt;</span>');


### PR DESCRIPTION
I think this only allowed nested parameters, in function-typed parameters, to be referenced without prefix. But there is nothing to link to, and this is unnecessarily generous. If we want to allow this, for some reason, in the future, we can use a dotted syntax.