### PR TITLE
Prepare mixin-like classes for Dart 3.0.0

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -651,7 +651,7 @@ class DartdocOptionSyntheticOnly<T> extends DartdocOption<T>
       : super(name, null, help, optionIs, mustExist, null, resourceProvider);
 }
 
-abstract class DartdocSyntheticOption<T> implements DartdocOption<T> {
+mixin DartdocSyntheticOption<T> implements DartdocOption<T> {
   T Function(DartdocSyntheticOption<T>, Folder) get _compute;
 
   @override
@@ -841,7 +841,7 @@ class DartdocOptionFileOnly<T> extends DartdocOption<T>
 }
 
 /// Implements checking for options contained in dartdoc.yaml.
-abstract class _DartdocFileOption<T> implements DartdocOption<T> {
+mixin _DartdocFileOption<T> implements DartdocOption<T> {
   /// If true, the parent directory's value overrides the child's.
   ///
   /// Otherwise, the child's value overrides values in parents.
@@ -1018,7 +1018,7 @@ abstract class _DartdocFileOption<T> implements DartdocOption<T> {
 }
 
 /// Mixin class implementing command-line arguments for [DartdocOption].
-abstract class _DartdocArgOption<T> implements DartdocOption<T> {
+mixin _DartdocArgOption<T> implements DartdocOption<T> {
   /// For [ArgParser], set to true if the argument can be negated with `--no` on
   /// the command line.
   bool get negatable;

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -25,8 +25,9 @@ mixin ElementTypeBuilderImpl implements ElementTypeBuilder {
 
 /// Base class representing a type in Dartdoc.  It wraps a [DartType], and
 /// may link to a [ModelElement].
-abstract class ElementType extends Privacy
-    with CommentReferable, Nameable, ModelBuilder {
+abstract class ElementType
+    with CommentReferable, Nameable, ModelBuilder
+    implements Privacy {
   final DartType type;
   @override
   final PackageGraph packageGraph;

--- a/lib/src/experiment_options.dart
+++ b/lib/src/experiment_options.dart
@@ -13,8 +13,7 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/dart/analysis/experiments.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 
-abstract class DartdocExperimentOptionContext
-    implements DartdocOptionContextBase {
+mixin DartdocExperimentOptionContext implements DartdocOptionContextBase {
   List<String> get enableExperiment =>
       optionSet['enable-experiment'].valueAt(context);
 }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -757,7 +757,6 @@ class _Renderer_Categorization extends RendererBase<Categorization> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                ..._Renderer_Object.propertyMap<CT_>(),
                 'categories': Property(
                   getValue: (CT_ c) => c.categories,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -4110,7 +4109,7 @@ class _Renderer_ElementType extends RendererBase<ElementType> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                ..._Renderer_Privacy.propertyMap<CT_>(),
+                ..._Renderer_Object.propertyMap<CT_>(),
                 ..._Renderer_CommentReferable.propertyMap<CT_>(),
                 ..._Renderer_Nameable.propertyMap<CT_>(),
                 ..._Renderer_ModelBuilder.propertyMap<CT_>(),
@@ -6535,7 +6534,6 @@ class _Renderer_Indexable extends RendererBase<Indexable> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                ..._Renderer_Object.propertyMap<CT_>(),
                 'href': Property(
                   getValue: (CT_ c) => c.href,
                   renderVariable:
@@ -8546,7 +8544,6 @@ class _Renderer_Locatable extends RendererBase<Locatable> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                ..._Renderer_Object.propertyMap<CT_>(),
                 'documentationFrom': Property(
                   getValue: (CT_ c) => c.documentationFrom,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -9754,11 +9751,10 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
           () => {
                 ..._Renderer_Canonicalization.propertyMap<CT_>(),
                 ..._Renderer_CommentReferable.propertyMap<CT_>(),
-                ..._Renderer_Privacy.propertyMap<CT_>(),
                 ..._Renderer_Warnable.propertyMap<CT_>(),
                 ..._Renderer_Locatable.propertyMap<CT_>(),
                 ..._Renderer_Nameable.propertyMap<CT_>(),
-                ..._Renderer_SourceCodeMixin.propertyMap<CT_>(),
+                ..._Renderer_SourceCode.propertyMap<CT_>(),
                 ..._Renderer_Indexable.propertyMap<CT_>(),
                 ..._Renderer_FeatureSet.propertyMap<CT_>(),
                 ..._Renderer_DocumentationComment.propertyMap<CT_>(),
@@ -12657,36 +12653,6 @@ class _Renderer_ParameterizedElementType
   }
 }
 
-class _Renderer_Privacy extends RendererBase<Privacy> {
-  static final Map<Type, Object> _propertyMapCache = {};
-  static Map<String, Property<CT_>> propertyMap<CT_ extends Privacy>() =>
-      _propertyMapCache.putIfAbsent(
-          CT_,
-          () => {
-                ..._Renderer_Object.propertyMap<CT_>(),
-                'isPublic': Property(
-                  getValue: (CT_ c) => c.isPublic,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isPublic == true,
-                ),
-              }) as Map<String, Property<CT_>>;
-
-  _Renderer_Privacy(Privacy context, RendererBase<Object>? parent,
-      Template template, StringSink sink)
-      : super(context, parent, template, sink);
-
-  @override
-  Property<Privacy>? getProperty(String key) {
-    if (propertyMap<Privacy>().containsKey(key)) {
-      return propertyMap<Privacy>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
 String renderProperty(PropertyTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PropertyTemplateData(context, template.ast, template, buffer);
@@ -12991,14 +12957,12 @@ class _Renderer_Rendered extends RendererBase<Rendered> {
   }
 }
 
-class _Renderer_SourceCodeMixin extends RendererBase<SourceCodeMixin> {
+class _Renderer_SourceCode extends RendererBase<SourceCode> {
   static final Map<Type, Object> _propertyMapCache = {};
-  static Map<String, Property<CT_>> propertyMap<
-          CT_ extends SourceCodeMixin>() =>
+  static Map<String, Property<CT_>> propertyMap<CT_ extends SourceCode>() =>
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                ..._Renderer_Object.propertyMap<CT_>(),
                 'characterLocation': Property(
                   getValue: (CT_ c) => c.characterLocation,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -13090,14 +13054,14 @@ class _Renderer_SourceCodeMixin extends RendererBase<SourceCodeMixin> {
                 ),
               }) as Map<String, Property<CT_>>;
 
-  _Renderer_SourceCodeMixin(SourceCodeMixin context,
-      RendererBase<Object>? parent, Template template, StringSink sink)
+  _Renderer_SourceCode(SourceCode context, RendererBase<Object>? parent,
+      Template template, StringSink sink)
       : super(context, parent, template, sink);
 
   @override
-  Property<SourceCodeMixin>? getProperty(String key) {
-    if (propertyMap<SourceCodeMixin>().containsKey(key)) {
-      return propertyMap<SourceCodeMixin>()[key];
+  Property<SourceCode>? getProperty(String key) {
+    if (propertyMap<SourceCode>().containsKey(key)) {
+      return propertyMap<SourceCode>()[key];
     } else {
       return null;
     }
@@ -13789,7 +13753,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                ..._Renderer_Object.propertyMap<CT_>(),
                 'classes': Property(
                   getValue: (CT_ c) => c.classes,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -16255,10 +16218,8 @@ const _invisibleGetters = {
     'documentationFrom',
     'documentationIsLocal',
     'fullyQualifiedName',
-    'hashCode',
     'href',
-    'location',
-    'runtimeType'
+    'location'
   },
   'Map': {
     'entries',

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -125,7 +125,7 @@ void startLogging(LoggingContext config) {
   }
 }
 
-abstract class LoggingContext implements DartdocOptionContextBase {
+mixin LoggingContext on DartdocOptionContextBase {
   bool get json => optionSet['json'].valueAt(context);
 
   bool get showProgress => optionSet['showProgress'].valueAt(context);

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -5,7 +5,7 @@
 import 'package:dartdoc/src/model/model.dart';
 
 /// Classes extending this class have canonicalization support in Dartdoc.
-abstract class Canonicalization implements Locatable, Documentable {
+abstract /*mixin*/ class Canonicalization implements Locatable, Documentable {
   bool get isCanonical;
 
   Library? get canonicalLibrary;

--- a/lib/src/model/categorization.dart
+++ b/lib/src/model/categorization.dart
@@ -10,7 +10,7 @@ final RegExp _categoryRegExp = RegExp(
     multiLine: true);
 
 /// Mixin implementing dartdoc categorization for ModelElements.
-abstract class Categorization implements ModelElement {
+mixin Categorization implements ModelElement {
   @override
   String buildDocumentationAddition(String rawDocs) =>
       _stripAndSetDartdocCategories(rawDocs);

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -36,8 +36,7 @@ final _htmlInjectRegExp = RegExp(r'<dartdoc-html>([a-f0-9]+)</dartdoc-html>');
 ///
 /// [_processCommentWithoutTools] and [processComment] are the primary
 /// entrypoints.
-mixin DocumentationComment
-    on Documentable, Warnable, Locatable, SourceCodeMixin {
+mixin DocumentationComment on Documentable, Warnable, Locatable, SourceCode {
   @override
   Element get element;
 

--- a/lib/src/model/indexable.dart
+++ b/lib/src/model/indexable.dart
@@ -5,7 +5,7 @@
 import 'package:dartdoc/src/model/model.dart';
 
 /// Something able to be indexed.
-abstract class Indexable implements Nameable {
+mixin Indexable implements Nameable {
   String? get href;
 
   String get kind;

--- a/lib/src/model/library_container.dart
+++ b/lib/src/model/library_container.dart
@@ -10,7 +10,7 @@ import 'package:dartdoc/src/model_utils.dart' as model_utils;
 ///
 /// Do not cache return values of any methods or members excepting [libraries]
 /// and [name] before finishing initialization of a [LibraryContainer].
-abstract class LibraryContainer
+abstract /*mixin*/ class LibraryContainer
     implements Nameable, Comparable<LibraryContainer> {
   final List<Library> libraries = [];
 

--- a/lib/src/model/locatable.dart
+++ b/lib/src/model/locatable.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/element/element.dart' show Element;
 
 /// Something that can be located for warning purposes.
-abstract class Locatable {
+mixin Locatable {
   List<Locatable> get documentationFrom;
 
   /// True if documentationFrom contains only one item, [this].

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -114,16 +114,15 @@ mixin ModelElementBuilderImpl implements ModelElementBuilder {
 abstract class ModelElement extends Canonicalization
     with
         CommentReferable,
-        Privacy,
         Warnable,
         Locatable,
         Nameable,
-        SourceCodeMixin,
+        SourceCode,
         Indexable,
         FeatureSet,
         DocumentationComment,
         ModelBuilder
-    implements Comparable<ModelElement>, Documentable {
+    implements Comparable<ModelElement>, Documentable, Privacy {
   // TODO(jcollins-g): This really wants a "member that has a type" class.
   final Member? _originalMember;
   final Library _library;

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -7,7 +7,7 @@ import 'package:collection/collection.dart';
 import 'locatable.dart';
 
 /// Something that has a name.
-abstract class Nameable {
+abstract /*mixin*/ class Nameable {
   String get name;
 
   String get fullyQualifiedName => name;

--- a/lib/src/model/privacy.dart
+++ b/lib/src/model/privacy.dart
@@ -3,6 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Classes implementing this have a public/private distinction.
-abstract interface class Privacy {
+abstract /*interface*/ class Privacy {
   bool get isPublic;
 }

--- a/lib/src/model/privacy.dart
+++ b/lib/src/model/privacy.dart
@@ -3,6 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Classes implementing this have a public/private distinction.
-abstract class Privacy {
+abstract interface class Privacy {
   bool get isPublic;
 }

--- a/lib/src/model/source_code_mixin.dart
+++ b/lib/src/model/source_code_mixin.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/model/model.dart';
 
-abstract class SourceCodeMixin implements Documentable {
+mixin SourceCode implements Documentable {
   ModelNode? get modelNode;
 
   CharacterLocation? get characterLocation;

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -11,7 +11,7 @@ import 'package:dartdoc/src/model_utils.dart' as model_utils;
 ///
 /// Do not call any methods or members excepting [name] and the private Lists
 /// below before finishing initialization of a [TopLevelContainer].
-abstract class TopLevelContainer implements Nameable {
+mixin TopLevelContainer implements Nameable {
   Iterable<Class> get classes;
 
   Iterable<Extension> get extensions;

--- a/lib/src/source_linker.dart
+++ b/lib/src/source_linker.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart' as p;
 
 final _uriTemplateRegExp = RegExp(r'(%[frl]%)');
 
-abstract class SourceLinkerOptionContext implements DartdocOptionContextBase {
+mixin SourceLinkerOptionContext implements DartdocOptionContextBase {
   List<String> get linkToSourceExcludes =>
       optionSet['linkToSource']['excludes'].valueAt(context);
 

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -14,7 +14,7 @@ import 'package:dartdoc/src/package_meta.dart';
 
 const _namePlaceholder = '@@name@@';
 
-abstract class PackageWarningOptionContext implements DartdocOptionContextBase {
+mixin PackageWarningOptionContext implements DartdocOptionContextBase {
   bool get allowNonLocalWarnings =>
       optionSet['allowNonLocalWarnings'].valueAt(context);
 

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -131,7 +131,7 @@ void main() {
       expect(
           resourceProvider
               .readAsMalformedAllowedStringSync(p.getReadmeContents()!),
-          startsWith('Welcome'));
+          contains('Welcome to the Dart API reference documentation'));
     });
 
     test('does not have a license', () {

--- a/test/package_meta_test.dart
+++ b/test/package_meta_test.dart
@@ -131,7 +131,7 @@ void main() {
       expect(
           resourceProvider
               .readAsMalformedAllowedStringSync(p.getReadmeContents()!),
-          contains('Welcome to the Dart API reference documentation'));
+          contains('Welcome to the'));
     });
 
     test('does not have a license', () {


### PR DESCRIPTION
We have a lot of mixin-like classes that need to be mixins. Some need to be `abstract mixin class`, but we can't do that until we can bump our SDK constraints to use 3.0.0 at minimum.