### PR TITLE
Fix package selection in package doc-generation task

### DIFF
--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -21,7 +21,7 @@ elif [ "$DARTDOC_BOT" = "flutter" ]; then
   dart run tool/task.dart doc flutter
 elif [ "$DARTDOC_BOT" = "packages" ]; then
   echo "Running packages dartdoc bot"
-  dart run tool/task.dart doc package --name=access --version=">=1.0.1+2"
+  dart run tool/task.dart doc package --name=access --version=">=3.0.0"
   # Negative test for flutter_plugin_tools, make sure right error message is displayed.
   dart run tool/task.dart doc package --name=flutter_plugin_tools --version=">=0.0.14+1" 2>&1 | grep "warning: package:flutter_plugin_tools has no documentable libraries"
 else

--- a/tool/task.dart
+++ b/tool/task.dart
@@ -386,9 +386,8 @@ Future<String> docPackage({
   ]);
   var cache = Directory(path.join(env['PUB_CACHE']!, 'hosted', 'pub.dev'));
   // The pub package should be predictably in a location like this.
-  var pubPackageDirOrig = cache
-      .listSync()
-      .firstWhere((e) => e.path.contains('/$name-${version ?? ''}'));
+  var pubPackageDirOrig =
+      cache.listSync().firstWhere((e) => e.path.contains('/$name-'));
   var pubPackageDir = Directory.systemTemp.createTempSync(name);
   io_utils.copy(pubPackageDirOrig, pubPackageDir);
 

--- a/tool/task.dart
+++ b/tool/task.dart
@@ -305,10 +305,6 @@ Future<void> docFlutter({bool withStats = false}) async {
     label: 'docs',
     withStats: withStats,
   );
-  var indexContents =
-      File(path.join(flutterDir.path, 'dev', 'docs', 'doc', 'index.html'))
-          .readAsLinesSync();
-  print([...indexContents.take(25), '...\n'].join('\n'));
 }
 
 Future<Iterable<Map<String, Object?>>> _docFlutter({
@@ -389,8 +385,10 @@ Future<String> docPackage({
     name,
   ]);
   var cache = Directory(path.join(env['PUB_CACHE']!, 'hosted', 'pub.dev'));
-  var pubPackageDirOrig =
-      cache.listSync().firstWhere((e) => e.path.contains(name));
+  // The pub package should be predictably in a location like this.
+  var pubPackageDirOrig = cache
+      .listSync()
+      .firstWhere((e) => e.path.contains('/$name-${version ?? ''}'));
   var pubPackageDir = Directory.systemTemp.createTempSync(name);
   io_utils.copy(pubPackageDirOrig, pubPackageDir);
 


### PR DESCRIPTION
The old `firstWhere` logic was choosing the `test_reflective_loader` package when I was trying to generate docs for the `test` package.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
