### PR TITLE
Bump tests involving records to use Dart 3.0.0

### DIFF
--- a/test/record_test.dart
+++ b/test/record_test.dart
@@ -22,10 +22,7 @@ class RecordTest extends DartdocTestBase {
   String get libraryName => 'records';
 
   @override
-  String get sdkConstraint => '>=2.19.0-0 <4.0.0';
-
-  @override
-  List<String> get experiments => ['records'];
+  String get sdkConstraint => '>=3.0.0 <4.0.0';
 
   void test_noFields() async {
     var library = await bootPackageWithLibrary('''

--- a/test/typedef_test.dart
+++ b/test/typedef_test.dart
@@ -24,10 +24,7 @@ class TypedefTest extends DartdocTestBase {
   String get libraryName => 'typedefs';
 
   @override
-  String get sdkConstraint => '>=2.19.0-0 <3.0.0';
-
-  @override
-  List<String> get experiments => ['records'];
+  String get sdkConstraint => '>=3.0.0 <4.0.0';
 
   void test_basicFunctionTypedef() async {
     var library = await bootPackageWithLibrary('''


### PR DESCRIPTION
These are causing issues with how records are now parsed in with Dart Language Version 2.19.