### PR TITLE
Begin changelog for next release after 6.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.2.0-dev
+
+* Stop generating a null-safety badge for elements
+  in a null-safe library. (#3295)
+* Use a sun icon for switching to the light theme. (#3309)
+* Standardize the search icon style to a new SVG. (#3302)
+* Remove CSS classes no longer used in dartdoc generated content. (#3302)
+
 ## 6.1.5
 
 * Fix remote linking in Dart 2.18. (#3267)
@@ -45,7 +53,7 @@
 * Reduce memory usage by much more extensive use of non-growable Lists, and
   constant empty lists. (#3151 and #3154)
 * Make `Warnable.package` non-nullable. (#3155)
-* Refactor the various `Renderer` classses. Specifically add abstract
+* Refactor the various `Renderer` classes. Specifically add abstract
   `ElementTypeRendererHtml` and `ElementTypeRendererMd` classes which implement
   some shared calculations. (#3163)
 * Deprecate `ElementTypeRenderer.wrapNullability`. (#3163)

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v6.1.5/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v6.2.0-dev/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.1.5';
+const packageVersion = '6.2.0-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `dart run grinder build` after updating.
-version: 6.1.5
+version: 6.2.0-dev
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
The next release very well might be 7.0.0, but so far no code breaking changes have made it in yet, so will keep it here for now.