### PR TITLE
Allow InvalidType as dynamic

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -5,8 +5,6 @@
 /// The models used to represent Dart code.
 library dartdoc.element_type;
 
-import 'dart:html';
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -5,6 +5,8 @@
 /// The models used to represent Dart code.
 library dartdoc.element_type;
 
+import 'dart:html';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -104,7 +106,7 @@ class UndefinedElementType extends ElementType {
   String get name {
     if (type is VoidType) return 'void';
     if (type is DynamicType) return 'dynamic';
-    assert(const {'Never'}.contains(typeElement!.name),
+    assert(const {'Never'}.contains(typeElement?.name),
         'Unrecognized type for UndefinedElementType: ${type.toString()}');
     return typeElement!.name!;
   }

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -104,6 +104,9 @@ class UndefinedElementType extends ElementType {
   String get name {
     if (type is VoidType) return 'void';
     if (type is DynamicType) return 'dynamic';
+    // We can not simply throw here because not all SDK libraries resolve
+    // all types.
+    if (type is InvalidType) return 'dynamic';
     assert(const {'Never'}.contains(typeElement?.name),
         'Unrecognized type for UndefinedElementType: ${type.toString()}');
     return typeElement!.name!;


### PR DESCRIPTION
Fixes #3417.

It seems sometimes (perhaps, only on Linux/Windows?) that the SDK actually contains invalid types from a Dart perspective.   It's safe for dartdoc to assume they're dynamic for documentation purposes.   Also, fix a bug in an assert where we might not actually display the intended information when it fires.