### PR TITLE
Tidy the Category class

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1015,20 +1015,6 @@ class _Renderer_Category extends RendererBase<Category> {
                         parent: r);
                   },
                 ),
-                'categoryDefinition': Property(
-                  getValue: (CT_ c) => c.categoryDefinition,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'CategoryDefinition'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.categoryDefinition, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['CategoryDefinition']!);
-                  },
-                ),
                 'categoryIndex': Property(
                   getValue: (CT_ c) => c.categoryIndex,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -12821,13 +12807,13 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -16353,13 +16339,6 @@ class _Renderer_Warnable extends RendererBase<Warnable> {
 }
 
 const _invisibleGetters = {
-  'CategoryDefinition': {
-    'displayName',
-    'documentationMarkdown',
-    'hashCode',
-    'name',
-    'runtimeType'
-  },
   'CharacterLocation': {
     'columnNumber',
     'hashCode',

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -25,29 +25,45 @@ class Category extends Nameable
         ModelBuilder
     implements Documentable {
   /// All libraries in [libraries] must come from [_package].
-  final Package _package;
-
   @override
-  Package get package => _package;
+  final Package package;
 
   final String? _name;
 
-  final DartdocOptionContext _config;
-
   @override
-  DartdocOptionContext get config => _config;
+  final DartdocOptionContext config;
 
   final List<Class> _classes = [];
-  final List<Extension> _extensions = [];
-  final List<Enum> _enums = [];
-  final List<Mixin> _mixins = [];
-  final List<Class> _exceptions = [];
-  final List<TopLevelVariable> _constants = [];
-  final List<TopLevelVariable> _properties = [];
-  final List<ModelFunction> _functions = [];
-  final List<Typedef> _typedefs = [];
 
-  Category(this._name, this._package, this._config);
+  final List<Class> _exceptions = [];
+
+  @override
+  final List<TopLevelVariable> constants = [];
+
+  @override
+  final List<Extension> extensions = [];
+
+  @override
+  final List<Enum> enums = [];
+
+  @override
+  final List<ModelFunction> functions = [];
+
+  @override
+  final List<Mixin> mixins = [];
+
+  @override
+  final List<TopLevelVariable> properties = [];
+
+  @override
+  final List<Typedef> typedefs = [];
+
+  final CategoryDefinition _categoryDefinition;
+
+  Category(this._name, this.package, this.config)
+      : _categoryDefinition =
+            config.categories.categoryDefinitions[_name.orDefault] ??
+                CategoryDefinition(_name, null, null);
 
   void addClass(Class class_) {
     if (class_.isErrorOrException) {
@@ -61,10 +77,10 @@ class Category extends Nameable
   Element? get element => null;
 
   @override
-  String get name => categoryDefinition.displayName;
+  String get name => _categoryDefinition.displayName;
 
   @override
-  String get sortKey => _name ?? '<default>';
+  String get sortKey => _name.orDefault;
 
   @override
   List<String> get containerOrder => config.categoryOrder;
@@ -102,11 +118,7 @@ class Category extends Nameable
   String get linkedName => _categoryRenderer.renderLinkedName(this);
 
   /// The position in the container order for this category.
-  late final int categoryIndex = package.categories.indexOf(this);
-
-  late final CategoryDefinition categoryDefinition =
-      config.categories.categoryDefinitions[sortKey] ??
-          CategoryDefinition(_name, null, null);
+  int get categoryIndex => package.categories.indexOf(this);
 
   @override
   bool get isCanonical =>
@@ -116,40 +128,19 @@ class Category extends Nameable
   Kind get kind => Kind.topic;
 
   @override
-  late final File? documentationFile = () {
-    var documentationMarkdown = categoryDefinition.documentationMarkdown;
+  File? get documentationFile {
+    var documentationMarkdown = _categoryDefinition.documentationMarkdown;
     if (documentationMarkdown != null) {
-      return _config.resourceProvider.getFile(documentationMarkdown);
+      return config.resourceProvider.getFile(documentationMarkdown);
     }
     return null;
-  }();
+  }
 
   @override
   Iterable<Class> get classes => _classes;
 
   @override
-  List<TopLevelVariable> get constants => _constants;
-
-  @override
-  List<Enum> get enums => _enums;
-
-  @override
   Iterable<Class> get exceptions => _exceptions;
-
-  @override
-  List<Extension> get extensions => _extensions;
-
-  @override
-  List<ModelFunction> get functions => _functions;
-
-  @override
-  List<Mixin> get mixins => _mixins;
-
-  @override
-  List<TopLevelVariable> get properties => _properties;
-
-  @override
-  List<Typedef> get typedefs => _typedefs;
 
   CategoryRenderer get _categoryRenderer =>
       packageGraph.rendererFactory.categoryRenderer;
@@ -159,4 +150,8 @@ class Category extends Nameable
 
   @override
   Iterable<CommentReferable> get referenceParents => const [];
+}
+
+extension on String? {
+  String get orDefault => this ?? '<default>';
 }


### PR DESCRIPTION
* Nine private-field / public-getter pairs can just be made final public fields.
* Two late final fields can be made getters (less memory; not increased time).
* One late final field can be initialized in the constructor, and made private.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
