### PR TITLE
Fix example class modifiers

### DIFF
--- a/testing/test_package_experiments/lib/class_modifiers.dart
+++ b/testing/test_package_experiments/lib/class_modifiers.dart
@@ -19,6 +19,3 @@ abstract mixin class L {}
 abstract base mixin class M {}
 mixin N {}
 base mixin O {}
-interface mixin P {}
-final mixin Q {}
-sealed mixin R {}


### PR DESCRIPTION
Some of the no-longer-valid class modifiers were left over in the example package; does not affect production or automated test code.