### PR TITLE
Add GitHub light/dark mode image syntax

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -88,6 +88,18 @@
   cursor: pointer;
 }
 
+/*
+Only show images that fit their theme using GitHub's syntax, see:
+https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/
+*/
+.dark-theme img[src$="#gh-light-mode-only"] {
+  display: none;
+}
+
+.light-theme img[src$="#gh-dark-mode-only"] {
+  display: none;
+}
+
 /* for layout */
 html,
 body {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3145

This PR adds some simple css to support GitHub's image light/dark mode syntax:

```dart
/// ![](https://i.imgur.com/GSrsRgB.png#gh-light-mode-only)
/// ![](https://i.imgur.com/Cy4P87R.png#gh-dark-mode-only)
library doc_test;
```

https://user-images.githubusercontent.com/2466461/191844025-03f63e95-7704-4a5d-a58d-20f80fe7a801.mp4