### PR TITLE
Record rendering simplification

### DIFF
--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -123,7 +123,6 @@ class RecordElementTypeRendererHtml
   @override
   String renderLinkedName(RecordElementType elementType) {
     var buffer = StringBuffer()
-      ..write(elementType.nameWithGenerics)
       ..write('(')
       ..write(const RecordTypeFieldListHtmlRenderer()
           .renderLinkedFields(elementType)

--- a/lib/src/render/record_type_field_renderer.dart
+++ b/lib/src/render/record_type_field_renderer.dart
@@ -86,14 +86,12 @@ abstract class _RecordTypeFieldListRenderer {
         var linkedTypeName = typeName(modelType.linkedName);
         if (linkedTypeName.isNotEmpty) {
           fieldBuffer.write(linkedTypeName);
-          fieldBuffer.write(' ');
         }
-        var name = field is RecordTypeNamedField
-            ? field.name
-            : _fieldName(field, index);
-        fieldBuffer.write(fieldName(name));
+        if (field is RecordTypeNamedField) {
+          fieldBuffer.write(' ');
+          fieldBuffer.write(fieldName(field.name));
+        }
         fieldBuffer.write(suffix);
-
         buffer.write(listItem(this.field(fieldBuffer.toString())));
       });
     }
@@ -114,6 +112,4 @@ abstract class _RecordTypeFieldListRenderer {
     }
     return orderedList(buffer.toString());
   }
-
-  String _fieldName(RecordTypeField field, int index) => '\$$index';
 }

--- a/test/record_test.dart
+++ b/test/record_test.dart
@@ -22,34 +22,33 @@ class RecordTest extends DartdocTestBase {
   String get libraryName => 'records';
 
   @override
-  String get sdkConstraint => '>=2.19.0-0 <3.0.0';
+  String get sdkConstraint => '>=2.19.0-0 <4.0.0';
 
   @override
   List<String> get experiments => ['records'];
 
   void test_noFields() async {
     var library = await bootPackageWithLibrary('''
-void f(() record) {}
+void f(() r) {}
 ''');
     var fFunction = library.functions.named('f');
     var recordType = fFunction.modelType.parameters.first.modelType;
-    expect(recordType.linkedName, equals('Record()'));
+    expect(recordType.linkedName, equals('()'));
     expect(recordType.nameWithGenerics, equals('Record'));
   }
 
   void test_onePositionalField() async {
     var library = await bootPackageWithLibrary('''
-void f((int) record) {}
+void f((int) r) {}
 ''');
     var fFunction = library.functions.named('f');
     var recordType = fFunction.modelType.parameters.first.modelType;
     expect(recordType.linkedName, matchesCompressed(r'''
-        Record\(
+        \(
           <span class="field">
             <span class="type-annotation">
               <a href=".*/dart-core/int-class.html">int</a>
             </span>
-            <span class="field-name">\$0</span>
           </span>
         \)
       '''));
@@ -58,23 +57,21 @@ void f((int) record) {}
 
   void test_positionalFields() async {
     var library = await bootPackageWithLibrary('''
-void f((int, String) record) {}
+void f((int, String) r) {}
 ''');
     var fFunction = library.functions.named('f');
     var recordType = fFunction.modelType.parameters.first.modelType;
     expect(recordType.linkedName, matchesCompressed(r'''
-        Record\(
+        \(
           <span class="field">
             <span class="type-annotation">
               <a href=".*/dart-core/int-class.html">int</a>
-            </span>
-            <span class="field-name">\$0</span>,
+            </span>,
           </span>
           <span class="field">
             <span class="type-annotation">
               <a href=".*/dart-core/String-class.html">String</a>
             </span>
-            <span class="field-name">\$1</span>
           </span>
         \)
       '''));
@@ -88,7 +85,7 @@ void f(({int bbb, String aaa}) record) {}
     var fFunction = library.functions.named('f');
     var recordType = fFunction.modelType.parameters.first.modelType;
     expect(recordType.linkedName, matchesCompressed(r'''
-        Record\(
+        \(
           <span class="field">
             \{
             <span class="type-annotation">
@@ -115,18 +112,16 @@ void f((int one, String two, {int ccc, String aaa, int bbb}) record) {}
     var fFunction = library.functions.named('f');
     var recordType = fFunction.modelType.parameters.first.modelType;
     expect(recordType.linkedName, matchesCompressed(r'''
-        Record\(
+        \(
           <span class="field">
             <span class="type-annotation">
               <a href=".*/dart-core/int-class.html">int</a>
-            </span>
-            <span class="field-name">\$0</span>,
+            </span>,
           </span>
           <span class="field">
             <span class="type-annotation">
               <a href=".*/dart-core/String-class.html">String</a>
-            </span>
-            <span class="field-name">\$1</span>,
+            </span>,
           </span>
           <span class="field">
             \{


### PR DESCRIPTION
Completes #3122.

Already approved, but for historical purposes:

This simplifies Record type rendering so it looks both more in line with Record type annotations as described in the spec and therefore, other types rendered by Dartdoc.  We do this by dropping `Record` and the `$n` names.

Here are some sample screenshots:

![Screenshot 2023-02-21 at 3 40 26 PM](https://user-images.githubusercontent.com/14116827/220483647-0f408a5c-d0fe-4810-a327-a7cbbfce7008.png)
![Screenshot 2023-02-21 at 3 40 37 PM](https://user-images.githubusercontent.com/14116827/220483660-d95983c6-f8f6-415c-9994-ca4e0bac0df0.png)

