### PR TITLE
Remove cross-export warning

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -518,19 +518,6 @@ abstract class ModelElement
           (lookup is PropertyAccessorElement ? lookup.variable2 : lookup);
     }).toList(growable: true);
 
-    // Avoid claiming canonicalization for elements outside of this element's
-    // defining package.
-    // TODO(jcollins-g): Make the else block unconditional.
-    if (candidateLibraries.isNotEmpty &&
-        !candidateLibraries.any((l) => l.package == definingLibrary.package)) {
-      warn(PackageWarning.reexportedPrivateApiAcrossPackages,
-          message: definingLibrary.package.fullyQualifiedName,
-          referredFrom: candidateLibraries);
-    } else {
-      candidateLibraries
-          .removeWhere((l) => l.package != definingLibrary.package);
-    }
-
     if (candidateLibraries.isEmpty) {
       return null;
     }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -475,7 +475,6 @@ class PackageGraph with CommentReferable, Nameable {
       PackageWarning.ambiguousDocReference ||
       PackageWarning.ignoredCanonicalFor ||
       PackageWarning.packageOrderGivesMissingPackageName ||
-      PackageWarning.reexportedPrivateApiAcrossPackages ||
       PackageWarning.unresolvedDocReference ||
       PackageWarning.unknownMacro ||
       PackageWarning.unknownHtmlFragment ||

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -181,13 +181,6 @@ enum PackageWarning implements Comparable<PackageWarning> {
         'The category-order flag on the command line was given the name of a '
         'nonexistent package',
   ),
-  reexportedPrivateApiAcrossPackages(
-    'reexported-private-api-across-packages',
-    'private API of {0} is reexported by libraries in other packages: ',
-    shortHelp:
-        'One or more libraries reexports private API members from outside its '
-        'own package',
-  ),
   unresolvedDocReference(
     'unresolved-doc-reference',
     'unresolved doc reference [{0}]',


### PR DESCRIPTION
There are a few examples of exporting (and even documenting) one package's elements from another package:

* `package:flutter/widgets.dart` exports `package:characters/characters.dart`
* `package:test/expect.dart` exports `package:matcher/expect.dart`
* `package:test/fake.dart` exports `package:test_api/fake.dart`

Theoretically these packages were getting warnings about cross-package exports, but the logic that determined if the warning should be shown was wrong: The logic was "If _none_ of the re-exports are from the same package" (or, "if _all_ of the re-exports are cross-package"). But that would even include the library where an element is declared, so I don't think the warning ever fired. Given that it wasn't working, and we don't need the warning (devs get use out of these cross-package exports), we should remove it.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
