### PR TITLE
Bump markdown dep to a pre-release of 7.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,13 @@ dependencies:
   glob: ^2.0.1
   html: ^0.15.0
   logging: ^1.0.2
-  markdown: ">=5.0.0 <7.0.0"
+  # TODO(srawlins): Bump this to '>=7.0.0' when 7.0.0 is released.
+  markdown:
+    git:
+      url: https://github.com/dart-lang/markdown.git
+      # This commit includes the breaking changes for markdown 7.0.0,
+      # but does not include the markdown 7.0.0 release.
+      ref: f51c24c5c5603ac20b6d88aded78ef3aa23619ac
   meta: ^1.7.0
   package_config: ^2.0.2
   path: ^1.8.0
@@ -44,3 +50,5 @@ dev_dependencies:
 
 executables:
   dartdoc: null
+
+dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,13 +16,7 @@ dependencies:
   glob: ^2.0.1
   html: ^0.15.0
   logging: ^1.0.2
-  # TODO(srawlins): Bump this to '>=7.0.0' when 7.0.0 is released.
-  markdown:
-    git:
-      url: https://github.com/dart-lang/markdown.git
-      # This commit includes the breaking changes for markdown 7.0.0,
-      # but does not include the markdown 7.0.0 release.
-      ref: f51c24c5c5603ac20b6d88aded78ef3aa23619ac
+  markdown: ">=5.0.0 <7.0.0"
   meta: ^1.7.0
   package_config: ^2.0.2
   path: ^1.8.0
@@ -52,3 +46,10 @@ executables:
   dartdoc: null
 
 dependency_overrides:
+  # TODO(srawlins): Bump this to '>=7.0.0' when 7.0.0 is released.
+  markdown:
+    git:
+      url: https://github.com/dart-lang/markdown.git
+      # This commit includes the breaking changes for markdown 7.0.0,
+      # but does not include the markdown 7.0.0 release.
+      ref: f51c24c5c5603ac20b6d88aded78ef3aa23619ac

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1216,7 +1216,10 @@ void main() {
       });
 
       test('Verify table appearance', () {
-        expect(docsAsHtml, contains('<table><thead><tr><th>Component</th>'));
+        expect(
+          docsAsHtml,
+          contains('<table>\n<thead>\n<tr>\n<th>Component</th>'),
+        );
       });
 
       test('Verify links inside of table headers', () {
@@ -1228,9 +1231,11 @@ void main() {
 
       test('Verify links inside of table body', () {
         expect(
-            docsAsHtml,
-            contains(
-                '<tbody><tr><td><a href="${htmlBasePlaceholder}fake/DocumentWithATable/foo-constant.html">foo</a></td>'));
+          docsAsHtml,
+          contains('<tbody>\n'
+              '<tr>\n'
+              '<td><a href="${htmlBasePlaceholder}fake/DocumentWithATable/foo-constant.html">foo</a></td>'),
+        );
       });
 
       test('Verify there is no emoji support', () {
@@ -1523,7 +1528,8 @@ void main() {
     test('no references', () {
       expect(
           Apple.documentationAsHtml,
-          '<p>Sample class <code>String</code></p><pre class="language-dart">  A\n'
+          '<p>Sample class <code>String</code></p>\n'
+          '<pre class="language-dart">  A\n'
           '   B\n'
           '</pre>');
     });


### PR DESCRIPTION
* There are new newlines in table output
* Markdown 7.0.0 is incompatible with the custom `parseLinesGenerator` method. I remove it, and just use `parseLines`.
  * `parseLinesGenerator` was used to avoid parsing multiple blocks in markdown documents when they weren't necessary but I think we will suffer none-to-minimal performance loss:
      1. most doc comments are 1 or 2 paragraphs,
      2. even if we do parse all of the block elements, we still delay parsing the inline text,
      3. we are forced to use `sync*` in the generator, which is known to be slow
  * Also, I think this fixes an unreported bug. I imagine today we don't resolve links which refer to a link reference ([text]: url as its own block) in 1-paragraph doc summaries. Using parseLines instead of parseLinesGenerator should solve this... theoretical... bug.

Work towards #3320 