### PR TITLE
Support extension types in sidebars and categories

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1740,7 +1740,7 @@ String renderSidebarForContainer<T extends Documentable>(
       }
     }
   }
-  buffer.writeln();
+  buffer.write('\n\n    ');
   if (context1.isClassOrEnum == true) {
     if (context1.hasPublicInstanceFields == true) {
       buffer.writeln();
@@ -1816,7 +1816,7 @@ String renderSidebarForContainer<T extends Documentable>(
       }
     }
   }
-  buffer.writeln();
+  buffer.write('\n\n    ');
   if (context1.isExtension == true) {
     if (context1.hasPublicInstanceFields == true) {
       buffer.writeln();
@@ -1866,8 +1866,8 @@ String renderSidebarForContainer<T extends Documentable>(
       }
     }
   }
-  buffer.writeln();
-  if (context1.isClassOrEnumOrExtension == true) {
+  buffer.write('\n\n    ');
+  if (context1.isInterfaceOrExtension == true) {
     if (context1.hasPublicVariableStaticFields == true) {
       buffer.writeln();
       buffer.write('''
@@ -1945,13 +1945,13 @@ String renderSidebarForLibrary<T extends Documentable>(
     }
   }
   buffer.writeln();
-  if (context1.hasPublicExtensions == true) {
+  if (context1.hasPublicEnums == true) {
     buffer.writeln();
     buffer.write('''
       <li class="section-title"><a href="''');
     buffer.write(context1.href);
-    buffer.write('''#extensions">Extensions</a></li>''');
-    var context4 = context1.publicExtensionsSorted;
+    buffer.write('''#enums">Enums</a></li>''');
+    var context4 = context1.publicEnumsSorted;
     for (var context5 in context4) {
       buffer.writeln();
       buffer.write('''
@@ -2025,34 +2025,18 @@ String renderSidebarForLibrary<T extends Documentable>(
     }
   }
   buffer.writeln();
-  if (context1.hasPublicEnums == true) {
-    buffer.writeln();
-    buffer.write('''
-      <li class="section-title"><a href="''');
-    buffer.write(context1.href);
-    buffer.write('''#enums">Enums</a></li>''');
-    var context14 = context1.publicEnumsSorted;
-    for (var context15 in context14) {
-      buffer.writeln();
-      buffer.write('''
-        <li>''');
-      buffer.write(context15.linkedName);
-      buffer.write('''</li>''');
-    }
-  }
-  buffer.writeln();
   if (context1.hasPublicTypedefs == true) {
     buffer.writeln();
     buffer.write('''
       <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#typedefs">Typedefs</a></li>''');
-    var context16 = context1.publicTypedefsSorted;
-    for (var context17 in context16) {
+    var context14 = context1.publicTypedefsSorted;
+    for (var context15 in context14) {
       buffer.writeln();
       buffer.write('''
         <li>''');
-      buffer.write(context17.linkedName);
+      buffer.write(context15.linkedName);
       buffer.write('''</li>''');
     }
   }
@@ -2063,12 +2047,44 @@ String renderSidebarForLibrary<T extends Documentable>(
       <li class="section-title"><a href="''');
     buffer.write(context1.href);
     buffer.write('''#exceptions">Exceptions</a></li>''');
-    var context18 = context1.publicExceptionsSorted;
+    var context16 = context1.publicExceptionsSorted;
+    for (var context17 in context16) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context17.linkedName);
+      buffer.write('''</li>''');
+    }
+  }
+  buffer.writeln();
+  if (context1.hasPublicExtensions == true) {
+    buffer.writeln();
+    buffer.write('''
+      <li class="section-title"><a href="''');
+    buffer.write(context1.href);
+    buffer.write('''#extensions">Extensions</a></li>''');
+    var context18 = context1.publicExtensionsSorted;
     for (var context19 in context18) {
       buffer.writeln();
       buffer.write('''
         <li>''');
       buffer.write(context19.linkedName);
+      buffer.write('''</li>''');
+    }
+  }
+  buffer.writeln();
+  if (context1.hasPublicExtensionTypes == true) {
+    buffer.writeln();
+    buffer.write('''
+      <li class="section-title"><a href="''');
+    buffer.write(context1.href);
+    buffer.write('''#extension-types">Extension Types</a></li>''');
+    var context20 = context1.publicExtensionTypesSorted;
+    for (var context21 in context20) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context21.linkedName);
       buffer.write('''</li>''');
     }
   }
@@ -2350,14 +2366,14 @@ String _renderCategory_partial_sidebar_for_category_11(
   }
   buffer.writeln();
   var context5 = context0.self;
-  if (context5.hasPublicMixins == true) {
+  if (context5.hasPublicClasses == true) {
     buffer.writeln();
     buffer.write('''
     <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
-    buffer.write('''#mixins">Mixins</a></li>''');
+    buffer.write('''#classes">Classes</a></li>''');
     var context6 = context0.self;
-    var context7 = context6.publicMixinsSorted;
+    var context7 = context6.publicClassesSorted;
     for (var context8 in context7) {
       buffer.writeln();
       buffer.write('''
@@ -2368,14 +2384,14 @@ String _renderCategory_partial_sidebar_for_category_11(
   }
   buffer.writeln();
   var context9 = context0.self;
-  if (context9.hasPublicClasses == true) {
+  if (context9.hasPublicEnums == true) {
     buffer.writeln();
     buffer.write('''
     <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
-    buffer.write('''#classes">Classes</a></li>''');
+    buffer.write('''#enums">Enums</a></li>''');
     var context10 = context0.self;
-    var context11 = context10.publicClassesSorted;
+    var context11 = context10.publicEnumsSorted;
     for (var context12 in context11) {
       buffer.writeln();
       buffer.write('''
@@ -2386,14 +2402,14 @@ String _renderCategory_partial_sidebar_for_category_11(
   }
   buffer.writeln();
   var context13 = context0.self;
-  if (context13.hasPublicConstants == true) {
+  if (context13.hasPublicMixins == true) {
     buffer.writeln();
     buffer.write('''
     <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
-    buffer.write('''#constants">Constants</a></li>''');
+    buffer.write('''#mixins">Mixins</a></li>''');
     var context14 = context0.self;
-    var context15 = context14.publicConstantsSorted;
+    var context15 = context14.publicMixinsSorted;
     for (var context16 in context15) {
       buffer.writeln();
       buffer.write('''
@@ -2404,14 +2420,14 @@ String _renderCategory_partial_sidebar_for_category_11(
   }
   buffer.writeln();
   var context17 = context0.self;
-  if (context17.hasPublicProperties == true) {
+  if (context17.hasPublicConstants == true) {
     buffer.writeln();
     buffer.write('''
     <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
-    buffer.write('''#properties">Properties</a></li>''');
+    buffer.write('''#constants">Constants</a></li>''');
     var context18 = context0.self;
-    var context19 = context18.publicPropertiesSorted;
+    var context19 = context18.publicConstantsSorted;
     for (var context20 in context19) {
       buffer.writeln();
       buffer.write('''
@@ -2422,14 +2438,14 @@ String _renderCategory_partial_sidebar_for_category_11(
   }
   buffer.writeln();
   var context21 = context0.self;
-  if (context21.hasPublicFunctions == true) {
+  if (context21.hasPublicProperties == true) {
     buffer.writeln();
     buffer.write('''
     <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
-    buffer.write('''#functions">Functions</a></li>''');
+    buffer.write('''#properties">Properties</a></li>''');
     var context22 = context0.self;
-    var context23 = context22.publicFunctionsSorted;
+    var context23 = context22.publicPropertiesSorted;
     for (var context24 in context23) {
       buffer.writeln();
       buffer.write('''
@@ -2440,14 +2456,14 @@ String _renderCategory_partial_sidebar_for_category_11(
   }
   buffer.writeln();
   var context25 = context0.self;
-  if (context25.hasPublicEnums == true) {
+  if (context25.hasPublicFunctions == true) {
     buffer.writeln();
     buffer.write('''
     <li class="section-title"><a href="''');
     buffer.write(context0.self.href);
-    buffer.write('''#enums">Enums</a></li>''');
+    buffer.write('''#functions">Functions</a></li>''');
     var context26 = context0.self;
-    var context27 = context26.publicEnumsSorted;
+    var context27 = context26.publicFunctionsSorted;
     for (var context28 in context27) {
       buffer.writeln();
       buffer.write('''
@@ -2489,6 +2505,42 @@ String _renderCategory_partial_sidebar_for_category_11(
       buffer.write('''
   <li>''');
       buffer.write(context36.linkedName);
+      buffer.write('''</li>''');
+    }
+  }
+  buffer.writeln();
+  var context37 = context0.self;
+  if (context37.hasPublicExtensions == true) {
+    buffer.writeln();
+    buffer.write('''
+  <li class="section-title"><a href="''');
+    buffer.write(context0.self.href);
+    buffer.write('''#extensions">Extensions</a></li>''');
+    var context38 = context0.self;
+    var context39 = context38.publicExtensionsSorted;
+    for (var context40 in context39) {
+      buffer.writeln();
+      buffer.write('''
+  <li>''');
+      buffer.write(context40.linkedName);
+      buffer.write('''</li>''');
+    }
+  }
+  buffer.writeln();
+  var context41 = context0.self;
+  if (context41.hasPublicExtensionTypes == true) {
+    buffer.writeln();
+    buffer.write('''
+  <li class="section-title"><a href="''');
+    buffer.write(context0.self.href);
+    buffer.write('''#extension-types">Extension Types</a></li>''');
+    var context42 = context0.self;
+    var context43 = context42.publicExtensionTypesSorted;
+    for (var context44 in context43) {
+      buffer.writeln();
+      buffer.write('''
+  <li>''');
+      buffer.write(context44.linkedName);
       buffer.write('''</li>''');
     }
   }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3148,26 +3148,12 @@ class _Renderer_Container extends RendererBase<Container> {
                         _render_Operator(e, ast, r.template, sink, parent: r));
                   },
                 ),
-                'isClass': Property(
-                  getValue: (CT_ c) => c.isClass,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isClass == true,
-                ),
                 'isClassOrEnum': Property(
                   getValue: (CT_ c) => c.isClassOrEnum,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isClassOrEnum == true,
-                ),
-                'isClassOrEnumOrExtension': Property(
-                  getValue: (CT_ c) => c.isClassOrEnumOrExtension,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isClassOrEnumOrExtension == true,
                 ),
                 'isEnum': Property(
                   getValue: (CT_ c) => c.isEnum,
@@ -3182,6 +3168,13 @@ class _Renderer_Container extends RendererBase<Container> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isExtension == true,
+                ),
+                'isInterfaceOrExtension': Property(
+                  getValue: (CT_ c) => c.isInterfaceOrExtension,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isInterfaceOrExtension == true,
                 ),
                 'isMixin': Property(
                   getValue: (CT_ c) => c.isMixin,

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -38,16 +38,14 @@ abstract class Container extends ModelElement
   @override
   bool get hasParameters => false;
 
-  /// Whether this a class or mixin, but not an enum.
-  bool get isClass => element is InterfaceElement;
   bool get isExtension => element is ExtensionElement;
 
-  /// Whether this is a class, an enum, or an extension.
+  /// Whether this is an interface type (class, enum, mixin, extension type) or
+  /// an extension.
   ///
-  /// For templates, classes and extensions have much in common despite
+  /// For templates, interfaces and extensions have much in common despite
   /// differing underlying implementations in the analyzer.
-  bool get isClassOrEnumOrExtension =>
-      element is InterfaceElement || isExtension;
+  bool get isInterfaceOrExtension => element is InterfaceElement || isExtension;
 
   /// Whether this is an enum.
   bool get isEnum => element is EnumElement;

--- a/lib/templates/html/_sidebar_for_category.html
+++ b/lib/templates/html/_sidebar_for_category.html
@@ -6,19 +6,26 @@
     {{ /self.publicLibrariesSorted }}
   {{ /self.hasPublicLibraries }}
 
-  {{ #self.hasPublicMixins }}
-    <li class="section-title"><a href="{{{ self.href }}}#mixins">Mixins</a></li>
-    {{ #self.publicMixinsSorted }}
-      <li>{{{ linkedName }}}</li>
-    {{ /self.publicMixinsSorted }}
-  {{ /self.hasPublicMixins }}
-
   {{ #self.hasPublicClasses }}
     <li class="section-title"><a href="{{{ self.href }}}#classes">Classes</a></li>
     {{ #self.publicClassesSorted }}
       <li>{{{ linkedName }}}</li>
     {{ /self.publicClassesSorted }}
   {{ /self.hasPublicClasses }}
+
+  {{ #self.hasPublicEnums }}
+    <li class="section-title"><a href="{{{ self.href }}}#enums">Enums</a></li>
+    {{ #self.publicEnumsSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicEnumsSorted }}
+  {{ /self.hasPublicEnums }}
+
+  {{ #self.hasPublicMixins }}
+    <li class="section-title"><a href="{{{ self.href }}}#mixins">Mixins</a></li>
+    {{ #self.publicMixinsSorted }}
+      <li>{{{ linkedName }}}</li>
+    {{ /self.publicMixinsSorted }}
+  {{ /self.hasPublicMixins }}
 
   {{ #self.hasPublicConstants}}
     <li class="section-title"><a href="{{{ self.href }}}#constants">Constants</a></li>
@@ -41,13 +48,6 @@
     {{ /self.publicFunctionsSorted }}
   {{ /self.hasPublicFunctions }}
 
-  {{ #self.hasPublicEnums }}
-    <li class="section-title"><a href="{{{ self.href }}}#enums">Enums</a></li>
-    {{ #self.publicEnumsSorted }}
-      <li>{{{ linkedName }}}</li>
-    {{ /self.publicEnumsSorted }}
-  {{ /self.hasPublicEnums }}
-
   {{ #self.hasPublicTypedefs }}
   <li class="section-title"><a href="{{{ self.href }}}#typedefs">Typedefs</a></li>
   {{ #self.publicTypedefsSorted }}
@@ -61,4 +61,18 @@
   <li>{{{ linkedName }}}</li>
   {{ /self.publicExceptionsSorted }}
   {{ /self.hasPublicExceptions }}
+
+  {{ #self.hasPublicExtensions }}
+  <li class="section-title"><a href="{{{ self.href }}}#extensions">Extensions</a></li>
+  {{ #self.publicExtensionsSorted }}
+  <li>{{{ linkedName }}}</li>
+  {{ /self.publicExtensionsSorted }}
+  {{ /self.hasPublicExtensions }}
+
+  {{ #self.hasPublicExtensionTypes }}
+  <li class="section-title"><a href="{{{ self.href }}}#extension-types">Extension Types</a></li>
+  {{ #self.publicExtensionTypesSorted }}
+  <li>{{{ linkedName }}}</li>
+  {{ /self.publicExtensionTypesSorted }}
+  {{ /self.hasPublicExtensionTypes }}
 </ol>

--- a/lib/templates/html/_sidebar_for_container.html
+++ b/lib/templates/html/_sidebar_for_container.html
@@ -19,6 +19,7 @@
       {{ /hasPublicEnumValues }}
     {{ /isEnum }}
 
+    {{!-- Instance members which may or may not be inherited. --}}
     {{ #isClassOrEnum }}
       {{ #hasPublicInstanceFields }}
         <li class="section-title{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}">
@@ -44,6 +45,7 @@
       {{ /hasPublicInstanceOperators }}
     {{ /isClassOrEnum }}
 
+    {{!-- Instance members with no inheritance concept. --}}
     {{ #isExtension }}
       {{ #hasPublicInstanceFields }}
         <li class="section-title"> <a href="{{{ href }}}#instance-properties">Properties</a></li>
@@ -67,7 +69,8 @@
       {{ /hasPublicInstanceOperators }}
     {{ /isExtension }}
 
-    {{ #isClassOrEnumOrExtension }}
+    {{!-- Static members. --}}
+    {{ #isInterfaceOrExtension }}
       {{ #hasPublicVariableStaticFields }}
         <li class="section-title"><a href="{{{ href }}}#static-properties">Static properties</a></li>
         {{ #publicVariableStaticFieldsSorted }}
@@ -88,6 +91,6 @@
           <li>{{{ linkedName }}}</li>
         {{ /publicConstantFieldsSorted }}
       {{ /hasPublicConstantFields }}
-    {{ /isClassOrEnumOrExtension }}
+    {{ /isInterfaceOrExtension }}
   {{ /container }}
 </ol>

--- a/lib/templates/html/_sidebar_for_library.html
+++ b/lib/templates/html/_sidebar_for_library.html
@@ -7,12 +7,12 @@
       {{ /publicClassesSorted }}
     {{ /hasPublicClasses }}
 
-    {{ #hasPublicExtensions }}
-      <li class="section-title"><a href="{{{ href }}}#extensions">Extensions</a></li>
-      {{ #publicExtensionsSorted }}
+    {{ #hasPublicEnums }}
+      <li class="section-title"><a href="{{{ href }}}#enums">Enums</a></li>
+      {{ #publicEnumsSorted }}
         <li>{{{ linkedName }}}</li>
-      {{ /publicExtensionsSorted }}
-    {{ /hasPublicExtensions }}
+      {{ /publicEnumsSorted }}
+    {{ /hasPublicEnums }}
 
     {{ #hasPublicMixins }}
       <li class="section-title"><a href="{{{ href }}}#mixins">Mixins</a></li>
@@ -42,13 +42,6 @@
       {{ /publicFunctionsSorted }}
     {{ /hasPublicFunctions }}
 
-    {{ #hasPublicEnums }}
-      <li class="section-title"><a href="{{{ href }}}#enums">Enums</a></li>
-      {{ #publicEnumsSorted }}
-        <li>{{{ linkedName }}}</li>
-      {{ /publicEnumsSorted }}
-    {{ /hasPublicEnums }}
-
     {{ #hasPublicTypedefs }}
       <li class="section-title"><a href="{{{ href }}}#typedefs">Typedefs</a></li>
       {{ #publicTypedefsSorted }}
@@ -62,5 +55,19 @@
         <li>{{{ linkedName }}}</li>
       {{ /publicExceptionsSorted }}
     {{ /hasPublicExceptions }}
+
+    {{ #hasPublicExtensions }}
+      <li class="section-title"><a href="{{{ href }}}#extensions">Extensions</a></li>
+      {{ #publicExtensionsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicExtensionsSorted }}
+    {{ /hasPublicExtensions }}
+
+    {{ #hasPublicExtensionTypes }}
+      <li class="section-title"><a href="{{{ href }}}#extension-types">Extension Types</a></li>
+      {{ #publicExtensionTypesSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicExtensionTypesSorted }}
+    {{ /hasPublicExtensionTypes }}
   {{ /library }}
 </ol>

--- a/test/templates/category_test.dart
+++ b/test/templates/category_test.dart
@@ -22,12 +22,7 @@ void main() async {
   late DartdocGeneratorOptionContext context;
   late List<String> topicOneLines;
 
-  setUp(() {});
-
-  Future<PubPackageBuilder> createPackageBuilder({
-    List<String> additionalOptions = const [],
-    bool skipUnreachableSdkLibraries = true,
-  }) async {
+  Future<PubPackageBuilder> createPackageBuilder() async {
     context = await utils.generatorContextFromArgv([
       '--input',
       packagePath,
@@ -36,7 +31,6 @@ void main() async {
       '--sdk-dir',
       packageMetaProvider.defaultSdkDir.path,
       '--no-link-to-remote',
-      ...additionalOptions,
     ], packageMetaProvider);
 
     var packageConfigProvider = utils
@@ -47,18 +41,12 @@ void main() async {
       context,
       packageMetaProvider,
       packageConfigProvider,
-      skipUnreachableSdkLibraries: skipUnreachableSdkLibraries,
+      skipUnreachableSdkLibraries: true,
     );
   }
 
-  Future<Dartdoc> buildDartdoc({
-    List<String> additionalOptions = const [],
-    bool skipUnreachableSdkLibraries = true,
-  }) async {
-    final packageBuilder = await createPackageBuilder(
-      additionalOptions: additionalOptions,
-      skipUnreachableSdkLibraries: skipUnreachableSdkLibraries,
-    );
+  Future<Dartdoc> buildDartdoc() async {
+    final packageBuilder = await createPackageBuilder();
     return await Dartdoc.fromContext(
       context,
       packageBuilder,
@@ -71,6 +59,17 @@ void main() async {
         packageMetaProvider.resourceProvider as MemoryResourceProvider;
     packagePath = await d.createPackage(
       packageName,
+      pubspec: '''
+name: categories
+version: 0.0.1
+environment:
+  sdk: '>=3.3.0-0 <4.0.0'
+''',
+      analysisOptions: '''
+analyzer:
+  enable-experiment:
+    - inline-class
+''',
       dartdocOptions: '''
 dartdoc:
   categories:
@@ -90,10 +89,6 @@ const c1 = 1;
 /// An enum.
 /// {@category One}
 enum E1 { one, two }
-
-/// An extension.
-/// {@category One}
-extension Ex on int {}
 
 /// A function.
 /// {@category One}
@@ -115,6 +110,14 @@ typedef T1 = void Function();
 /// {@category One}
 // TODO(srawlins): Properly unit-test "typedef pointing to typedef".
 typedef T2 = T1;
+
+/// An extension.
+/// {@category One}
+extension Ex on int {}
+
+/// An extension type.
+/// {@category One}
+extension type ExType(int it) {}
 '''),
       ],
       files: [
@@ -130,84 +133,167 @@ typedef T2 = T1;
         .split('\n');
   });
 
-  test('category page links to classes annotated with category', () async {
-    // TODO(srawlins): Use expectMainContentContainsAllInOrder throughout.
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Classes</h2>'),
-          matches('<a href="../lib/C1-class.html">C1</a>'),
-          matches('A class.'),
-        ]));
+  test('page links to classes annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Classes</h2>'),
+      matches('<a href="../lib/C1-class.html">C1</a>'),
+      matches('A class.'),
+    ]);
   });
 
-  test('category page links to constants annotated with category', () async {
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Constants</h2>'),
-          matches('<a href="../lib/c1-constant.html">c1</a>'),
-          matches('A constant.'),
-        ]));
+  test('page links to constants annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Constants</h2>'),
+      matches('<a href="../lib/c1-constant.html">c1</a>'),
+      matches('A constant.'),
+    ]);
   });
 
-  test('category page links to enums annotated with category', () async {
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Enums</h2>'),
-          matches('<a href="../lib/E1.html">E1</a>'),
-          matches('An enum.'),
-        ]));
+  test('page links to enums annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Enums</h2>'),
+      matches('<a href="../lib/E1.html">E1</a>'),
+      matches('An enum.'),
+    ]);
   });
 
-  test('category page links to extensions annotated with category', () async {
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Extensions</h2>'),
-          matches('<a href="../lib/Ex.html">Ex</a>'),
-          matches('An extension.'),
-        ]));
+  test('page links to extensions annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Extensions</h2>'),
+      matches('<a href="../lib/Ex.html">Ex</a>'),
+      matches('An extension.'),
+    ]);
   });
 
-  test('category page links to functions annotated with category', () async {
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Functions</h2>'),
-          matches('<a href="../lib/F1.html">F1</a>'),
-          matches('A function.'),
-        ]));
+  test('page links to functions annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Functions</h2>'),
+      matches('<a href="../lib/F1.html">F1</a>'),
+      matches('A function.'),
+    ]);
   });
 
-  test('category page links to mixins annotated with category', () async {
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Mixins</h2>'),
-          matches('<a href="../lib/M1-mixin.html">M1</a>'),
-          matches('A mixin.'),
-        ]));
+  test('page links to mixins annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Mixins</h2>'),
+      matches('<a href="../lib/M1-mixin.html">M1</a>'),
+      matches('A mixin.'),
+    ]);
   });
 
-  test('category page links to properties annotated with category', () async {
-    expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Properties</h2>'),
-          matches('<a href="../lib/p1.html">p1</a>'),
-          matches('A property.'),
-        ]));
+  test('page links to properties annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Properties</h2>'),
+      matches('<a href="../lib/p1.html">p1</a>'),
+      matches('A property.'),
+    ]);
   });
 
-  test('category page links to typedefs annotated with category', () async {
+  test('page links to typedefs annotated with category', () async {
+    topicOneLines.expectMainContentContainsAllInOrder([
+      matches('<h2>Typedefs</h2>'),
+      matches('<a href="../lib/T1.html">T1</a>'),
+      matches('A typedef.'),
+    ]);
+  });
+
+  test('sidebar contains classes', () async {
     expect(
-        topicOneLines,
-        containsAllInOrder([
-          matches('<h2>Typedefs</h2>'),
-          matches('<a href="../lib/T1.html">T1</a>'),
-          matches('A typedef.'),
-        ]));
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#classes">Classes</a>'),
+        matches('<a href="../lib/C1-class.html">C1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains enums', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#enums">Enums</a>'),
+        matches('<a href="../lib/E1.html">E1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains mixins', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#mixins">Mixins</a>'),
+        matches('<a href="../lib/M1-mixin.html">M1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains constants', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#constants">Constants</a>'),
+        matches('<a href="../lib/c1-constant.html">c1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains properties', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#properties">Properties</a>'),
+        matches('<a href="../lib/p1.html">p1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains functions', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#functions">Functions</a>'),
+        matches('<a href="../lib/F1.html">F1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains typedefs', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#typedefs">Typedefs</a>'),
+        matches('<a href="../lib/T1.html">T1</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains extensions', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#extensions">Extensions</a>'),
+        matches('<a href="../lib/Ex.html">Ex</a>'),
+      ]),
+    );
+  });
+
+  test('sidebar contains extension types', () async {
+    expect(
+      topicOneLines,
+      containsAllInOrder([
+        matches('<div id="dartdoc-sidebar-right" '),
+        matches('<a href="../topics/One-topic.html#extension-types">'
+            'Extension Types</a>'),
+        matches('<a href="../lib/ExType-extension-type.html">ExType</a>'),
+      ]),
+    );
   });
 }


### PR DESCRIPTION
* Add extension types in all of the appropriate sidebars.
* Add tests for category sidebars, and for extension types in categories.
* Re-order the sidebars to be Classes, then Enums, then Mixins, then lots of other stuff, then Extensions, then Extension Types.
* Rename isClassOrEnumOrExtension to isClassOrEnumOrExtension - we would have had to add 'orExtensionType'; no thank you.
* Remove Container.isClass - no longer used by the templates.
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
