### PR TITLE
Make Library.inheritanceManager static

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -8580,20 +8580,6 @@ class _Renderer_Library extends RendererBase<Library> {
                     _render_String(c.href!, ast, r.template, sink, parent: r);
                   },
                 ),
-                'inheritanceManager': Property(
-                  getValue: (CT_ c) => c.inheritanceManager,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'InheritanceManager3'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.inheritanceManager, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['InheritanceManager3']!);
-                  },
-                ),
                 'isAnonymous': Property(
                   getValue: (CT_ c) => c.isAnonymous,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -17130,7 +17116,6 @@ const _invisibleGetters = {
     'overriddenDepth',
     'overriddenElement'
   },
-  'InheritanceManager3': {'hashCode', 'runtimeType'},
   'InterfaceElement': {
     'allSupertypes',
     'augmentationTarget',

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -4,6 +4,9 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/inheritance_manager3.dart'
+    show InheritanceManager3;
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -146,10 +149,9 @@ abstract class InheritingContainer extends Container
       return const <ExecutableElement>[];
     }
 
-    final inheritance = definingLibrary.inheritanceManager;
     final concreteInheritenceMap =
-        inheritance.getInheritedConcreteMap2(element);
-    final inheritenceMap = inheritance.getInheritedMap2(element);
+        _inheritanceManager.getInheritedConcreteMap2(element);
+    final inheritenceMap = _inheritanceManager.getInheritedMap2(element);
 
     List<InterfaceElement>? inheritanceChainElements;
 
@@ -188,6 +190,8 @@ abstract class InheritingContainer extends Container
 
     return combinedMap.values.toList(growable: false);
   }();
+
+  static final InheritanceManager3 _inheritanceManager = InheritanceManager3();
 
   /// All fields defined on this container, _including inherited fields_.
   late final List<Field> allFields = () {

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -10,9 +10,6 @@ import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/element/inheritance_manager3.dart'
-    show InheritanceManager3;
-// ignore: implementation_imports
 import 'package:analyzer/src/generated/sdk.dart' show SdkLibrary;
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -361,9 +358,6 @@ class Library extends ModelElement
     }
     return '${package.baseHref}$filePath';
   }
-
-  // TODO(srawlins): Make a static field, likely on [Class].
-  late final InheritanceManager3 inheritanceManager = InheritanceManager3();
 
   bool get isAnonymous => element.name.isEmpty;
 


### PR DESCRIPTION
Better to not store a ton of junk in many InheritanceManagers. Just need one.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
