### PR TITLE
introduce an environmentProvider abstraction

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,3 @@
-# Change analysis_options.yaml and analysis_options_presubmit.yaml
-# together.
 include: package:lints/recommended.yaml
 
 analyzer:

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1410,9 +1410,10 @@ List<DartdocOption> createDartdocOptions(
         help: 'Package names to ignore.', splitCommas: true),
     DartdocOptionSyntheticOnly<String?>('flutterRoot',
         (DartdocSyntheticOption<String?> option, Folder dir) {
-      var envFlutterRoot = Platform.environment['FLUTTER_ROOT'];
-      if (envFlutterRoot == null) return null;
-      return resourceProvider.pathContext.resolveTildePath(envFlutterRoot);
+      var flutterRootEnv =
+          packageMetaProvider.environmentProvider['FLUTTER_ROOT'];
+      if (flutterRootEnv == null) return null;
+      return resourceProvider.pathContext.resolveTildePath(flutterRootEnv);
     }, resourceProvider,
         optionIs: OptionKind.dir,
         help: 'Root of the Flutter SDK, specified from environment.',
@@ -1483,7 +1484,6 @@ List<DartdocOption> createDartdocOptions(
               .sdkType(option.parent.parent['flutterRoot'].valueAt(dir));
           // Analyzer may be confused because package_meta still needs
           // migrating.  It can definitely return null.
-          // ignore: unnecessary_null_comparison
           if (inSdk != null) {
             Map<String, String> sdks = option.parent['sdks'].valueAt(dir);
             var inSdkVal = sdks[inSdk];
@@ -1513,7 +1513,6 @@ List<DartdocOption> createDartdocOptions(
       'packageMeta',
       (DartdocSyntheticOption<PackageMeta> option, Folder dir) {
         var packageMeta = packageMetaProvider.fromDir(dir);
-        // ignore: unnecessary_null_comparison
         if (packageMeta == null) {
           throw DartdocOptionError(
               'Unable to determine package for directory: ${dir.path}');
@@ -1557,7 +1556,6 @@ List<DartdocOption> createDartdocOptions(
         (DartdocSyntheticOption<PackageMeta> option, Folder dir) {
       var packageMeta = packageMetaProvider.fromDir(
           resourceProvider.getFolder(option.parent['inputDir'].valueAt(dir)));
-      // ignore: unnecessary_null_comparison
       if (packageMeta == null) {
         throw DartdocOptionError(
             'Unable to generate documentation: no package found');

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -33,16 +33,18 @@ const List<List<String>> _sdkDirFilePathsPosix = [
 ];
 
 final PackageMetaProvider pubPackageMetaProvider = PackageMetaProvider(
-    PubPackageMeta.fromElement,
-    PubPackageMeta.fromFilename,
-    PubPackageMeta.fromDir,
-    PhysicalResourceProvider.INSTANCE,
-    PhysicalResourceProvider.INSTANCE
-        .getFile(PhysicalResourceProvider.INSTANCE.pathContext
-            .absolute(Platform.resolvedExecutable))
-        .parent
-        .parent,
-    messageForMissingPackageMeta: PubPackageMeta.messageForMissingPackageMeta);
+  PubPackageMeta.fromElement,
+  PubPackageMeta.fromFilename,
+  PubPackageMeta.fromDir,
+  PhysicalResourceProvider.INSTANCE,
+  PhysicalResourceProvider.INSTANCE
+      .getFile(PhysicalResourceProvider.INSTANCE.pathContext
+          .absolute(Platform.resolvedExecutable))
+      .parent
+      .parent,
+  Platform.environment,
+  messageForMissingPackageMeta: PubPackageMeta.messageForMissingPackageMeta,
+);
 
 /// Sets the supported way of constructing [PackageMeta] objects.
 ///
@@ -51,18 +53,33 @@ final PackageMetaProvider pubPackageMetaProvider = PackageMetaProvider(
 /// provide their own [PackageMeta] types.
 ///
 /// By using a different provider, these implementations can control how
-/// [PackageMeta] objects is built.
+/// [PackageMeta] objects are built.
 class PackageMetaProvider {
-  final ResourceProvider resourceProvider;
-  final Folder defaultSdkDir;
-  final DartSdk? defaultSdk;
-
   final PackageMeta? Function(LibraryElement, String, ResourceProvider)
       _fromElement;
   final PackageMeta? Function(String, ResourceProvider) _fromFilename;
   final PackageMeta? Function(Folder, ResourceProvider) _fromDir;
+
+  final ResourceProvider resourceProvider;
+  final Folder defaultSdkDir;
+  final DartSdk? defaultSdk;
+  final Map<String, String> environmentProvider;
+
   final String Function(LibraryElement, DartdocOptionContext)
       _messageForMissingPackageMeta;
+
+  PackageMetaProvider(
+    this._fromElement,
+    this._fromFilename,
+    this._fromDir,
+    this.resourceProvider,
+    this.defaultSdkDir,
+    this.environmentProvider, {
+    this.defaultSdk,
+    String Function(LibraryElement, DartdocOptionContext)?
+        messageForMissingPackageMeta,
+  }) : _messageForMissingPackageMeta = messageForMissingPackageMeta ??
+            _defaultMessageForMissingPackageMeta;
 
   PackageMeta? fromElement(LibraryElement library, String s) =>
       _fromElement(library, s, resourceProvider);
@@ -72,14 +89,6 @@ class PackageMetaProvider {
   String getMessageForMissingPackageMeta(
           LibraryElement library, DartdocOptionContext optionContext) =>
       _messageForMissingPackageMeta(library, optionContext);
-
-  PackageMetaProvider(this._fromElement, this._fromFilename, this._fromDir,
-      this.resourceProvider, this.defaultSdkDir,
-      {this.defaultSdk,
-      String Function(LibraryElement, DartdocOptionContext)?
-          messageForMissingPackageMeta})
-      : _messageForMissingPackageMeta = messageForMissingPackageMeta ??
-            _defaultMessageForMissingPackageMeta;
 
   static String _defaultMessageForMissingPackageMeta(
       LibraryElement library, DartdocOptionContext optionContext) {

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -5,7 +5,6 @@
 library dartdoc.dartdoc_test;
 
 import 'dart:async';
-import 'dart:io' show Platform;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/dartdoc.dart' show Dartdoc, DartdocResults;
@@ -119,9 +118,8 @@ void main() {
           useSomethingInAnotherPackage.modelType.linkedName,
           matches(
               r'<a href="https://pub.dev/documentation/meta/[^"]*/meta/Required-class.html">Required</a>'));
-      var stringLink = RegExp(
-          'https://api.dart.dev/(dev|stable|edge|be|beta)/${Platform.version.split(' ').first}/dart-core/String-class.html">String</a>');
-      expect(useSomethingInTheSdk.modelType.linkedName, contains(stringLink));
+      var link = RegExp('/dart-core/String-class.html">String</a>');
+      expect(useSomethingInTheSdk.modelType.linkedName, contains(link));
     });
 
     group('validate basic doc generation', () {

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -151,6 +151,7 @@ PackageMetaProvider get testPackageMetaProvider {
     PubPackageMeta.fromDir,
     resourceProvider,
     sdkRoot,
+    {},
     defaultSdk: FolderBasedDartSdk(resourceProvider, sdkRoot),
     messageForMissingPackageMeta: PubPackageMeta.messageForMissingPackageMeta,
   );


### PR DESCRIPTION
- introduce an `environmentProvider` abstraction into the `PackageMetaProvider` class
- update the two normal PackageMetaProvider instances (the one used by normal dartdoc, and the one used by tests) to pass in values for `environmentProvider`

This addresses an issue I had been seeing locally. For quite a while now I have not been able to run the dartdoc tests locally - I always saw several hundred test errors, and didn't know why I saw that locally vs. what I saw on the bots. I tracked this down to:
- the first `dart` version on my command line path is from an install of the flutter sdk
- that dart, when run, automatically has a value populated for the `FLUTTER_ROOT` env var
- having that var set changes what the `flutterRoot` dartdoc option will return
- tests use a mock sdk with a memory file system
- there was some validation that the dir pointed to by flutterRoot exists if set; this would throw an exception in these circumstances as `flutterRoot` was pointing to an (existing) path on disk, but is was validating against the memory file system

This PR allows tests to both provide an instance of an SDK as well as provide something you can get env. vars from; this ensures things are in sync (using the real file system and `Platform.environment`, or using the test file system and a mock env. provider).
