### PR TITLE
Make many Strings in DocumentationComment non-nullable

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3824,10 +3824,10 @@ class _Renderer_Documentable extends RendererBase<Documentable> {
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.oneLineDoc == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.oneLineDoc!, ast, r.template, sink,
+                    _render_String(c.oneLineDoc, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -3942,11 +3942,23 @@ class _Renderer_DocumentationComment
                         nextProperty,
                         [...remainingNames.skip(1)]);
                   },
-                  isNullValue: (CT_ c) => c.documentationLocal == null,
+                  isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.documentationLocal!, ast, r.template, sink,
+                    _render_String(c.documentationLocal, ast, r.template, sink,
                         parent: r);
+                  },
+                ),
+                'element': Property(
+                  getValue: (CT_ c) => c.element,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'Element'),
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    renderSimple(c.element, ast, r.template, sink,
+                        parent: r, getters: _invisibleGetters['Element']!);
                   },
                 ),
                 'elementDocumentation': Property(
@@ -9769,29 +9781,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         parent: r);
                   },
                 ),
-                'documentationComment': Property(
-                  getValue: (CT_ c) => c.documentationComment,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(
-                        c.documentationComment, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'element': Property(
                   getValue: (CT_ c) => c.element,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -10005,13 +9994,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.hasDocumentation == true,
-                ),
-                'hasDocumentationComment': Property(
-                  getValue: (CT_ c) => c.hasDocumentationComment,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.hasDocumentationComment == true,
                 ),
                 'hasFeatures': Property(
                   getValue: (CT_ c) => c.hasFeatures,
@@ -15783,6 +15765,7 @@ const _invisibleGetters = {
     'documentationComment',
     'documentationFrom',
     'documentationLocal',
+    'element',
     'elementDocumentation',
     'fullyQualifiedNameWithoutLibrary',
     'hasDocumentationComment',

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -17,7 +17,7 @@ abstract class Documentable extends Nameable {
 
   bool get hasDocumentation;
 
-  String? get oneLineDoc;
+  String get oneLineDoc;
 
   PackageGraph get packageGraph;
 

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -190,7 +190,7 @@ mixin GetterSetterCombo on ModelElement {
         // We have to check against `dropTextFrom` here since
         // `documentationFrom` doesn't yield the real elements for
         // [GetterSetterCombo]s.
-        if (!config.dropTextFrom.contains(fromGetter.element!.library!.name)) {
+        if (!config.dropTextFrom.contains(fromGetter.element.library!.name)) {
           if (fromGetter.hasDocumentationComment) {
             getterComment = fromGetter.documentationComment;
           }
@@ -206,7 +206,7 @@ mixin GetterSetterCombo on ModelElement {
     if (!setter.isSynthetic && setter.isPublic) {
       assert(setter.documentationFrom.length == 1);
       var fromSetter = setter.documentationFrom.first;
-      if (!config.dropTextFrom.contains(fromSetter.element!.library!.name)) {
+      if (!config.dropTextFrom.contains(fromSetter.element.library!.name)) {
         if (fromSetter.hasDocumentationComment) {
           return getterComment.isEmpty
               ? fromSetter.documentationComment

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -871,12 +871,6 @@ abstract class ModelElement extends Canonicalization
   }();
 
   @override
-  String get documentationComment => element.documentationComment ?? '';
-
-  @override
-  bool get hasDocumentationComment => element.documentationComment != null;
-
-  @override
   late final String sourceCode =
       _sourceCodeRenderer.renderSourceCode(super.sourceCode);
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -3804,7 +3804,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('inheritance of docs from SDK works for getter/setter combos', () {
       expect(
           ExtraSpecialListLength
-              .getter!.documentationFrom.first.element!.library!.name,
+              .getter!.documentationFrom.first.element.library!.name,
           equals('dart.core'));
       expect(ExtraSpecialListLength.oneLineDoc == '', isFalse);
     });


### PR DESCRIPTION
* Documentable.oneLineDoc should be non-nullable String
* DocumentationComment.element should be non-nullable Element
* Move ModelElement.documentationComment and ModelElement.hasDocumentationComment to DocumentationComment; improved separation of duties
* DocumentationComment._documentationLocal was nullable to support an ad-hoc "late final" concept. Made actually `late final` and guard with a new `_documentationLocalIsSet` bool.
* Remove DocumentationComment._buildDocumentationLocal; it had weird comments about overrides; perhaps hold-overs from a time when it was public?