### PR TITLE
Fix remote linking in 2.18 and 3.0.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,11 +39,6 @@ jobs:
             job: flutter
           - sdk: stable
             job: sdk-docs
-            # Do not run the "packages" job on "stable", until "stable"
-            # means >= 2.19. This is where pub switches the hosted
-            # directory on disk from pub.dartlang.org to pub.dev.
-          - sdk: stable
-            job: packages
 
     steps:
       - name: Store date

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1459,7 +1459,10 @@ List<DartdocOption> createDartdocOptions(
       ..addAll([
         DartdocOptionArgOnly<Map<String, String>>(
             'hosted',
-            {'pub.dev': 'https://pub.dev/documentation/%n%/%v%'},
+            {
+              'pub.dartlang.org': 'https://pub.dev/documentation/%n%/%v%',
+              'pub.dev': 'https://pub.dev/documentation/%n%/%v%',
+            },
             resourceProvider,
             help: 'Specify URLs for hosted pub packages'),
         DartdocOptionArgOnly<Map<String, String>>(

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -98,8 +98,7 @@ void main() {
           contains('Tool "drill" returned non-zero exit code'));
     });
 
-    test('basic interlinking test', skip: Platform.version.contains('2.18'),
-        () async {
+    test('basic interlinking test', () async {
       var dartdoc = await buildDartdoc(
           ['--exclude-packages=args'], _testPackageDir, tempDir);
       var results = await dartdoc.generateDocs();

--- a/testing/sky_engine/pubspec.yaml
+++ b/testing/sky_engine/pubspec.yaml
@@ -2,4 +2,4 @@ name: sky_engine
 description: package with embedder yaml
 version: 0.0.1
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -29,7 +29,6 @@ elif [ "$DARTDOC_BOT" = "packages" ]; then
   PACKAGE_NAME=access PACKAGE_VERSION=">=1.0.1+2" dart run grinder build-pub-package
   # Negative test for flutter_plugin_tools, make sure right error message is displayed.
   PACKAGE_NAME=flutter_plugin_tools PACKAGE_VERSION=">=0.0.14+1" dart run grinder build-pub-package 2>&1 | grep "warning: package:flutter_plugin_tools has no documentable libraries"
-  PACKAGE_NAME=shelf_exception_handler PACKAGE_VERSION=">=0.2.0" dart run grinder build-pub-package
 elif [ "$DARTDOC_BOT" = "sdk-analyzer" ]; then
   echo "Running all tests against the SDK analyzer"
   unset COVERAGE_TOKEN

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -921,7 +921,9 @@ Future<String> _buildPubPackageDocs(
     if (version != null) ...['-v', version],
     pubPackageName,
   ]);
-  var cache = Directory(p.join(env['PUB_CACHE']!, 'hosted', 'pub.dev'));
+  var pubHost =
+      Platform.version.contains('2.18') ? 'pub.dartlang.org' : 'pub.dev';
+  var cache = Directory(p.join(env['PUB_CACHE']!, 'hosted', pubHost));
   var pubPackageDirOrig =
       cache.listSync().firstWhere((e) => e.path.contains(pubPackageName));
   var pubPackageDir = Directory.systemTemp.createTempSync(pubPackageName);


### PR DESCRIPTION
Should fix issues with cross-linking to remote packages, found in https://github.com/dart-lang/pub-dev/pull/6264

* Add a pair to the 'hosted' Map default value for the 'linkTo' command line option.
* Remove test of shelf_exception_handler, which is a dead package.
* Bump the environment for sky_engine to handle Dart 3.0.0-dev.