### PR TITLE
Simplify Accessor.overriddenElement

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1727,7 +1727,7 @@ class _Renderer_Class extends RendererBase<Class> {
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.inheritanceChain.map((e) =>
-                        _render_InheritingContainer(e!, ast, r.template, sink,
+                        _render_InheritingContainer(e, ast, r.template, sink,
                             parent: r));
                   },
                 ),
@@ -4374,7 +4374,7 @@ class _Renderer_Enum extends RendererBase<Enum> {
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.inheritanceChain.map((e) =>
-                        _render_InheritingContainer(e!, ast, r.template, sink,
+                        _render_InheritingContainer(e, ast, r.template, sink,
                             parent: r));
                   },
                 ),
@@ -6895,7 +6895,7 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.inheritanceChain.map((e) =>
-                        _render_InheritingContainer(e!, ast, r.template, sink,
+                        _render_InheritingContainer(e, ast, r.template, sink,
                             parent: r));
                   },
                 ),
@@ -9380,7 +9380,7 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.inheritanceChain.map((e) =>
-                        _render_InheritingContainer(e!, ast, r.template, sink,
+                        _render_InheritingContainer(e, ast, r.template, sink,
                             parent: r));
                   },
                 ),

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -53,7 +53,7 @@ class Class extends InheritingContainer
   }
 
   @override
-  late final List<InheritingContainer?> inheritanceChain = [
+  late final List<InheritingContainer> inheritanceChain = [
     this,
 
     // Caching should make this recursion a little less painful.

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -19,7 +19,7 @@ class Enum extends InheritingContainer
   ];
 
   @override
-  late final List<InheritingContainer?> inheritanceChain = [
+  late final List<InheritingContainer> inheritanceChain = [
     this,
     for (var container in mixedInTypes.reversed.modelElements)
       ...container.inheritanceChain,

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -288,13 +288,13 @@ abstract class InheritingContainer extends Container
   late final DefinedElementType modelType =
       modelBuilder.typeFrom(element.thisType, library) as DefinedElementType;
 
-  /// Not the same as superChain as it may include mixins.
+  /// Not the same as [superChain] as it may include mixins.
   ///
   /// It's really not even the same as ordinary Dart inheritance, either,
   /// because we pretend that interfaces are part of the inheritance chain
   /// to include them in the set of things we might link to for documentation
   /// purposes in abstract classes.
-  List<InheritingContainer?> get inheritanceChain;
+  List<InheritingContainer> get inheritanceChain;
 
   List<DefinedElementType> get superChain {
     var typeChain = <DefinedElementType>[];
@@ -324,7 +324,7 @@ abstract class InheritingContainer extends Container
   Iterable<DefinedElementType> get publicSuperChainReversed =>
       publicSuperChain.reversed;
 
-  late final List<ExecutableElement?> _inheritedElements = () {
+  late final List<ExecutableElement> _inheritedElements = () {
     if (element is ClassElement && (element as ClassElement).isDartCoreObject) {
       return const <ExecutableElement>[];
     }
@@ -334,11 +334,11 @@ abstract class InheritingContainer extends Container
         inheritance.getInheritedConcreteMap2(element);
     final inheritenceMap = inheritance.getInheritedMap2(element);
 
-    List<InterfaceElement?>? inheritanceChainElements;
+    List<InterfaceElement>? inheritanceChainElements;
 
     final combinedMap = {
       for (final name in concreteInheritenceMap.keys)
-        name.name: concreteInheritenceMap[name],
+        name.name: concreteInheritenceMap[name]!,
     };
     for (final name in inheritenceMap.keys) {
       final inheritenceElement = inheritenceMap[name]!;
@@ -351,7 +351,7 @@ abstract class InheritingContainer extends Container
       // Elements in the inheritance chain starting from `this.element` down to,
       // but not including, [Object].
       inheritanceChainElements ??=
-          inheritanceChain.map((c) => c!.element).toList(growable: false);
+          inheritanceChain.map((c) => c.element).toList(growable: false);
       final enclosingElement =
           inheritenceElement.enclosingElement3 as InterfaceElement;
       assert(inheritanceChainElements.contains(enclosingElement) ||
@@ -363,7 +363,7 @@ abstract class InheritingContainer extends Container
       // `inheritedMap2`, prefer `inheritedMap2`. This correctly accounts for
       // intermediate abstract classes that have method/field implementations.
       if (inheritanceChainElements.indexOf(
-              combinedMapElement.enclosingElement3 as InterfaceElement?) <
+              combinedMapElement.enclosingElement3 as InterfaceElement) <
           inheritanceChainElements.indexOf(enclosingElement)) {
         combinedMap[name.name] = inheritenceElement;
       }
@@ -372,6 +372,7 @@ abstract class InheritingContainer extends Container
     return combinedMap.values.toList(growable: false);
   }();
 
+  /// All fields defined on this container, _including inherited fields_.
   late final List<Field> allFields = () {
     var inheritedAccessorElements = {
       ..._inheritedElements.whereType<PropertyAccessorElement>()
@@ -379,6 +380,11 @@ abstract class InheritingContainer extends Container
 
     // This structure keeps track of inherited accessors, allowing lookup
     // by field name (stripping the '=' from setters).
+    // TODO(srawlins): Each value List should only contain 1 or 2 elements:
+    // up to one getter and one setter. We then perform repeated
+    // `.firstWhereOrNull((e) => e.isGetter)` and
+    // `.firstWhereOrNull((e) => e.isSetter)` calls, which would be much simpler
+    // if we used some sort of "pair" class instead.
     var accessorMap = <String, List<PropertyAccessorElement>>{};
     for (var accessorElement in inheritedAccessorElements) {
       accessorMap
@@ -409,13 +415,12 @@ abstract class InheritingContainer extends Container
 
     // Now we only have inherited accessors who aren't associated with
     // anything in the fields.
-    for (var fieldName in accessorMap.keys) {
-      var elements = accessorMap[fieldName]!.toList(growable: false);
-      var getterElement = elements.firstWhereOrNull((e) => e.isGetter);
-      var setterElement = elements.firstWhereOrNull((e) => e.isSetter);
+    accessorMap.forEach((fieldName, elements) {
+      final getterElement = elements.firstWhereOrNull((e) => e.isGetter);
+      final setterElement = elements.firstWhereOrNull((e) => e.isSetter);
       fields.add(_createSingleField(
           getterElement, setterElement, inheritedAccessorElements));
-    }
+    });
 
     return fields;
   }();
@@ -433,23 +438,20 @@ abstract class InheritingContainer extends Container
       PropertyAccessorElement? setterElement,
       Set<PropertyAccessorElement> inheritedAccessors,
       [FieldElement? field]) {
-    // Return an [ContainerAccessor] with `isInherited = true` if [element] is
+    // Return a [ContainerAccessor] with `isInherited = true` if [element] is
     // in [inheritedAccessors].
-    ContainerAccessor? containerAccessorFrom(PropertyAccessorElement? element,
-        Set<PropertyAccessorElement> inheritedAccessors) {
+    ContainerAccessor? containerAccessorFrom(PropertyAccessorElement? element) {
       if (element == null) return null;
-      if (inheritedAccessors.contains(element)) {
-        return modelBuilder.from(element, library, enclosingContainer: this)
-            as ContainerAccessor;
-      } else {
-        return modelBuilder.from(element, library) as ContainerAccessor;
-      }
+      final enclosingContainer =
+          inheritedAccessors.contains(element) ? this : null;
+      return modelBuilder.from(element, library,
+          enclosingContainer: enclosingContainer) as ContainerAccessor;
     }
 
-    var getter = containerAccessorFrom(getterElement, inheritedAccessors);
-    var setter = containerAccessorFrom(setterElement, inheritedAccessors);
-    // Rebind getterElement/setterElement as ModelElement.from can resolve
-    // MultiplyInheritedExecutableElements or resolve Members.
+    var getter = containerAccessorFrom(getterElement);
+    var setter = containerAccessorFrom(setterElement);
+    // Rebind [getterElement], [setterElement] as [ModelElement.from] can
+    // resolve [MultiplyInheritedExecutableElement]s or resolve [Member]s.
     getterElement = getter?.element;
     setterElement = setter?.element;
     assert(getter != null || setter != null);
@@ -523,7 +525,7 @@ extension DefinedElementTypeIterableExtensions on Iterable<DefinedElementType> {
       map((e) => e.modelElement as InheritingContainer);
 
   /// Expands the `ModelElement` for each element to its inheritance chain.
-  Iterable<InheritingContainer?> get expandInheritanceChain =>
+  Iterable<InheritingContainer> get expandInheritanceChain =>
       expand((e) => (e.modelElement as InheritingContainer).inheritanceChain);
 }
 

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -41,7 +41,7 @@ class Mixin extends InheritingContainer with TypeImplementing {
   String get kind => 'mixin';
 
   @override
-  late final List<InheritingContainer?> inheritanceChain = [
+  late final List<InheritingContainer> inheritanceChain = [
     this,
 
     // Mix-in interfaces come before other interfaces.

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -48,7 +48,7 @@ ModelElement resolveMultiplyInheritedElement(
   var lowIndex = enclosingClass.inheritanceChain.length;
   for (var inheritable in inheritables) {
     var index = enclosingClass.inheritanceChain
-        .indexOf(inheritable.enclosingElement as InheritingContainer?);
+        .indexOf(inheritable.enclosingElement as InheritingContainer);
     if (index < lowIndex) {
       foundInheritable = inheritable;
       lowIndex = index;

--- a/lib/src/model/model_object_builder.dart
+++ b/lib/src/model/model_object_builder.dart
@@ -15,7 +15,8 @@ abstract class ModelObjectBuilder
     implements ModelElementBuilder, ElementTypeBuilder {}
 
 abstract class ModelElementBuilder {
-  ModelElement from(Element e, Library library, {Container enclosingContainer});
+  ModelElement from(Element e, Library library,
+      {Container? enclosingContainer});
 
   ModelElement fromElement(Element e);
 


### PR DESCRIPTION
This initializer (closure) was a little complicated, and had an implicit return. It also unnecessarily considered (a) _all_ inherited fields of _each_ supertype, and (b) static fields.

* Only consider _declared_ _instance_ fields for `possibleFields`.
* `InheritingContainer.inheritenceChain` is a List of non-nullable `InheritingContainer`s.
* `InheritingContainer._inheritedElements` is a List of non-nullable `ExecutableElement`s.
* `InheritingContainer.expandInheritenceChain` is an Iterable of non-nullable `InheritingContainer`s.