### PR TITLE
Remove support for deprecated leading new in comment references

### DIFF
--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -157,29 +157,20 @@ class CommentReferenceParser {
     return children;
   }
 
-  static const _constructorHintPrefix = 'new';
   static const _ignorePrefixes = ['const', 'final', 'var'];
 
   /// Implement parsing a prefix to a comment reference.
   ///
   /// ```text
-  /// <prefix> ::= <constructorPrefixHint>
-  ///    | <leadingJunk>
+  /// <prefix> ::= <leadingModifiers>
   ///
-  /// <constructorPrefixHint> ::= 'new '
-  ///
-  /// <leadingJunk> ::= ('const' | 'final' | 'var')(' '+)
+  /// <leadingModifiers> ::= ('const' | 'final' | 'var')(' '+)
   /// ```
   _PrefixParseResult _parsePrefix() {
     if (_atEnd) {
       return _PrefixParseResult.endOfFile;
     }
     _walkPastWhitespace();
-    if (_tryMatchLiteral(_constructorHintPrefix,
-        requireTrailingNonidentifier: true)) {
-      return _PrefixParseResult.ok(
-          ConstructorHintStartNode(_constructorHintPrefix));
-    }
     if (_ignorePrefixes
         .any((p) => _tryMatchLiteral(p, requireTrailingNonidentifier: true))) {
       return _PrefixParseResult.junk;
@@ -387,9 +378,6 @@ class _PrefixParseResult {
 
   const _PrefixParseResult._(this.type, this.node);
 
-  factory _PrefixParseResult.ok(ConstructorHintStartNode node) =>
-      _PrefixParseResult._(_PrefixResultType.parsedConstructorHint, node);
-
   static const _PrefixParseResult endOfFile =
       _PrefixParseResult._(_PrefixResultType.endOfFile, null);
 
@@ -482,16 +470,6 @@ class _SuffixParseResult {
 // TODO(jcollins-g): add SourceSpans?
 sealed class CommentReferenceNode {
   String get text;
-}
-
-class ConstructorHintStartNode extends CommentReferenceNode {
-  @override
-  final String text;
-
-  ConstructorHintStartNode(this.text);
-
-  @override
-  String toString() => 'ConstructorHintStartNode["$text"]';
 }
 
 class CallableHintEndNode extends CommentReferenceNode {

--- a/lib/src/matching_link_result.dart
+++ b/lib/src/matching_link_result.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dartdoc/src/model/comment_referable.dart';
-import 'package:dartdoc/src/model/model.dart';
 
 class MatchingLinkResult {
   final CommentReferable? commentReferable;
@@ -19,8 +18,6 @@ class MatchingLinkResult {
 
   @override
   String toString() {
-    // TODO(srawlins): Scrap the 'new' keyword?
-    final newKeyword = commentReferable is Constructor ? 'new ' : '';
-    return 'element: [$newKeyword${commentReferable?.fullyQualifiedName}]';
+    return 'element: [${commentReferable?.fullyQualifiedName}]';
   }
 }

--- a/test/comment_referable/parser_test.dart
+++ b/test/comment_referable/parser_test.dart
@@ -9,13 +9,10 @@ void main() {
   void expectParseEquivalent(String codeRef, List<String> parts,
       {bool constructorHint = false, bool callableHint = false}) {
     var result = CommentReferenceParser(codeRef).parse();
-    var hasConstructorHint =
-        result.isNotEmpty && result.first is ConstructorHintStartNode;
     var hasCallableHint =
         result.isNotEmpty && result.last is CallableHintEndNode;
     var stringParts = result.whereType<IdentifierNode>().map((i) => i.text);
     expect(stringParts, equals(parts));
-    expect(hasConstructorHint, equals(constructorHint));
     expect(hasCallableHint, equals(callableHint));
   }
 
@@ -52,15 +49,12 @@ void main() {
     test('Check that basic references parse', () {
       expectParseEquivalent('Funvas.u', ['Funvas', 'u']);
       expectParseEquivalent('valid', ['valid']);
-      expectParseEquivalent('new valid', ['valid'], constructorHint: true);
       expectParseEquivalent('valid()', ['valid'], callableHint: true);
       expectParseEquivalent('const valid()', ['valid'], callableHint: true);
       expectParseEquivalent('final valid', ['valid']);
       expectParseEquivalent('this.is.valid', ['this', 'is', 'valid']);
       expectParseEquivalent('this.is.valid()', ['this', 'is', 'valid'],
           callableHint: true);
-      expectParseEquivalent('new this.is.valid', ['this', 'is', 'valid'],
-          constructorHint: true);
       expectParseEquivalent('const this.is.valid', ['this', 'is', 'valid']);
       expectParseEquivalent('final this.is.valid', ['this', 'is', 'valid']);
       expectParseEquivalent('var this.is.valid', ['this', 'is', 'valid']);
@@ -79,10 +73,8 @@ void main() {
       expectParsePassthrough('operatorThingy');
       expectParseEquivalent('operator+', ['+']);
       expectParseError('const()');
-      // TODO(jcollins-g): might need to revisit these two with constructor
-      // tearoffs?
       expectParsePassthrough('new');
-      expectParseError('new()');
+      expectParseEquivalent('new()', ['new'], callableHint: true);
     });
 
     test('Check that operator references parse', () {

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -112,40 +112,16 @@ void main() {
     });
 
     test('reference regression', () {
-      expect(referenceLookup(constructorTearoffs, 'A.A'),
-          equals(MatchingLinkResult(Anew)));
-      expect(referenceLookup(constructorTearoffs, 'new A()'),
-          equals(MatchingLinkResult(Anew)));
       expect(referenceLookup(constructorTearoffs, 'A()'),
           equals(MatchingLinkResult(Anew)));
-      expect(referenceLookup(constructorTearoffs, 'B.B'),
-          equals(MatchingLinkResult(Bnew)));
-      expect(referenceLookup(constructorTearoffs, 'new B()'),
-          equals(MatchingLinkResult(Bnew)));
       expect(referenceLookup(constructorTearoffs, 'B()'),
           equals(MatchingLinkResult(Bnew)));
-      expect(referenceLookup(constructorTearoffs, 'C.C'),
-          equals(MatchingLinkResult(Cnew)));
-      expect(referenceLookup(constructorTearoffs, 'new C()'),
-          equals(MatchingLinkResult(Cnew)));
       expect(referenceLookup(constructorTearoffs, 'C()'),
           equals(MatchingLinkResult(Cnew)));
-      expect(referenceLookup(constructorTearoffs, 'D.D'),
-          equals(MatchingLinkResult(Dnew)));
-      expect(referenceLookup(constructorTearoffs, 'new D()'),
-          equals(MatchingLinkResult(Dnew)));
       expect(referenceLookup(constructorTearoffs, 'D()'),
           equals(MatchingLinkResult(Dnew)));
-      expect(referenceLookup(constructorTearoffs, 'E.E'),
-          equals(MatchingLinkResult(Enew)));
-      expect(referenceLookup(constructorTearoffs, 'new E()'),
-          equals(MatchingLinkResult(Enew)));
       expect(referenceLookup(constructorTearoffs, 'E()'),
           equals(MatchingLinkResult(Enew)));
-      expect(referenceLookup(constructorTearoffs, 'F.F'),
-          equals(MatchingLinkResult(Fnew)));
-      expect(referenceLookup(constructorTearoffs, 'new F()'),
-          equals(MatchingLinkResult(Fnew)));
       expect(referenceLookup(constructorTearoffs, 'F()'),
           equals(MatchingLinkResult(Fnew)));
     });

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -1332,19 +1332,19 @@ void main() {
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
-                'Link to constructor (implied): <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">new renamedLib.YetAnotherHelper()</a>'));
-        expect(
-            aFunctionUsingRenamedLib.documentationAsHtml,
-            contains(
                 'Link to constructor (implied, no new): <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">renamedLib.YetAnotherHelper()</a>'));
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
                 'Link to class: <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper-class.html">renamedLib.YetAnotherHelper</a>'));
         expect(
-            aFunctionUsingRenamedLib.documentationAsHtml,
-            contains(
-                'Link to constructor (direct): <a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">renamedLib.YetAnotherHelper.YetAnotherHelper</a>'));
+          aFunctionUsingRenamedLib.documentationAsHtml,
+          contains(
+            'Link to constructor (direct): '
+            '<a href="${htmlBasePlaceholder}mylibpub/YetAnotherHelper/YetAnotherHelper.html">'
+            'renamedLib.YetAnotherHelper.new</a>',
+          ),
+        );
         expect(
             aFunctionUsingRenamedLib.documentationAsHtml,
             contains(
@@ -2666,9 +2666,10 @@ void main() {
 
         test('in class scope overridden by constructors when specified', () {
           expect(
-              referenceLookup(FactoryConstructorThings,
-                  'new FactoryConstructorThings.anotherName'),
-              equals(MatchingLinkResult(anotherName)));
+            referenceLookup(FactoryConstructorThings,
+                'FactoryConstructorThings.anotherName()'),
+            equals(MatchingLinkResult(anotherName)),
+          );
         });
 
         test(
@@ -2699,9 +2700,10 @@ void main() {
               equals(MatchingLinkResult(anotherConstructor)));
           // A conflicting constructor has to be explicit.
           expect(
-              referenceLookup(
-                  anotherName, 'new FactoryConstructorThings.anotherName'),
-              equals(MatchingLinkResult(anotherName)));
+            referenceLookup(
+                anotherName, 'FactoryConstructorThings.anotherName()'),
+            equals(MatchingLinkResult(anotherName)),
+          );
         });
 
         test('in method scope referring to parameters and variables', () {
@@ -2749,18 +2751,22 @@ void main() {
       });
 
       test(
-          'Verify that constructors do not override member fields unless explicitly specified',
-          () {
-        expect(referenceLookup(baseForDocComments, 'aConstructorShadowed'),
-            equals(MatchingLinkResult(aConstructorShadowedField)));
+          'Verify that constructors do not override member fields unless '
+          'explicitly specified', () {
         expect(
-            referenceLookup(
-                baseForDocComments, 'BaseForDocComments.aConstructorShadowed'),
-            equals(MatchingLinkResult(aConstructorShadowedField)));
+          referenceLookup(baseForDocComments, 'aConstructorShadowed'),
+          equals(MatchingLinkResult(aConstructorShadowedField)),
+        );
         expect(
-            referenceLookup(baseForDocComments,
-                'new BaseForDocComments.aConstructorShadowed'),
-            equals(MatchingLinkResult(aConstructorShadowed)));
+          referenceLookup(
+              baseForDocComments, 'BaseForDocComments.aConstructorShadowed'),
+          equals(MatchingLinkResult(aConstructorShadowedField)),
+        );
+        expect(
+          referenceLookup(
+              baseForDocComments, 'BaseForDocComments.aConstructorShadowed()'),
+          equals(MatchingLinkResult(aConstructorShadowed)),
+        );
       });
 
       test('Deprecated lookup styles still function', () {
@@ -2770,9 +2776,9 @@ void main() {
 
       test('Verify basic linking inside class', () {
         expect(
-            referenceLookup(
-                baseForDocComments, 'BaseForDocComments.BaseForDocComments'),
-            equals(MatchingLinkResult(defaultConstructor)));
+          referenceLookup(baseForDocComments, 'BaseForDocComments.new'),
+          equals(MatchingLinkResult(defaultConstructor)),
+        );
 
         // We don't want the parameter on the default constructor, here.
         expect(
@@ -3728,20 +3734,21 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
 
     test('indentation is not lost inside indented code samples', () {
       expect(
-          aProperty.documentation,
-          equals(
-              'This property is quite fancy, and requires sample code to understand.\n'
-              '\n'
-              '```dart\n'
-              'AClassWithFancyProperties x = new AClassWithFancyProperties();\n'
-              '\n'
-              'if (x.aProperty.contains(\'Hello\')) {\n'
-              '  print("I am indented!");\n'
-              '  if (x.aProperty.contains(\'World\')) {\n'
-              '    print ("I am indented even more!!!");\n'
-              '  }\n'
-              '}\n'
-              '```'));
+        aProperty.documentation,
+        equals(
+            'This property is quite fancy, and requires sample code to understand.\n'
+            '\n'
+            '```dart\n'
+            'AClassWithFancyProperties x = AClassWithFancyProperties();\n'
+            '\n'
+            'if (x.aProperty.contains(\'Hello\')) {\n'
+            '  print("I am indented!");\n'
+            '  if (x.aProperty.contains(\'World\')) {\n'
+            '    print ("I am indented even more!!!");\n'
+            '  }\n'
+            '}\n'
+            '```'),
+      );
     });
 
     test('Docs from inherited implicit accessors are preserved', () {
@@ -4308,13 +4315,17 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('calculates comment references to classes vs. constructors correctly',
         () {
       expect(
-          referToADefaultConstructor.documentationAsHtml,
-          contains(
-              '<a href="${htmlBasePlaceholder}fake/ReferToADefaultConstructor-class.html">ReferToADefaultConstructor</a>'));
+        referToADefaultConstructor.documentationAsHtml,
+        contains(
+            '<a href="${htmlBasePlaceholder}fake/ReferToADefaultConstructor-class.html">'
+            'ReferToADefaultConstructor</a>'),
+      );
       expect(
-          referToADefaultConstructor.documentationAsHtml,
-          contains(
-              '<a href="${htmlBasePlaceholder}fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">ReferToADefaultConstructor.ReferToADefaultConstructor</a>'));
+        referToADefaultConstructor.documentationAsHtml,
+        contains(
+            '<a href="${htmlBasePlaceholder}fake/ReferToADefaultConstructor/ReferToADefaultConstructor.html">'
+            'ReferToADefaultConstructor.new</a>'),
+      );
     });
 
     test('displays generic parameters correctly', () {

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -104,10 +104,9 @@ abstract class BaseThingy2 implements BaseThingy {
 /// This function has a link to a renamed library class member.
 ///
 /// Link to library: [renamedLib]
-/// Link to constructor (implied): [new renamedLib.YetAnotherHelper()]
 /// Link to constructor (implied, no new): [renamedLib.YetAnotherHelper()]
 /// Link to class: [renamedLib.YetAnotherHelper]
-/// Link to constructor (direct): [renamedLib.YetAnotherHelper.YetAnotherHelper]
+/// Link to constructor (direct): [renamedLib.YetAnotherHelper.new]
 /// Link to class member: [renamedLib.YetAnotherHelper.getMoreContents]
 /// Link to function: [renamedLib.helperFunction]
 /// Link to overlapping prefix: [renamedLib2.theOnlyThingInTheLibrary]
@@ -243,7 +242,7 @@ class AClassWithFancyProperties {
   /// This property is quite fancy, and requires sample code to understand.
   ///
   /// ```dart
-  /// AClassWithFancyProperties x = new AClassWithFancyProperties();
+  /// AClassWithFancyProperties x = AClassWithFancyProperties();
   ///
   /// if (x.aProperty.contains('Hello')) {
   ///   print("I am indented!");
@@ -1030,7 +1029,7 @@ void paintImage2(String fooParam,
 /// This is to test referring to a constructor.
 ///
 /// This should refer to a class: [ReferToADefaultConstructor].
-/// This should refer to the constructor: [ReferToADefaultConstructor.ReferToADefaultConstructor].
+/// This should refer to the constructor: [ReferToADefaultConstructor.new].
 class ReferToADefaultConstructor {
   /// A default constructor.
   ReferToADefaultConstructor();


### PR DESCRIPTION
The syntax, `[new Foo]` and `[Foo.Foo]` have long been deprecated. The analyzer reports `[new Foo]` as well, suggesting to replace with `[Foo.new]`. This Change removes the support for the deprecated syntaxes.

All examples in tests have been changed to `[Foo.new]`. There are also tests for the disambiguation of a constructor and an instance field with the same name which is allowed), e.g. in `[Foo.foo]`. The supported disambiguation hint is to add trailing parentheses: `[Foo.foo()]` to indicate the constructor.

Fixes https://github.com/dart-lang/dartdoc/issues/3531

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
