### PR TITLE
Use equal signs to set default parameter values

### DIFF
--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -166,7 +166,7 @@ class Apple {
 
   operator *(Apple other) => this;
 
-  bool isGreaterThan(int number, {int check: 5}) {
+  bool isGreaterThan(int number, {int check = 5}) {
     return number > check;
   }
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -797,7 +797,7 @@ void onlyPositionalWithNoDefaultNoType([@greatestAnnotation anything]) {}
 
 /// Top-level function with 1 param and 2 optional named params, 1 with a
 /// default value.
-void soIntense(anything, {bool flag: true, int? value}) {}
+void soIntense(anything, {bool flag = true, int? value}) {}
 
 /// [FooBar] comes from another library.
 void paramFromAnotherLib(Apple thing) {}
@@ -1013,7 +1013,7 @@ void paintImage1(
     required int rect,
     required ExtraSpecialList image,
     BaseForDocComments? colorFilter,
-    String repeat: LongFirstLine.THING}) {
+    String repeat = LongFirstLine.THING}) {
   // nothing to do here -
 }
 


### PR DESCRIPTION
The colon-based syntax will become an error in Dart 3.