### PR TITLE
Replace additionalOptions

### DIFF
--- a/lib/options.dart
+++ b/lib/options.dart
@@ -80,8 +80,10 @@ List<DartdocOption<bool>> createDartdocProgramOptions(
 
 DartdocProgramOptionContext? parseOptions(
   PackageMetaProvider packageMetaProvider,
-  List<String> arguments,
-) {
+  List<String> arguments, {
+  // Additional options are given in google3.
+  OptionGenerator? additionalOptions,
+}) {
   var optionRoot = DartdocOptionRoot.fromOptionGenerators(
       'dartdoc',
       [
@@ -89,6 +91,7 @@ DartdocProgramOptionContext? parseOptions(
         createDartdocProgramOptions,
         createLoggingOptions,
         createGeneratorOptions,
+        if (additionalOptions != null) additionalOptions,
       ],
       packageMetaProvider);
 


### PR DESCRIPTION
This partially reverts https://github.com/dart-lang/dartdoc/commit/96e6190326cfbd93e0e35465e2d5ea2c18f5f1ce.

It turns out this parameter is needed in google3.