### PR TITLE
Move doc directive documentation to source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .settings/
 .vscode/
 build/
-doc/
+doc/api/
 lcov.info
 test_data/
 testing/**/doc

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -14,6 +14,9 @@ The supported directives are listed below:
 An element whose doc comment should not appear in the generated documenation can
 include the `@nodoc` directive.
 
+Note that the `@nodoc` directive does not have curly braces, like most of the
+other directives.
+
 ## `{@category}` and `{@subCategory}` - Categories
 
 Elements such as libraries and classes can be grouped into categories and
@@ -23,7 +26,7 @@ own documentation page, listing all of the categorized elements.
 
 ## `{@template}` and `{@macro}` - Templates and macros
 
-TODO(srawlins): Document
+TODO(srawlins): Document.
 
 ## `{@example}` - Examples (deprecated)
 
@@ -32,7 +35,7 @@ directive. The file path, the region, and the example language can all be
 specified with the following syntax:
 
 ```none
-{@example PATH [region=NAME] [lang=NAME]}
+/// {@example PATH [region=NAME] [lang=NAME]}
 ```
 
 All example file names must have the extension, `.md`, and this extension must
@@ -52,9 +55,9 @@ HTML can be rendered unmodified by including it between `{@inject-html}` and
 `{@end-inject-html}` directive tags. The tags take no arguments:
 
 ```none
-{@inject-html}
-INJECTED HTML
-{@end-inject-html}
+/// {@inject-html}
+/// <p>Injected HTML.</p>
+/// {@end-inject-html}
 ```
 
 The `{@inject-html}` directive is only available when the `--inject-html` flag
@@ -67,7 +70,7 @@ HTML5 videos can be embedded with the `{@animation}` directive. This directive
 accepts width and height arguments, and an optional ID argument:
 
 ```none
-{@animation 320 240 URL [id=ID]}
+/// {@animation 320 240 URL [id=ID]}
 ```
 
 This directive renders the HTML which embeds an HTML5 video.
@@ -85,7 +88,7 @@ A YouTube video can be embedded with the `{@youtube}` directive. This directive
 accepts width and height arguments, using the following syntax:
 
 ```none
-{@youtube 320 240 https://www.youtube.com/watch?v=oHg5SJYRHA0}
+/// {@youtube 320 240 https://www.youtube.com/watch?v=oHg5SJYRHA0}
 ```
 
 This directive embeds the YouTube video with id "oHg5SJYRHA0" into the
@@ -110,7 +113,7 @@ When that heuristic needs to be overridden, a user can use this directive.
 Example:
 
 ```none
-{@canonicalFor some_library.SomeClass}
+/// {@canonicalFor some_library.SomeClass}
 ```
 
 When this directive is used on a library's doc comment, that library is marked

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -1,0 +1,117 @@
+Dartdoc supports several **directives** within Dart doc comments. Each directive
+is then processed during documentation generation, and new text is inserted in
+place of the directive. Not all directives are supported for package
+documentation at https://pub.dev/.
+
+A doc comment directive consists of either one directive tag, which looks
+something like `{@DIRECTIVE ARG=VALUE ...}`, or two such tags (an opening and a
+closing tag), with content in between.
+
+The supported directives are listed below:
+
+## `@nodoc` - Do not include documentation
+
+An element whose doc comment should not appear in the generated documenation can
+include the `@nodoc` directive.
+
+## `{@category}` and `{@subCategory}` - Categories
+
+Elements such as libraries and classes can be grouped into categories and
+sub-categories by adding `{@category CATEGORY NAME}` and
+`{@subCategory SUB-CATEGORY NAME}` in doc comments. Each category then gets its
+own documentation page, listing all of the categorized elements.
+
+## `{@template}` and `{@macro}` - Templates and macros
+
+TODO(srawlins): Document
+
+## `{@example}` - Examples (deprecated)
+
+Examples from the file system can be inlined by using the `{@example}`
+directive. The file path, the region, and the example language can all be
+specified with the following syntax:
+
+```none
+{@example PATH [region=NAME] [lang=NAME]}
+```
+
+All example file names must have the extension, `.md`, and this extension must
+not be specified in the example `PATH`. `PATH` must be specified as a relative
+path from the root of the project for which documentation is being generated.
+Given `dir/file.dart` as `PATH`, an example will be extracted from
+`dir/file.dart.md`, relative to the project root directory.
+
+During doc generation, dartdoc will replace the `{@example}` directive with the
+contents of the example file, verbatim.
+
+TODO(srawlins): Document region, lang, `--example-path-prefix`.
+
+## `{@inject-html}` - Injected HTML
+
+HTML can be rendered unmodified by including it between `{@inject-html}` and
+`{@end-inject-html}` directive tags. The tags take no arguments:
+
+```none
+{@inject-html}
+INJECTED HTML
+{@end-inject-html}
+```
+
+The `{@inject-html}` directive is only available when the `--inject-html` flag
+is passed to `dart doc`. It is not available for documentation published on
+https://pub.dev.
+
+## `{@animation}` - Animations
+
+HTML5 videos can be embedded with the `{@animation}` directive. This directive
+accepts width and height arguments, and an optional ID argument:
+
+```none
+{@animation 320 240 URL [id=ID]}
+```
+
+This directive renders the HTML which embeds an HTML5 video.
+
+The optional ID should be a unique id that is a valid JavaScript identifier, and
+will be used as the id for the video tag. If no ID is supplied, then a unique
+identifier (starting with "animation_") will be generated.
+
+The width and height must be integers specifying the dimensions of the video
+file in pixels.
+
+## `{@youtube}` - YouTube videos
+
+A YouTube video can be embedded with the `{@youtube}` directive. This directive
+accepts width and height arguments, using the following syntax:
+
+```none
+{@youtube 320 240 https://www.youtube.com/watch?v=oHg5SJYRHA0}
+```
+
+This directive embeds the YouTube video with id "oHg5SJYRHA0" into the
+documentation page, with a width of 320 pixels, and a height of 240 pixels. The
+height and width are used to calculate the aspect ratio of the video; the video
+is always rendered to take up all available horizontal space to accommodate
+different screen sizes on desktop and mobile.
+
+The video URL must have the following format:
+`https://www.youtube.com/watch?v=oHg5SJYRHA0`. This format can usually be found
+in the address bar of the browser when viewing a YouTube video.
+
+## `{@tool}` - External tools
+
+TODO(srawlins): Document.
+
+## `{@canonicalFor}` - Canonicalization
+
+Dartdoc uses some heuristics to decide what the public-facing libraries are,
+and which public-facing library is the "canonical" location for an element.
+When that heuristic needs to be overridden, a user can use this directive.
+Example:
+
+```none
+{@canonicalFor some_library.SomeClass}
+```
+
+When this directive is used on a library's doc comment, that library is marked
+as the canonical library for `some_library.SomeClass`.


### PR DESCRIPTION
This documentation currently lives in [the wiki](https://github.com/dart-lang/dartdoc/wiki/Doc-comment-directives). However, we are planning to move the dartdoc code to the Dart SDK repo, and this wiki will be going away.

The text in this PR is more-or-less a dump of the wiki contents, and I tweaked the wording and typos a bit.

A full review of the text is fine, but I will likely respond for requests to document "more" or document "better" by writing in TODOs. I still encourage a full read of the text.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
