### PR TITLE
Deprecate many elements on ModelElement

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -171,10 +171,10 @@ class _Renderer_Accessor extends RendererBase<Accessor> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.filePath == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath!, ast, r.template, sink,
+                    _render_String(c.filePath, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -5574,6 +5574,13 @@ class _Renderer_Field extends RendererBase<Field> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isLate == true,
                 ),
+                'isStatic': Property(
+                  getValue: (CT_ c) => c.isStatic,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isStatic == true,
+                ),
                 'kind': Property(
                   getValue: (CT_ c) => c.kind,
                   renderVariable:
@@ -5973,7 +5980,7 @@ class _Renderer_GetterSetterCombo extends RendererBase<GetterSetterCombo> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Annotation>'),
+                          c, remainingNames, 'List<Annotation>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.annotations.map((e) => _render_Annotation(
@@ -9640,7 +9647,7 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Annotation>'),
+                          c, remainingNames, 'List<Annotation>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.annotations.map((e) => _render_Annotation(
@@ -9827,6 +9834,29 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         parent: r, getters: _invisibleGetters['Element']!);
                   },
                 ),
+                'enclosingElement': Property(
+                  getValue: (CT_ c) => c.enclosingElement,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_ModelElement.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as ModelElement,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.enclosingElement == null,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_ModelElement(
+                        c.enclosingElement!, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
                 'exportedInLibraries': Property(
                   getValue: (CT_ c) => c.exportedInLibraries,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -9912,10 +9942,10 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.filePath == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath!, ast, r.template, sink,
+                    _render_String(c.filePath, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -10636,6 +10666,13 @@ class _Renderer_ModelFunction extends RendererBase<ModelFunction> {
                         parent: r,
                         getters: _invisibleGetters['FunctionElement']!);
                   },
+                ),
+                'isAsynchronous': Property(
+                  getValue: (CT_ c) => c.isAsynchronous,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isAsynchronous == true,
                 ),
                 'isStatic': Property(
                   getValue: (CT_ c) => c.isStatic,

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -9834,28 +9834,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         parent: r);
                   },
                 ),
-                'enclosingElement': Property(
-                  getValue: (CT_ c) => c.enclosingElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Warnable.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Warnable,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.enclosingElement == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.enclosingElement, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Warnable']!);
-                  },
-                ),
                 'exportedInLibraries': Property(
                   getValue: (CT_ c) => c.exportedInLibraries,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -16445,7 +16423,6 @@ const _invisibleGetters = {
     'runtimeType'
   },
   'TypeSystem': {'hashCode', 'runtimeType'},
-  'Warnable': {'element', 'package'},
   'int': {
     'bitLength',
     'hashCode',

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -136,7 +136,7 @@ class Accessor extends ModelElement implements EnclosedElement {
   }
 
   @override
-  String? get filePath => enclosingCombo.filePath;
+  String get filePath => enclosingCombo.filePath;
 
   @override
   bool get isCanonical => enclosingCombo.isCanonical;

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -105,6 +105,11 @@ class Field extends ModelElement
   bool get isInherited => _isInherited;
 
   @override
+  bool get isStatic {
+    return (element as PropertyInducingElement).isStatic;
+  }
+
+  @override
   String get kind => isConst ? 'constant' : 'property';
 
   String get fullkind => element.isAbstract ? 'abstract $kind' : kind;

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -105,9 +105,7 @@ class Field extends ModelElement
   bool get isInherited => _isInherited;
 
   @override
-  bool get isStatic {
-    return (element as PropertyInducingElement).isStatic;
-  }
+  bool get isStatic => element.isStatic;
 
   @override
   String get kind => isConst ? 'constant' : 'property';

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -27,7 +27,7 @@ mixin GetterSetterCombo on ModelElement {
   Accessor? get setter;
 
   @override
-  Iterable<Annotation> get annotations => [
+  List<Annotation> get annotations => [
         ...super.annotations,
         if (hasGetter) ...getter!.annotations,
         if (hasSetter) ...setter!.annotations,

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -53,7 +54,8 @@ mixin Inheritable on ContainerMember {
     }
     return canonicalEnclosingContainer.allCanonicalModelElements
         .firstWhereOrNull((m) =>
-            m.name == name && m.isPropertyAccessor == isPropertyAccessor);
+            m.name == name &&
+            m is PropertyAccessorElement == this is PropertyAccessorElement);
   }();
 
   @override

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -398,7 +398,6 @@ abstract class ModelElement extends Canonicalization
     throw UnimplementedError('Unknown type ${e.runtimeType}');
   }
 
-  @override
   ModelElement? get enclosingElement;
 
   // Stub for mustache, which would otherwise search enclosing elements to find
@@ -446,8 +445,6 @@ abstract class ModelElement extends Canonicalization
     }
     return utils.hasPublicName(element) && !hasNodoc;
   }();
-
-  Warnable? get enclosingElement;
 
   @override
   late final DartdocOptionContext config =

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -20,6 +20,9 @@ class ModelFunction extends ModelFunctionTyped with Categorization {
 
   @override
   FunctionElement get element => super.element as FunctionElement;
+
+  @override
+  bool get isAsynchronous => element.isAsynchronous;
 }
 
 /// A [ModelElement] for a [FunctionTypedElement] that is part of an

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -317,7 +317,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       if (kind == PackageWarning.ambiguousReexport) {
         var enclosingElement = warnable.enclosingElement;
         while (enclosingElement != null && enclosingElement is! Library) {
-          warnable = enclosingElement as ModelElement;
+          warnable = enclosingElement;
           enclosingElement = warnable.enclosingElement;
         }
       }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3181,14 +3181,6 @@ void main() {
       expect(f1.name, 'function1');
     });
 
-    test('local element', () {
-      expect(f1.isLocalElement, true);
-    });
-
-    test('is executable', () {
-      expect(f1.isExecutable, true);
-    });
-
     test('is static', () {
       expect(f1.isStatic, true);
     });


### PR DESCRIPTION
I noticed that ModelElement has a lot of fields which are only relevant for certain subclasses of ModelElement. I've deprecated some of these, and performed some adjacent cleanup:

* `ModelElement.isExecutable`, `.isLocalElement`, `.isPropertyAccessor`, `.isPropertyInducer`
* `ModelElement.isAsynchronous` is deprecated and moved to `ModelFunction`.
* `ModelElement.isStatic` is deprecated and moved to `Field`.
* `annotations` getters are made to be Lists
* `ModelElement.filePath` is made non-nullable
* `ModelElement.enclosingElement` is narrowed to be a `ModelElement?`
* `ModelElement.definingLibrary` is simplified.
* `ModelElement.documentation` is now an arrow function
* `ModelElement.linkedName`'s initializer is inlined.