### PR TITLE
Use a sun-like icon for light theme toggle instead of moon

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -70,11 +70,24 @@
   display: none;
 }
 
+#theme-button {
+  position: absolute;
+  right: 30px;
+  height: 24px;
+}
+
 #theme-button .material-symbols-outlined {
-  padding-top: 6px;
   color: var(--main-icon-color);
   user-select: none;
   cursor: pointer;
+}
+
+.light-theme #light-theme-button {
+  display: none;
+}
+
+.dark-theme #dark-theme-button {
+  display: none;
 }
 
 /*
@@ -951,11 +964,6 @@ button {
 
 .navbar-right {
   padding-right: 60px;
-}
-
-#theme-button {
-  position: absolute;
-  right: 30px;
 }
 
 .tt-menu {

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3126,8 +3126,11 @@ String _deduplicated_lib_templates_html__head_html(
   <div class="toggle" id="theme-button">
     <label for="theme">
       <input type="checkbox" id="theme" value="light-theme">
-      <span class="material-symbols-outlined">
+      <span id="dark-theme-button" class="material-symbols-outlined">
         brightness_4
+      </span>
+      <span id="light-theme-button" class="material-symbols-outlined">
+        brightness_5
       </span>
     </label>
   </div>

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -60,8 +60,11 @@
   <div class="toggle" id="theme-button">
     <label for="theme">
       <input type="checkbox" id="theme" value="light-theme">
-      <span class="material-symbols-outlined">
+      <span id="dark-theme-button" class="material-symbols-outlined">
         brightness_4
+      </span>
+      <span id="light-theme-button" class="material-symbols-outlined">
+        brightness_5
       </span>
     </label>
   </div>


### PR DESCRIPTION
Currently the docs use the same moon icon for toggling back to light mode. This PR adjusts that to switch to a sun-like icon when in dark mode:

**New:**
<img width="109" alt="New sun icon" src="https://user-images.githubusercontent.com/18372958/214394532-ebe0f9cd-57be-4cb6-a6db-ad8d18ce402a.png">

**Before:**
<img width="71" alt="Old moon icon" src="https://user-images.githubusercontent.com/18372958/214394711-80c75da6-2e3b-414b-bfd3-1609e564f48e.png">
