### PR TITLE
Fix enclosingCombo initialization issue

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -17,8 +17,12 @@ import 'package:dartdoc/src/warnings.dart';
 /// Getters and setters.
 class Accessor extends ModelElement implements EnclosedElement {
   /// The combo ([Field] or [TopLevelVariable]) containing this accessor.
-  /// Initialized by the combo's constructor.
-  late final GetterSetterCombo enclosingCombo;
+  ///
+  /// Initialized in [Field]'s constructor and in [TopLevelVariable]'s
+  /// constructor.
+  // TODO(srawlins): This might be super fragile. This field should somehow be
+  // initialized by code inside this library.
+  late GetterSetterCombo enclosingCombo;
 
   Accessor(
       PropertyAccessorElement super.element, super.library, super.packageGraph,

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -20,8 +20,8 @@ class Field extends ModelElement
   Field(FieldElement super.element, super.library, super.packageGraph,
       this.getter, this.setter)
       : assert(getter != null || setter != null) {
-    if (getter != null) getter!.enclosingCombo = this;
-    if (setter != null) setter!.enclosingCombo = this;
+    getter?.enclosingCombo = this;
+    setter?.enclosingCombo = this;
   }
 
   factory Field.inherited(

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -875,7 +875,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
         modelElement = null;
       }
     }
-    // Prefer Fields.
+    // Prefer fields and top-level variables.
     if (e is PropertyAccessorElement && modelElement is Accessor) {
       modelElement = modelElement.enclosingCombo;
     }

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -18,12 +18,8 @@ class TopLevelVariable extends ModelElement
 
   TopLevelVariable(TopLevelVariableElement super.element, super.library,
       super.packageGraph, this.getter, this.setter) {
-    if (getter != null) {
-      getter!.enclosingCombo = this;
-    }
-    if (setter != null) {
-      setter!.enclosingCombo = this;
-    }
+    getter?.enclosingCombo = this;
+    setter?.enclosingCombo = this;
   }
 
   @override


### PR DESCRIPTION
Accessor.enclosingCombo is initialized in a fragile way. We should initialize it within the library, but for now it is initialized in Field and TopLevelVariable constructors.

This protects an un "initialized" Accessor created in CommentReferable by first creating the element for the enclosing variable.

Fixes https://github.com/dart-lang/dartdoc/issues/3210 