### PR TITLE
tool/grind.dart: cleanup directory signature calculation

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:io' hide ProcessException;
 
 import 'package:analyzer/file_system/physical_file_system.dart';
+import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -1037,7 +1038,7 @@ Future<void> buildWeb() async {
   ]);
   delete(File('lib/resources/docs.dart.js.deps'));
 
-  final compileSig = calcDartFilesSig(Directory('web'));
+  final compileSig = await _calcDartFilesSig(Directory('web'));
   File(p.join('web', 'sig.txt')).writeAsStringSync('$compileSig\n');
 }
 
@@ -1088,7 +1089,7 @@ Future<void> checkBuild() async {
   }
 
   // Verify that the web frontend has been compiled.
-  final currentCodeSig = calcDartFilesSig(Directory('web'));
+  final currentCodeSig = await _calcDartFilesSig(Directory('web'));
   final lastCompileSig =
       File(p.join('web', 'sig.txt')).readAsStringSync().trim();
   if (currentCodeSig != lastCompileSig) {
@@ -1314,46 +1315,29 @@ int _findCount(String str, String match) {
   return count;
 }
 
-String calcDartFilesSig(Directory dir) {
-  final files = dir
-      .listSync(recursive: true)
-      .whereType<File>()
-      .where((file) => file.path.endsWith('.dart'))
-      .toList();
-  files.sort((a, b) => a.path.toLowerCase().compareTo(b.path.toLowerCase()));
+Future<String> _calcDartFilesSig(Directory dir) async {
+  final digest = await _dartFileLines(dir)
+      .transform(utf8.encoder)
+      .transform(crypto.md5)
+      .single;
 
-  var output = AccumulatorSink<crypto.Digest>();
-  var input = crypto.md5.startChunkedConversion(output);
-  for (var file in files) {
-    for (var line in file.readAsLinesSync()) {
-      input.add(utf8.encoder.convert(line.trim()));
-    }
-  }
-  input.close();
-
-  var result = output.events.single;
-  return result.bytes
+  return digest.bytes
       .map((byte) => byte.toRadixString(16).padLeft(2, '0').toUpperCase())
       .join();
 }
 
-class AccumulatorSink<T> implements Sink<T> {
-  List<T> get events => _events;
-  final _events = <T>[];
+/// Yields all of the trimmed lines of all of the `.dart` files in [dir].
+Stream<String> _dartFileLines(Directory dir) async* {
+  final files = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.dart'))
+      .toList()
+    ..sort((a, b) => compareAsciiLowerCase(a.path, b.path));
 
-  var _isClosed = false;
-
-  @override
-  void add(T event) {
-    if (_isClosed) {
-      throw StateError("Can't add to a closed sink.");
+  for (var file in files) {
+    for (var line in file.readAsLinesSync()) {
+      yield line.trim();
     }
-
-    _events.add(event);
-  }
-
-  @override
-  void close() {
-    _isClosed = true;
   }
 }


### PR DESCRIPTION
Use better conventions for stream processing
Drop now unneeded AccumulatorSink
