### PR TITLE
Greatly simplify ModelCommentReference

### DIFF
--- a/lib/src/comment_references/model_comment_reference.dart
+++ b/lib/src/comment_references/model_comment_reference.dart
@@ -4,82 +4,26 @@
 //
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/comment_references/parser.dart';
 
-abstract class ModelCommentReference {
-  String get codeRef;
-  bool get hasCallableHint;
-  List<String> get referenceBy;
-  Element? get staticElement;
-
-  /// Construct a [ModelCommentReference] using the analyzer AST.
-  factory ModelCommentReference(
-          CommentReference ref, ResourceProvider resourceProvider) =>
-      _ModelCommentReferenceImpl(ref, resourceProvider);
-
-  /// Construct a [ModelCommentReference] given a raw string.
-  factory ModelCommentReference.synthetic(String codeRef) =>
-      _ModelCommentReferenceImpl.synthetic(codeRef, null);
-}
-
 /// A stripped down analyzer AST [CommentReference] containing only that
-/// information needed for Dartdoc.  Drops link to the [CommentReference]
-/// and [ResourceProvider] after construction.
-class _ModelCommentReferenceImpl implements ModelCommentReference {
-  @override
+/// information needed for Dartdoc.
+class ModelCommentReference {
   final String codeRef;
 
-  @override
   bool get hasCallableHint =>
       parsed.isNotEmpty &&
       ((parsed.length > 1 && parsed.last.text == 'new') ||
           parsed.last is CallableHintEndNode);
 
-  @override
   List<String> get referenceBy => parsed
       .whereType<IdentifierNode>()
       .map<String>((i) => i.text)
       .toList(growable: false);
 
-  @override
-  final Element? staticElement;
-
-  _ModelCommentReferenceImpl(
-      CommentReference ref, ResourceProvider resourceProvider)
-      : codeRef = _referenceText(ref, resourceProvider),
-        staticElement = ref.expression.element;
-
-  _ModelCommentReferenceImpl.synthetic(this.codeRef, this.staticElement);
-
-  /// "Unparse" the code reference into the raw text associated with the
-  /// [CommentReference].
-  static String _referenceText(
-      CommentReference ref, ResourceProvider resourceProvider) {
-    var token = (ref.parent as Comment)
-        .tokens
-        .firstWhere((t) => t.offset <= ref.offset && t.end >= ref.end);
-    // This is a little sketchy, but works since comments happen to be a token
-    // that is fully preserved in its string representation.
-    // TODO(jcollins-g): replace unparsing in general with lower level changes.
-    return token
-        .toString()
-        .substring(ref.offset - token.offset, ref.end - token.offset);
-  }
+  /// Constructs a [ModelCommentReference] given a raw string.
+  ModelCommentReference(this.codeRef);
 
   late final List<CommentReferenceNode> parsed =
       CommentReferenceParser(codeRef).parse();
-}
-
-extension on CommentReferableExpression {
-  Element? get element {
-    var self = this;
-    return switch (self) {
-      PrefixedIdentifier() => self.staticElement,
-      PropertyAccess() => self.propertyName.staticElement,
-      SimpleIdentifier() => self.staticElement,
-      _ => null
-    };
-  }
 }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -17009,14 +17009,7 @@ const _invisibleGetters = {
     'superclassConstraints'
   },
   'ModelElementRenderer': {'hashCode', 'runtimeType'},
-  'ModelNode': {
-    'commentRefs',
-    'element',
-    'hashCode',
-    'resourceProvider',
-    'runtimeType',
-    'sourceCode'
-  },
+  'ModelNode': {'hashCode', 'runtimeType', 'sourceCode'},
   'ModelObjectBuilder': {'hashCode', 'runtimeType'},
   'PackageGraph': {
     'allCanonicalModelElements',

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -162,7 +162,7 @@ bool _requireCallable(CommentReferable? referable) =>
 
 MatchingLinkResult _getMatchingLinkElement(
     String referenceText, Warnable element) {
-  var commentReference = ModelCommentReference.synthetic(referenceText);
+  var commentReference = ModelCommentReference(referenceText);
 
   // A filter to be used by [CommentReferable.referenceBy].
   bool Function(CommentReferable?) filter;


### PR DESCRIPTION
* Remove unnecessary complexity of an abstract class and an impl.
* Remove unused staticElement.
* In ModelNode, remove unused `commentRefs` field, and privatize `element` and `resourceProvider`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
