### PR TITLE
Refactor canonicalization

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1325,8 +1325,7 @@ class DartdocOptionContext extends DartdocOptionContextBase
 
   bool get validateLinks => optionSet['validateLinks'].valueAt(context);
 
-  bool isLibraryExcluded(String name) =>
-      exclude.any((pattern) => name == pattern);
+  bool isLibraryExcluded(String nameOrPath) => exclude.contains(nameOrPath);
 
   bool isPackageExcluded(String name) => _excludePackages.contains(name);
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -886,28 +886,6 @@ class _Renderer_Canonicalization extends RendererBase<Canonicalization> {
           CT_,
           () => {
                 ..._Renderer_Object.propertyMap<CT_>(),
-                'canonicalLibrary': Property(
-                  getValue: (CT_ c) => c.canonicalLibrary,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Library.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Library,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.canonicalLibrary == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_Library(c.canonicalLibrary!, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'isCanonical': Property(
                   getValue: (CT_ c) => c.isCanonical,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -1116,28 +1094,6 @@ class _Renderer_Category extends RendererBase<Category> {
                 ..._Renderer_TopLevelContainer.propertyMap<CT_>(),
                 ..._Renderer_Indexable.propertyMap<CT_>(),
                 ..._Renderer_ModelBuilder.propertyMap<CT_>(),
-                'canonicalLibrary': Property(
-                  getValue: (CT_ c) => c.canonicalLibrary,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Library.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Library,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_Library(c.canonicalLibrary, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'categoryIndex': Property(
                   getValue: (CT_ c) => c.categoryIndex,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -12103,28 +12059,6 @@ class _Renderer_Package extends RendererBase<Package> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.baseHref, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
-                'canonicalLibrary': Property(
-                  getValue: (CT_ c) => c.canonicalLibrary,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Library.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Library,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.canonicalLibrary == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_Library(c.canonicalLibrary!, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -8,8 +8,6 @@ import 'package:dartdoc/src/model/model.dart';
 abstract mixin class Canonicalization implements Locatable, Documentable {
   bool get isCanonical;
 
-  Library? get canonicalLibrary;
-
   /// Pieces of the location, split to remove 'package:' and slashes.
   Set<String> get locationPieces;
 
@@ -18,49 +16,48 @@ abstract mixin class Canonicalization implements Locatable, Documentable {
       ..sort();
   }
 
-  ScoredCandidate _scoreElementWithLibrary(Library lib) {
-    var scoredCandidate = ScoredCandidate(lib);
-    Iterable<String> resplit(Set<String> items) sync* {
-      for (var item in items) {
-        for (var subItem in item.split('_')) {
-          yield subItem;
-        }
-      }
-    }
+  ScoredCandidate _scoreElementWithLibrary(Library library) {
+    var scoredCandidate = ScoredCandidate(library);
 
-    // Large boost for @canonicalFor, essentially overriding all other concerns.
-    if (lib.canonicalFor.contains(fullyQualifiedName)) {
-      scoredCandidate._alterScore(5.0, 'marked @canonicalFor');
+    // Large boost for `@canonicalFor`, essentially overriding all other
+    // concerns.
+    if (library.canonicalFor.contains(fullyQualifiedName)) {
+      scoredCandidate._alterScore(5.0, _Reason.canonicalFor);
     }
     // Penalty for deprecated libraries.
-    if (lib.isDeprecated) scoredCandidate._alterScore(-1.0, 'is deprecated');
+    if (library.isDeprecated) {
+      scoredCandidate._alterScore(-1.0, _Reason.deprecated);
+    }
     // Give a big boost if the library has the package name embedded in it.
-    if (lib.package.namePieces.intersection(lib.namePieces).isEmpty) {
-      scoredCandidate._alterScore(1.0, 'embeds package name');
+    if (library.package.namePieces.intersection(library.namePieces).isEmpty) {
+      scoredCandidate._alterScore(1.0, _Reason.packageName);
     }
     // Give a tiny boost for libraries with long names, assuming they're
     // more specific (and therefore more likely to be the owner of this symbol).
-    scoredCandidate._alterScore(.01 * lib.namePieces.length, 'name is long');
-    // If we don't know the location of this element, return our best guess.
-    // TODO(jcollins-g): is that even possible?
+    scoredCandidate._alterScore(
+        .01 * library.namePieces.length, _Reason.longName);
+    // If we don't know the location of this element (which shouldn't be
+    // possible), return our best guess.
     assert(locationPieces.isNotEmpty);
     if (locationPieces.isEmpty) return scoredCandidate;
-    // The more pieces we have of the location in our library name, the more we should boost our score.
+    // The more pieces we have of the location in our library name, the more we
+    // should boost our score.
     scoredCandidate._alterScore(
-        lib.namePieces.intersection(locationPieces).length.toDouble() /
-            locationPieces.length.toDouble(),
-        'element location shares parts with name');
-    // If pieces of location at least start with elements of our library name, boost the score a little bit.
+      library.namePieces.intersection(locationPieces).length.toDouble() /
+          locationPieces.length.toDouble(),
+      _Reason.sharedNamePart,
+    );
+    // If pieces of location at least start with elements of our library name,
+    // boost the score a little bit.
     var scoreBoost = 0.0;
-    for (var piece in resplit(locationPieces)) {
-      for (var namePiece in lib.namePieces) {
+    for (var piece in locationPieces.expand((item) => item.split('_'))) {
+      for (var namePiece in library.namePieces) {
         if (piece.startsWith(namePiece)) {
           scoreBoost += 0.001;
         }
       }
     }
-    scoredCandidate._alterScore(
-        scoreBoost, 'element location parts start with parts of name');
+    scoredCandidate._alterScore(scoreBoost, _Reason.locationPartStart);
     return scoredCandidate;
   }
 }
@@ -68,7 +65,7 @@ abstract mixin class Canonicalization implements Locatable, Documentable {
 /// This class represents the score for a particular element; how likely
 /// it is that this is the canonical element.
 class ScoredCandidate implements Comparable<ScoredCandidate> {
-  final List<String> _reasons = [];
+  final List<(_Reason, double)> _reasons = [];
 
   final Library library;
 
@@ -78,21 +75,37 @@ class ScoredCandidate implements Comparable<ScoredCandidate> {
 
   ScoredCandidate(this.library);
 
-  void _alterScore(double scoreDelta, String reason) {
+  void _alterScore(double scoreDelta, _Reason reason) {
     score += scoreDelta;
     if (scoreDelta != 0) {
-      _reasons.add(
-          "$reason (${scoreDelta >= 0 ? '+' : ''}${scoreDelta.toStringAsPrecision(4)})");
+      _reasons.add((reason, scoreDelta));
     }
   }
 
   @override
-  int compareTo(ScoredCandidate other) {
-    //assert(element == other.element);
-    return score.compareTo(other.score);
-  }
+  int compareTo(ScoredCandidate other) => score.compareTo(other.score);
 
   @override
-  String toString() =>
-      "${library.name}: ${score.toStringAsPrecision(4)} - ${_reasons.join(', ')}";
+  String toString() {
+    var reasonText = _reasons.map((r) {
+      var (reason, scoreDelta) = r;
+      var scoreDeltaPrefix = scoreDelta >= 0 ? '+' : '';
+      return '$reason ($scoreDeltaPrefix${scoreDelta.toStringAsPrecision(4)})';
+    });
+    return '${library.name}: ${score.toStringAsPrecision(4)} - $reasonText';
+  }
+}
+
+/// A reason that a candidate's score is changed.
+enum _Reason {
+  canonicalFor('marked @canonicalFor'),
+  deprecated('is deprecated'),
+  packageName('embeds package name'),
+  longName('name is long'),
+  sharedNamePart('element location shares parts with name'),
+  locationPartStart('element location parts start with parts of name');
+
+  final String text;
+
+  const _Reason(this.text);
 }

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -95,10 +95,6 @@ class Category extends Nameable
   PackageGraph get packageGraph => package.packageGraph;
 
   @override
-  Library get canonicalLibrary =>
-      throw UnimplementedError('Categories can not have associated libraries.');
-
-  @override
   List<Locatable> get documentationFrom => [this];
 
   @override

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -282,8 +282,10 @@ class Library extends ModelElement
     if (sdkLib != null && (sdkLib.isInternal || !sdkLib.isDocumented)) {
       return false;
     }
-    if (config.isLibraryExcluded(name) ||
-        config.isLibraryExcluded(element.librarySource.uri.toString())) {
+    if (
+        // TODO(srawlins): Stop supporting a 'name' here.
+        config.isLibraryExcluded(name) ||
+            config.isLibraryExcluded(element.librarySource.uri.toString())) {
       return false;
     }
     return true;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -81,9 +81,6 @@ class Package extends LibraryContainer
   @override
   bool get isCanonical => true;
 
-  @override
-  Library? get canonicalLibrary => null;
-
   /// Number of times we have invoked a tool for this package.
   int toolInvocationIndex = 0;
 


### PR DESCRIPTION
This aims to be a no-op simplification of the canonicalization code:

* Use enums instead of bare strings in canonicalization score reasons. This defers all of the `toString` String concatenation code until `toString` is actually called (almost never?). This should result in speed + memory improvements.
* If an element has a private name, really short circuit it's canonical library to `null`.
* Refactor the `ModelElement.canonicalLibrary` code to be less cyclomatically complex, and short circuit return more. This code is I think more understandable.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
