### PR TITLE
Convert complex late final fields to getters: InheritingContainer, Library, and Package

### DIFF
--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -79,14 +79,14 @@ mixin Constructable on InheritingContainer {
 abstract class InheritingContainer extends Container
     with ExtensionTarget
     implements EnclosedElement {
-  late final DefinedElementType? supertype = () {
+  DefinedElementType? get supertype {
     final elementSupertype = element.supertype;
     return elementSupertype == null ||
             elementSupertype.element.supertype == null
         ? null
         : modelBuilder.typeFrom(elementSupertype, library)
             as DefinedElementType;
-  }();
+  }
 
   /// Class modifiers from the Dart feature specification.
   ///
@@ -112,7 +112,7 @@ abstract class InheritingContainer extends Container
     ...typeParameters,
   ];
 
-  late final Iterable<Method> inheritedMethods = () {
+  Iterable<Method> get inheritedMethods {
     var methodNames = declaredMethods.map((m) => m.element.name).toSet();
     var inheritedMethodElements = _inheritedElements
         .whereType<MethodElement>()
@@ -126,8 +126,9 @@ abstract class InheritingContainer extends Container
       for (var e in inheritedMethodElements)
         modelBuilder.from(e, library, enclosingContainer: this) as Method,
     ];
-  }();
-  late final List<Operator> inheritedOperators = () {
+  }
+
+  List<Operator> get inheritedOperators {
     var operatorNames = declaredOperators.map((o) => o.element.name).toSet();
     var inheritedOperatorElements = _inheritedElements
         .whereType<MethodElement>()
@@ -138,13 +139,16 @@ abstract class InheritingContainer extends Container
       for (var e in inheritedOperatorElements)
         modelBuilder.from(e, library, enclosingContainer: this) as Operator,
     ];
-  }();
+  }
+
   @override
   late final DefinedElementType modelType =
       modelBuilder.typeFrom(element.thisType, library) as DefinedElementType;
+
   late final List<DefinedElementType> publicSuperChain =
       model_utils.filterNonPublic(superChain).toList(growable: false);
-  late final List<ExecutableElement> _inheritedElements = () {
+
+  List<ExecutableElement> get _inheritedElements {
     if (element is ClassElement && (element as ClassElement).isDartCoreObject) {
       return const <ExecutableElement>[];
     }
@@ -189,12 +193,12 @@ abstract class InheritingContainer extends Container
     }
 
     return combinedMap.values.toList(growable: false);
-  }();
+  }
 
   static final InheritanceManager3 _inheritanceManager = InheritanceManager3();
 
   /// All fields defined on this container, _including inherited fields_.
-  late final List<Field> allFields = () {
+  List<Field> get allFields {
     var inheritedAccessorElements = {
       ..._inheritedElements.whereType<PropertyAccessorElement>()
     };
@@ -244,7 +248,7 @@ abstract class InheritingContainer extends Container
     });
 
     return fields;
-  }();
+  }
 
   @override
   late final Iterable<Method> declaredMethods =

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -294,7 +294,7 @@ class Library extends ModelElement
 
   /// Map of each import prefix ('import "foo" as prefix;') to the set of
   /// libraries which are imported via that prefix.
-  late final Map<String, Set<Library>> prefixToLibrary = () {
+  Map<String, Set<Library>> get prefixToLibrary {
     var prefixToLibrary = <String, Set<Library>>{};
     // It is possible to have overlapping prefixes.
     for (var i in element.libraryImports) {
@@ -307,7 +307,7 @@ class Library extends ModelElement
       }
     }
     return prefixToLibrary;
-  }();
+  }
 
   late final String dirName = (isAnonymous ? nameFromPath : name)
       .replaceAll(':', '-')
@@ -348,10 +348,10 @@ class Library extends ModelElement
   String get belowSidebarPath => sidebarPath;
 
   @override
-  late final List<ModelFunction> functions =
-      _exportedAndLocalElements.whereType<FunctionElement>().map((e) {
-    return modelBuilder.from(e, this) as ModelFunction;
-  }).toList(growable: false);
+  late final List<ModelFunction> functions = _exportedAndLocalElements
+      .whereType<FunctionElement>()
+      .map((e) => modelBuilder.from(e, this) as ModelFunction)
+      .toList(growable: false);
 
   @override
   String? get href {
@@ -370,7 +370,7 @@ class Library extends ModelElement
   Library get library => this;
 
   @override
-  late final String name = () {
+  String get name {
     var source = element.source;
     if (source.uri.isScheme('dart')) {
       // There are inconsistencies in library naming + URIs for the Dart
@@ -391,7 +391,7 @@ class Library extends ModelElement
       return baseName.substring(0, baseName.length - dartExtensionLength);
     }
     return baseName;
-  }();
+  }
 
   /// Generate a name for this library based on its location.
   ///
@@ -429,7 +429,7 @@ class Library extends ModelElement
       .map((e) => modelBuilder.from(e, this) as Class)
       .toList(growable: false);
 
-  late final List<TopLevelVariable> _variables = () {
+  List<TopLevelVariable> get _variables {
     var elements =
         _exportedAndLocalElements.whereType<TopLevelVariableElement>().toSet();
     elements.addAll(_exportedAndLocalElements
@@ -452,7 +452,7 @@ class Library extends ModelElement
       variables.add(me as TopLevelVariable);
     }
     return variables;
-  }();
+  }
 
   /// Reverses URIs if needed to get a package URI.
   ///
@@ -482,6 +482,8 @@ class Library extends ModelElement
 
   /// A mapping of all [Element]s in this library to the [ModelElement]s which
   /// represent them in dartdoc.
+  // Note: Keep this a late final field; converting to a getter (without further
+  // investigation) causes dartdoc to hang.
   late final HashMap<Element, Set<ModelElement>> modelElementsMap = () {
     var modelElements = HashMap<Element, Set<ModelElement>>();
     for (var modelElement in <ModelElement>[
@@ -508,7 +510,7 @@ class Library extends ModelElement
       ];
 
   @override
-  late final Map<String, CommentReferable> referenceChildren = () {
+  Map<String, CommentReferable> get referenceChildren {
     var referenceChildrenBuilder = <String, CommentReferable>{};
     var definedNamesModelElements = element.exportNamespace.definedNames.values
         .map(modelBuilder.fromElement);
@@ -523,7 +525,7 @@ class Library extends ModelElement
       referenceChildrenBuilder.putIfAbsent(prefix, () => libraries.first);
     }
     return referenceChildrenBuilder;
-  }();
+  }
 
   @override
   Iterable<CommentReferable> get referenceParents => [package];

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -116,13 +116,13 @@ class Package extends LibraryContainer
 
   /// The documentation from the README contents.
   @override
-  late final String? documentation = () {
+  String? get documentation {
     final docFile = packageMeta.getReadmeContents();
     return docFile != null
         ? packageGraph.resourceProvider
             .readAsMalformedAllowedStringSync(docFile)
         : null;
-  }();
+  }
 
   @override
   bool get hasDocumentation => documentation?.isNotEmpty == true;
@@ -143,7 +143,7 @@ class Package extends LibraryContainer
   /// Return true if this is the default package, this is part of an embedder
   /// SDK, or if [DartdocOptionContext.autoIncludeDependencies] is true -- but
   /// only if the package was not excluded on the command line.
-  late final bool isLocal = () {
+  bool get isLocal {
     // Do not document as local if we excluded this package by name.
     if (_isExcluded) return false;
     // Document as local if this is the default package.
@@ -157,7 +157,7 @@ class Package extends LibraryContainer
     final packagePath = packageGraph.packageMeta.dir.path;
     return libraries.any(
         (l) => _pathContext.isWithin(packagePath, l.element.source.fullName));
-  }();
+  }
 
   /// True if the global config excludes this package by name.
   bool get _isExcluded => packageGraph.config.isPackageExcluded(name);
@@ -170,7 +170,7 @@ class Package extends LibraryContainer
 
   /// Returns the location of documentation for this package, for linkToRemote
   /// and canonicalization decision making.
-  late final DocumentLocation documentedWhere = () {
+  DocumentLocation get documentedWhere {
     if (isLocal && isPublic) {
       return DocumentLocation.local;
     }
@@ -181,7 +181,7 @@ class Package extends LibraryContainer
       return DocumentLocation.remote;
     }
     return DocumentLocation.missing;
-  }();
+  }
 
   @override
   String get enclosingName => packageGraph.defaultPackageName;
@@ -400,16 +400,15 @@ class Package extends LibraryContainer
   List<String> get containerOrder => config.packageOrder;
 
   @override
-  late final Map<String, CommentReferable> referenceChildren =
-      <String, CommentReferable>{
+  late final Map<String, CommentReferable> referenceChildren = {
     for (var library in publicLibrariesSorted) library.referenceName: library,
   }
-        // Do not override any preexisting data, and insert based on the
-        // public library sort order.
-        // TODO(jcollins-g): warn when results require package-global
-        // lookups like this.
-        ..addEntriesIfAbsent(
-            publicLibrariesSorted.expand((l) => l.referenceChildren.entries));
+    // Do not override any preexisting data, and insert based on the
+    // public library sort order.
+    // TODO(jcollins-g): warn when results require package-global
+    // lookups like this.
+    ..addEntriesIfAbsent(
+        publicLibrariesSorted.expand((l) => l.referenceChildren.entries));
 
   @override
   Iterable<CommentReferable> get referenceParents => [packageGraph];


### PR DESCRIPTION
Testing showed this change does not slow down documenting a package (collection 1.18.0), nor does it increase the peak RSS for the dartdoc process (documenting collection 1.18.0).

These are not the only late final fields in these classes; these are the ones defined by an immediately executed closure, which can be hard to read, reason about, and are generally uncommon and surprising.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
