### PR TITLE
Update the text in test/README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,10 +1,14 @@
 # Tests
 
-Most of dartdoc's tests are large end-to-end tests which read real files in
-real packages, in the `testing/` directory. Unit tests exist in `test/unit/`.
+Many of dartdoc's tests are large end-to-end tests which read real files in
+real packages, in the `testing/` directory. These tests are found in
+`test/end2end/`. Smaller unit tests are found in `test/` and other
+subdirectories.
 
-Many of the end-to-end test cases should be rewritten as unit tests.
+Many of the end-to-end test cases are being rewritten as unit tests. Eventually,
+the content in the `testing/` directory should dwindle down to very targeted
+tests which cannot be rewritten as unit tests.
 
-At some point, the distinction should flip, such that unit tests are generally
-located in `test/`, and end-to-end tests are found in a specific directory, or
-in files whose names signify the distinction.
+There are some end-to-end tests which would require a serious refactoring of the
+implementation in order to migrate to unit tests, such as any "tool" test
+(testing the `{@tool}` directive).


### PR DESCRIPTION
I forgot to update this text, which stated that unit tests are in `test/unit`. Now, instead, unit tests are in `test/` and end-to-end tests are in `test/end2end/`.