### PR TITLE
Prepare for dartdoc 6.2.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.2.2
+* Add chips to class pages for class modifiers (#3401)
+* Fix a case where dartdoc was not properly handling extension
+  method resolution. (#3393)
+
 ## 6.2.1
 * Do not show induced modifiers from analyzer in class headers.
   (#3371)

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v6.2.1/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v6.2.2/%f%#L%l%'

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.2.1';
+const packageVersion = '6.2.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc
 # Run `dart run grinder build` after updating.
-version: 6.2.1
+version: 6.2.2
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
In addition to being a standard release, this commit will be targeted for a cherry pick into the SDK.