### PR TITLE
Fix a reexport case for comment reference linking to extension methods

### DIFF
--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -43,11 +43,8 @@ mixin ContainerMember on ModelElement implements EnclosedElement {
           as Container?;
     }
     // TODO(jcollins-g): move Extension specific code to [Extendable]
-    if (enclosingElement.isDocumented) {
-      return packageGraph.findCanonicalModelElementFor(enclosingElement.element)
-          as Container?;
-    }
-    return null;
+    return packageGraph.findCanonicalModelElementFor(enclosingElement.element)
+        as Container?;
   }
 
   @override

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -48,10 +48,6 @@ mixin Inheritable on ContainerMember {
     if (canonicalEnclosingContainer == null) {
       return null;
     }
-    // TODO(jcollins-g): factor out extension logic into [Extendable]
-    if (canonicalEnclosingContainer is Extension) {
-      return this;
-    }
     return canonicalEnclosingContainer.allCanonicalModelElements
         .firstWhereOrNull((m) =>
             m.name == name &&

--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -104,7 +104,6 @@ $libraryContent
       {bool reexportPrivate = false,
       List<String> show = const [],
       List<String> hide = const []}) async {
-
     final subdir = reexportPrivate ? 'src' : 'subdir';
     await d.dir('lib', [
       d.dir(subdir, [

--- a/test/extension_methods_test.dart
+++ b/test/extension_methods_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartdoc/src/markdown_processor.dart';
+import 'package:dartdoc/src/model/extension.dart';
+import 'package:dartdoc/src/model/method.dart';
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'dartdoc_test_base.dart';
+import 'src/utils.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    if (classModifiersAllowed) {
+      defineReflectiveTests(ExtensionMethodsTest);
+    }
+  });
+}
+
+@reflectiveTest
+class ExtensionMethodsTest extends DartdocTestBase {
+  @override
+  String get libraryName => 'extension_methods';
+
+  static const String reexportedContent = '''
+class AClassNotNeedingExtending {}
+
+class AClassNeedingExtending {}
+
+extension AnExtension on AClassNeedingExtending {
+  void aMethod() {}
+}
+''';
+
+  static const String libraryContent = '''
+/// This is an amazing public function.
+var aPublicFunction() {}
+''';
+
+  void test_reexportWithShow() async {
+    var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true, show: ['AClassNeedingExtending', 'AnExtension']);
+    var aPublicFunction = library.functions.named('aPublicFunction');
+    var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
+    var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
+    var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
+    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
+    expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
+    expect(anExtension.isCanonical, isTrue);
+    var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
+    expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
+    expect(anExtensionMethod.isCanonical, isTrue);
+    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+  }
+
+  /*void test_reexportWithHide() async {
+    var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true, hide: ['AClassNotNeedingExtending']);
+    var aPublicFunction = library.functions.named('aPublicFunction');
+    var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
+    var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
+    var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
+    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
+    expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
+    expect(anExtension.isCanonical, isTrue);
+    var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
+    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+    expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
+    expect(anExtensionMethod.isCanonical, isTrue);
+  }
+
+  void test_reexportFull() async {
+    var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true);
+    var aPublicFunction = library.functions.named('aPublicFunction');
+    var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
+    var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
+    var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
+    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
+    expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
+    expect(anExtension.isCanonical, isTrue);
+    var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
+    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+    expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
+    expect(anExtensionMethod.isCanonical, isTrue);
+  }*/
+}

--- a/test/extension_methods_test.dart
+++ b/test/extension_methods_test.dart
@@ -5,6 +5,7 @@
 import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/model/extension.dart';
 import 'package:dartdoc/src/model/method.dart';
+import 'package:dartdoc/src/model/model_element.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -39,19 +40,21 @@ extension AnExtension on AClassNeedingExtending {
 var aPublicFunction() {}
 ''';
 
+  void expectReferenceValid(ModelElement reference, ModelElement expected, String href) {
+    expect(identical(reference.canonicalModelElement, expected), isTrue);
+    expect(expected.isCanonical, isTrue);
+    expect(expected.href, endsWith(href)); 
+  }
+
   void test_reexportWithShow() async {
     var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true, show: ['AClassNeedingExtending', 'AnExtension']);
     var aPublicFunction = library.functions.named('aPublicFunction');
     var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
     var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
-    expect(anExtension.isCanonical, isTrue);
-    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
-    var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
-    expect(anExtensionMethod.isCanonical, isTrue);
-    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+    expectReferenceValid(anExtensionReference, anExtension, '%extension_methods_lib/AnExtension.html');
+    var anExtensionMethodReference = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
+    expectReferenceValid(anExtensionMethodReference, anExtensionMethod, '%extension_methods_lib/AnExtension/aMethod.html');
   }
 
   void test_reexportWithHide() async {
@@ -60,13 +63,9 @@ var aPublicFunction() {}
     var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
     var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
-    expect(anExtension.isCanonical, isTrue);
-    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
-    var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
-    expect(anExtensionMethod.isCanonical, isTrue);
-    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+    expectReferenceValid(anExtensionReference, anExtension, '%extension_methods_lib/AnExtension.html');
+    var anExtensionMethodReference = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
+    expectReferenceValid(anExtensionMethodReference, anExtensionMethod, '%extension_methods_lib/AnExtension/aMethod.html');
   }
 
   void test_reexportFull() async {
@@ -75,12 +74,8 @@ var aPublicFunction() {}
     var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
     var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
-    expect(anExtension.isCanonical, isTrue);
-    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
-    var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
-    expect(anExtensionMethod.isCanonical, isTrue);
-    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+    expectReferenceValid(anExtensionReference, anExtension, '%extension_methods_lib/AnExtension.html');
+    var anExtensionMethodReference = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
+    expectReferenceValid(anExtensionMethodReference, anExtensionMethod, '%extension_methods_lib/AnExtension/aMethod.html');
   }
 }

--- a/test/extension_methods_test.dart
+++ b/test/extension_methods_test.dart
@@ -40,42 +40,76 @@ extension AnExtension on AClassNeedingExtending {
 var aPublicFunction() {}
 ''';
 
-  void expectReferenceValid(ModelElement reference, ModelElement expected, String href) {
+  void expectReferenceValid(
+      ModelElement reference, ModelElement expected, String href) {
     expect(identical(reference.canonicalModelElement, expected), isTrue);
     expect(expected.isCanonical, isTrue);
-    expect(expected.href, endsWith(href)); 
+    expect(expected.href, endsWith(href));
   }
 
   void test_reexportWithShow() async {
-    var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true, show: ['AClassNeedingExtending', 'AnExtension']);
+    var library = await bootPackageWithReexportedLibrary(
+        reexportedContent, libraryContent,
+        reexportPrivate: true, show: ['AClassNeedingExtending', 'AnExtension']);
     var aPublicFunction = library.functions.named('aPublicFunction');
-    var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
+    var anExtension = library.package.publicLibraries
+        .named('${libraryName}_lib')
+        .extensions
+        .named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
-    var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expectReferenceValid(anExtensionReference, anExtension, '%extension_methods_lib/AnExtension.html');
-    var anExtensionMethodReference = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expectReferenceValid(anExtensionMethodReference, anExtensionMethod, '%extension_methods_lib/AnExtension/aMethod.html');
+    var anExtensionReference =
+        getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable
+            as Extension;
+    expectReferenceValid(anExtensionReference, anExtension,
+        '%extension_methods_lib/AnExtension.html');
+    var anExtensionMethodReference =
+        getMatchingLinkElement('AnExtension.aMethod', aPublicFunction)
+            .commentReferable as Method;
+    expectReferenceValid(anExtensionMethodReference, anExtensionMethod,
+        '%extension_methods_lib/AnExtension/aMethod.html');
   }
 
   void test_reexportWithHide() async {
-    var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true, hide: ['AClassNotNeedingExtending']);
+    var library = await bootPackageWithReexportedLibrary(
+        reexportedContent, libraryContent,
+        reexportPrivate: true, hide: ['AClassNotNeedingExtending']);
     var aPublicFunction = library.functions.named('aPublicFunction');
-    var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
+    var anExtension = library.package.publicLibraries
+        .named('${libraryName}_lib')
+        .extensions
+        .named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
-    var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expectReferenceValid(anExtensionReference, anExtension, '%extension_methods_lib/AnExtension.html');
-    var anExtensionMethodReference = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expectReferenceValid(anExtensionMethodReference, anExtensionMethod, '%extension_methods_lib/AnExtension/aMethod.html');
+    var anExtensionReference =
+        getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable
+            as Extension;
+    expectReferenceValid(anExtensionReference, anExtension,
+        '%extension_methods_lib/AnExtension.html');
+    var anExtensionMethodReference =
+        getMatchingLinkElement('AnExtension.aMethod', aPublicFunction)
+            .commentReferable as Method;
+    expectReferenceValid(anExtensionMethodReference, anExtensionMethod,
+        '%extension_methods_lib/AnExtension/aMethod.html');
   }
 
   void test_reexportFull() async {
-    var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true);
+    var library = await bootPackageWithReexportedLibrary(
+        reexportedContent, libraryContent,
+        reexportPrivate: true);
     var aPublicFunction = library.functions.named('aPublicFunction');
-    var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
+    var anExtension = library.package.publicLibraries
+        .named('${libraryName}_lib')
+        .extensions
+        .named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
-    var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expectReferenceValid(anExtensionReference, anExtension, '%extension_methods_lib/AnExtension.html');
-    var anExtensionMethodReference = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expectReferenceValid(anExtensionMethodReference, anExtensionMethod, '%extension_methods_lib/AnExtension/aMethod.html');
+    var anExtensionReference =
+        getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable
+            as Extension;
+    expectReferenceValid(anExtensionReference, anExtension,
+        '%extension_methods_lib/AnExtension.html');
+    var anExtensionMethodReference =
+        getMatchingLinkElement('AnExtension.aMethod', aPublicFunction)
+            .commentReferable as Method;
+    expectReferenceValid(anExtensionMethodReference, anExtensionMethod,
+        '%extension_methods_lib/AnExtension/aMethod.html');
   }
 }

--- a/test/extension_methods_test.dart
+++ b/test/extension_methods_test.dart
@@ -45,28 +45,28 @@ var aPublicFunction() {}
     var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
     var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
     expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
     expect(anExtension.isCanonical, isTrue);
+    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
     var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
     expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
     expect(anExtensionMethod.isCanonical, isTrue);
     expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
   }
 
-  /*void test_reexportWithHide() async {
+  void test_reexportWithHide() async {
     var library = await bootPackageWithReexportedLibrary(reexportedContent, libraryContent, reexportPrivate: true, hide: ['AClassNotNeedingExtending']);
     var aPublicFunction = library.functions.named('aPublicFunction');
     var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
     var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
     expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
     expect(anExtension.isCanonical, isTrue);
+    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
     var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
     expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
     expect(anExtensionMethod.isCanonical, isTrue);
+    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
   }
 
   void test_reexportFull() async {
@@ -75,12 +75,12 @@ var aPublicFunction() {}
     var anExtension = library.package.publicLibraries.named('${libraryName}_lib').extensions.named('AnExtension');
     var anExtensionMethod = anExtension.instanceMethods.named('aMethod');
     var anExtensionReference = getMatchingLinkElement('AnExtension', aPublicFunction).commentReferable as Extension;
-    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
     expect(identical(anExtensionReference.canonicalModelElement, anExtension), isTrue);
     expect(anExtension.isCanonical, isTrue);
+    expect(anExtensionReference.href, endsWith('%extension_methods_lib/AnExtension.html'));
     var anExtensionReferenceMethod = getMatchingLinkElement('AnExtension.aMethod', aPublicFunction).commentReferable as Method;
-    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
     expect(identical(anExtensionReferenceMethod.canonicalModelElement, anExtensionMethod), isTrue);
     expect(anExtensionMethod.isCanonical, isTrue);
-  }*/
+    expect(anExtensionReferenceMethod.href, endsWith('%extension_methods_lib/AnExtension/aMethod.html'));
+  }
 }


### PR DESCRIPTION
Fixes #3325.  Also introduces a new test helper for reflective tests that should make it easier to test canonicalization edge cases.