### PR TITLE
Refactor ModelElement.element to be a getter; subclasses provide the field

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2970,28 +2970,6 @@ class _Renderer_Container extends RendererBase<Container> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isMixin == true,
                 ),
-                'package': Property(
-                  getValue: (CT_ c) => c.package,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Package.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Package,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_Package(c.package, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'publicConstantFields': Property(
                   getValue: (CT_ c) => c.publicConstantFields,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -4358,6 +4336,19 @@ class _Renderer_Enum extends RendererBase<Enum> {
                         _render_Field(e, ast, r.template, sink, parent: r));
                   },
                 ),
+                'element': Property(
+                  getValue: (CT_ c) => c.element,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'EnumElement'),
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    renderSimple(c.element, ast, r.template, sink,
+                        parent: r, getters: _invisibleGetters['EnumElement']!);
+                  },
+                ),
                 'hasPublicEnumValues': Property(
                   getValue: (CT_ c) => c.hasPublicEnumValues,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -5376,6 +5367,19 @@ class _Renderer_Field extends RendererBase<Field> {
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.documentation, ast, r.template, sink,
                         parent: r);
+                  },
+                ),
+                'element': Property(
+                  getValue: (CT_ c) => c.element,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'FieldElement'),
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    renderSimple(c.element, ast, r.template, sink,
+                        parent: r, getters: _invisibleGetters['FieldElement']!);
                   },
                 ),
                 'enclosingElement': Property(
@@ -12198,13 +12202,13 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -14321,6 +14325,20 @@ class _Renderer_TopLevelVariable extends RendererBase<TopLevelVariable> {
                         parent: r);
                   },
                 ),
+                'element': Property(
+                  getValue: (CT_ c) => c.element,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'TopLevelVariableElement'),
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    renderSimple(c.element, ast, r.template, sink,
+                        parent: r,
+                        getters: _invisibleGetters['TopLevelVariableElement']!);
+                  },
+                ),
                 'enclosingElement': Property(
                   getValue: (CT_ c) => c.enclosingElement,
                   renderVariable:
@@ -15880,6 +15898,7 @@ const _invisibleGetters = {
     'isVisibleForTesting',
     'runtimeType'
   },
+  'EnumElement': {'augmented', 'hashCode', 'runtimeType'},
   'ExecutableMember': {
     'context',
     'declaration',
@@ -16382,6 +16401,12 @@ const _invisibleGetters = {
     'runtimeType',
     'toolVersion',
     'useBaseHref'
+  },
+  'TopLevelVariableElement': {
+    'declaration',
+    'hashCode',
+    'isExternal',
+    'runtimeType'
   },
   'TypeAliasElement': {
     'aliasedElement',

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -16,12 +16,14 @@ import 'package:dartdoc/src/warnings.dart';
 
 /// Getters and setters.
 class Accessor extends ModelElement implements EnclosedElement {
+  @override
+  final PropertyAccessorElement element;
+
   /// The combo ([Field] or [TopLevelVariable]) containing this accessor.
   /// Initialized by the combo's constructor.
   late final GetterSetterCombo enclosingCombo;
 
-  Accessor(
-      PropertyAccessorElement super.element, super.library, super.packageGraph,
+  Accessor(this.element, super.library, super.packageGraph,
       [ExecutableMember? super.originalMember]);
 
   @override
@@ -33,10 +35,6 @@ class Accessor extends ModelElement implements EnclosedElement {
     }
     return super.characterLocation;
   }
-
-  @override
-  PropertyAccessorElement get element =>
-      super.element as PropertyAccessorElement;
 
   @override
   ExecutableMember? get originalMember =>

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -14,13 +14,13 @@ import 'package:dartdoc/src/model/model.dart';
 /// **inherited**: Filtered getters giving only inherited children.
 class Class extends InheritingContainer
     with Constructable, TypeImplementing, MixedInTypes {
-  Class(ClassElement element, Library library, PackageGraph packageGraph)
-      : super(element, library, packageGraph) {
+  @override
+  final ClassElement element;
+
+  Class(this.element, Library library, PackageGraph packageGraph)
+      : super(library, packageGraph) {
     packageGraph.specialClasses.addSpecial(this);
   }
-
-  @override
-  ClassElement get element => super.element as ClassElement;
 
   @override
   late final List<ModelElement> allModelElements = [

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -11,8 +11,10 @@ import 'package:dartdoc/src/model/model.dart';
 class Constructor extends ModelElement
     with TypeParameters, ContainerMember
     implements EnclosedElement {
-  Constructor(
-      ConstructorElement super.element, super.library, super.packageGraph);
+  @override
+  final ConstructorElement element;
+
+  Constructor(this.element, super.library, super.packageGraph);
 
   @override
   CharacterLocation? get characterLocation {
@@ -24,9 +26,6 @@ class Constructor extends ModelElement
     }
     return super.characterLocation;
   }
-
-  @override
-  ConstructorElement get element => super.element as ConstructorElement;
 
   @override
   List<TypeParameter> get typeParameters =>

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -29,11 +29,7 @@ import 'package:meta/meta.dart';
 ///   are empty.  These are available mostly for the templating system.
 abstract class Container extends ModelElement
     with Categorization, TypeParameters {
-  Container(super.element, super.library, super.packageGraph);
-
-  /// Containers must have associated packages.
-  @override
-  Package get package => super.package;
+  Container(super.library, super.packageGraph);
 
   // TODO(jcollins-g): Implement a ContainerScope that flattens supertypes?
   @override

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -8,8 +8,11 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Dynamic extends ModelElement with HasNoPage {
-  Dynamic(Element element, PackageGraph packageGraph)
-      : super(element, Library.sentinel, packageGraph);
+  @override
+  final Element element;
+
+  Dynamic(this.element, PackageGraph packageGraph)
+      : super(Library.sentinel, packageGraph);
 
   UndefinedElementType get modelType =>
       throw UnimplementedError('(${element.runtimeType}) $element');

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -10,7 +10,10 @@ import 'package:dartdoc/src/render/enum_field_renderer.dart';
 
 class Enum extends InheritingContainer
     with Constructable, TypeImplementing, MixedInTypes {
-  Enum(super.element, super.library, super.packageGraph);
+  @override
+  final EnumElement element;
+
+  Enum(this.element, super.library, super.packageGraph);
 
   @override
   late final List<ModelElement> allModelElements = [
@@ -63,7 +66,7 @@ class EnumField extends Field {
 
   @override
   String get constantValueBase =>
-      element.library!.featureSet.isEnabled(Feature.enhanced_enums)
+      element.library.featureSet.isEnabled(Feature.enhanced_enums)
           ? super.constantValueBase
           : _fieldRenderer.renderValue(this);
 

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -12,10 +12,13 @@ import 'package:meta/meta.dart';
 
 /// Extension methods
 class Extension extends Container implements EnclosedElement {
+  @override
+  final ExtensionElement element;
+
   late final ElementType extendedType =
       modelBuilder.typeFrom(element.extendedType, library);
 
-  Extension(ExtensionElement super.element, super.library, super.packageGraph);
+  Extension(this.element, super.library, super.packageGraph);
 
   /// Detect if this extension applies to every object.
   bool get alwaysApplies =>
@@ -55,9 +58,6 @@ class Extension extends Container implements EnclosedElement {
   late List<Method> declaredMethods = element.methods
       .map((e) => modelBuilder.from(e, library) as Method)
       .toList(growable: false);
-
-  @override
-  ExtensionElement get element => super.element as ExtensionElement;
 
   @override
   String get name => element.name == null ? '' : super.name;

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -10,6 +10,9 @@ import 'package:dartdoc/src/render/source_code_renderer.dart';
 class Field extends ModelElement
     with GetterSetterCombo, ContainerMember, Inheritable
     implements EnclosedElement {
+  @override
+  final FieldElement element;
+
   bool _isInherited = false;
   late final Container _enclosingContainer;
   @override
@@ -17,8 +20,8 @@ class Field extends ModelElement
   @override
   final ContainerAccessor? setter;
 
-  Field(FieldElement super.element, super.library, super.packageGraph,
-      this.getter, this.setter)
+  Field(
+      this.element, super.library, super.packageGraph, this.getter, this.setter)
       : assert(getter != null || setter != null) {
     if (getter != null) getter!.enclosingCombo = this;
     if (setter != null) setter!.enclosingCombo = this;
@@ -135,7 +138,7 @@ class Field extends ModelElement
     return allFeatures;
   }
 
-  FieldElement? get field => element as FieldElement?;
+  FieldElement? get field => element;
 
   @override
   String get fileName => '${isConst ? '$name-constant' : name}.$fileType';

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -182,17 +182,18 @@ abstract class InheritingContainer extends Container
     with ExtensionTarget
     implements EnclosedElement {
   @override
-  InterfaceElement get element => super.element as InterfaceElement;
+  InterfaceElement get element;
 
-  DefinedElementType? _supertype;
-  DefinedElementType? get supertype =>
-      _supertype ??= element.supertype?.element2.supertype == null
-          ? null
-          : modelBuilder.typeFrom(element.supertype!, library)
-              as DefinedElementType?;
+  late final DefinedElementType? supertype = () {
+    final elementSupertype = element.supertype;
+    return elementSupertype == null ||
+            elementSupertype.element2.supertype == null
+        ? null
+        : modelBuilder.typeFrom(elementSupertype, library)
+            as DefinedElementType;
+  }();
 
-  InheritingContainer(
-      InterfaceElement super.element, super.library, super.packageGraph);
+  InheritingContainer(super.library, super.packageGraph);
 
   @override
   Iterable<Method> get instanceMethods =>

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -59,6 +59,9 @@ class _LibrarySentinel implements Library {
 }
 
 class Library extends ModelElement with Categorization, TopLevelContainer {
+  @override
+  final LibraryElement element;
+
   final Set<Element> _exportedAndLocalElements;
   final String _restoredUri;
 
@@ -77,9 +80,9 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
   /// abstract getter.
   static final Library sentinel = _LibrarySentinel();
 
-  Library._(LibraryElement element, PackageGraph packageGraph, this.package,
+  Library._(this.element, PackageGraph packageGraph, this.package,
       this._restoredUri, this._exportedAndLocalElements)
-      : super(element, sentinel, packageGraph);
+      : super(sentinel, packageGraph);
 
   factory Library.fromLibraryResult(DartDocResolvedLibrary resolvedLibrary,
       PackageGraph packageGraph, Package package) {
@@ -184,9 +187,6 @@ class Library extends ModelElement with Categorization, TopLevelContainer {
 
   @override
   Iterable<Class> get classes => allClasses.where((c) => !c.isErrorOrException);
-
-  @override
-  LibraryElement get element => super.element as LibraryElement;
 
   @override
   late final Iterable<Extension> extensions = _exportedAndLocalElements

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -14,20 +14,26 @@ import 'package:dartdoc/src/model/model.dart';
 class Method extends ModelElement
     with ContainerMember, Inheritable, TypeParameters
     implements EnclosedElement {
-  bool _isInherited = false;
+  @override
+  final MethodElement element;
+
   Container? _enclosingContainer;
+
+  final bool _isInherited;
+
   @override
   late final List<TypeParameter> typeParameters;
 
-  Method(MethodElement super.element, super.library, super.packageGraph) {
+  Method(this.element, super.library, super.packageGraph)
+      : _isInherited = false {
     _calcTypeParameters();
   }
 
-  Method.inherited(MethodElement element, this._enclosingContainer,
-      Library library, PackageGraph packageGraph,
+  Method.inherited(this.element, this._enclosingContainer, Library library,
+      PackageGraph packageGraph,
       {ExecutableMember? originalMember})
-      : super(element, library, packageGraph, originalMember) {
-    _isInherited = true;
+      : _isInherited = true,
+        super(library, packageGraph, originalMember) {
     _calcTypeParameters();
   }
 
@@ -51,11 +57,8 @@ class Method extends ModelElement
   }
 
   @override
-  Container get enclosingElement {
-    _enclosingContainer ??=
-        modelBuilder.from(element.enclosingElement3, library) as Container?;
-    return _enclosingContainer!;
-  }
+  Container get enclosingElement => _enclosingContainer ??=
+      modelBuilder.from(element.enclosingElement3, library) as Container;
 
   @override
   String get filePath =>
@@ -118,9 +121,6 @@ class Method extends ModelElement
     }
     return null;
   }
-
-  @override
-  MethodElement get element => super.element as MethodElement;
 
   /// Methods can not be covariant; always returns false.
   @override

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -12,10 +12,10 @@ import 'package:dartdoc/src/special_elements.dart';
 import 'package:meta/meta.dart';
 
 class Mixin extends InheritingContainer with TypeImplementing {
-  Mixin(super.element, super.library, super.packageGraph);
-
   @override
-  MixinElement get element => super.element as MixinElement;
+  final MixinElement element;
+
+  Mixin(this.element, super.library, super.packageGraph);
 
   late final List<ParameterizedElementType> superclassConstraints = [
     ...element.superclassConstraints

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -124,14 +124,13 @@ abstract class ModelElement extends Canonicalization
         DocumentationComment,
         ModelBuilder
     implements Comparable<ModelElement>, Documentable {
-  final Element _element;
-
   // TODO(jcollins-g): This really wants a "member that has a type" class.
   final Member? _originalMember;
   final Library _library;
 
-  ModelElement(this._element, this._library, this._packageGraph,
-      [this._originalMember]);
+  final PackageGraph _packageGraph;
+
+  ModelElement(this._library, this._packageGraph, [this._originalMember]);
 
   /// Creates a [ModelElement] from [e].
   factory ModelElement._fromElement(Element e, PackageGraph p) {
@@ -647,7 +646,7 @@ abstract class ModelElement extends Canonicalization
   }
 
   @override
-  Element get element => _element;
+  Element get element;
 
   @override
   String get location {
@@ -816,8 +815,6 @@ abstract class ModelElement extends Canonicalization
   String get oneLineDoc => elementDocumentation.asOneLiner;
 
   Member? get originalMember => _originalMember;
-
-  final PackageGraph _packageGraph;
 
   @override
   PackageGraph get packageGraph => _packageGraph;

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -35,13 +35,15 @@ class ModelFunctionTyped extends ModelElement
     with TypeParameters
     implements EnclosedElement {
   @override
+  final FunctionTypedElement element;
+
+  @override
   late final List<TypeParameter> typeParameters = [
     for (var p in element.typeParameters)
       modelBuilder.from(p, library) as TypeParameter,
   ];
 
-  ModelFunctionTyped(
-      FunctionTypedElement super.element, super.library, super.packageGraph);
+  ModelFunctionTyped(this.element, super.library, super.packageGraph);
 
   @override
   ModelElement get enclosingElement => library;
@@ -73,9 +75,6 @@ class ModelFunctionTyped extends ModelElement
 
   @override
   Iterable<CommentReferable> get referenceParents => [definingLibrary];
-
-  @override
-  FunctionTypedElement get element => super.element as FunctionTypedElement;
 
   late final Callable modelType =
       modelBuilder.typeFrom(element.type, library) as Callable;

--- a/lib/src/model/never.dart
+++ b/lib/src/model/never.dart
@@ -7,8 +7,11 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class NeverType extends ModelElement with HasNoPage {
-  NeverType(Element element, PackageGraph packageGraph)
-      : super(element, Library.sentinel, packageGraph);
+  @override
+  final Element element;
+
+  NeverType(this.element, PackageGraph packageGraph)
+      : super(Library.sentinel, packageGraph);
 
   /// `Never` is not a real object, and so we can't document it, so there
   /// can be nothing canonical for it.

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -10,14 +10,14 @@ import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Parameter extends ModelElement with HasNoPage {
-  Parameter(
-      ParameterElement element, Library library, PackageGraph packageGraph,
+  @override
+  final ParameterElement element;
+
+  Parameter(this.element, Library library, PackageGraph packageGraph,
       {ParameterMember? originalMember})
-      : super(element, library, packageGraph, originalMember);
-  String? get defaultValue {
-    if (!hasDefaultValue) return null;
-    return element.defaultValueCode;
-  }
+      : super(library, packageGraph, originalMember);
+
+  String? get defaultValue => hasDefaultValue ? element.defaultValueCode : null;
 
   @override
   ModelElement? get enclosingElement {
@@ -95,9 +95,6 @@ class Parameter extends ModelElement with HasNoPage {
     final enclosingElement = this.enclosingElement;
     return [if (enclosingElement != null) enclosingElement];
   }
-
-  @override
-  ParameterElement get element => super.element as ParameterElement;
 
   @override
   ParameterMember? get originalMember =>

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -12,9 +12,12 @@ import 'package:dartdoc/src/model/model.dart';
 /// Like [Parameter], it doesn't have doc pages, but participates in lookups.
 /// Forwards to its referenced library if referred to directly.
 class Prefix extends ModelElement with HasNoPage implements EnclosedElement {
+  @override
+  final PrefixElement element;
+
   /// [library] is the library the prefix is defined in, not the [Library]
   /// referred to by the [PrefixElement].
-  Prefix(PrefixElement super.element, super.library, super.packageGraph);
+  Prefix(this.element, super.library, super.packageGraph);
 
   @override
   bool get isCanonical => false;
@@ -31,9 +34,6 @@ class Prefix extends ModelElement with HasNoPage implements EnclosedElement {
 
   @override
   Scope get scope => element.scope;
-
-  @override
-  PrefixElement get element => super.element as PrefixElement;
 
   @override
   ModelElement get enclosingElement => library;

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -12,12 +12,15 @@ class TopLevelVariable extends ModelElement
     with GetterSetterCombo, Categorization
     implements EnclosedElement {
   @override
+  final TopLevelVariableElement element;
+
+  @override
   final Accessor? getter;
   @override
   final Accessor? setter;
 
-  TopLevelVariable(TopLevelVariableElement super.element, super.library,
-      super.packageGraph, this.getter, this.setter) {
+  TopLevelVariable(this.element, super.library, super.packageGraph, this.getter,
+      this.setter) {
     if (getter != null) {
       getter!.enclosingCombo = this;
     }
@@ -57,18 +60,18 @@ class TopLevelVariable extends ModelElement
   }
 
   @override
-  bool get isConst => _variable!.isConst;
+  bool get isConst => element.isConst;
 
   @override
   bool get isFinal {
     /// isFinal returns true for the variable even if it has an explicit getter
     /// (which means we should not document it as "final").
     if (hasExplicitGetter) return false;
-    return _variable!.isFinal;
+    return element.isFinal;
   }
 
   @override
-  bool get isLate => isFinal && _variable!.isLate;
+  bool get isLate => isFinal && element.isLate;
 
   @override
   String get kind => isConst ? 'top-level constant' : 'top-level property';
@@ -78,8 +81,6 @@ class TopLevelVariable extends ModelElement
 
   @override
   String get fileName => '${isConst ? '$name-constant' : name}.$fileType';
-
-  TopLevelVariableElement? get _variable => element as TopLevelVariableElement?;
 
   @override
   Iterable<CommentReferable> get referenceParents => [definingLibrary];

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -9,8 +9,10 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/type_parameters_renderer.dart';
 
 class TypeParameter extends ModelElement with HasNoPage {
-  TypeParameter(
-      TypeParameterElement super.element, super.library, super.packageGraph);
+  @override
+  final TypeParameterElement element;
+
+  TypeParameter(this.element, super.library, super.packageGraph);
 
   @override
   ModelElement get enclosingElement =>
@@ -58,8 +60,6 @@ class TypeParameter extends ModelElement with HasNoPage {
 
   @override
   Iterable<CommentReferable> get referenceParents => [enclosingElement];
-  @override
-  TypeParameterElement get element => super.element as TypeParameterElement;
 
   @override
   String get referenceName => element.name;

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -12,16 +12,15 @@ import 'package:dartdoc/src/render/typedef_renderer.dart';
 abstract class Typedef extends ModelElement
     with TypeParameters, Categorization
     implements EnclosedElement {
-  Typedef(TypeAliasElement super.element, super.library, super.packageGraph);
+  @override
+  final TypeAliasElement element;
+
+  Typedef(this.element, super.library, super.packageGraph);
 
   DartType get aliasedType => element.aliasedType;
 
-  @override
-  TypeAliasElement get element => super.element as TypeAliasElement;
-
-  ElementType? _modelType;
-  ElementType get modelType =>
-      _modelType ??= modelBuilder.typeFrom(element.aliasedType, library);
+  late final ElementType modelType =
+      modelBuilder.typeFrom(element.aliasedType, library);
 
   @override
   Library get enclosingElement => library;


### PR DESCRIPTION
I think this is the more correct layout for ModelElement and its subclasses. Code in ModelElement (and outside its subclasses) just needs to know about the Element. Subclasses define the backing field with Element subtypes. This does not seem to have grand performance characteristics, but should result in simpler code, fewer casts, and fewer parameters in super calls.