### PR TITLE
Remove use of NodeLocator2

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -12715,7 +12715,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -12953,7 +12953,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -56,10 +56,15 @@ class Accessor extends ModelElement implements EnclosedElement {
   late final GetterSetterCombo definingCombo =
       modelBuilder.fromElement(element.variable) as GetterSetterCombo;
 
-  late final String _sourceCode = isSynthetic
-      ? _sourceCodeRenderer.renderSourceCode(
-          packageGraph.getModelNodeFor(definingCombo.element)!.sourceCode)
-      : super.sourceCode;
+  String get _sourceCode {
+    if (!isSynthetic) {
+      return super.sourceCode;
+    }
+    var modelNode = packageGraph.getModelNodeFor(definingCombo.element);
+    return modelNode == null
+        ? ''
+        : _sourceCodeRenderer.renderSourceCode(modelNode.sourceCode);
+  }
 
   @override
   String get sourceCode => _sourceCode;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -385,7 +385,7 @@ abstract class ModelElement extends Canonicalization
   Iterable<Category?> get displayedCategories => const [];
 
   @override
-  late final ModelNode? modelNode = packageGraph.getModelNodeFor(element);
+  ModelNode? get modelNode => packageGraph.getModelNodeFor(element);
 
   /// This element's [Annotation]s.
   ///

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -16,8 +16,6 @@ import 'package:analyzer/src/context/builder.dart' show EmbedderYamlLocator;
 import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart'
     show AnalysisContextCollectionImpl;
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/ast/utilities.dart' show NodeLocator2;
-// ignore: implementation_imports
 import 'package:analyzer/src/dart/sdk/sdk.dart'
     show EmbedderSdk, FolderBasedDartSdk;
 // ignore: implementation_imports
@@ -479,27 +477,9 @@ class PubPackageBuilder implements PackageBuilder {
 /// the library.
 class DartDocResolvedLibrary {
   final LibraryElement element;
-  final Map<String, CompilationUnit> _units;
+  final List<CompilationUnit> units;
 
   DartDocResolvedLibrary(ResolvedLibraryResult result)
       : element = result.element,
-        _units = {
-          for (var unit in result.units) unit.path: unit.unit,
-        };
-
-  /// Returns the [AstNode] for a given [Element].
-  ///
-  /// Uses a precomputed map of `element.source.fullName` to [CompilationUnit]
-  /// to avoid linear traversal in
-  /// `ResolvedLibraryElementImpl.getElementDeclaration`.
-  AstNode? getAstNode(Element element) {
-    var fullName = element.source?.fullName;
-    if (fullName != null && !element.isSynthetic && element.nameOffset != -1) {
-      var unit = _units[fullName];
-      if (unit != null) {
-        return NodeLocator2(element.nameOffset).searchWithin(unit);
-      }
-    }
-    return null;
-  }
+        units = result.units.map((unit) => unit.unit).toList();
 }


### PR DESCRIPTION
When we first resolve a library, we have full access to both the LibraryElement and the CompilationUnit (AST nodes) objects. We should use those pronto, rather than painstakingly recalculate them with NodeLocator2.

This is a pretty big ball of wax. But this is one step in untangling it. Almost everything we need to know about source elements in Dartdoc is on the element model, with two exceptions:

* Element `documentationComment` fields only contain the documentation comment text; it's a String. To get knowledge about comment references, we have to go back to the syntax tree.
* In order to extract the literal source code, to write in the "implementation" section of docs, we must use offsets only found in the syntax tree.

To hang onto some of this syntax tree data, without hanging onto any AST nodes, we do some pre-processing into ModelNode objects. This pre-processing is led by Library.fromLibraryResult. It used to use an ElementVisitor named `_HashableChildLibraryElementVisitor`. This is simpler now, and called `_ModelNodeGatherer`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
