### PR TITLE
Stop using deprecated set-output command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Store date
         id: date
-        run: echo "::set-output name=today::$(date +'%Y-%m-%d')"
+        run: echo "name=today::$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache clean flutter
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812


### PR DESCRIPTION
Implement [the change to set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

The immediate effect is to remove the deprecation warnings in annotations on test runs.  Compare head before this change,  https://github.com/dart-lang/dartdoc/actions/runs/4283771731, to a test run with this change, https://github.com/dart-lang/dartdoc/actions/runs/4285374760.