### PR TITLE
Remove unused warnings

### DIFF
--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -184,12 +184,8 @@ mixin DocumentationComment
       if (nameEndIndex == -1) return;
       var name = docs.substring(nameStartIndex + 2, nameEndIndex);
       if (!_allDirectiveNames.contains(name)) {
-        if (_allDirectiveNames.contains(name.toLowerCase())) {
-          warn(PackageWarning.unknownDirective,
-              message: "'$name' (use lowercase)");
-        } else {
-          warn(PackageWarning.unknownDirective, message: "'$name'");
-        }
+        // Ignore unknown directive name; the analyzer now reports this
+        // natively.
       }
       // TODO(srawlins): Replace all `replaceAllMapped` usage within this file,
       // running regex after regex over [docs], with simple calls here. This has

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -354,9 +354,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       PackageWarning.ignoredCanonicalFor ||
       PackageWarning.packageOrderGivesMissingPackageName ||
       PackageWarning.reexportedPrivateApiAcrossPackages ||
-      PackageWarning.notImplemented ||
       PackageWarning.unresolvedDocReference ||
-      PackageWarning.unknownDirective ||
       PackageWarning.unknownMacro ||
       PackageWarning.unknownHtmlFragment ||
       PackageWarning.brokenLink ||

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -185,10 +185,6 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
         "`import 'package:dartdoc/lib/foo.dart';`.",
     defaultWarningMode: PackageWarningMode.error,
   ),
-  PackageWarning.notImplemented: PackageWarningDefinition(
-      PackageWarning.notImplemented,
-      'not-implemented',
-      'The code makes use of a feature that is not yet implemented in dartdoc'),
   PackageWarning.noDocumentableLibrariesInPackage: PackageWarningDefinition(
     PackageWarning.noDocumentableLibrariesInPackage,
     'no-documentable-libraries',
@@ -223,10 +219,6 @@ const Map<PackageWarning, PackageWarningDefinition> packageWarningDefinitions =
   ),
   PackageWarning.brokenLink: PackageWarningDefinition(PackageWarning.brokenLink,
       'broken-link', 'Dartdoc generated a link to a non-existent file'),
-  PackageWarning.unknownDirective: PackageWarningDefinition(
-      PackageWarning.unknownDirective,
-      'unknown-directive',
-      'A comment contains an unknown directive'),
   PackageWarning.unknownMacro: PackageWarningDefinition(
       PackageWarning.unknownMacro,
       'unknown-macro',
@@ -346,7 +338,6 @@ enum PackageWarning {
   noCanonicalFound('no canonical library found for {0}, not linking'),
   noDefiningLibraryFound('could not find the defining library for {0}; the '
       'library may be imported or exported with a non-standard URI'),
-  notImplemented('{0}'),
   noDocumentableLibrariesInPackage('{0} has no documentable libraries'),
   noLibraryLevelDocs('{0} has no library level documentation comments'),
   packageOrderGivesMissingPackageName(
@@ -355,7 +346,6 @@ enum PackageWarning {
       'private API of {0} is reexported by libraries in other packages: '),
   unresolvedDocReference('unresolved doc reference [{0}]',
       referredFromPrefix: 'in documentation inherited from'),
-  unknownDirective('undefined directive: {0}'),
   unknownMacro('undefined macro [{0}]'),
   unknownHtmlFragment('undefined HTML fragment identifier [{0}]'),
   brokenLink('dartdoc generated a broken link to: {0}',

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -101,30 +101,6 @@ Text.
 More text.'''));
   }
 
-  void test_unknownDirective() async {
-    await libraryModel.processComment('''
-/// Text.
-///
-/// {@marco name}
-''');
-    expect(
-        packageGraph.packageWarningCounter.hasWarning(
-            libraryModel, PackageWarning.unknownDirective, "'marco'"),
-        isTrue);
-  }
-
-  void test_directiveWithWrongCase() async {
-    await libraryModel.processComment('''
-/// Text.
-///
-/// {@youTube url}
-''');
-    expect(
-        packageGraph.packageWarningCounter.hasWarning(libraryModel,
-            PackageWarning.unknownDirective, "'youTube' (use lowercase)"),
-        isTrue);
-  }
-
   void test_processesAanimationDirective() async {
     var doc = await libraryModel.processComment('''
 /// Text.


### PR DESCRIPTION
Two warnings are removed here:

* notInimplemented - nothing is unimplemented; not sure when this was last used.
* unknownDirective - analyzer now reports these.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
