### PR TITLE
Do not hide stacktrace of DartdocFailures

### DIFF
--- a/lib/src/dartdoc.dart
+++ b/lib/src/dartdoc.dart
@@ -283,14 +283,9 @@ class Dartdoc {
         runtimeStats.endPerfTask();
         await postProcessCallback?.call(config);
       },
-      (e, chain) {
-        if (e is DartdocFailure) {
-          stderr.writeln('\n$_dartdocFailedMessage: $e.');
-          exitCode = 1;
-        } else {
-          stderr.writeln('\n$_dartdocFailedMessage: $e\n$chain');
-          exitCode = 255;
-        }
+      (e, stackTrace) {
+        stderr.writeln('\n$_dartdocFailedMessage: $e\n$stackTrace');
+        exitCode = e is DartdocFailure ? 1 : 255;
       },
       zoneSpecification: ZoneSpecification(
         print: (_, __, ___, String line) => logPrint(line),

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -233,7 +233,8 @@ abstract class PubPackageMeta extends PackageMeta {
     folder = original;
     if (!original.exists) {
       throw PackageMetaFailure(
-          'fatal error: unable to locate the input directory at ${original.path}.');
+          'fatal error: unable to locate the input directory at '
+          "'${original.path}'.");
     }
 
     if (!_packageMetaCache.containsKey(folder.path)) {


### PR DESCRIPTION
A bug report was unable to include a stacktrace because it was not being printed. This fixes that.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
