### PR TITLE
Remove dependency on code_builder

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -12,35 +12,33 @@
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
 // ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
-// ignore_for_file: use_super_parameters
 
-// ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:convert' as _i23;
+import 'dart:convert';
 
-import 'package:dartdoc/src/generator/template_data.dart' as _i1;
-import 'package:dartdoc/src/model/accessor.dart' as _i22;
-import 'package:dartdoc/src/model/category.dart' as _i4;
-import 'package:dartdoc/src/model/class.dart' as _i10;
-import 'package:dartdoc/src/model/constructor.dart' as _i12;
-import 'package:dartdoc/src/model/container.dart' as _i6;
-import 'package:dartdoc/src/model/documentable.dart' as _i3;
-import 'package:dartdoc/src/model/enum.dart' as _i13;
-import 'package:dartdoc/src/model/extension.dart' as _i2;
-import 'package:dartdoc/src/model/field.dart' as _i11;
-import 'package:dartdoc/src/model/getter_setter_combo.dart' as _i19;
-import 'package:dartdoc/src/model/inheriting_container.dart' as _i20;
-import 'package:dartdoc/src/model/library.dart' as _i5;
-import 'package:dartdoc/src/model/method.dart' as _i15;
-import 'package:dartdoc/src/model/mixin.dart' as _i16;
-import 'package:dartdoc/src/model/model_element.dart' as _i18;
-import 'package:dartdoc/src/model/model_function.dart' as _i8;
-import 'package:dartdoc/src/model/operator.dart' as _i21;
-import 'package:dartdoc/src/model/package.dart' as _i14;
-import 'package:dartdoc/src/model/top_level_variable.dart' as _i7;
-import 'package:dartdoc/src/model/typedef.dart' as _i9;
-import 'package:dartdoc/src/warnings.dart' as _i17;
+import 'package:dartdoc/src/generator/template_data.dart';
+import 'package:dartdoc/src/model/accessor.dart';
+import 'package:dartdoc/src/model/category.dart';
+import 'package:dartdoc/src/model/class.dart';
+import 'package:dartdoc/src/model/constructor.dart';
+import 'package:dartdoc/src/model/container.dart';
+import 'package:dartdoc/src/model/documentable.dart';
+import 'package:dartdoc/src/model/enum.dart';
+import 'package:dartdoc/src/model/extension.dart';
+import 'package:dartdoc/src/model/field.dart';
+import 'package:dartdoc/src/model/getter_setter_combo.dart';
+import 'package:dartdoc/src/model/inheriting_container.dart';
+import 'package:dartdoc/src/model/library.dart';
+import 'package:dartdoc/src/model/method.dart';
+import 'package:dartdoc/src/model/mixin.dart';
+import 'package:dartdoc/src/model/model_element.dart';
+import 'package:dartdoc/src/model/model_function.dart';
+import 'package:dartdoc/src/model/operator.dart';
+import 'package:dartdoc/src/model/package.dart';
+import 'package:dartdoc/src/model/top_level_variable.dart';
+import 'package:dartdoc/src/model/typedef.dart';
+import 'package:dartdoc/src/warnings.dart';
 
-String renderCategory(_i1.CategoryTemplateData context0) {
+String renderCategory(CategoryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderCategory_partial_head_0(context0));
   buffer.writeln();
@@ -277,7 +275,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
   return buffer.toString();
 }
 
-String renderClass(_i1.ClassTemplateData context0) {
+String renderClass(ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderClass_partial_head_0(context0));
   buffer.writeln();
@@ -427,7 +425,7 @@ String renderClass(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String renderConstructor(_i1.ConstructorTemplateData context0) {
+String renderConstructor(ConstructorTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderConstructor_partial_head_0(context0));
   buffer.writeln();
@@ -510,7 +508,7 @@ String renderConstructor(_i1.ConstructorTemplateData context0) {
   return buffer.toString();
 }
 
-String renderEnum(_i1.EnumTemplateData context0) {
+String renderEnum(EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderEnum_partial_head_0(context0));
   buffer.writeln();
@@ -651,7 +649,7 @@ String renderEnum(_i1.EnumTemplateData context0) {
   return buffer.toString();
 }
 
-String renderError(_i1.PackageTemplateData context0) {
+String renderError(PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderError_partial_head_0(context0));
   buffer.writeln();
@@ -698,8 +696,7 @@ String renderError(_i1.PackageTemplateData context0) {
   return buffer.toString();
 }
 
-String renderExtension<T extends _i2.Extension>(
-    _i1.ExtensionTemplateData<T> context0) {
+String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
   final buffer = StringBuffer();
   buffer.write(_renderExtension_partial_head_0(context0));
   buffer.writeln();
@@ -810,7 +807,7 @@ String renderExtension<T extends _i2.Extension>(
   return buffer.toString();
 }
 
-String renderFunction(_i1.FunctionTemplateData context0) {
+String renderFunction(FunctionTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderFunction_partial_head_0(context0));
   buffer.writeln();
@@ -882,7 +879,7 @@ String renderFunction(_i1.FunctionTemplateData context0) {
   return buffer.toString();
 }
 
-String renderIndex(_i1.PackageTemplateData context0) {
+String renderIndex(PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderIndex_partial_head_0(context0));
   buffer.writeln();
@@ -968,7 +965,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
   return buffer.toString();
 }
 
-String renderLibrary(_i1.LibraryTemplateData context0) {
+String renderLibrary(LibraryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderLibrary_partial_head_0(context0));
   buffer.writeln();
@@ -1218,7 +1215,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
   return buffer.toString();
 }
 
-String renderMethod(_i1.MethodTemplateData context0) {
+String renderMethod(MethodTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderMethod_partial_head_0(context0));
   buffer.writeln();
@@ -1288,7 +1285,7 @@ String renderMethod(_i1.MethodTemplateData context0) {
   return buffer.toString();
 }
 
-String renderMixin(_i1.MixinTemplateData context0) {
+String renderMixin(MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderMixin_partial_head_0(context0));
   buffer.writeln();
@@ -1433,7 +1430,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
   return buffer.toString();
 }
 
-String renderProperty(_i1.PropertyTemplateData context0) {
+String renderProperty(PropertyTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderProperty_partial_head_0(context0));
   buffer.writeln();
@@ -1520,7 +1517,7 @@ String renderProperty(_i1.PropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String renderSearchPage(_i1.PackageTemplateData context0) {
+String renderSearchPage(PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderSearchPage_partial_head_0(context0));
   buffer.writeln();
@@ -1555,8 +1552,8 @@ String renderSearchPage(_i1.PackageTemplateData context0) {
   return buffer.toString();
 }
 
-String renderSidebarForContainer<T extends _i3.Documentable>(
-    _i1.TemplateDataWithContainer<T> context0) {
+String renderSidebarForContainer<T extends Documentable>(
+    TemplateDataWithContainer<T> context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
   var context1 = context0.container;
@@ -1786,8 +1783,8 @@ String renderSidebarForContainer<T extends _i3.Documentable>(
   return buffer.toString();
 }
 
-String renderSidebarForLibrary<T extends _i3.Documentable>(
-    _i1.TemplateDataWithLibrary<T> context0) {
+String renderSidebarForLibrary<T extends Documentable>(
+    TemplateDataWithLibrary<T> context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
   var context1 = context0.library;
@@ -1942,7 +1939,7 @@ String renderSidebarForLibrary<T extends _i3.Documentable>(
   return buffer.toString();
 }
 
-String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
+String renderTopLevelProperty(TopLevelPropertyTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderTopLevelProperty_partial_head_0(context0));
   buffer.writeln();
@@ -2028,7 +2025,7 @@ String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String renderTypedef(_i1.TypedefTemplateData context0) {
+String renderTypedef(TypedefTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderTypedef_partial_head_0(context0));
   buffer.writeln();
@@ -2100,21 +2097,28 @@ String renderTypedef(_i1.TypedefTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) =>
+String _renderCategory_partial_head_0(CategoryTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderCategory_partial_documentation_1(_i4.Category context1) =>
+
+String _renderCategory_partial_documentation_1(Category context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderCategory_partial_library_2(_i5.Library context2) =>
+
+String _renderCategory_partial_library_2(Library context2) =>
     _deduplicated_lib_templates_html__library_html(context2);
-String _renderCategory_partial_container_3(_i6.Container context2) =>
+
+String _renderCategory_partial_container_3(Container context2) =>
     _deduplicated_lib_templates_html__container_html(context2);
-String _renderCategory_partial_extension_4(_i2.Extension context2) =>
+
+String _renderCategory_partial_extension_4(Extension context2) =>
     _deduplicated_lib_templates_html__extension_html(context2);
-String _renderCategory_partial_constant_5(_i7.TopLevelVariable context2) =>
+
+String _renderCategory_partial_constant_5(TopLevelVariable context2) =>
     _deduplicated_lib_templates_html__constant_html(context2);
-String _renderCategory_partial_property_6(_i7.TopLevelVariable context2) =>
+
+String _renderCategory_partial_property_6(TopLevelVariable context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderCategory_partial_callable_7(_i8.ModelFunctionTyped context2) {
+
+String _renderCategory_partial_callable_7(ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context2.htmlId);
@@ -2163,20 +2167,25 @@ String _renderCategory_partial_callable_7(_i8.ModelFunctionTyped context2) {
 }
 
 String __renderCategory_partial_callable_7_partial_categorization_0(
-        _i8.ModelFunctionTyped context2) =>
+        ModelFunctionTyped context2) =>
     _deduplicated_lib_templates_html__categorization_html(context2);
+
 String __renderCategory_partial_callable_7_partial_features_1(
-        _i8.ModelFunctionTyped context2) =>
+        ModelFunctionTyped context2) =>
     _deduplicated_lib_templates_html__features_html(context2);
-String _renderCategory_partial_typedef_8(_i9.Typedef context2) =>
+
+String _renderCategory_partial_typedef_8(Typedef context2) =>
     _deduplicated_lib_templates_html__typedef_html(context2);
+
 String _renderCategory_partial_search_sidebar_9(
-        _i1.CategoryTemplateData context0) =>
+        CategoryTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderCategory_partial_packages_10(_i1.CategoryTemplateData context0) =>
+
+String _renderCategory_partial_packages_10(CategoryTemplateData context0) =>
     _deduplicated_lib_templates_html__packages_html(context0);
+
 String _renderCategory_partial_sidebar_for_category_11(
-    _i1.CategoryTemplateData context0) {
+    CategoryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
   var context1 = context0.self;
@@ -2348,21 +2357,28 @@ String _renderCategory_partial_sidebar_for_category_11(
   return buffer.toString();
 }
 
-String _renderCategory_partial_footer_12(_i1.CategoryTemplateData context0) =>
+String _renderCategory_partial_footer_12(CategoryTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderClass_partial_head_0(_i1.ClassTemplateData context0) =>
+
+String _renderClass_partial_head_0(ClassTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderClass_partial_source_link_1(_i10.Class context1) =>
+
+String _renderClass_partial_source_link_1(Class context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderClass_partial_feature_set_2(_i10.Class context1) =>
+
+String _renderClass_partial_feature_set_2(Class context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderClass_partial_categorization_3(_i10.Class context1) =>
+
+String _renderClass_partial_categorization_3(Class context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderClass_partial_documentation_4(_i10.Class context1) =>
+
+String _renderClass_partial_documentation_4(Class context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderClass_partial_super_chain_5(_i10.Class context1) =>
+
+String _renderClass_partial_super_chain_5(Class context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderClass_partial_interfaces_6(_i10.Class context1) {
+
+String _renderClass_partial_interfaces_6(Class context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicInterfaces == true) {
     buffer.writeln();
@@ -2389,7 +2405,7 @@ String _renderClass_partial_interfaces_6(_i10.Class context1) {
   return buffer.toString();
 }
 
-String _renderClass_partial_mixed_in_types_7(_i10.Class context1) {
+String _renderClass_partial_mixed_in_types_7(Class context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicMixedInTypes == true) {
     buffer.writeln();
@@ -2416,58 +2432,80 @@ String _renderClass_partial_mixed_in_types_7(_i10.Class context1) {
   return buffer.toString();
 }
 
-String _renderClass_partial_container_annotations_8(_i10.Class context1) =>
+String _renderClass_partial_container_annotations_8(Class context1) =>
     _deduplicated_lib_templates_html__container_annotations_html(context1);
-String _renderClass_partial_constructors_9(_i10.Class context1) =>
+
+String _renderClass_partial_constructors_9(Class context1) =>
     _deduplicated_lib_templates_html__constructors_html(context1);
-String _renderClass_partial_property_10(_i11.Field context2) =>
+
+String _renderClass_partial_property_10(Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderClass_partial_instance_methods_11(_i10.Class context1) =>
+
+String _renderClass_partial_instance_methods_11(Class context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderClass_partial_instance_operators_12(_i10.Class context1) =>
+
+String _renderClass_partial_instance_operators_12(Class context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderClass_partial_static_properties_13(_i10.Class context1) =>
+
+String _renderClass_partial_static_properties_13(Class context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderClass_partial_static_methods_14(_i10.Class context1) =>
+
+String _renderClass_partial_static_methods_14(Class context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderClass_partial_static_constants_15(_i10.Class context1) =>
+
+String _renderClass_partial_static_constants_15(Class context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderClass_partial_search_sidebar_16(_i1.ClassTemplateData context0) =>
+
+String _renderClass_partial_search_sidebar_16(ClassTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderClass_partial_footer_17(_i1.ClassTemplateData context0) =>
+
+String _renderClass_partial_footer_17(ClassTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderConstructor_partial_head_0(
-        _i1.ConstructorTemplateData context0) =>
+
+String _renderConstructor_partial_head_0(ConstructorTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderConstructor_partial_source_link_1(_i12.Constructor context1) =>
+
+String _renderConstructor_partial_source_link_1(Constructor context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderConstructor_partial_feature_set_2(_i12.Constructor context1) =>
+
+String _renderConstructor_partial_feature_set_2(Constructor context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderConstructor_partial_annotations_3(_i12.Constructor context1) =>
+
+String _renderConstructor_partial_annotations_3(Constructor context1) =>
     _deduplicated_lib_templates_html__annotations_html(context1);
-String _renderConstructor_partial_documentation_4(_i12.Constructor context1) =>
+
+String _renderConstructor_partial_documentation_4(Constructor context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderConstructor_partial_source_code_5(_i12.Constructor context1) =>
+
+String _renderConstructor_partial_source_code_5(Constructor context1) =>
     _deduplicated_lib_templates_html__source_code_html(context1);
+
 String _renderConstructor_partial_search_sidebar_6(
-        _i1.ConstructorTemplateData context0) =>
+        ConstructorTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderConstructor_partial_footer_7(
-        _i1.ConstructorTemplateData context0) =>
+
+String _renderConstructor_partial_footer_7(ConstructorTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) =>
+
+String _renderEnum_partial_head_0(EnumTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderEnum_partial_source_link_1(_i13.Enum context1) =>
+
+String _renderEnum_partial_source_link_1(Enum context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderEnum_partial_feature_set_2(_i13.Enum context1) =>
+
+String _renderEnum_partial_feature_set_2(Enum context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderEnum_partial_categorization_3(_i13.Enum context1) =>
+
+String _renderEnum_partial_categorization_3(Enum context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderEnum_partial_documentation_4(_i13.Enum context1) =>
+
+String _renderEnum_partial_documentation_4(Enum context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderEnum_partial_super_chain_5(_i13.Enum context1) =>
+
+String _renderEnum_partial_super_chain_5(Enum context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderEnum_partial_interfaces_6(_i13.Enum context1) {
+
+String _renderEnum_partial_interfaces_6(Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicInterfaces == true) {
     buffer.writeln();
@@ -2494,7 +2532,7 @@ String _renderEnum_partial_interfaces_6(_i13.Enum context1) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_mixed_in_types_7(_i13.Enum context1) {
+String _renderEnum_partial_mixed_in_types_7(Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicMixedInTypes == true) {
     buffer.writeln();
@@ -2521,79 +2559,109 @@ String _renderEnum_partial_mixed_in_types_7(_i13.Enum context1) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_container_annotations_8(_i13.Enum context1) =>
+String _renderEnum_partial_container_annotations_8(Enum context1) =>
     _deduplicated_lib_templates_html__container_annotations_html(context1);
-String _renderEnum_partial_constructors_9(_i13.Enum context1) =>
+
+String _renderEnum_partial_constructors_9(Enum context1) =>
     _deduplicated_lib_templates_html__constructors_html(context1);
-String _renderEnum_partial_constant_10(_i11.Field context2) =>
+
+String _renderEnum_partial_constant_10(Field context2) =>
     _deduplicated_lib_templates_html__constant_html(context2);
-String _renderEnum_partial_property_11(_i11.Field context2) =>
+
+String _renderEnum_partial_property_11(Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderEnum_partial_instance_methods_12(_i13.Enum context1) =>
+
+String _renderEnum_partial_instance_methods_12(Enum context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderEnum_partial_instance_operators_13(_i13.Enum context1) =>
+
+String _renderEnum_partial_instance_operators_13(Enum context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderEnum_partial_static_properties_14(_i13.Enum context1) =>
+
+String _renderEnum_partial_static_properties_14(Enum context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderEnum_partial_static_methods_15(_i13.Enum context1) =>
+
+String _renderEnum_partial_static_methods_15(Enum context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderEnum_partial_static_constants_16(_i13.Enum context1) =>
+
+String _renderEnum_partial_static_constants_16(Enum context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderEnum_partial_search_sidebar_17(_i1.EnumTemplateData context0) =>
+
+String _renderEnum_partial_search_sidebar_17(EnumTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderEnum_partial_footer_18(_i1.EnumTemplateData context0) =>
+
+String _renderEnum_partial_footer_18(EnumTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderError_partial_head_0(_i1.PackageTemplateData context0) =>
+
+String _renderError_partial_head_0(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderError_partial_search_sidebar_1(
-        _i1.PackageTemplateData context0) =>
+
+String _renderError_partial_search_sidebar_1(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderError_partial_packages_2(_i1.PackageTemplateData context0) =>
+
+String _renderError_partial_packages_2(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__packages_html(context0);
-String _renderError_partial_footer_3(_i1.PackageTemplateData context0) =>
+
+String _renderError_partial_footer_3(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderExtension_partial_head_0<T extends _i2.Extension>(
-        _i1.ExtensionTemplateData<T> context0) =>
+
+String _renderExtension_partial_head_0<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderExtension_partial_source_link_1(_i2.Extension context1) =>
+
+String _renderExtension_partial_source_link_1(Extension context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderExtension_partial_feature_set_2(_i2.Extension context1) =>
+
+String _renderExtension_partial_feature_set_2(Extension context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderExtension_partial_categorization_3(_i2.Extension context1) =>
+
+String _renderExtension_partial_categorization_3(Extension context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderExtension_partial_documentation_4(_i2.Extension context1) =>
+
+String _renderExtension_partial_documentation_4(Extension context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderExtension_partial_container_annotations_5(
-        _i2.Extension context1) =>
+
+String _renderExtension_partial_container_annotations_5(Extension context1) =>
     _deduplicated_lib_templates_html__container_annotations_html(context1);
-String _renderExtension_partial_property_6(_i11.Field context2) =>
+
+String _renderExtension_partial_property_6(Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderExtension_partial_instance_methods_7(_i2.Extension context1) =>
+
+String _renderExtension_partial_instance_methods_7(Extension context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderExtension_partial_instance_operators_8(_i2.Extension context1) =>
+
+String _renderExtension_partial_instance_operators_8(Extension context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderExtension_partial_static_properties_9(_i2.Extension context1) =>
+
+String _renderExtension_partial_static_properties_9(Extension context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderExtension_partial_static_methods_10(_i2.Extension context1) =>
+
+String _renderExtension_partial_static_methods_10(Extension context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderExtension_partial_static_constants_11(_i2.Extension context1) =>
+
+String _renderExtension_partial_static_constants_11(Extension context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderExtension_partial_search_sidebar_12<T extends _i2.Extension>(
-        _i1.ExtensionTemplateData<T> context0) =>
+
+String _renderExtension_partial_search_sidebar_12<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderExtension_partial_footer_13<T extends _i2.Extension>(
-        _i1.ExtensionTemplateData<T> context0) =>
+
+String _renderExtension_partial_footer_13<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) =>
+
+String _renderFunction_partial_head_0(FunctionTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderFunction_partial_source_link_1(_i8.ModelFunction context1) =>
+
+String _renderFunction_partial_source_link_1(ModelFunction context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderFunction_partial_feature_set_2(_i8.ModelFunction context1) =>
+
+String _renderFunction_partial_feature_set_2(ModelFunction context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderFunction_partial_categorization_3(_i8.ModelFunction context1) =>
+
+String _renderFunction_partial_categorization_3(ModelFunction context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderFunction_partial_callable_multiline_4(
-    _i8.ModelFunction context1) {
+
+String _renderFunction_partial_callable_multiline_4(ModelFunction context1) {
   final buffer = StringBuffer();
   buffer.write(
       __renderFunction_partial_callable_multiline_4_partial_annotations_0(
@@ -2620,54 +2688,75 @@ String _renderFunction_partial_callable_multiline_4(
 }
 
 String __renderFunction_partial_callable_multiline_4_partial_annotations_0(
-        _i8.ModelFunction context1) =>
+        ModelFunction context1) =>
     _deduplicated_lib_templates_html__annotations_html(context1);
+
 String __renderFunction_partial_callable_multiline_4_partial_name_summary_1(
-        _i8.ModelFunction context1) =>
+        ModelFunction context1) =>
     _deduplicated_lib_templates_html__name_summary_html(context1);
-String _renderFunction_partial_features_5(_i8.ModelFunction context1) =>
+
+String _renderFunction_partial_features_5(ModelFunction context1) =>
     _deduplicated_lib_templates_html__features_html(context1);
-String _renderFunction_partial_documentation_6(_i8.ModelFunction context1) =>
+
+String _renderFunction_partial_documentation_6(ModelFunction context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderFunction_partial_source_code_7(_i8.ModelFunction context1) =>
+
+String _renderFunction_partial_source_code_7(ModelFunction context1) =>
     _deduplicated_lib_templates_html__source_code_html(context1);
+
 String _renderFunction_partial_search_sidebar_8(
-        _i1.FunctionTemplateData context0) =>
+        FunctionTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderFunction_partial_footer_9(_i1.FunctionTemplateData context0) =>
+
+String _renderFunction_partial_footer_9(FunctionTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) =>
+
+String _renderIndex_partial_head_0(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderIndex_partial_documentation_1(_i14.Package context1) =>
+
+String _renderIndex_partial_documentation_1(Package context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderIndex_partial_library_2(_i5.Library context3) =>
+
+String _renderIndex_partial_library_2(Library context3) =>
     _deduplicated_lib_templates_html__library_html(context3);
-String _renderIndex_partial_search_sidebar_3(
-        _i1.PackageTemplateData context0) =>
+
+String _renderIndex_partial_search_sidebar_3(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderIndex_partial_packages_4(_i1.PackageTemplateData context0) =>
+
+String _renderIndex_partial_packages_4(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__packages_html(context0);
-String _renderIndex_partial_footer_5(_i1.PackageTemplateData context0) =>
+
+String _renderIndex_partial_footer_5(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) =>
+
+String _renderLibrary_partial_head_0(LibraryTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderLibrary_partial_source_link_1(_i5.Library context1) =>
+
+String _renderLibrary_partial_source_link_1(Library context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderLibrary_partial_feature_set_2(_i5.Library context1) =>
+
+String _renderLibrary_partial_feature_set_2(Library context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderLibrary_partial_categorization_3(_i5.Library context1) =>
+
+String _renderLibrary_partial_categorization_3(Library context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderLibrary_partial_documentation_4(_i5.Library context1) =>
+
+String _renderLibrary_partial_documentation_4(Library context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderLibrary_partial_container_5(_i6.Container context3) =>
+
+String _renderLibrary_partial_container_5(Container context3) =>
     _deduplicated_lib_templates_html__container_html(context3);
-String _renderLibrary_partial_extension_6(_i2.Extension context3) =>
+
+String _renderLibrary_partial_extension_6(Extension context3) =>
     _deduplicated_lib_templates_html__extension_html(context3);
-String _renderLibrary_partial_constant_7(_i7.TopLevelVariable context3) =>
+
+String _renderLibrary_partial_constant_7(TopLevelVariable context3) =>
     _deduplicated_lib_templates_html__constant_html(context3);
-String _renderLibrary_partial_property_8(_i7.TopLevelVariable context3) =>
+
+String _renderLibrary_partial_property_8(TopLevelVariable context3) =>
     _deduplicated_lib_templates_html__property_html(context3);
-String _renderLibrary_partial_callable_9(_i8.ModelFunctionTyped context3) {
+
+String _renderLibrary_partial_callable_9(ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context3.htmlId);
@@ -2715,27 +2804,35 @@ String _renderLibrary_partial_callable_9(_i8.ModelFunctionTyped context3) {
 }
 
 String __renderLibrary_partial_callable_9_partial_categorization_0(
-        _i8.ModelFunctionTyped context3) =>
+        ModelFunctionTyped context3) =>
     _deduplicated_lib_templates_html__categorization_html(context3);
+
 String __renderLibrary_partial_callable_9_partial_features_1(
-        _i8.ModelFunctionTyped context3) =>
+        ModelFunctionTyped context3) =>
     _deduplicated_lib_templates_html__features_html(context3);
-String _renderLibrary_partial_typedef_10(_i9.Typedef context3) =>
+
+String _renderLibrary_partial_typedef_10(Typedef context3) =>
     _deduplicated_lib_templates_html__typedef_html(context3);
-String _renderLibrary_partial_search_sidebar_11(
-        _i1.LibraryTemplateData context0) =>
+
+String _renderLibrary_partial_search_sidebar_11(LibraryTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderLibrary_partial_packages_12(_i1.LibraryTemplateData context0) =>
+
+String _renderLibrary_partial_packages_12(LibraryTemplateData context0) =>
     _deduplicated_lib_templates_html__packages_html(context0);
-String _renderLibrary_partial_footer_13(_i1.LibraryTemplateData context0) =>
+
+String _renderLibrary_partial_footer_13(LibraryTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) =>
+
+String _renderMethod_partial_head_0(MethodTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderMethod_partial_source_link_1(_i15.Method context1) =>
+
+String _renderMethod_partial_source_link_1(Method context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderMethod_partial_feature_set_2(_i15.Method context1) =>
+
+String _renderMethod_partial_feature_set_2(Method context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderMethod_partial_callable_multiline_3(_i15.Method context1) {
+
+String _renderMethod_partial_callable_multiline_3(Method context1) {
   final buffer = StringBuffer();
   buffer.write(
       __renderMethod_partial_callable_multiline_3_partial_annotations_0(
@@ -2762,35 +2859,47 @@ String _renderMethod_partial_callable_multiline_3(_i15.Method context1) {
 }
 
 String __renderMethod_partial_callable_multiline_3_partial_annotations_0(
-        _i15.Method context1) =>
+        Method context1) =>
     _deduplicated_lib_templates_html__annotations_html(context1);
+
 String __renderMethod_partial_callable_multiline_3_partial_name_summary_1(
-        _i15.Method context1) =>
+        Method context1) =>
     _deduplicated_lib_templates_html__name_summary_html(context1);
-String _renderMethod_partial_features_4(_i15.Method context1) =>
+
+String _renderMethod_partial_features_4(Method context1) =>
     _deduplicated_lib_templates_html__features_html(context1);
-String _renderMethod_partial_documentation_5(_i15.Method context1) =>
+
+String _renderMethod_partial_documentation_5(Method context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderMethod_partial_source_code_6(_i15.Method context1) =>
+
+String _renderMethod_partial_source_code_6(Method context1) =>
     _deduplicated_lib_templates_html__source_code_html(context1);
-String _renderMethod_partial_search_sidebar_7(
-        _i1.MethodTemplateData context0) =>
+
+String _renderMethod_partial_search_sidebar_7(MethodTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderMethod_partial_footer_8(_i1.MethodTemplateData context0) =>
+
+String _renderMethod_partial_footer_8(MethodTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) =>
+
+String _renderMixin_partial_head_0(MixinTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderMixin_partial_source_link_1(_i16.Mixin context1) =>
+
+String _renderMixin_partial_source_link_1(Mixin context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderMixin_partial_feature_set_2(_i16.Mixin context1) =>
+
+String _renderMixin_partial_feature_set_2(Mixin context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderMixin_partial_categorization_3(_i16.Mixin context1) =>
+
+String _renderMixin_partial_categorization_3(Mixin context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderMixin_partial_documentation_4(_i16.Mixin context1) =>
+
+String _renderMixin_partial_documentation_4(Mixin context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderMixin_partial_super_chain_5(_i16.Mixin context1) =>
+
+String _renderMixin_partial_super_chain_5(Mixin context1) =>
     _deduplicated_lib_templates_html__super_chain_html(context1);
-String _renderMixin_partial_interfaces_6(_i16.Mixin context1) {
+
+String _renderMixin_partial_interfaces_6(Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicInterfaces == true) {
     buffer.writeln();
@@ -2817,106 +2926,147 @@ String _renderMixin_partial_interfaces_6(_i16.Mixin context1) {
   return buffer.toString();
 }
 
-String _renderMixin_partial_annotations_7(_i16.Mixin context1) =>
+String _renderMixin_partial_annotations_7(Mixin context1) =>
     _deduplicated_lib_templates_html__annotations_html(context1);
-String _renderMixin_partial_property_8(_i11.Field context2) =>
+
+String _renderMixin_partial_property_8(Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
-String _renderMixin_partial_instance_methods_9(_i16.Mixin context1) =>
+
+String _renderMixin_partial_instance_methods_9(Mixin context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
-String _renderMixin_partial_instance_operators_10(_i16.Mixin context1) =>
+
+String _renderMixin_partial_instance_operators_10(Mixin context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
-String _renderMixin_partial_static_properties_11(_i16.Mixin context1) =>
+
+String _renderMixin_partial_static_properties_11(Mixin context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
-String _renderMixin_partial_static_methods_12(_i16.Mixin context1) =>
+
+String _renderMixin_partial_static_methods_12(Mixin context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
-String _renderMixin_partial_static_constants_13(_i16.Mixin context1) =>
+
+String _renderMixin_partial_static_constants_13(Mixin context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
-String _renderMixin_partial_search_sidebar_14(_i1.MixinTemplateData context0) =>
+
+String _renderMixin_partial_search_sidebar_14(MixinTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderMixin_partial_footer_15(_i1.MixinTemplateData context0) =>
+
+String _renderMixin_partial_footer_15(MixinTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) =>
+
+String _renderProperty_partial_head_0(PropertyTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderProperty_partial_source_link_1(_i11.Field context1) =>
+
+String _renderProperty_partial_source_link_1(Field context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderProperty_partial_feature_set_2(_i11.Field context1) =>
+
+String _renderProperty_partial_feature_set_2(Field context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderProperty_partial_annotations_3(_i11.Field context1) =>
+
+String _renderProperty_partial_annotations_3(Field context1) =>
     _deduplicated_lib_templates_html__annotations_html(context1);
-String _renderProperty_partial_name_summary_4(_i11.Field context1) =>
+
+String _renderProperty_partial_name_summary_4(Field context1) =>
     _deduplicated_lib_templates_html__name_summary_html(context1);
-String _renderProperty_partial_features_5(_i11.Field context1) =>
+
+String _renderProperty_partial_features_5(Field context1) =>
     _deduplicated_lib_templates_html__features_html(context1);
-String _renderProperty_partial_documentation_6(_i11.Field context1) =>
+
+String _renderProperty_partial_documentation_6(Field context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderProperty_partial_source_code_7(_i11.Field context1) =>
+
+String _renderProperty_partial_source_code_7(Field context1) =>
     _deduplicated_lib_templates_html__source_code_html(context1);
-String _renderProperty_partial_accessor_getter_8(_i11.Field context1) =>
+
+String _renderProperty_partial_accessor_getter_8(Field context1) =>
     _deduplicated_lib_templates_html__accessor_getter_html(context1);
-String _renderProperty_partial_accessor_setter_9(_i11.Field context1) =>
+
+String _renderProperty_partial_accessor_setter_9(Field context1) =>
     _deduplicated_lib_templates_html__accessor_setter_html(context1);
+
 String _renderProperty_partial_search_sidebar_10(
-        _i1.PropertyTemplateData context0) =>
+        PropertyTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderProperty_partial_footer_11(_i1.PropertyTemplateData context0) =>
+
+String _renderProperty_partial_footer_11(PropertyTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderSearchPage_partial_head_0(_i1.PackageTemplateData context0) =>
+
+String _renderSearchPage_partial_head_0(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
+
 String _renderSearchPage_partial_search_sidebar_1(
-        _i1.PackageTemplateData context0) =>
+        PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderSearchPage_partial_packages_2(_i1.PackageTemplateData context0) =>
+
+String _renderSearchPage_partial_packages_2(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__packages_html(context0);
-String _renderSearchPage_partial_footer_3(_i1.PackageTemplateData context0) =>
+
+String _renderSearchPage_partial_footer_3(PackageTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
+
 String _renderTopLevelProperty_partial_head_0(
-        _i1.TopLevelPropertyTemplateData context0) =>
+        TopLevelPropertyTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
+
 String _renderTopLevelProperty_partial_source_link_1(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
+
 String _renderTopLevelProperty_partial_feature_set_2(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
+
 String _renderTopLevelProperty_partial_categorization_3(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
+
 String _renderTopLevelProperty_partial_annotations_4(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__annotations_html(context1);
+
 String _renderTopLevelProperty_partial_name_summary_5(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__name_summary_html(context1);
-String _renderTopLevelProperty_partial_features_6(
-        _i7.TopLevelVariable context1) =>
+
+String _renderTopLevelProperty_partial_features_6(TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__features_html(context1);
+
 String _renderTopLevelProperty_partial_documentation_7(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
+
 String _renderTopLevelProperty_partial_source_code_8(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__source_code_html(context1);
+
 String _renderTopLevelProperty_partial_accessor_getter_9(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__accessor_getter_html(context1);
+
 String _renderTopLevelProperty_partial_accessor_setter_10(
-        _i7.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_html__accessor_setter_html(context1);
+
 String _renderTopLevelProperty_partial_search_sidebar_11(
-        _i1.TopLevelPropertyTemplateData context0) =>
+        TopLevelPropertyTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
+
 String _renderTopLevelProperty_partial_footer_12(
-        _i1.TopLevelPropertyTemplateData context0) =>
+        TopLevelPropertyTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) =>
+
+String _renderTypedef_partial_head_0(TypedefTemplateData context0) =>
     _deduplicated_lib_templates_html__head_html(context0);
-String _renderTypedef_partial_source_link_1(_i9.Typedef context1) =>
+
+String _renderTypedef_partial_source_link_1(Typedef context1) =>
     _deduplicated_lib_templates_html__source_link_html(context1);
-String _renderTypedef_partial_feature_set_2(_i9.Typedef context1) =>
+
+String _renderTypedef_partial_feature_set_2(Typedef context1) =>
     _deduplicated_lib_templates_html__feature_set_html(context1);
-String _renderTypedef_partial_categorization_3(_i9.Typedef context1) =>
+
+String _renderTypedef_partial_categorization_3(Typedef context1) =>
     _deduplicated_lib_templates_html__categorization_html(context1);
-String _renderTypedef_partial_typedef_multiline_4(_i9.Typedef context1) {
+
+String _renderTypedef_partial_typedef_multiline_4(Typedef context1) {
   final buffer = StringBuffer();
   if (context1.isCallable == true) {
     var context2 = context1.asCallable;
@@ -2966,7 +3116,7 @@ String _renderTypedef_partial_typedef_multiline_4(_i9.Typedef context1) {
 }
 
 String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
-    _i9.Typedef context1) {
+    Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
@@ -3001,19 +3151,22 @@ String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
 
 String
     ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
-            _i9.Typedef context1) =>
+            Typedef context1) =>
         _deduplicated_lib_templates_html__name_summary_html(context1);
-String _renderTypedef_partial_documentation_5(_i9.Typedef context1) =>
+
+String _renderTypedef_partial_documentation_5(Typedef context1) =>
     _deduplicated_lib_templates_html__documentation_html(context1);
-String _renderTypedef_partial_source_code_6(_i9.Typedef context1) =>
+
+String _renderTypedef_partial_source_code_6(Typedef context1) =>
     _deduplicated_lib_templates_html__source_code_html(context1);
-String _renderTypedef_partial_search_sidebar_7(
-        _i1.TypedefTemplateData context0) =>
+
+String _renderTypedef_partial_search_sidebar_7(TypedefTemplateData context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
-String _renderTypedef_partial_footer_8(_i1.TypedefTemplateData context0) =>
+
+String _renderTypedef_partial_footer_8(TypedefTemplateData context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
-String _deduplicated_lib_templates_html__head_html(
-    _i1.TemplateDataBase context0) {
+
+String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
   final buffer = StringBuffer();
   buffer.write('''<!DOCTYPE html>
 <html lang="en">
@@ -3168,8 +3321,7 @@ String _deduplicated_lib_templates_html__head_html(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__documentation_html(
-    _i17.Warnable context0) {
+String _deduplicated_lib_templates_html__documentation_html(Warnable context0) {
   final buffer = StringBuffer();
   if (context0.hasDocumentation == true) {
     buffer.writeln();
@@ -3186,7 +3338,7 @@ String _deduplicated_lib_templates_html__documentation_html(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__library_html(_i5.Library context0) {
+String _deduplicated_lib_templates_html__library_html(Library context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3213,7 +3365,7 @@ String _deduplicated_lib_templates_html__library_html(_i5.Library context0) {
 }
 
 String __deduplicated_lib_templates_html__library_html_partial_categorization_0(
-    _i5.Library context0) {
+    Library context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3228,7 +3380,7 @@ String __deduplicated_lib_templates_html__library_html_partial_categorization_0(
 }
 
 String _deduplicated_lib_templates_html__categorization_html(
-    _i18.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3242,8 +3394,7 @@ String _deduplicated_lib_templates_html__categorization_html(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__container_html(
-    _i6.Container context0) {
+String _deduplicated_lib_templates_html__container_html(Container context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3275,7 +3426,7 @@ String _deduplicated_lib_templates_html__container_html(
 
 String
     __deduplicated_lib_templates_html__container_html_partial_categorization_0(
-        _i6.Container context0) {
+        Container context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3289,8 +3440,7 @@ String
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__extension_html(
-    _i2.Extension context0) {
+String _deduplicated_lib_templates_html__extension_html(Extension context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3322,7 +3472,7 @@ String _deduplicated_lib_templates_html__extension_html(
 
 String
     __deduplicated_lib_templates_html__extension_html_partial_categorization_0(
-        _i2.Extension context0) {
+        Extension context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3337,7 +3487,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__constant_html(
-    _i19.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3402,7 +3552,7 @@ String _deduplicated_lib_templates_html__constant_html(
 
 String
     __deduplicated_lib_templates_html__constant_html_partial_categorization_0(
-        _i19.GetterSetterCombo context0) {
+        GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3417,7 +3567,7 @@ String
 }
 
 String __deduplicated_lib_templates_html__constant_html_partial_features_1(
-    _i19.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3429,8 +3579,7 @@ String __deduplicated_lib_templates_html__constant_html_partial_features_1(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__features_html(
-    _i18.ModelElement context0) {
+String _deduplicated_lib_templates_html__features_html(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3443,7 +3592,7 @@ String _deduplicated_lib_templates_html__features_html(
 }
 
 String _deduplicated_lib_templates_html__property_html(
-    _i19.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3487,7 +3636,7 @@ String _deduplicated_lib_templates_html__property_html(
 
 String
     __deduplicated_lib_templates_html__property_html_partial_categorization_0(
-        _i19.GetterSetterCombo context0) {
+        GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3502,7 +3651,7 @@ String
 }
 
 String __deduplicated_lib_templates_html__property_html_partial_features_1(
-    _i19.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3514,7 +3663,7 @@ String __deduplicated_lib_templates_html__property_html_partial_features_1(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__typedef_html(_i9.Typedef context0) {
+String _deduplicated_lib_templates_html__typedef_html(Typedef context0) {
   final buffer = StringBuffer();
   if (context0.isCallable == true) {
     var context1 = context0.asCallable;
@@ -3573,7 +3722,7 @@ String _deduplicated_lib_templates_html__typedef_html(_i9.Typedef context0) {
 }
 
 String __deduplicated_lib_templates_html__typedef_html_partial_categorization_0(
-    _i9.FunctionTypedef context1) {
+    FunctionTypedef context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     var context2 = context1.displayedCategories;
@@ -3588,7 +3737,7 @@ String __deduplicated_lib_templates_html__typedef_html_partial_categorization_0(
 }
 
 String __deduplicated_lib_templates_html__typedef_html_partial_features_1(
-    _i9.FunctionTypedef context1) {
+    FunctionTypedef context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3601,7 +3750,7 @@ String __deduplicated_lib_templates_html__typedef_html_partial_features_1(
 }
 
 String __deduplicated_lib_templates_html__typedef_html_partial_type_2(
-    _i9.Typedef context0) {
+    Typedef context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3653,7 +3802,7 @@ String __deduplicated_lib_templates_html__typedef_html_partial_type_2(
 
 String
     ___deduplicated_lib_templates_html__typedef_html_partial_type_2_partial_categorization_0(
-        _i9.Typedef context0) {
+        Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3669,7 +3818,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__typedef_html_partial_type_2_partial_features_1(
-        _i9.Typedef context0) {
+        Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3681,7 +3830,7 @@ String
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_html__type_html(_i9.Typedef context0) {
+String _deduplicated_lib_templates_html__type_html(Typedef context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
@@ -3731,7 +3880,7 @@ String _deduplicated_lib_templates_html__type_html(_i9.Typedef context0) {
 }
 
 String __deduplicated_lib_templates_html__type_html_partial_categorization_0(
-    _i9.Typedef context0) {
+    Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     var context1 = context0.displayedCategories;
@@ -3746,7 +3895,7 @@ String __deduplicated_lib_templates_html__type_html_partial_categorization_0(
 }
 
 String __deduplicated_lib_templates_html__type_html_partial_features_1(
-    _i9.Typedef context0) {
+    Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -3759,7 +3908,7 @@ String __deduplicated_lib_templates_html__type_html_partial_features_1(
 }
 
 String _deduplicated_lib_templates_html__search_sidebar_html(
-    _i1.TemplateDataBase context0) {
+    TemplateDataBase context0) {
   final buffer = StringBuffer();
   buffer.write(
       '''<!-- The search input and breadcrumbs below are only responsively visible at low resolutions. -->
@@ -3821,7 +3970,7 @@ String _deduplicated_lib_templates_html__search_sidebar_html(
 }
 
 String _deduplicated_lib_templates_html__packages_html(
-    _i1.TemplateDataBase context0) {
+    TemplateDataBase context0) {
   final buffer = StringBuffer();
   buffer.write('''<ol>''');
   var context1 = context0.localPackages;
@@ -3886,7 +4035,7 @@ String _deduplicated_lib_templates_html__packages_html(
 }
 
 String _deduplicated_lib_templates_html__footer_html(
-    _i1.TemplateDataBase context0) {
+    TemplateDataBase context0) {
   final buffer = StringBuffer();
   buffer.write('''</main>
 
@@ -3937,7 +4086,7 @@ String _deduplicated_lib_templates_html__footer_html(
 }
 
 String _deduplicated_lib_templates_html__source_link_html(
-    _i18.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasSourceHref == true) {
     buffer.writeln();
@@ -3953,7 +4102,7 @@ String _deduplicated_lib_templates_html__source_link_html(
 }
 
 String _deduplicated_lib_templates_html__feature_set_html(
-    _i18.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatureSet == true) {
     var context1 = context0.displayedLanguageFeatures;
@@ -3968,7 +4117,7 @@ String _deduplicated_lib_templates_html__feature_set_html(
 }
 
 String _deduplicated_lib_templates_html__super_chain_html(
-    _i20.InheritingContainer context0) {
+    InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -4003,7 +4152,7 @@ String _deduplicated_lib_templates_html__super_chain_html(
 }
 
 String _deduplicated_lib_templates_html__container_annotations_html(
-    _i6.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasAnnotations == true) {
     buffer.writeln();
@@ -4032,7 +4181,7 @@ String _deduplicated_lib_templates_html__container_annotations_html(
 }
 
 String _deduplicated_lib_templates_html__constructors_html(
-    _i20.InheritingContainer context0) {
+    InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicConstructors == true) {
     buffer.writeln();
@@ -4081,7 +4230,7 @@ String _deduplicated_lib_templates_html__constructors_html(
 }
 
 String _deduplicated_lib_templates_html__instance_methods_html(
-    _i6.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicInstanceMethods == true) {
     buffer.writeln();
@@ -4113,7 +4262,7 @@ String _deduplicated_lib_templates_html__instance_methods_html(
 
 String
     __deduplicated_lib_templates_html__instance_methods_html_partial_callable_0(
-        _i15.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context1.htmlId);
@@ -4165,7 +4314,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__instance_methods_html_partial_callable_0_partial_categorization_0(
-        _i15.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     var context2 = context1.displayedCategories;
@@ -4181,7 +4330,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__instance_methods_html_partial_callable_0_partial_features_1(
-        _i15.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4194,7 +4343,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__instance_operators_html(
-    _i6.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicInstanceOperators == true) {
     buffer.writeln();
@@ -4226,7 +4375,7 @@ String _deduplicated_lib_templates_html__instance_operators_html(
 
 String
     __deduplicated_lib_templates_html__instance_operators_html_partial_callable_0(
-        _i21.Operator context1) {
+        Operator context1) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context1.htmlId);
@@ -4278,7 +4427,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__instance_operators_html_partial_callable_0_partial_categorization_0(
-        _i21.Operator context1) {
+        Operator context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     var context2 = context1.displayedCategories;
@@ -4294,7 +4443,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__instance_operators_html_partial_callable_0_partial_features_1(
-        _i21.Operator context1) {
+        Operator context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4307,7 +4456,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__static_properties_html(
-    _i6.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicVariableStaticFields == true) {
     buffer.writeln();
@@ -4334,7 +4483,7 @@ String _deduplicated_lib_templates_html__static_properties_html(
 
 String
     __deduplicated_lib_templates_html__static_properties_html_partial_property_0(
-        _i11.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context1.htmlId);
@@ -4378,7 +4527,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_categorization_0(
-        _i11.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     var context2 = context1.displayedCategories;
@@ -4394,7 +4543,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_features_1(
-        _i11.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4407,7 +4556,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__static_methods_html(
-    _i6.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicStaticMethods == true) {
     buffer.writeln();
@@ -4433,7 +4582,7 @@ String _deduplicated_lib_templates_html__static_methods_html(
 
 String
     __deduplicated_lib_templates_html__static_methods_html_partial_callable_0(
-        _i15.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context1.htmlId);
@@ -4485,7 +4634,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__static_methods_html_partial_callable_0_partial_categorization_0(
-        _i15.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     var context2 = context1.displayedCategories;
@@ -4501,7 +4650,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__static_methods_html_partial_callable_0_partial_features_1(
-        _i15.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4514,7 +4663,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__static_constants_html(
-    _i6.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   if (context0.hasPublicConstantFields == true) {
@@ -4542,7 +4691,7 @@ String _deduplicated_lib_templates_html__static_constants_html(
 
 String
     __deduplicated_lib_templates_html__static_constants_html_partial_constant_0(
-        _i11.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context1.htmlId);
@@ -4607,7 +4756,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__static_constants_html_partial_constant_0_partial_categorization_0(
-        _i11.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     var context2 = context1.displayedCategories;
@@ -4623,7 +4772,7 @@ String
 
 String
     ___deduplicated_lib_templates_html__static_constants_html_partial_constant_0_partial_features_1(
-        _i11.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4636,7 +4785,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__annotations_html(
-    _i18.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasAnnotations == true) {
     buffer.writeln();
@@ -4661,7 +4810,7 @@ String _deduplicated_lib_templates_html__annotations_html(
 }
 
 String _deduplicated_lib_templates_html__source_code_html(
-    _i18.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasSourceCode == true) {
     buffer.writeln();
@@ -4679,7 +4828,7 @@ String _deduplicated_lib_templates_html__source_code_html(
 }
 
 String _deduplicated_lib_templates_html__name_summary_html(
-    _i18.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.isConst == true) {
     buffer.write('''const ''');
@@ -4696,7 +4845,7 @@ String _deduplicated_lib_templates_html__name_summary_html(
 }
 
 String _deduplicated_lib_templates_html__accessor_getter_html(
-    _i19.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   var context1 = context0.getter;
   if (context1 != null) {
@@ -4745,7 +4894,7 @@ String _deduplicated_lib_templates_html__accessor_getter_html(
 
 String
     __deduplicated_lib_templates_html__accessor_getter_html_partial_annotations_0(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
@@ -4771,7 +4920,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_getter_html_partial_name_summary_1(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -4789,7 +4938,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_getter_html_partial_features_2(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4803,7 +4952,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_getter_html_partial_documentation_3(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -4822,7 +4971,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_getter_html_partial_source_code_4(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -4840,7 +4989,7 @@ String
 }
 
 String _deduplicated_lib_templates_html__accessor_setter_html(
-    _i19.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   var context1 = context0.setter;
   if (context1 != null) {
@@ -4890,7 +5039,7 @@ String _deduplicated_lib_templates_html__accessor_setter_html(
 
 String
     __deduplicated_lib_templates_html__accessor_setter_html_partial_annotations_0(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
@@ -4916,7 +5065,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_setter_html_partial_name_summary_1(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -4934,7 +5083,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_setter_html_partial_features_2(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''<div class="features">''');
@@ -4948,7 +5097,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_setter_html_partial_documentation_3(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -4967,7 +5116,7 @@ String
 
 String
     __deduplicated_lib_templates_html__accessor_setter_html_partial_source_code_4(
-        _i22.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -4986,6 +5135,6 @@ String
 
 extension on StringBuffer {
   void writeEscaped(String? value) {
-    write(_i23.htmlEscape.convert(value ?? ''));
+    write(htmlEscape.convert(value ?? ''));
   }
 }

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -12,34 +12,32 @@
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
 // ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
-// ignore_for_file: use_super_parameters
 
-// ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:convert' as _i22;
+import 'dart:convert';
 
-import 'package:dartdoc/src/generator/template_data.dart' as _i1;
-import 'package:dartdoc/src/model/accessor.dart' as _i21;
-import 'package:dartdoc/src/model/category.dart' as _i3;
-import 'package:dartdoc/src/model/class.dart' as _i9;
-import 'package:dartdoc/src/model/constructor.dart' as _i11;
-import 'package:dartdoc/src/model/container.dart' as _i5;
-import 'package:dartdoc/src/model/enum.dart' as _i12;
-import 'package:dartdoc/src/model/extension.dart' as _i2;
-import 'package:dartdoc/src/model/field.dart' as _i10;
-import 'package:dartdoc/src/model/getter_setter_combo.dart' as _i18;
-import 'package:dartdoc/src/model/inheriting_container.dart' as _i19;
-import 'package:dartdoc/src/model/library.dart' as _i4;
-import 'package:dartdoc/src/model/method.dart' as _i14;
-import 'package:dartdoc/src/model/mixin.dart' as _i15;
-import 'package:dartdoc/src/model/model_element.dart' as _i17;
-import 'package:dartdoc/src/model/model_function.dart' as _i7;
-import 'package:dartdoc/src/model/operator.dart' as _i20;
-import 'package:dartdoc/src/model/package.dart' as _i13;
-import 'package:dartdoc/src/model/top_level_variable.dart' as _i6;
-import 'package:dartdoc/src/model/typedef.dart' as _i8;
-import 'package:dartdoc/src/warnings.dart' as _i16;
+import 'package:dartdoc/src/generator/template_data.dart';
+import 'package:dartdoc/src/model/accessor.dart';
+import 'package:dartdoc/src/model/category.dart';
+import 'package:dartdoc/src/model/class.dart';
+import 'package:dartdoc/src/model/constructor.dart';
+import 'package:dartdoc/src/model/container.dart';
+import 'package:dartdoc/src/model/enum.dart';
+import 'package:dartdoc/src/model/extension.dart';
+import 'package:dartdoc/src/model/field.dart';
+import 'package:dartdoc/src/model/getter_setter_combo.dart';
+import 'package:dartdoc/src/model/inheriting_container.dart';
+import 'package:dartdoc/src/model/library.dart';
+import 'package:dartdoc/src/model/method.dart';
+import 'package:dartdoc/src/model/mixin.dart';
+import 'package:dartdoc/src/model/model_element.dart';
+import 'package:dartdoc/src/model/model_function.dart';
+import 'package:dartdoc/src/model/operator.dart';
+import 'package:dartdoc/src/model/package.dart';
+import 'package:dartdoc/src/model/top_level_variable.dart';
+import 'package:dartdoc/src/model/typedef.dart';
+import 'package:dartdoc/src/warnings.dart';
 
-String renderCategory(_i1.CategoryTemplateData context0) {
+String renderCategory(CategoryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderCategory_partial_head_0(context0));
   buffer.writeln();
@@ -189,7 +187,7 @@ String renderCategory(_i1.CategoryTemplateData context0) {
   return buffer.toString();
 }
 
-String renderClass(_i1.ClassTemplateData context0) {
+String renderClass(ClassTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderClass_partial_head_0(context0));
   buffer.writeln();
@@ -281,7 +279,7 @@ String renderClass(_i1.ClassTemplateData context0) {
   return buffer.toString();
 }
 
-String renderConstructor(_i1.ConstructorTemplateData context0) {
+String renderConstructor(ConstructorTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderConstructor_partial_head_0(context0));
   buffer.writeln();
@@ -331,7 +329,7 @@ String renderConstructor(_i1.ConstructorTemplateData context0) {
   return buffer.toString();
 }
 
-String renderEnum(_i1.EnumTemplateData context0) {
+String renderEnum(EnumTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderEnum_partial_head_0(context0));
   buffer.writeln();
@@ -419,8 +417,7 @@ You\'ve tried to visit a page that doesn\'t exist. Luckily this site has other
   return buffer.toString();
 }
 
-String renderExtension<T extends _i2.Extension>(
-    _i1.ExtensionTemplateData<T> context0) {
+String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
   final buffer = StringBuffer();
   buffer.write(_renderExtension_partial_head_0(context0));
   buffer.writeln();
@@ -478,7 +475,7 @@ on ''');
   return buffer.toString();
 }
 
-String renderFunction(_i1.FunctionTemplateData context0) {
+String renderFunction(FunctionTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderFunction_partial_head_0(context0));
   buffer.writeln();
@@ -513,7 +510,7 @@ String renderFunction(_i1.FunctionTemplateData context0) {
   return buffer.toString();
 }
 
-String renderIndex(_i1.PackageTemplateData context0) {
+String renderIndex(PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderIndex_partial_head_0(context0));
   buffer.writeln();
@@ -568,7 +565,7 @@ String renderIndex(_i1.PackageTemplateData context0) {
   return buffer.toString();
 }
 
-String renderLibrary(_i1.LibraryTemplateData context0) {
+String renderLibrary(LibraryTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderLibrary_partial_head_0(context0));
   buffer.writeln();
@@ -732,7 +729,7 @@ String renderLibrary(_i1.LibraryTemplateData context0) {
   return buffer.toString();
 }
 
-String renderMethod(_i1.MethodTemplateData context0) {
+String renderMethod(MethodTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderMethod_partial_head_0(context0));
   buffer.writeln();
@@ -765,7 +762,7 @@ String renderMethod(_i1.MethodTemplateData context0) {
   return buffer.toString();
 }
 
-String renderMixin(_i1.MixinTemplateData context0) {
+String renderMixin(MixinTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderMixin_partial_head_0(context0));
   buffer.writeln();
@@ -852,7 +849,7 @@ String renderMixin(_i1.MixinTemplateData context0) {
   return buffer.toString();
 }
 
-String renderProperty(_i1.PropertyTemplateData context0) {
+String renderProperty(PropertyTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderProperty_partial_head_0(context0));
   buffer.writeln();
@@ -903,7 +900,7 @@ String renderProperty(_i1.PropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String renderSearchPage(_i1.PackageTemplateData context0) {
+String renderSearchPage(PackageTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderSearchPage_partial_head_0(context0));
   buffer.writeln();
@@ -970,7 +967,7 @@ String renderSidebarForLibrary() {
   return buffer.toString();
 }
 
-String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
+String renderTopLevelProperty(TopLevelPropertyTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderTopLevelProperty_partial_head_0(context0));
   buffer.writeln();
@@ -1020,7 +1017,7 @@ String renderTopLevelProperty(_i1.TopLevelPropertyTemplateData context0) {
   return buffer.toString();
 }
 
-String renderTypedef(_i1.TypedefTemplateData context0) {
+String renderTypedef(TypedefTemplateData context0) {
   final buffer = StringBuffer();
   buffer.write(_renderTypedef_partial_head_0(context0));
   buffer.writeln();
@@ -1052,21 +1049,28 @@ String renderTypedef(_i1.TypedefTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderCategory_partial_head_0(_i1.CategoryTemplateData context0) =>
+String _renderCategory_partial_head_0(CategoryTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderCategory_partial_documentation_1(_i3.Category context1) =>
+
+String _renderCategory_partial_documentation_1(Category context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderCategory_partial_library_2(_i4.Library context2) =>
+
+String _renderCategory_partial_library_2(Library context2) =>
     _deduplicated_lib_templates_md__library_md(context2);
-String _renderCategory_partial_container_3(_i5.Container context2) =>
+
+String _renderCategory_partial_container_3(Container context2) =>
     _deduplicated_lib_templates_md__container_md(context2);
-String _renderCategory_partial_extension_4(_i2.Extension context2) =>
+
+String _renderCategory_partial_extension_4(Extension context2) =>
     _deduplicated_lib_templates_md__extension_md(context2);
-String _renderCategory_partial_constant_5(_i6.TopLevelVariable context2) =>
+
+String _renderCategory_partial_constant_5(TopLevelVariable context2) =>
     _deduplicated_lib_templates_md__constant_md(context2);
-String _renderCategory_partial_property_6(_i6.TopLevelVariable context2) =>
+
+String _renderCategory_partial_property_6(TopLevelVariable context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderCategory_partial_callable_7(_i7.ModelFunctionTyped context2) {
+
+String _renderCategory_partial_callable_7(ModelFunctionTyped context2) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context2.linkedName);
@@ -1090,28 +1094,38 @@ String _renderCategory_partial_callable_7(_i7.ModelFunctionTyped context2) {
 }
 
 String __renderCategory_partial_callable_7_partial_categorization_0(
-        _i7.ModelFunctionTyped context2) =>
+        ModelFunctionTyped context2) =>
     _deduplicated_lib_templates_md__categorization_md(context2);
+
 String __renderCategory_partial_callable_7_partial_features_1(
-        _i7.ModelFunctionTyped context2) =>
+        ModelFunctionTyped context2) =>
     _deduplicated_lib_templates_md__features_md(context2);
-String _renderCategory_partial_typedef_8(_i8.Typedef context2) =>
+
+String _renderCategory_partial_typedef_8(Typedef context2) =>
     _deduplicated_lib_templates_md__typedef_md(context2);
-String _renderCategory_partial_footer_9(_i1.CategoryTemplateData context0) =>
+
+String _renderCategory_partial_footer_9(CategoryTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderClass_partial_head_0(_i1.ClassTemplateData context0) =>
+
+String _renderClass_partial_head_0(ClassTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderClass_partial_source_link_1(_i9.Class context1) =>
+
+String _renderClass_partial_source_link_1(Class context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderClass_partial_categorization_2(_i9.Class context1) =>
+
+String _renderClass_partial_categorization_2(Class context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
-String _renderClass_partial_feature_set_3(_i9.Class context1) =>
+
+String _renderClass_partial_feature_set_3(Class context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderClass_partial_documentation_4(_i9.Class context1) =>
+
+String _renderClass_partial_documentation_4(Class context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderClass_partial_super_chain_5(_i9.Class context1) =>
+
+String _renderClass_partial_super_chain_5(Class context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderClass_partial_interfaces_6(_i9.Class context1) {
+
+String _renderClass_partial_interfaces_6(Class context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicInterfaces == true) {
     buffer.writeln();
@@ -1130,7 +1144,7 @@ String _renderClass_partial_interfaces_6(_i9.Class context1) {
   return buffer.toString();
 }
 
-String _renderClass_partial_mixed_in_types_7(_i9.Class context1) {
+String _renderClass_partial_mixed_in_types_7(Class context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicMixedInTypes == true) {
     buffer.writeln();
@@ -1149,49 +1163,67 @@ String _renderClass_partial_mixed_in_types_7(_i9.Class context1) {
   return buffer.toString();
 }
 
-String _renderClass_partial_annotations_8(_i9.Class context1) =>
+String _renderClass_partial_annotations_8(Class context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
-String _renderClass_partial_constructors_9(_i9.Class context1) =>
+
+String _renderClass_partial_constructors_9(Class context1) =>
     _deduplicated_lib_templates_md__constructors_md(context1);
-String _renderClass_partial_property_10(_i10.Field context2) =>
+
+String _renderClass_partial_property_10(Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderClass_partial_instance_methods_11(_i9.Class context1) =>
+
+String _renderClass_partial_instance_methods_11(Class context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderClass_partial_instance_operators_12(_i9.Class context1) =>
+
+String _renderClass_partial_instance_operators_12(Class context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderClass_partial_static_properties_13(_i9.Class context1) =>
+
+String _renderClass_partial_static_properties_13(Class context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderClass_partial_static_methods_14(_i9.Class context1) =>
+
+String _renderClass_partial_static_methods_14(Class context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderClass_partial_static_constants_15(_i9.Class context1) =>
+
+String _renderClass_partial_static_constants_15(Class context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderClass_partial_footer_16(_i1.ClassTemplateData context0) =>
+
+String _renderClass_partial_footer_16(ClassTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderConstructor_partial_head_0(
-        _i1.ConstructorTemplateData context0) =>
+
+String _renderConstructor_partial_head_0(ConstructorTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderConstructor_partial_source_link_1(_i11.Constructor context1) =>
+
+String _renderConstructor_partial_source_link_1(Constructor context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderConstructor_partial_feature_set_2(_i11.Constructor context1) =>
+
+String _renderConstructor_partial_feature_set_2(Constructor context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderConstructor_partial_documentation_3(_i11.Constructor context1) =>
+
+String _renderConstructor_partial_documentation_3(Constructor context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderConstructor_partial_source_code_4(_i11.Constructor context1) =>
+
+String _renderConstructor_partial_source_code_4(Constructor context1) =>
     _deduplicated_lib_templates_md__source_code_md(context1);
-String _renderConstructor_partial_footer_5(
-        _i1.ConstructorTemplateData context0) =>
+
+String _renderConstructor_partial_footer_5(ConstructorTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderEnum_partial_head_0(_i1.EnumTemplateData context0) =>
+
+String _renderEnum_partial_head_0(EnumTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderEnum_partial_source_link_1(_i12.Enum context1) =>
+
+String _renderEnum_partial_source_link_1(Enum context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderEnum_partial_feature_set_2(_i12.Enum context1) =>
+
+String _renderEnum_partial_feature_set_2(Enum context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderEnum_partial_documentation_3(_i12.Enum context1) =>
+
+String _renderEnum_partial_documentation_3(Enum context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderEnum_partial_super_chain_4(_i12.Enum context1) =>
+
+String _renderEnum_partial_super_chain_4(Enum context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderEnum_partial_interfaces_5(_i12.Enum context1) {
+
+String _renderEnum_partial_interfaces_5(Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicInterfaces == true) {
     buffer.writeln();
@@ -1210,7 +1242,7 @@ String _renderEnum_partial_interfaces_5(_i12.Enum context1) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_mixed_in_types_6(_i12.Enum context1) {
+String _renderEnum_partial_mixed_in_types_6(Enum context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicMixedInTypes == true) {
     buffer.writeln();
@@ -1229,64 +1261,90 @@ String _renderEnum_partial_mixed_in_types_6(_i12.Enum context1) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_annotations_7(_i12.Enum context1) =>
+String _renderEnum_partial_annotations_7(Enum context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
-String _renderEnum_partial_constructors_8(_i12.Enum context1) =>
+
+String _renderEnum_partial_constructors_8(Enum context1) =>
     _deduplicated_lib_templates_md__constructors_md(context1);
-String _renderEnum_partial_constant_9(_i10.Field context2) =>
+
+String _renderEnum_partial_constant_9(Field context2) =>
     _deduplicated_lib_templates_md__constant_md(context2);
-String _renderEnum_partial_property_10(_i10.Field context2) =>
+
+String _renderEnum_partial_property_10(Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderEnum_partial_instance_methods_11(_i12.Enum context1) =>
+
+String _renderEnum_partial_instance_methods_11(Enum context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderEnum_partial_instance_operators_12(_i12.Enum context1) =>
+
+String _renderEnum_partial_instance_operators_12(Enum context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderEnum_partial_static_properties_13(_i12.Enum context1) =>
+
+String _renderEnum_partial_static_properties_13(Enum context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderEnum_partial_static_methods_14(_i12.Enum context1) =>
+
+String _renderEnum_partial_static_methods_14(Enum context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderEnum_partial_static_constants_15(_i12.Enum context1) =>
+
+String _renderEnum_partial_static_constants_15(Enum context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderEnum_partial_footer_16(_i1.EnumTemplateData context0) =>
+
+String _renderEnum_partial_footer_16(EnumTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderExtension_partial_head_0<T extends _i2.Extension>(
-        _i1.ExtensionTemplateData<T> context0) =>
+
+String _renderExtension_partial_head_0<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderExtension_partial_source_link_1(_i2.Extension context1) =>
+
+String _renderExtension_partial_source_link_1(Extension context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderExtension_partial_categorization_2(_i2.Extension context1) =>
+
+String _renderExtension_partial_categorization_2(Extension context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
-String _renderExtension_partial_feature_set_3(_i2.Extension context1) =>
+
+String _renderExtension_partial_feature_set_3(Extension context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderExtension_partial_documentation_4(_i2.Extension context1) =>
+
+String _renderExtension_partial_documentation_4(Extension context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderExtension_partial_annotations_5(_i2.Extension context1) =>
+
+String _renderExtension_partial_annotations_5(Extension context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
-String _renderExtension_partial_property_6(_i10.Field context2) =>
+
+String _renderExtension_partial_property_6(Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderExtension_partial_instance_methods_7(_i2.Extension context1) =>
+
+String _renderExtension_partial_instance_methods_7(Extension context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderExtension_partial_instance_operators_8(_i2.Extension context1) =>
+
+String _renderExtension_partial_instance_operators_8(Extension context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderExtension_partial_static_properties_9(_i2.Extension context1) =>
+
+String _renderExtension_partial_static_properties_9(Extension context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderExtension_partial_static_methods_10(_i2.Extension context1) =>
+
+String _renderExtension_partial_static_methods_10(Extension context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderExtension_partial_static_constants_11(_i2.Extension context1) =>
+
+String _renderExtension_partial_static_constants_11(Extension context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderExtension_partial_footer_12<T extends _i2.Extension>(
-        _i1.ExtensionTemplateData<T> context0) =>
+
+String _renderExtension_partial_footer_12<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderFunction_partial_head_0(_i1.FunctionTemplateData context0) =>
+
+String _renderFunction_partial_head_0(FunctionTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderFunction_partial_source_link_1(_i7.ModelFunction context1) =>
+
+String _renderFunction_partial_source_link_1(ModelFunction context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderFunction_partial_categorization_2(_i7.ModelFunction context1) =>
+
+String _renderFunction_partial_categorization_2(ModelFunction context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
-String _renderFunction_partial_feature_set_3(_i7.ModelFunction context1) =>
+
+String _renderFunction_partial_feature_set_3(ModelFunction context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderFunction_partial_callable_multiline_4(
-    _i7.ModelFunction context1) {
+
+String _renderFunction_partial_callable_multiline_4(ModelFunction context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     var context2 = context1.annotations;
@@ -1315,43 +1373,61 @@ String _renderFunction_partial_callable_multiline_4(
 }
 
 String __renderFunction_partial_callable_multiline_4_partial_name_summary_0(
-        _i7.ModelFunction context1) =>
+        ModelFunction context1) =>
     _deduplicated_lib_templates_md__name_summary_md(context1);
-String _renderFunction_partial_features_5(_i7.ModelFunction context1) =>
+
+String _renderFunction_partial_features_5(ModelFunction context1) =>
     _deduplicated_lib_templates_md__features_md(context1);
-String _renderFunction_partial_documentation_6(_i7.ModelFunction context1) =>
+
+String _renderFunction_partial_documentation_6(ModelFunction context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderFunction_partial_source_code_7(_i7.ModelFunction context1) =>
+
+String _renderFunction_partial_source_code_7(ModelFunction context1) =>
     _deduplicated_lib_templates_md__source_code_md(context1);
-String _renderFunction_partial_footer_8(_i1.FunctionTemplateData context0) =>
+
+String _renderFunction_partial_footer_8(FunctionTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderIndex_partial_head_0(_i1.PackageTemplateData context0) =>
+
+String _renderIndex_partial_head_0(PackageTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderIndex_partial_documentation_1(_i13.Package context1) =>
+
+String _renderIndex_partial_documentation_1(Package context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderIndex_partial_library_2(_i4.Library context3) =>
+
+String _renderIndex_partial_library_2(Library context3) =>
     _deduplicated_lib_templates_md__library_md(context3);
-String _renderIndex_partial_footer_3(_i1.PackageTemplateData context0) =>
+
+String _renderIndex_partial_footer_3(PackageTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderLibrary_partial_head_0(_i1.LibraryTemplateData context0) =>
+
+String _renderLibrary_partial_head_0(LibraryTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderLibrary_partial_source_link_1(_i4.Library context1) =>
+
+String _renderLibrary_partial_source_link_1(Library context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderLibrary_partial_categorization_2(_i4.Library context1) =>
+
+String _renderLibrary_partial_categorization_2(Library context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
-String _renderLibrary_partial_feature_set_3(_i4.Library context1) =>
+
+String _renderLibrary_partial_feature_set_3(Library context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderLibrary_partial_documentation_4(_i4.Library context1) =>
+
+String _renderLibrary_partial_documentation_4(Library context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderLibrary_partial_container_5(_i5.Container context3) =>
+
+String _renderLibrary_partial_container_5(Container context3) =>
     _deduplicated_lib_templates_md__container_md(context3);
-String _renderLibrary_partial_extension_6(_i2.Extension context3) =>
+
+String _renderLibrary_partial_extension_6(Extension context3) =>
     _deduplicated_lib_templates_md__extension_md(context3);
-String _renderLibrary_partial_constant_7(_i6.TopLevelVariable context3) =>
+
+String _renderLibrary_partial_constant_7(TopLevelVariable context3) =>
     _deduplicated_lib_templates_md__constant_md(context3);
-String _renderLibrary_partial_property_8(_i6.TopLevelVariable context3) =>
+
+String _renderLibrary_partial_property_8(TopLevelVariable context3) =>
     _deduplicated_lib_templates_md__property_md(context3);
-String _renderLibrary_partial_callable_9(_i7.ModelFunctionTyped context3) {
+
+String _renderLibrary_partial_callable_9(ModelFunctionTyped context3) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context3.linkedName);
@@ -1374,22 +1450,29 @@ String _renderLibrary_partial_callable_9(_i7.ModelFunctionTyped context3) {
 }
 
 String __renderLibrary_partial_callable_9_partial_categorization_0(
-        _i7.ModelFunctionTyped context3) =>
+        ModelFunctionTyped context3) =>
     _deduplicated_lib_templates_md__categorization_md(context3);
+
 String __renderLibrary_partial_callable_9_partial_features_1(
-        _i7.ModelFunctionTyped context3) =>
+        ModelFunctionTyped context3) =>
     _deduplicated_lib_templates_md__features_md(context3);
-String _renderLibrary_partial_typedef_10(_i8.Typedef context3) =>
+
+String _renderLibrary_partial_typedef_10(Typedef context3) =>
     _deduplicated_lib_templates_md__typedef_md(context3);
-String _renderLibrary_partial_footer_11(_i1.LibraryTemplateData context0) =>
+
+String _renderLibrary_partial_footer_11(LibraryTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderMethod_partial_head_0(_i1.MethodTemplateData context0) =>
+
+String _renderMethod_partial_head_0(MethodTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderMethod_partial_source_link_1(_i14.Method context1) =>
+
+String _renderMethod_partial_source_link_1(Method context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderMethod_partial_feature_set_2(_i14.Method context1) =>
+
+String _renderMethod_partial_feature_set_2(Method context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderMethod_partial_callable_multiline_3(_i14.Method context1) {
+
+String _renderMethod_partial_callable_multiline_3(Method context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     var context2 = context1.annotations;
@@ -1418,29 +1501,40 @@ String _renderMethod_partial_callable_multiline_3(_i14.Method context1) {
 }
 
 String __renderMethod_partial_callable_multiline_3_partial_name_summary_0(
-        _i14.Method context1) =>
+        Method context1) =>
     _deduplicated_lib_templates_md__name_summary_md(context1);
-String _renderMethod_partial_features_4(_i14.Method context1) =>
+
+String _renderMethod_partial_features_4(Method context1) =>
     _deduplicated_lib_templates_md__features_md(context1);
-String _renderMethod_partial_documentation_5(_i14.Method context1) =>
+
+String _renderMethod_partial_documentation_5(Method context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderMethod_partial_source_code_6(_i14.Method context1) =>
+
+String _renderMethod_partial_source_code_6(Method context1) =>
     _deduplicated_lib_templates_md__source_code_md(context1);
-String _renderMethod_partial_footer_7(_i1.MethodTemplateData context0) =>
+
+String _renderMethod_partial_footer_7(MethodTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderMixin_partial_head_0(_i1.MixinTemplateData context0) =>
+
+String _renderMixin_partial_head_0(MixinTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderMixin_partial_source_link_1(_i15.Mixin context1) =>
+
+String _renderMixin_partial_source_link_1(Mixin context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderMixin_partial_categorization_2(_i15.Mixin context1) =>
+
+String _renderMixin_partial_categorization_2(Mixin context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
-String _renderMixin_partial_feature_set_3(_i15.Mixin context1) =>
+
+String _renderMixin_partial_feature_set_3(Mixin context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderMixin_partial_documentation_4(_i15.Mixin context1) =>
+
+String _renderMixin_partial_documentation_4(Mixin context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderMixin_partial_super_chain_5(_i15.Mixin context1) =>
+
+String _renderMixin_partial_super_chain_5(Mixin context1) =>
     _deduplicated_lib_templates_md__super_chain_md(context1);
-String _renderMixin_partial_interfaces_6(_i15.Mixin context1) {
+
+String _renderMixin_partial_interfaces_6(Mixin context1) {
   final buffer = StringBuffer();
   if (context1.hasPublicInterfaces == true) {
     buffer.writeln();
@@ -1459,97 +1553,135 @@ String _renderMixin_partial_interfaces_6(_i15.Mixin context1) {
   return buffer.toString();
 }
 
-String _renderMixin_partial_annotations_7(_i15.Mixin context1) =>
+String _renderMixin_partial_annotations_7(Mixin context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
-String _renderMixin_partial_property_8(_i10.Field context2) =>
+
+String _renderMixin_partial_property_8(Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
-String _renderMixin_partial_instance_methods_9(_i15.Mixin context1) =>
+
+String _renderMixin_partial_instance_methods_9(Mixin context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
-String _renderMixin_partial_instance_operators_10(_i15.Mixin context1) =>
+
+String _renderMixin_partial_instance_operators_10(Mixin context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
-String _renderMixin_partial_static_properties_11(_i15.Mixin context1) =>
+
+String _renderMixin_partial_static_properties_11(Mixin context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
-String _renderMixin_partial_static_methods_12(_i15.Mixin context1) =>
+
+String _renderMixin_partial_static_methods_12(Mixin context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
-String _renderMixin_partial_static_constants_13(_i15.Mixin context1) =>
+
+String _renderMixin_partial_static_constants_13(Mixin context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
-String _renderMixin_partial_footer_14(_i1.MixinTemplateData context0) =>
+
+String _renderMixin_partial_footer_14(MixinTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderProperty_partial_head_0(_i1.PropertyTemplateData context0) =>
+
+String _renderProperty_partial_head_0(PropertyTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderProperty_partial_source_link_1(_i10.Field context1) =>
+
+String _renderProperty_partial_source_link_1(Field context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderProperty_partial_feature_set_2(_i10.Field context1) =>
+
+String _renderProperty_partial_feature_set_2(Field context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderProperty_partial_annotations_3(_i10.Field context1) =>
+
+String _renderProperty_partial_annotations_3(Field context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
-String _renderProperty_partial_name_summary_4(_i10.Field context1) =>
+
+String _renderProperty_partial_name_summary_4(Field context1) =>
     _deduplicated_lib_templates_md__name_summary_md(context1);
-String _renderProperty_partial_features_5(_i10.Field context1) =>
+
+String _renderProperty_partial_features_5(Field context1) =>
     _deduplicated_lib_templates_md__features_md(context1);
-String _renderProperty_partial_documentation_6(_i10.Field context1) =>
+
+String _renderProperty_partial_documentation_6(Field context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderProperty_partial_source_code_7(_i10.Field context1) =>
+
+String _renderProperty_partial_source_code_7(Field context1) =>
     _deduplicated_lib_templates_md__source_code_md(context1);
-String _renderProperty_partial_accessor_getter_8(_i10.Field context1) =>
+
+String _renderProperty_partial_accessor_getter_8(Field context1) =>
     _deduplicated_lib_templates_md__accessor_getter_md(context1);
-String _renderProperty_partial_accessor_setter_9(_i10.Field context1) =>
+
+String _renderProperty_partial_accessor_setter_9(Field context1) =>
     _deduplicated_lib_templates_md__accessor_setter_md(context1);
-String _renderProperty_partial_footer_10(_i1.PropertyTemplateData context0) =>
+
+String _renderProperty_partial_footer_10(PropertyTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderSearchPage_partial_head_0(_i1.PackageTemplateData context0) =>
+
+String _renderSearchPage_partial_head_0(PackageTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderSearchPage_partial_documentation_1(_i13.Package context1) =>
+
+String _renderSearchPage_partial_documentation_1(Package context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderSearchPage_partial_library_2(_i4.Library context3) =>
+
+String _renderSearchPage_partial_library_2(Library context3) =>
     _deduplicated_lib_templates_md__library_md(context3);
-String _renderSearchPage_partial_footer_3(_i1.PackageTemplateData context0) =>
+
+String _renderSearchPage_partial_footer_3(PackageTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
+
 String _renderTopLevelProperty_partial_head_0(
-        _i1.TopLevelPropertyTemplateData context0) =>
+        TopLevelPropertyTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
+
 String _renderTopLevelProperty_partial_source_link_1(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
+
 String _renderTopLevelProperty_partial_categorization_2(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
+
 String _renderTopLevelProperty_partial_feature_set_3(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
+
 String _renderTopLevelProperty_partial_annotations_4(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
+
 String _renderTopLevelProperty_partial_name_summary_5(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__name_summary_md(context1);
-String _renderTopLevelProperty_partial_features_6(
-        _i6.TopLevelVariable context1) =>
+
+String _renderTopLevelProperty_partial_features_6(TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__features_md(context1);
+
 String _renderTopLevelProperty_partial_documentation_7(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
+
 String _renderTopLevelProperty_partial_source_code_8(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__source_code_md(context1);
+
 String _renderTopLevelProperty_partial_accessor_getter_9(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__accessor_getter_md(context1);
+
 String _renderTopLevelProperty_partial_accessor_setter_10(
-        _i6.TopLevelVariable context1) =>
+        TopLevelVariable context1) =>
     _deduplicated_lib_templates_md__accessor_setter_md(context1);
+
 String _renderTopLevelProperty_partial_footer_11(
-        _i1.TopLevelPropertyTemplateData context0) =>
+        TopLevelPropertyTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _renderTypedef_partial_head_0(_i1.TypedefTemplateData context0) =>
+
+String _renderTypedef_partial_head_0(TypedefTemplateData context0) =>
     _deduplicated_lib_templates_md__head_md(context0);
-String _renderTypedef_partial_source_link_1(_i8.Typedef context1) =>
+
+String _renderTypedef_partial_source_link_1(Typedef context1) =>
     _deduplicated_lib_templates_md__source_link_md(context1);
-String _renderTypedef_partial_categorization_2(_i8.Typedef context1) =>
+
+String _renderTypedef_partial_categorization_2(Typedef context1) =>
     _deduplicated_lib_templates_md__categorization_md(context1);
-String _renderTypedef_partial_feature_set_3(_i8.Typedef context1) =>
+
+String _renderTypedef_partial_feature_set_3(Typedef context1) =>
     _deduplicated_lib_templates_md__feature_set_md(context1);
-String _renderTypedef_partial_typedef_multiline_4(_i8.Typedef context1) {
+
+String _renderTypedef_partial_typedef_multiline_4(Typedef context1) {
   final buffer = StringBuffer();
   if (context1.isCallable == true) {
     var context2 = context1.asCallable;
@@ -1582,7 +1714,7 @@ String _renderTypedef_partial_typedef_multiline_4(_i8.Typedef context1) {
 }
 
 String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
-    _i8.Typedef context1) {
+    Typedef context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     var context2 = context1.annotations;
@@ -1607,15 +1739,19 @@ String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
 
 String
     ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
-            _i8.Typedef context1) =>
+            Typedef context1) =>
         _deduplicated_lib_templates_md__name_summary_md(context1);
-String _renderTypedef_partial_documentation_5(_i8.Typedef context1) =>
+
+String _renderTypedef_partial_documentation_5(Typedef context1) =>
     _deduplicated_lib_templates_md__documentation_md(context1);
-String _renderTypedef_partial_source_code_6(_i8.Typedef context1) =>
+
+String _renderTypedef_partial_source_code_6(Typedef context1) =>
     _deduplicated_lib_templates_md__source_code_md(context1);
-String _renderTypedef_partial_footer_7(_i1.TypedefTemplateData context0) =>
+
+String _renderTypedef_partial_footer_7(TypedefTemplateData context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
-String _deduplicated_lib_templates_md__head_md(_i1.TemplateDataBase context0) {
+
+String _deduplicated_lib_templates_md__head_md(TemplateDataBase context0) {
   final buffer = StringBuffer();
   buffer.write(context0.customHeader);
   buffer.writeln();
@@ -1623,8 +1759,7 @@ String _deduplicated_lib_templates_md__head_md(_i1.TemplateDataBase context0) {
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__documentation_md(
-    _i16.Warnable context0) {
+String _deduplicated_lib_templates_md__documentation_md(Warnable context0) {
   final buffer = StringBuffer();
   if (context0.hasDocumentation == true) {
     buffer.writeln();
@@ -1635,7 +1770,7 @@ String _deduplicated_lib_templates_md__documentation_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__library_md(_i4.Library context0) {
+String _deduplicated_lib_templates_md__library_md(Library context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1649,7 +1784,7 @@ String _deduplicated_lib_templates_md__library_md(_i4.Library context0) {
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__container_md(_i5.Container context0) {
+String _deduplicated_lib_templates_md__container_md(Container context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1666,7 +1801,7 @@ String _deduplicated_lib_templates_md__container_md(_i5.Container context0) {
 }
 
 String __deduplicated_lib_templates_md__container_md_partial_categorization_0(
-    _i5.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -1684,7 +1819,7 @@ Categories:''');
 }
 
 String _deduplicated_lib_templates_md__categorization_md(
-    _i17.ModelElement context0) {
+    ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -1701,7 +1836,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__extension_md(_i2.Extension context0) {
+String _deduplicated_lib_templates_md__extension_md(Extension context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1717,7 +1852,7 @@ String _deduplicated_lib_templates_md__extension_md(_i2.Extension context0) {
 }
 
 String __deduplicated_lib_templates_md__extension_md_partial_categorization_0(
-    _i2.Extension context0) {
+    Extension context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -1734,8 +1869,7 @@ Categories:''');
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__constant_md(
-    _i18.GetterSetterCombo context0) {
+String _deduplicated_lib_templates_md__constant_md(GetterSetterCombo context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1757,7 +1891,7 @@ String _deduplicated_lib_templates_md__constant_md(
 }
 
 String __deduplicated_lib_templates_md__constant_md_partial_categorization_0(
-    _i18.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -1775,7 +1909,7 @@ Categories:''');
 }
 
 String __deduplicated_lib_templates_md__constant_md_partial_features_1(
-    _i18.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''_''');
@@ -1787,7 +1921,7 @@ String __deduplicated_lib_templates_md__constant_md_partial_features_1(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__features_md(_i17.ModelElement context0) {
+String _deduplicated_lib_templates_md__features_md(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''_''');
@@ -1799,8 +1933,7 @@ String _deduplicated_lib_templates_md__features_md(_i17.ModelElement context0) {
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__property_md(
-    _i18.GetterSetterCombo context0) {
+String _deduplicated_lib_templates_md__property_md(GetterSetterCombo context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1824,7 +1957,7 @@ String _deduplicated_lib_templates_md__property_md(
 }
 
 String __deduplicated_lib_templates_md__property_md_partial_categorization_0(
-    _i18.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -1842,7 +1975,7 @@ Categories:''');
 }
 
 String __deduplicated_lib_templates_md__property_md_partial_features_1(
-    _i18.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''_''');
@@ -1854,7 +1987,7 @@ String __deduplicated_lib_templates_md__property_md_partial_features_1(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__typedef_md(_i8.Typedef context0) {
+String _deduplicated_lib_templates_md__typedef_md(Typedef context0) {
   final buffer = StringBuffer();
   if (context0.isCallable == true) {
     var context1 = context0.asCallable;
@@ -1887,7 +2020,7 @@ String _deduplicated_lib_templates_md__typedef_md(_i8.Typedef context0) {
 }
 
 String __deduplicated_lib_templates_md__typedef_md_partial_categorization_0(
-    _i8.FunctionTypedef context1) {
+    FunctionTypedef context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
@@ -1905,7 +2038,7 @@ Categories:''');
 }
 
 String __deduplicated_lib_templates_md__typedef_md_partial_features_1(
-    _i8.FunctionTypedef context1) {
+    FunctionTypedef context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -1918,7 +2051,7 @@ String __deduplicated_lib_templates_md__typedef_md_partial_features_1(
 }
 
 String __deduplicated_lib_templates_md__typedef_md_partial_type_2(
-    _i8.Typedef context0) {
+    Typedef context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1943,7 +2076,7 @@ String __deduplicated_lib_templates_md__typedef_md_partial_type_2(
 
 String
     ___deduplicated_lib_templates_md__typedef_md_partial_type_2_partial_categorization_0(
-        _i8.Typedef context0) {
+        Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -1962,7 +2095,7 @@ Categories:''');
 
 String
     ___deduplicated_lib_templates_md__typedef_md_partial_type_2_partial_features_1(
-        _i8.Typedef context0) {
+        Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''_''');
@@ -1974,7 +2107,7 @@ String
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__type_md(_i8.Typedef context0) {
+String _deduplicated_lib_templates_md__type_md(Typedef context0) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context0.linkedName);
@@ -1997,7 +2130,7 @@ String _deduplicated_lib_templates_md__type_md(_i8.Typedef context0) {
 }
 
 String __deduplicated_lib_templates_md__type_md_partial_categorization_0(
-    _i8.Typedef context0) {
+    Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasCategoryNames == true) {
     buffer.writeln();
@@ -2015,7 +2148,7 @@ Categories:''');
 }
 
 String __deduplicated_lib_templates_md__type_md_partial_features_1(
-    _i8.Typedef context0) {
+    Typedef context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatures == true) {
     buffer.write('''_''');
@@ -2027,8 +2160,7 @@ String __deduplicated_lib_templates_md__type_md_partial_features_1(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__footer_md(
-    _i1.TemplateDataBase context0) {
+String _deduplicated_lib_templates_md__footer_md(TemplateDataBase context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   buffer.write(context0.customInnerFooter);
@@ -2039,8 +2171,7 @@ String _deduplicated_lib_templates_md__footer_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__source_link_md(
-    _i17.ModelElement context0) {
+String _deduplicated_lib_templates_md__source_link_md(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasSourceHref == true) {
     buffer.writeln();
@@ -2054,8 +2185,7 @@ String _deduplicated_lib_templates_md__source_link_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__feature_set_md(
-    _i17.ModelElement context0) {
+String _deduplicated_lib_templates_md__feature_set_md(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasFeatureSet == true) {
     var context1 = context0.displayedLanguageFeatures;
@@ -2070,7 +2200,7 @@ String _deduplicated_lib_templates_md__feature_set_md(
 }
 
 String _deduplicated_lib_templates_md__super_chain_md(
-    _i19.InheritingContainer context0) {
+    InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicSuperChainReversed == true) {
     buffer.writeln();
@@ -2095,8 +2225,7 @@ String _deduplicated_lib_templates_md__super_chain_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__annotations_md(
-    _i17.ModelElement context0) {
+String _deduplicated_lib_templates_md__annotations_md(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasAnnotations == true) {
     buffer.writeln();
@@ -2116,7 +2245,7 @@ String _deduplicated_lib_templates_md__annotations_md(
 }
 
 String _deduplicated_lib_templates_md__constructors_md(
-    _i19.InheritingContainer context0) {
+    InheritingContainer context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicConstructors == true) {
     buffer.writeln();
@@ -2148,8 +2277,7 @@ String _deduplicated_lib_templates_md__constructors_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__instance_methods_md(
-    _i5.Container context0) {
+String _deduplicated_lib_templates_md__instance_methods_md(Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicInstanceMethods == true) {
     buffer.writeln();
@@ -2170,7 +2298,7 @@ String _deduplicated_lib_templates_md__instance_methods_md(
 }
 
 String __deduplicated_lib_templates_md__instance_methods_md_partial_callable_0(
-    _i14.Method context1) {
+    Method context1) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context1.linkedName);
@@ -2197,7 +2325,7 @@ String __deduplicated_lib_templates_md__instance_methods_md_partial_callable_0(
 
 String
     ___deduplicated_lib_templates_md__instance_methods_md_partial_callable_0_partial_categorization_0(
-        _i14.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
@@ -2216,7 +2344,7 @@ Categories:''');
 
 String
     ___deduplicated_lib_templates_md__instance_methods_md_partial_callable_0_partial_features_1(
-        _i14.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2229,7 +2357,7 @@ String
 }
 
 String _deduplicated_lib_templates_md__instance_operators_md(
-    _i5.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicInstanceOperators == true) {
     buffer.writeln();
@@ -2251,7 +2379,7 @@ String _deduplicated_lib_templates_md__instance_operators_md(
 
 String
     __deduplicated_lib_templates_md__instance_operators_md_partial_callable_0(
-        _i20.Operator context1) {
+        Operator context1) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context1.linkedName);
@@ -2278,7 +2406,7 @@ String
 
 String
     ___deduplicated_lib_templates_md__instance_operators_md_partial_callable_0_partial_categorization_0(
-        _i20.Operator context1) {
+        Operator context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
@@ -2297,7 +2425,7 @@ Categories:''');
 
 String
     ___deduplicated_lib_templates_md__instance_operators_md_partial_callable_0_partial_features_1(
-        _i20.Operator context1) {
+        Operator context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2310,7 +2438,7 @@ String
 }
 
 String _deduplicated_lib_templates_md__static_properties_md(
-    _i5.Container context0) {
+    Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicVariableStaticFields == true) {
     buffer.writeln();
@@ -2331,7 +2459,7 @@ String _deduplicated_lib_templates_md__static_properties_md(
 }
 
 String __deduplicated_lib_templates_md__static_properties_md_partial_property_0(
-    _i10.Field context1) {
+    Field context1) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context1.linkedName);
@@ -2357,7 +2485,7 @@ String __deduplicated_lib_templates_md__static_properties_md_partial_property_0(
 
 String
     ___deduplicated_lib_templates_md__static_properties_md_partial_property_0_partial_categorization_0(
-        _i10.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
@@ -2376,7 +2504,7 @@ Categories:''');
 
 String
     ___deduplicated_lib_templates_md__static_properties_md_partial_property_0_partial_features_1(
-        _i10.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2388,8 +2516,7 @@ String
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__static_methods_md(
-    _i5.Container context0) {
+String _deduplicated_lib_templates_md__static_methods_md(Container context0) {
   final buffer = StringBuffer();
   if (context0.hasPublicStaticMethods == true) {
     buffer.writeln();
@@ -2410,7 +2537,7 @@ String _deduplicated_lib_templates_md__static_methods_md(
 }
 
 String __deduplicated_lib_templates_md__static_methods_md_partial_callable_0(
-    _i14.Method context1) {
+    Method context1) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context1.linkedName);
@@ -2437,7 +2564,7 @@ String __deduplicated_lib_templates_md__static_methods_md_partial_callable_0(
 
 String
     ___deduplicated_lib_templates_md__static_methods_md_partial_callable_0_partial_categorization_0(
-        _i14.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
@@ -2456,7 +2583,7 @@ Categories:''');
 
 String
     ___deduplicated_lib_templates_md__static_methods_md_partial_callable_0_partial_features_1(
-        _i14.Method context1) {
+        Method context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2468,8 +2595,7 @@ String
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__static_constants_md(
-    _i5.Container context0) {
+String _deduplicated_lib_templates_md__static_constants_md(Container context0) {
   final buffer = StringBuffer();
   buffer.writeln();
   if (context0.hasPublicConstantFields == true) {
@@ -2491,7 +2617,7 @@ String _deduplicated_lib_templates_md__static_constants_md(
 }
 
 String __deduplicated_lib_templates_md__static_constants_md_partial_constant_0(
-    _i10.Field context1) {
+    Field context1) {
   final buffer = StringBuffer();
   buffer.write('''##### ''');
   buffer.write(context1.linkedName);
@@ -2515,7 +2641,7 @@ String __deduplicated_lib_templates_md__static_constants_md_partial_constant_0(
 
 String
     ___deduplicated_lib_templates_md__static_constants_md_partial_constant_0_partial_categorization_0(
-        _i10.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasCategoryNames == true) {
     buffer.writeln();
@@ -2534,7 +2660,7 @@ Categories:''');
 
 String
     ___deduplicated_lib_templates_md__static_constants_md_partial_constant_0_partial_features_1(
-        _i10.Field context1) {
+        Field context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2546,8 +2672,7 @@ String
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__source_code_md(
-    _i17.ModelElement context0) {
+String _deduplicated_lib_templates_md__source_code_md(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.hasSourceCode == true) {
     buffer.writeln();
@@ -2566,8 +2691,7 @@ String _deduplicated_lib_templates_md__source_code_md(
   return buffer.toString();
 }
 
-String _deduplicated_lib_templates_md__name_summary_md(
-    _i17.ModelElement context0) {
+String _deduplicated_lib_templates_md__name_summary_md(ModelElement context0) {
   final buffer = StringBuffer();
   if (context0.isConst == true) {
     buffer.write('''const ''');
@@ -2585,7 +2709,7 @@ String _deduplicated_lib_templates_md__name_summary_md(
 }
 
 String _deduplicated_lib_templates_md__accessor_getter_md(
-    _i18.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   var context1 = context0.getter;
   if (context1 != null) {
@@ -2620,7 +2744,7 @@ String _deduplicated_lib_templates_md__accessor_getter_md(
 
 String
     __deduplicated_lib_templates_md__accessor_getter_md_partial_annotations_0(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
@@ -2641,7 +2765,7 @@ String
 
 String
     __deduplicated_lib_templates_md__accessor_getter_md_partial_name_summary_1(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -2659,7 +2783,7 @@ String
 }
 
 String __deduplicated_lib_templates_md__accessor_getter_md_partial_features_2(
-    _i21.Accessor context1) {
+    Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2673,7 +2797,7 @@ String __deduplicated_lib_templates_md__accessor_getter_md_partial_features_2(
 
 String
     __deduplicated_lib_templates_md__accessor_getter_md_partial_documentation_3(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -2686,7 +2810,7 @@ String
 
 String
     __deduplicated_lib_templates_md__accessor_getter_md_partial_source_code_4(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -2706,7 +2830,7 @@ String
 }
 
 String _deduplicated_lib_templates_md__accessor_setter_md(
-    _i18.GetterSetterCombo context0) {
+    GetterSetterCombo context0) {
   final buffer = StringBuffer();
   var context1 = context0.setter;
   if (context1 != null) {
@@ -2741,7 +2865,7 @@ String _deduplicated_lib_templates_md__accessor_setter_md(
 
 String
     __deduplicated_lib_templates_md__accessor_setter_md_partial_annotations_0(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasAnnotations == true) {
     buffer.writeln();
@@ -2762,7 +2886,7 @@ String
 
 String
     __deduplicated_lib_templates_md__accessor_setter_md_partial_name_summary_1(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.isConst == true) {
     buffer.write('''const ''');
@@ -2780,7 +2904,7 @@ String
 }
 
 String __deduplicated_lib_templates_md__accessor_setter_md_partial_features_2(
-    _i21.Accessor context1) {
+    Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasFeatures == true) {
     buffer.write('''_''');
@@ -2794,7 +2918,7 @@ String __deduplicated_lib_templates_md__accessor_setter_md_partial_features_2(
 
 String
     __deduplicated_lib_templates_md__accessor_setter_md_partial_documentation_3(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation == true) {
     buffer.writeln();
@@ -2807,7 +2931,7 @@ String
 
 String
     __deduplicated_lib_templates_md__accessor_setter_md_partial_source_code_4(
-        _i21.Accessor context1) {
+        Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode == true) {
     buffer.writeln();
@@ -2828,6 +2952,6 @@ String
 
 extension on StringBuffer {
   void writeEscaped(String? value) {
-    write(_i22.htmlEscape.convert(value ?? ''));
+    write(htmlEscape.convert(value ?? ''));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
 
 dev_dependencies:
   async: ^2.11.0
-  code_builder: ^4.4.0
   dart_style: ^2.3.1
   grinder: ^0.9.4
   http: ">=0.13.6 <2.0.0"

--- a/test/mustachio/aot_compiler_builder_test.dart
+++ b/test/mustachio/aot_compiler_builder_test.dart
@@ -66,8 +66,7 @@ import 'annotations.dart';
       ],
     );
     var generatedContent = await File(aotRenderersForHtmlPath).readAsString();
-    expect(
-        generatedContent, contains('String renderFoo<T>(_i1.Foo<T> context0)'));
+    expect(generatedContent, contains('String renderFoo<T>(Foo<T> context0)'));
   });
 
   test('builds a private render function for a partial', () async {
@@ -94,10 +93,8 @@ import 'annotations.dart';
       ],
     );
     var generatedContent = await File(aotRenderersForHtmlPath).readAsString();
-    expect(
-        generatedContent,
-        contains(
-            'String _renderFoo_partial_foo_header_0<T>(_i1.Foo<T> context0)'));
+    expect(generatedContent,
+        contains('String _renderFoo_partial_foo_header_0<T>(Foo<T> context0)'));
   });
 
   test('builds a renderer for a generic, bounded type', () async {
@@ -151,12 +148,12 @@ import 'annotations.dart';
     var generatedContent = await File(aotRenderersForHtmlPath).readAsString();
     expect(
       generatedContent,
-      contains('String _renderFoo_partial_base_0(_i1.Foo context0) =>\n'
+      contains('String _renderFoo_partial_base_0(Foo context0) =>\n'
           '    _deduplicated_lib_templates_html__base_html(context0);\n'),
     );
     expect(
       generatedContent,
-      contains('String _renderBar_partial_base_0(_i1.Bar context0) =>\n'
+      contains('String _renderBar_partial_base_0(Bar context0) =>\n'
           '    _deduplicated_lib_templates_html__base_html(context0);\n'),
     );
     expect(
@@ -198,11 +195,11 @@ import 'annotations.dart';
     var generatedContent = await File(aotRenderersForHtmlPath).readAsString();
     expect(
       generatedContent,
-      contains('String _renderFoo_partial_base_0(_i1.Foo context0) {'),
+      contains('String _renderFoo_partial_base_0(Foo context0) {'),
     );
     expect(
       generatedContent,
-      contains('String _renderBar_partial_base_0(_i1.Bar context0) {'),
+      contains('String _renderBar_partial_base_0(Bar context0) {'),
     );
   });
 }

--- a/test/mustachio/aot_compiler_render_test.dart
+++ b/test/mustachio/aot_compiler_render_test.dart
@@ -90,6 +90,8 @@ import 'annotations.dart';
     var generatedContent = await File(
             '${d.sandbox}/foo_package/lib/foo.aot_renderers_for_html.dart')
         .readAsString();
+    generatedContent = generatedContent.replaceFirst(
+        "import 'foo.dart';", "import 'package:foo/foo.dart';");
     renderScript.writeAsStringSync('''
 import 'dart:io';
 
@@ -179,7 +181,7 @@ void main() {
       () => [
         d.dir('lib/templates/html', [d.file('foo.html', 'Text {{s1}}')]),
       ],
-      '_i1.Foo()..s1 = "<p>hello</p>"',
+      'Foo()..s1 = "<p>hello</p>"',
     );
     expect(output, equals('Text &lt;p&gt;hello&lt;&#47;p&gt;'));
   });
@@ -189,7 +191,7 @@ void main() {
       () => [
         d.dir('lib/templates/html', [d.file('foo.html', 'Text {{{s1}}}')]),
       ],
-      '_i1.Foo()..s1 = "<p>hello</p>"',
+      'Foo()..s1 = "<p>hello</p>"',
     );
     expect(output, equals('Text <p>hello</p>'));
   });
@@ -199,7 +201,7 @@ void main() {
       () => [
         d.dir('lib/templates/html', [d.file('foo.html', 'Text {{b1}}')]),
       ],
-      '_i1.Foo()..b1 = true',
+      'Foo()..b1 = true',
     );
     expect(output, equals('Text true'));
   });
@@ -209,7 +211,7 @@ void main() {
       () => [
         d.dir('lib/templates/html', [d.file('foo.html', 'Text {{l1}}')]),
       ],
-      '_i1.Foo()..l1 = [1, 2, 3]',
+      'Foo()..l1 = [1, 2, 3]',
     );
     expect(output, equals('Text [1, 2, 3]'));
   });
@@ -220,7 +222,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{#b1}}Section{{/b1}}')]),
       ],
-      '_i1.Foo()..b1 = true',
+      'Foo()..b1 = true',
     );
     expect(output, equals('Text Section'));
   });
@@ -231,7 +233,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{#b1}}Section{{/b1}}')]),
       ],
-      '_i1.Foo()..b1 = false',
+      'Foo()..b1 = false',
     );
     expect(output, equals('Text '));
   });
@@ -242,7 +244,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{#b1}}Section{{/b1}}')]),
       ],
-      '_i1.Foo()..b1 = false',
+      'Foo()..b1 = false',
     );
     expect(output, equals('Text '));
   });
@@ -254,7 +256,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{^b1}}Section{{/b1}}')]),
       ],
-      '_i1.Foo()..b1 = true',
+      'Foo()..b1 = true',
     );
     expect(output, equals('Text '));
   });
@@ -265,7 +267,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{^b1}}Section{{/b1}}')]),
       ],
-      '_i1.Foo()..b1 = false',
+      'Foo()..b1 = false',
     );
     expect(output, equals('Text Section'));
   });
@@ -276,7 +278,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{#l1}}Num {{.}}, {{/l1}}')]),
       ],
-      '_i1.Foo()..l1 = [1, 2, 3]',
+      'Foo()..l1 = [1, 2, 3]',
     );
     expect(output, equals('Text Num 1, Num 2, Num 3, '));
   });
@@ -288,7 +290,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('bar.html', 'Text {{#foo.l1}}Num {{.}}, {{/foo.l1}}')]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..l1 = [1, 2, 3])',
+      'Bar()..foo = (Foo()..l1 = [1, 2, 3])',
     );
     expect(output, equals('Text Num 1, Num 2, Num 3, '));
   });
@@ -299,7 +301,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{#l1}}Num {{.}}, {{/l1}}')]),
       ],
-      '_i1.Foo()..l1 = []',
+      'Foo()..l1 = []',
     );
     expect(output, equals('Text '));
   });
@@ -310,7 +312,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{^l1}}Empty{{/l1}}')]),
       ],
-      '_i1.Foo()..l1 = []',
+      'Foo()..l1 = []',
     );
     expect(output, equals('Text Empty'));
   });
@@ -321,7 +323,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{^l1}}Empty{{/l1}}')]),
       ],
-      '_i1.Foo()..l1 = [1, 2, 3]',
+      'Foo()..l1 = [1, 2, 3]',
     );
     expect(output, equals('Text '));
   });
@@ -332,7 +334,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('bar.html', 'Text {{#foo}}Foo: {{s1}}{{/foo}}')]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")',
+      'Bar()..foo = (Foo()..s1 = "hello")',
     );
     expect(output, equals('Text Foo: hello'));
   });
@@ -344,7 +346,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('bar.html', 'Text {{#foo}}One {{#s2}}Two{{/s2}}{{/foo}}')]),
       ],
-      '_i1.Bar()..foo = _i1.Foo()..s2 = "hello"',
+      'Bar()..foo = Foo()..s2 = "hello"',
     );
     expect(output, equals('Text One Two'));
   });
@@ -355,7 +357,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{#s1}}"{{.}}" ({{length}}){{/s1}}')]),
       ],
-      '_i1.Foo()..s1 = null',
+      'Foo()..s1 = null',
     );
     expect(output, equals('Text '));
   });
@@ -366,7 +368,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{^s1}}Section{{/s1}}')]),
       ],
-      '_i1.Foo()..s1 = "hello"',
+      'Foo()..s1 = "hello"',
     );
     expect(output, equals('Text '));
   });
@@ -377,7 +379,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('foo.html', 'Text {{^s1}}Section{{/s1}}')]),
       ],
-      '_i1.Foo()..s1 = null',
+      'Foo()..s1 = null',
     );
     expect(output, equals('Text Section'));
   });
@@ -388,7 +390,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('bar.html', 'Text {{#foo}}{{s1}}{{/foo}}')]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")',
+      'Bar()..foo = (Foo()..s1 = "hello")',
     );
     expect(output, equals('Text hello'));
   });
@@ -400,7 +402,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('bar.html', 'Text {{#foo}}{{s2}}{{/foo}}')]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")..s2 = "goodbye"',
+      'Bar()..foo = (Foo()..s1 = "hello")..s2 = "goodbye"',
     );
     expect(output, equals('Text goodbye'));
   });
@@ -410,7 +412,7 @@ void main() {
       () => [
         d.dir('lib/templates/html', [d.file('bar.html', 'Text {{foo.s1}}')]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")..s2 = "goodbye"',
+      'Bar()..foo = (Foo()..s1 = "hello")..s2 = "goodbye"',
     );
     expect(output, equals('Text hello'));
   });
@@ -420,7 +422,7 @@ void main() {
       () => [
         d.dir('lib/templates/html', [d.file('foo.html', 'Text {{p1.p2.s}}')]),
       ],
-      '_i1.Foo()..p1 = (_i1.Property1()..p2 = (_i1.Property2()..s = "hello"))',
+      'Foo()..p1 = (Property1()..p2 = (Property2()..s = "hello"))',
     );
     expect(output, equals('Text hello'));
   });
@@ -432,9 +434,9 @@ void main() {
         d.dir(
             'lib/templates/html', [d.file('foo.html', 'Text {{p1.p2.p3.s}}')]),
       ],
-      '_i1.Foo()'
-      '..p1 = (_i1.Property1()'
-      '..p2 = (_i1.Property2()..p3 = (_i1.Property3()..s = "hello")))',
+      'Foo()'
+      '..p1 = (Property1()'
+      '..p2 = (Property2()..p3 = (Property3()..s = "hello")))',
     );
     expect(output, equals('Text hello'));
   });
@@ -445,7 +447,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('bar.html', 'Text {{#foo}}{{foo.s1}}{{/foo}}')]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")..s2 = "goodbye"',
+      'Bar()..foo = (Foo()..s1 = "hello")..s2 = "goodbye"',
     );
     expect(output, equals('Text hello'));
   });
@@ -456,7 +458,7 @@ void main() {
         d.dir('lib/templates/html',
             [d.file('baz.html', 'Text {{#bar}}{{bar.foo.s1}}{{/bar}}')]),
       ],
-      '_i1.Baz()..bar = (_i1.Bar()..foo = (_i1.Foo()..s1 = "hello"))',
+      'Baz()..bar = (Bar()..foo = (Foo()..s1 = "hello"))',
     );
     expect(output, equals('Text hello'));
   });
@@ -469,7 +471,7 @@ void main() {
           d.file('baz.html', 'Text {{#bar}}{{bar.foo.baz.bar.foo.s1}}{{/bar}}')
         ]),
       ],
-      '_i1.Baz()..bar = (_i1.Bar()..foo = (_i1.Foo()..s1 = "hello"));'
+      'Baz()..bar = (Bar()..foo = (Foo()..s1 = "hello"));'
       'baz.bar!.foo!.baz = baz',
     );
     expect(output, equals('Text hello'));
@@ -483,7 +485,7 @@ void main() {
           d.file('_foo.mustache.html', 'Partial {{s1}}'),
         ]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")',
+      'Bar()..foo = (Foo()..s1 = "hello")',
     );
     expect(output, equals('Text Partial hello'));
   });
@@ -498,7 +500,7 @@ void main() {
           d.file('_foo.mustache.html', 'Partial {{s1}}'),
         ]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")',
+      'Bar()..foo = (Foo()..s1 = "hello")',
     );
     expect(output, equals('Text Partial hello'));
   });
@@ -515,7 +517,7 @@ void main() {
           d.file('_foo.mustache.html', 'Partial {{s2}}'),
         ]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello")..s2 = "goodbye"',
+      'Bar()..foo = (Foo()..s1 = "hello")..s2 = "goodbye"',
     );
     expect(output, equals('Text Partial goodbye'));
   });
@@ -530,7 +532,7 @@ void main() {
           d.file('_foo_l1.mustache.html', 'p2 {{.}}, '),
         ]),
       ],
-      '_i1.Bar()..foo = (_i1.Foo()..s1 = "hello"..l1 = [1, 2, 3])',
+      'Bar()..foo = (Foo()..s1 = "hello"..l1 = [1, 2, 3])',
     );
     expect(output, equals('Text, p1, p2 1, p2 2, p2 3, '));
   });
@@ -552,7 +554,7 @@ void main() {
         () => [
           d.dir('lib/templates/html', [d.file('foo.html', 'Text {{s2}}')]),
         ],
-        '_i1.Foo()',
+        'Foo()',
       ),
       throwsA(const TypeMatcher<MustachioResolutionError>()
           .having((e) => e.message, 'message', contains('''
@@ -571,7 +573,7 @@ line 1, column 8 of lib/templates/html/foo.html: Failed to resolve '[s2]' as a p
           d.dir('lib/templates/html',
               [d.file('foo.html', 'Text {{#s2}}Section{{/s2}}')]),
         ],
-        '_i1.Foo()',
+        'Foo()',
       ),
       throwsA(const TypeMatcher<MustachioResolutionError>()
           .having((e) => e.message, 'message', contains('''
@@ -590,7 +592,7 @@ line 1, column 9 of lib/templates/html/foo.html: Failed to resolve '[s2]' as a p
         () => [
           d.dir('lib/templates/html', [d.file('bar.html', 'Text {{foo.x}}')]),
         ],
-        '_i1.Bar()..foo = _i1.Foo()',
+        'Bar()..foo = Foo()',
       ),
       throwsA(const TypeMatcher<MustachioResolutionError>()
           .having((e) => e.message, 'message', contains('''
@@ -610,7 +612,7 @@ line 1, column 8 of lib/templates/html/bar.html: Failed to resolve 'x' on Bar wh
           d.dir('lib/templates/html',
               [d.file('bar.html', 'Text {{#foo.x}}Section{{/foo.x}}')]),
         ],
-        '_i1.Bar()..foo = _i1.Foo()',
+        'Bar()..foo = Foo()',
       ),
       throwsA(const TypeMatcher<MustachioResolutionError>()
           .having((e) => e.message, 'message', contains('''
@@ -634,7 +636,7 @@ line 1, column 13 of lib/templates/html/bar.html: Failed to resolve '[x]' as a p
             d.file('bar.html', 'Text {{#foo}}{{>missing.mustache}}{{/foo}}')
           ]),
         ],
-        '_i1.Bar()',
+        'Bar()',
       ),
       throwsA(const TypeMatcher<PathNotFoundException>()),
     );

--- a/test/mustachio/builder_test_base.dart
+++ b/test/mustachio/builder_test_base.dart
@@ -84,7 +84,8 @@ $sourceLibraryContent
     ]),
   ]).create();
   await d.dir('foo_package', [...additionalAssets()]).create();
-  await build('lib/foo.dart', root: p.join(d.sandbox, 'foo_package'));
+  await build(p.join(d.sandbox, 'foo_package', 'lib/foo.dart'),
+      root: p.join(d.sandbox, 'foo_package'));
 }
 
 Future<LibraryElement> resolveGeneratedLibrary(String libraryPath) async {

--- a/test/mustachio/foo.aot_renderers_for_html.dart
+++ b/test/mustachio/foo.aot_renderers_for_html.dart
@@ -12,14 +12,12 @@
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
 // ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
-// ignore_for_file: use_super_parameters
 
-// ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:convert' as _i2;
+import 'dart:convert';
 
-import 'foo.dart' as _i1;
+import 'foo.dart';
 
-String renderFoo(_i1.Foo context0) {
+String renderFoo(Foo context0) {
   final buffer = StringBuffer();
   buffer.write('''<div>
     ''');
@@ -81,7 +79,7 @@ String renderBaz() {
   return buffer.toString();
 }
 
-String _renderFoo_partial_foo_header_0(_i1.Foo context0) {
+String _renderFoo_partial_foo_header_0(Foo context0) {
   final buffer = StringBuffer();
   buffer.write('''<div class="partial">
     l1: ''');
@@ -95,6 +93,6 @@ String _renderFoo_partial_foo_header_0(_i1.Foo context0) {
 
 extension on StringBuffer {
   void writeEscaped(String? value) {
-    write(_i2.htmlEscape.convert(value ?? ''));
+    write(htmlEscape.convert(value ?? ''));
   }
 }

--- a/test/mustachio/foo.aot_renderers_for_md.dart
+++ b/test/mustachio/foo.aot_renderers_for_md.dart
@@ -12,14 +12,12 @@
 // non-bool, non-Iterable field is non-null.
 // ignore_for_file: unused_local_variable
 // ignore_for_file: non_constant_identifier_names, unnecessary_string_escapes
-// ignore_for_file: use_super_parameters
 
-// ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:convert' as _i2;
+import 'dart:convert';
 
-import 'foo.dart' as _i1;
+import 'foo.dart';
 
-String renderFoo(_i1.Foo context0) {
+String renderFoo(Foo context0) {
   final buffer = StringBuffer();
   buffer.write(_renderFoo_partial_foo_header_0(context0));
   buffer.writeln();
@@ -76,7 +74,7 @@ String renderBaz() {
   return buffer.toString();
 }
 
-String _renderFoo_partial_foo_header_0(_i1.Foo context0) {
+String _renderFoo_partial_foo_header_0(Foo context0) {
   final buffer = StringBuffer();
   buffer.write('''l1: ''');
   buffer.writeEscaped(context0.l1.toString());
@@ -86,6 +84,6 @@ String _renderFoo_partial_foo_header_0(_i1.Foo context0) {
 
 extension on StringBuffer {
   void writeEscaped(String? value) {
-    write(_i2.htmlEscape.convert(value ?? ''));
+    write(htmlEscape.convert(value ?? ''));
   }
 }


### PR DESCRIPTION
This removes the last blocker for moving this repo to the dart-lang/sdk repository 🎉 .

The generated code is almost the same, without the import prefixes. But even removing those, there are no import conflicts 🎉 .

The PR is basically just implementing the code_builder support natively, but it takes almost the same amount of code 🎉 .