### PR TITLE
ExtensionType members never override

### DIFF
--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -135,7 +135,7 @@ mixin Inheritable on ContainerMember {
     //
     // We use canonical elements here where possible to deal with reexports
     // as seen in Flutter.
-    if (enclosingElement is Extension) {
+    if (enclosingElement is Extension || enclosingElement is ExtensionType) {
       return false;
     }
 


### PR DESCRIPTION
Small fix for extension type declared members.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
