### PR TITLE
Convert some late final fields to getters in Accessor, Annotation, Constructor

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -159,7 +159,7 @@ class Accessor extends ModelElement implements EnclosedElement {
   @override
   Kind get kind => Kind.accessor;
 
-  late final String _namePart = super.namePart.split('=').first;
+  String get _namePart => super.namePart.split('=').first;
 
   @override
   String get namePart => _namePart;
@@ -218,7 +218,7 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
   Container get enclosingElement => _enclosingElement;
 
   @override
-  late final ContainerAccessor? overriddenElement = () {
+  ContainerAccessor? get overriddenElement {
     assert(packageGraph.allLibrariesAdded);
     final parent = element.enclosingElement;
     if (parent is! InterfaceElement) {
@@ -245,5 +245,6 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
       assert(!overridden.isInherited);
       return overridden;
     }
-  }();
+    return null;
+  }
 }

--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -32,29 +32,25 @@ class Annotation extends Attribute with ModelBuilder {
       // TODO(jcollins-g): consider linking to constructor instead of type?
       : modelType.linkedName;
 
-  late final ElementType modelType = () {
-    var annotatedWith = annotation.element;
-    return switch (annotatedWith) {
-      ConstructorElement() =>
-        modelBuilder.typeFrom(annotatedWith.returnType, library),
-      PropertyAccessorElement() =>
-        (modelBuilder.fromElement(annotatedWith.variable) as GetterSetterCombo)
-            .modelType,
-      _ => throw StateError(
-          'non-callable element used as annotation?: ${annotation.element}')
-    };
-  }();
+  late final ElementType modelType = switch (annotation.element) {
+    ConstructorElement(:var returnType) =>
+      modelBuilder.typeFrom(returnType, library),
+    PropertyAccessorElement(:var variable) =>
+      (modelBuilder.fromElement(variable) as GetterSetterCombo).modelType,
+    _ => throw StateError(
+        'non-callable element used as annotation?: ${annotation.element}')
+  };
 
   // TODO(srawlins): Attempt to revive constructor arguments in an annotation,
   // akin to source_gen's Reviver, in order to link to inner components. For
   // example, in `@Foo(const Bar(), baz: <Baz>[Baz.one, Baz.two])`, link to
   // `Foo`, `Bar`, `Baz`, `Baz.one`, and `Baz.two`.
   /// The textual representation of the argument(s) supplied to the annotation.
-  late final String parameterText = () {
+  String get parameterText {
     var source = annotation.toSource();
     var startIndex = source.indexOf('(');
     return source.substring(startIndex == -1 ? source.length : startIndex);
-  }();
+  }
 
   @override
   bool get isPublic =>

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -74,7 +74,7 @@ class Constructor extends ModelElement
       modelBuilder.typeFrom(element.type, library) as Callable;
 
   @override
-  late final String name = () {
+  String get name {
     // TODO(jcollins-g): After the old lookup code is retired, rationalize
     // [name] around the conventions used in referenceChildren and replace
     // code there and elsewhere with simple references to the name.
@@ -83,16 +83,16 @@ class Constructor extends ModelElement
       return enclosingElement.name;
     }
     return '${enclosingElement.name}.$constructorName';
-  }();
+  }
 
   @override
-  late final String nameWithGenerics = () {
+  String get nameWithGenerics {
     var constructorName = element.name;
     if (constructorName.isEmpty) {
       return '${enclosingElement.name}$genericParameters';
     }
     return '${enclosingElement.name}$genericParameters.$constructorName';
-  }();
+  }
 
   String? get shortName {
     if (name.contains('.')) {


### PR DESCRIPTION
These late final fields with immediately executed initializers are non-idiomatic and a little complex. The possible downsides of converting to getters is perhaps an increase in memory usage and time-to-document. No increase in either was observed.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
