### PR TITLE
Move Warnable.enclosingElement to ModelElement

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1097,29 +1097,6 @@ class _Renderer_Category extends RendererBase<Category> {
                         parent: r, getters: _invisibleGetters['Element']!);
                   },
                 ),
-                'enclosingElement': Property(
-                  getValue: (CT_ c) => c.enclosingElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ModelElement.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as ModelElement,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.enclosingElement == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_ModelElement(
-                        c.enclosingElement!, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'enclosingName': Property(
                   getValue: (CT_ c) => c.enclosingName,
                   renderVariable:
@@ -9827,6 +9804,28 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         parent: r, getters: _invisibleGetters['Element']!);
                   },
                 ),
+                'enclosingElement': Property(
+                  getValue: (CT_ c) => c.enclosingElement,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_Warnable.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as Warnable,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => c.enclosingElement == null,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    renderSimple(c.enclosingElement, ast, r.template, sink,
+                        parent: r, getters: _invisibleGetters['Warnable']!);
+                  },
+                ),
                 'exportedInLibraries': Property(
                   getValue: (CT_ c) => c.exportedInLibraries,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -11440,29 +11439,6 @@ class _Renderer_Package extends RendererBase<Package> {
                       List<MustachioNode> ast, StringSink sink) {
                     renderSimple(c.element, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['Element']!);
-                  },
-                ),
-                'enclosingElement': Property(
-                  getValue: (CT_ c) => c.enclosingElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ModelElement.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as ModelElement,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.enclosingElement == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_ModelElement(
-                        c.enclosingElement!, ast, r.template, sink,
-                        parent: r);
                   },
                 ),
                 'enclosingName': Property(
@@ -15611,28 +15587,6 @@ class _Renderer_Warnable extends RendererBase<Warnable> {
                         parent: r, getters: _invisibleGetters['Element']!);
                   },
                 ),
-                'enclosingElement': Property(
-                  getValue: (CT_ c) => c.enclosingElement,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Warnable.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Warnable,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.enclosingElement == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.enclosingElement, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Warnable']!);
-                  },
-                ),
                 'package': Property(
                   getValue: (CT_ c) => c.package,
                   renderVariable:
@@ -16452,7 +16406,7 @@ const _invisibleGetters = {
     'runtimeType'
   },
   'TypeSystem': {'hashCode', 'runtimeType'},
-  'Warnable': {'element', 'enclosingElement', 'package'},
+  'Warnable': {'element', 'package'},
   'int': {
     'bitLength',
     'hashCode',

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -58,9 +58,6 @@ class Category extends Nameable
   }
 
   @override
-  ModelElement? get enclosingElement => null;
-
-  @override
   Element? get element => null;
 
   @override

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -4,7 +4,6 @@
 
 import 'package:dartdoc/src/model/feature.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:meta/meta.dart';
 
 /// A [ModelElement] that is a [Container] member.
 mixin ContainerMember on ModelElement implements EnclosedElement {
@@ -52,16 +51,14 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
   }
 
   @override
-  @nonVirtual
   // TODO(jcollins-g): dart-lang/dartdoc#2693.
   Iterable<Container> get referenceParents =>
-      // If you don't want the ambiguity of where your comment
-      // references are resolved wrt documentation inheritance,
-      // that has to be resolved in the source by not inheriting
-      // documentation.
+      // If you don't want the ambiguity of where your comment references are
+      // resolved with respect to documentation inheritance, that has to be
+      // resolved in the source by not inheriting documentation.
       [
         enclosingElement,
-        documentationFrom.first.enclosingElement as Container,
+        (documentationFrom.first as ContainerMember).enclosingElement,
       ];
 
   @override

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -444,6 +444,8 @@ abstract class ModelElement extends Canonicalization
     return utils.hasPublicName(element) && !hasNodoc;
   }();
 
+  Warnable? get enclosingElement;
+
   @override
   late final DartdocOptionContext config =
       DartdocOptionContext.fromContextElement(

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -137,9 +137,6 @@ class Package extends LibraryContainer
   bool get isDocumented =>
       isFirstPackage || documentedWhere != DocumentLocation.missing;
 
-  @override
-  ModelElement? get enclosingElement => null;
-
   /// If we have public libraries, this is the default package, or we are
   /// auto-including dependencies, this package is public.
   @override

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -312,19 +312,20 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       {required String message,
       Iterable<Locatable>? referredFrom,
       Iterable<String>? extendedDebug}) {
-    if (warnable != null) {
+    if (warnable is ModelElement) {
       // This sort of warning is only applicable to top level elements.
       if (kind == PackageWarning.ambiguousReexport) {
         var enclosingElement = warnable.enclosingElement;
         while (enclosingElement != null && enclosingElement is! Library) {
-          warnable = enclosingElement;
+          warnable = enclosingElement as ModelElement;
           enclosingElement = warnable.enclosingElement;
         }
       }
-    } else {
-      // If we don't have an element, we need a message to disambiguate.
-      assert(message.isNotEmpty);
     }
+
+    // If we don't have an element, we need a message to disambiguate.
+    assert(warnable != null || message.isNotEmpty);
+
     if (packageWarningCounter.hasWarning(warnable, kind, message)) {
       return;
     }

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -296,8 +296,6 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
 mixin Warnable implements Canonicalization, CommentReferable {
   Element? get element;
 
-  Warnable? get enclosingElement;
-
   Package get package;
 
   void warn(


### PR DESCRIPTION
It made little sense that `enclosingElement` was specified on Warnable. Category and Package were forced to implement with `=> null` to comply statically, but it really just doesn't apply.

Moving to ModelElement requires changing some assumptions here and there, but the resulting code is still sound.