### PR TITLE
Format testing and fix static-type-parameter issue

### DIFF
--- a/testing/test_package/lib/example.dart
+++ b/testing/test_package/lib/example.dart
@@ -600,7 +600,7 @@ extension FancyList<Z> on List<Z> {
   List<Z> operator -() => this.reversed.toList();
   List<List<Z>> split(int at) =>
       <List<Z>>[this.sublist(0, at), this.sublist(at)];
-  static List<Z?> big() => List.filled(100, null);
+  static List big() => List.filled(100, null);
 }
 
 extension SymDiff<Q> on Set<Q> {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1285,7 +1285,8 @@ class FactoryConstructorThings {
 
 DTypeParam?
     aTopLevelTypeParameterFunction<DTypeParam extends TypeParameterThings>(
-        DTypeParam typedParam) => typedParam;
+            DTypeParam typedParam) =>
+        typedParam;
 
 abstract class TypeParameterThings<ATypeParam,
     BTypeParam extends FactoryConstructorThings> {

--- a/testing/test_package_experiments/lib/class_modifiers.dart
+++ b/testing/test_package_experiments/lib/class_modifiers.dart
@@ -5,17 +5,30 @@
 library class_modifiers.dart;
 
 class A {}
+
 base class B {}
+
 interface class C {}
+
 final class D {}
+
 sealed class E {}
+
 abstract class F {}
+
 abstract base class G {}
+
 abstract interface class H {}
+
 abstract final class I {}
+
 mixin class J {}
+
 base mixin class K {}
+
 abstract mixin class L {}
+
 abstract base mixin class M {}
+
 mixin N {}
 base mixin O {}

--- a/testing/test_package_experiments/lib/records.dart
+++ b/testing/test_package_experiments/lib/records.dart
@@ -24,7 +24,7 @@ RecordTypedef<U> foo<U>(U aThing, int x) {
 RecordTypedef<double> fromParameterizedRecordType = (3.5, 10, "A string");
 
 /// Implicit dynamic type parameter.
-RecordTypedef dynamicParameterizedRecordType = ([1,2,3], 5, "Another string");
+RecordTypedef dynamicParameterizedRecordType = ([1, 2, 3], 5, "Another string");
 
 /// Not using the typedef, but it could.
 var nonTypeDefRecordType = (["hello", "there"], 12, "From a record");
@@ -32,5 +32,6 @@ var nonTypeDefRecordType = (["hello", "there"], 12, "From a record");
 abstract class A<T> {
   (int, double) aMethod();
   RecordTypedef<T> aParameterizedTypedefRecordReturner();
-  void aMethodParametersWithRecords((String, List) aRecord, {required (int, String) b});
+  void aMethodParametersWithRecords((String, List) aRecord,
+      {required (int, String) b});
 }

--- a/testing/test_package_experiments/lib/sealed_classes.dart
+++ b/testing/test_package_experiments/lib/sealed_classes.dart
@@ -4,6 +4,4 @@
 
 library sealed_classes.dart;
 
-sealed class A {
-
-}
+sealed class A {}


### PR DESCRIPTION
I believe a new static error was landed in the SDK, so that we should make the testing code legal again.