### PR TITLE
Convert some late final fields to getters; more fixes

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -212,7 +212,7 @@ class ParameterizedElementType extends DefinedElementType with Rendered {
 
 /// A [ElementType] whose underlying type was referred to by a type alias.
 mixin Aliased implements ElementType, ModelBuilderInterface {
-  late final Element typeAliasElement = type.alias!.element;
+  Element get typeAliasElement => type.alias!.element;
 
   @override
   String get name => typeAliasElement.name!;
@@ -235,10 +235,6 @@ class AliasedElementType extends ParameterizedElementType with Aliased {
 
   @override
   ParameterizedType get type;
-
-  /// Parameters, if available, for the underlying typedef.
-  late final List<Parameter> aliasedParameters =
-      modelElement.isCallable ? modelElement.parameters : [];
 
   @override
   ElementTypeRenderer<AliasedElementType> get _renderer =>
@@ -282,14 +278,6 @@ abstract class DefinedElementType extends ElementType {
     assert(f is ParameterizedType || f is TypeParameterType);
     assert(f is! FunctionType,
         'detected DefinedElementType for FunctionType: analyzer version too old?');
-    // TODO(jcollins-g): strip out all the cruft that's accumulated
-    // here for non-generic type aliases.
-    var isGenericTypeAlias = f.alias?.element != null && f is! InterfaceType;
-    if (isGenericTypeAlias) {
-      assert(false);
-      return GenericTypeAliasElementType(
-          f as TypeParameterType, library, packageGraph, modelElement);
-    }
     if (f is TypeParameterType) {
       return TypeParameterElementType(f, library, packageGraph, modelElement);
     }
@@ -426,12 +414,6 @@ class CallableElementType extends DefinedElementType with Rendered, Callable {
           .map((f) => modelBuilder.typeFrom(f, library))
           .toList(growable: false) ??
       const [];
-}
-
-/// A non-callable type backed by a [GenericTypeAliasElement].
-class GenericTypeAliasElementType extends TypeParameterElementType {
-  GenericTypeAliasElementType(
-      super.t, super.library, super.packageGraph, super.element);
 }
 
 extension on DartType {

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -927,18 +927,6 @@ class _Renderer_Categorization extends RendererBase<Categorization> {
       _propertyMapCache.putIfAbsent(
           CT_,
           () => {
-                'categories': Property(
-                  getValue: (CT_ c) => c.categories,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Category>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.categories.map((e) =>
-                        _render_Category(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'categoryNames': Property(
                   getValue: (CT_ c) => c.categoryNames,
                   renderVariable: (CT_ c, Property<CT_> self,

--- a/lib/src/model/directives/categorization.dart
+++ b/lib/src/model/directives/categorization.dart
@@ -4,6 +4,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:meta/meta.dart';
 
 final RegExp _categoryRegExp = RegExp(
     r'[ ]*{@(api|category|subCategory|image|samples) (.+?)}[ ]*\n?',
@@ -90,9 +91,10 @@ mixin Categorization on DocumentationComment implements Indexable {
     return _samples;
   }
 
-  late final Iterable<Category> categories = [
-    ...?categoryNames?.map((n) => package.nameToCategory[n]).whereNotNull()
-  ]..sort();
+  @visibleForTesting
+  List<Category> get categories => [
+        ...?categoryNames?.map((n) => package.nameToCategory[n]).whereNotNull()
+      ]..sort();
 
   Iterable<Category> get displayedCategories {
     if (config.showUndocumentedCategories) return categories;

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -43,16 +43,11 @@ mixin Inheritable on ContainerMember {
       canonicalEnclosingContainer?.canonicalLibrary;
 
   @override
-  late final ModelElement? canonicalModelElement = () {
-    final canonicalEnclosingContainer = this.canonicalEnclosingContainer;
-    if (canonicalEnclosingContainer == null) {
-      return null;
-    }
-    return canonicalEnclosingContainer.allCanonicalModelElements
-        .firstWhereOrNull((m) =>
-            m.name == name &&
-            m is PropertyAccessorElement == this is PropertyAccessorElement);
-  }();
+  late final ModelElement? canonicalModelElement = canonicalEnclosingContainer
+      ?.allCanonicalModelElements
+      .firstWhereOrNull((m) =>
+          m.name == name &&
+          m is PropertyAccessorElement == this is PropertyAccessorElement);
 
   @override
   Container? computeCanonicalEnclosingContainer() {
@@ -171,7 +166,7 @@ mixin Inheritable on ContainerMember {
   }();
 
   @override
-  late final int overriddenDepth = () {
+  int get overriddenDepth {
     var depth = 0;
     var e = this;
     while (e.overriddenElement != null) {
@@ -179,5 +174,5 @@ mixin Inheritable on ContainerMember {
       e = e.overriddenElement!;
     }
     return depth;
-  }();
+  }
 }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -257,7 +257,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     return _implementors;
   }
 
-  late final Iterable<Extension> documentedExtensions =
+  Iterable<Extension> get documentedExtensions =>
       utils.filterNonDocumented(extensions).toList(growable: false);
 
   Iterable<Extension> get extensions {
@@ -603,8 +603,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
   late final Iterable<Library> libraries =
       packages.expand((p) => p.libraries).toList(growable: false)..sort();
 
-  /// The number of libraries.
-  late final int libraryCount = libraries.length;
+  int get libraryCount => libraries.length;
 
   late final Set<Library> publicLibraries = () {
     assert(allLibrariesAdded);
@@ -630,11 +629,12 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
           ?.linkedName ??
       'Object';
 
-  /// Return the set of [Class]es objects should inherit through if they
-  /// show up in the inheritance chain.  Do not call before interceptorElement is
-  /// found.  Add classes here if they are similar to Interceptor in that they
-  /// are to be ignored even when they are the implementors of [Inheritable]s,
-  /// and the class these inherit from should instead claim implementation.
+  /// Return the set of [Class]es which objects should inherit through if they
+  /// show up in the inheritance chain.
+  ///
+  /// Add classes here if they are similar to Interceptor in that they are to be
+  /// ignored even when they are the implementors of [Inheritable]s, and the
+  /// class these inherit from should instead claim implementation.
   late final Set<Class> inheritThrough = () {
     var interceptorSpecialClass = specialClasses[SpecialClass.interceptor];
     if (interceptorSpecialClass == null) {
@@ -644,8 +644,8 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     return {interceptorSpecialClass};
   }();
 
-  /// The set of [Class] objects that are similar to pragma
-  /// in that we should never count them as documentable annotations.
+  /// The set of [Class] objects that are similar to 'pragma' in that we should
+  /// never count them as documentable annotations.
   late final Set<Class> invisibleAnnotations = () {
     var pragmaSpecialClass = specialClasses[SpecialClass.pragma];
     if (pragmaSpecialClass == null) {

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -37,7 +37,7 @@ class TypeParameter extends ModelElement with HasNoPage {
   bool get hasParameters => false;
 
   @override
-  late final String name = element.bound != null
+  String get name => element.bound != null
       ? '${element.name} extends ${boundType!.nameWithGenerics}'
       : element.name;
 

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -294,13 +294,12 @@ abstract class PubPackageMeta extends PackageMeta {
 class _FilePackageMeta extends PubPackageMeta {
   File? _readme;
 
-  late final Map<dynamic, dynamic> _pubspec = () {
-    var pubspec = dir.getChildAssumingFile('pubspec.yaml');
-    assert(pubspec.exists);
-    return loadYaml(pubspec.readAsStringSync()) as YamlMap;
-  }();
+  late final Map<dynamic, dynamic> _pubspec;
 
-  _FilePackageMeta(super.dir, super.resourceProvider);
+  _FilePackageMeta(super.dir, super.resourceProvider)
+      : _pubspec = loadYaml(
+                dir.getChildAssumingFile('pubspec.yaml').readAsStringSync())
+            as YamlMap;
 
   @override
   late final String? hostedAt = () {

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -294,7 +294,7 @@ abstract class PubPackageMeta extends PackageMeta {
 class _FilePackageMeta extends PubPackageMeta {
   File? _readme;
 
-  late final Map<dynamic, dynamic> _pubspec;
+  final Map<dynamic, dynamic> _pubspec;
 
   _FilePackageMeta(super.dir, super.resourceProvider)
       : _pubspec = loadYaml(


### PR DESCRIPTION
* Convert `Aliased.typeAliasElement`, `Categorization.categories`, `Inheritable.overriddenDepth`, `PackageGraph.documentedExtensions`, `PackageGraph.libraryCount`, `TypeParameter.name`, from late final field to getter.
* Convert `_FilePackageMeta._pubspec` to be non-late.
* Delete unused `AliasedElementType.aliasedParameters`.
* Delete unused `GenericTypeAliasElementType`.
* Mark `Categorization.categories` as `visibleForTesting`.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
