### PR TITLE
Convert 'master' to 'main' for dartdoc and for external links where possible

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -3,7 +3,7 @@ on:
   # Only the default branch is supported.
   branch_protection_rule:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,9 @@ name: Test
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: 0 15 * * *
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ yet in the issue tracker, start by opening an issue. Thanks!
 ## Making Changes
 
 1. `grind` is needed to run dartdoc integration tests, see installed via `pub global activate grinder`.
-2. When a change is user-facing, please add a new entry to the [changelog](https://github.com/dart-lang/dartdoc/blob/master/CHANGELOG.md)
+2. When a change is user-facing, please add a new entry to the [changelog](https://github.com/dart-lang/dartdoc/blob/main/CHANGELOG.md)
 3. Please include a test for your change.  `dartdoc` has both `package:test`-style unittests as well as integration tests.  To run the unittests, use `grind test`.
 4. For major changes, run `grind compare-sdk-warnings` and `grind compare-flutter-warnings`, and include the summary results in your pull request.
 5. Be sure to format your Dart code using `dart format`, otherwise our CI will complain.
@@ -52,7 +52,7 @@ There are more added all the time -- run `grind --help` to see them all.
 
 ## License
 
-Please see the [dartdoc license](https://github.com/dart-lang/dartdoc/blob/master/LICENSE).
+Please see the [dartdoc license](https://github.com/dart-lang/dartdoc/blob/main/LICENSE).
 
 [user docs]: https://github.com/dart-lang/dartdoc#dartdoc
 [issue tracker]: https://github.com/dart-lang/dartdoc/issues

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dart documentation generator
 
 [![Build Status](https://github.com/dart-lang/dartdoc/workflows/Test/badge.svg)](https://github.com/dart-lang/dartdoc/actions?query=workflow%3ATest)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/dartdoc/badge.svg?branch=master)](https://coveralls.io/github/dart-lang/dartdoc?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/dartdoc/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/dartdoc?branch=main)
 [![OpenSSF
 Scorecard](https://api.securityscorecards.dev/projects/github.com/dart-lang/dartdoc/badge)](https://deps.dev/project/github/dart-lang%2Fdartdoc)
 
@@ -505,9 +505,9 @@ Please see the [dartdoc license][].
 Generated docs include:
 
  * Highlight.js -
-   [LICENSE](https://github.com/isagalaev/highlight.js/blob/master/LICENSE)
+   [LICENSE](https://github.com/isagalaev/highlight.js/blob/main/LICENSE)
    * With `github.css` (c) Vasily Polovnyov <vast@whiteants.net>
 
 [GitHub Issue Tracker]: https://github.com/dart-lang/dartdoc/issues
-[contributor docs]: https://github.com/dart-lang/dartdoc/blob/master/CONTRIBUTING.md
-[dartdoc license]: https://github.com/dart-lang/dartdoc/blob/master/LICENSE
+[contributor docs]: https://github.com/dart-lang/dartdoc/blob/main/CONTRIBUTING.md
+[dartdoc license]: https://github.com/dart-lang/dartdoc/blob/main/LICENSE

--- a/example/README.md
+++ b/example/README.md
@@ -15,8 +15,8 @@ Look for `BuildDartdocAPIDocs`.
 ## Flutter
 
 The Flutter team builds [API documentation for the Flutter SDK](https://api.flutter.dev)
-automatically.  A [shell script](https://github.com/flutter/flutter/blob/master/dev/bots/docs.sh)
-wraps a [small dart program](https://github.com/flutter/flutter/blob/master/dev/tools/dartdoc.dart)
+automatically.  A [shell script](https://github.com/flutter/flutter/blob/main/dev/bots/docs.sh)
+wraps a [small dart program](https://github.com/flutter/flutter/blob/main/dev/tools/dartdoc.dart)
 that manages the process.
 
 ## pub

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -551,7 +551,7 @@ h1 .category {
 }
 
 /* The badge under a declaration for things like "const", "read-only", etc. and for the badges inline like Null safety*/
-/* See https://github.com/dart-lang/dartdoc/blob/master/lib/src/model/feature.dart */
+/* See https://github.com/dart-lang/dartdoc/blob/main/lib/src/model/feature.dart */
 .feature {
   display: inline-block;
   background: var(--main-bg-color);

--- a/test/source_linker_test.dart
+++ b/test/source_linker_test.dart
@@ -40,10 +40,10 @@ void main() {
               lineNumber: 71,
               root: 'path',
               sourceFileName: 'path/to/file.dart',
-              uriTemplate: 'http://github.com/base/master/%f%/L%l%')
+              uriTemplate: 'http://github.com/base/main/%f%/L%l%')
           .href();
       expect(sourceLinkerHref(),
-          equals('http://github.com/base/master/to/file.dart/L71'));
+          equals('http://github.com/base/main/to/file.dart/L71'));
     });
 
     test('Throw if only revision specified', () {

--- a/testing/flutter_packages/test_package_flutter_plugin/pubspec.yaml
+++ b/testing/flutter_packages/test_package_flutter_plugin/pubspec.yaml
@@ -1,12 +1,12 @@
 name: test_package_flutter_plugin
 version: 0.1.0
 description: A happy flutter almost plugin being documented
-homepage: http://github.com/dart-lang/dartdoc/tree/master/testing/test_package_flutter_plugin
+homepage: http://github.com/dart-lang/dartdoc/tree/main/testing/test_package_flutter_plugin
 
 dependencies:
   flutter:
     sdk: flutter
 
 environment:
-  sdk: ">2.12.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  sdk: ">2.12.0 <4.0.0"
+  flutter: ">=0.1.4 <4.0.0"

--- a/testing/test_package/dartdoc_options.yaml
+++ b/testing/test_package/dartdoc_options.yaml
@@ -24,4 +24,4 @@ dartdoc:
     - broken-link
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/master/testing/test_package/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/main/testing/test_package/%f%#L%l%'

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -142,7 +142,7 @@ final String _pluginPackageDocsPath =
 String get dartdocOriginalBranch {
   var branch = Platform.environment['DARTDOC_ORIGINAL'];
   if (branch == null) {
-    return 'master';
+    return 'main';
   } else {
     log('using branch/tag: $branch for comparison from \$DARTDOC_ORIGINAL');
     return branch;
@@ -443,7 +443,7 @@ Future<String> createSdkDartdoc() async {
   await launcher.runStreamed('git', [
     'clone',
     '--branch',
-    'master',
+    'main',
     '--depth',
     '1',
     'https://dart.googlesource.com/sdk.git',

--- a/tool/mustachio/README.md
+++ b/tool/mustachio/README.md
@@ -153,11 +153,11 @@ types:
   tag is inverted, and the syntax tree of the section block
 * [Partial][] node - a node containing the partial tag key
 
-[Parser]: https://github.com/dart-lang/dartdoc/blob/master/lib/src/mustachio/parser.dart
-[Text]: https://github.com/dart-lang/dartdoc/blob/master/lib/src/mustachio/parser.dart#L422
-[Variable]: https://github.com/dart-lang/dartdoc/blob/master/lib/src/mustachio/parser.dart#L436
-[Section]: https://github.com/dart-lang/dartdoc/blob/master/lib/src/mustachio/parser.dart#L456
-[Partial]: https://github.com/dart-lang/dartdoc/blob/master/lib/src/mustachio/parser.dart#L477
+[Parser]: https://github.com/dart-lang/dartdoc/blob/main/lib/src/mustachio/parser.dart
+[Text]: https://github.com/dart-lang/dartdoc/blob/main/lib/src/mustachio/parser.dart#L422
+[Variable]: https://github.com/dart-lang/dartdoc/blob/main/lib/src/mustachio/parser.dart#L436
+[Section]: https://github.com/dart-lang/dartdoc/blob/main/lib/src/mustachio/parser.dart#L456
+[Partial]: https://github.com/dart-lang/dartdoc/blob/main/lib/src/mustachio/parser.dart#L477
 
 ## Generated renderer for a specific type which interprets templates at runtime
 


### PR DESCRIPTION
Fixes: #3370

Finish move from master to main branch for dartdoc.   Also converted all external links to use `main` instead where possible -- pub-dev has not moved to `main` yet, so one link remains.