### PR TITLE
Extension type constructors

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -852,7 +852,7 @@ String renderExtensionType<T extends ExtensionType>(
         <dt>on</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">''');
-  var context3 = context2.extendedType;
+  var context3 = context2.representationType;
   buffer.writeln();
   buffer.write('''
               <li>''');
@@ -868,7 +868,10 @@ String renderExtensionType<T extends ExtensionType>(
   buffer.writeln();
   buffer.write('''
     </section>
-''');
+
+    ''');
+  buffer.write(_renderExtensionType_partial_constructors_6(context2));
+  buffer.writeln();
   if (context2.hasPublicInstanceFields == true) {
     buffer.writeln();
     buffer.write('''
@@ -879,7 +882,7 @@ String renderExtensionType<T extends ExtensionType>(
     var context4 = context2.publicInstanceFieldsSorted;
     for (var context5 in context4) {
       buffer.write('\n            ');
-      buffer.write(_renderExtensionType_partial_property_6(context5));
+      buffer.write(_renderExtensionType_partial_property_7(context5));
     }
     buffer.writeln();
     buffer.write('''
@@ -887,15 +890,15 @@ String renderExtensionType<T extends ExtensionType>(
     </section>''');
   }
   buffer.write('\n\n    ');
-  buffer.write(_renderExtensionType_partial_instance_methods_7(context2));
+  buffer.write(_renderExtensionType_partial_instance_methods_8(context2));
   buffer.write('\n    ');
-  buffer.write(_renderExtensionType_partial_instance_operators_8(context2));
+  buffer.write(_renderExtensionType_partial_instance_operators_9(context2));
   buffer.write('\n    ');
-  buffer.write(_renderExtensionType_partial_static_properties_9(context2));
+  buffer.write(_renderExtensionType_partial_static_properties_10(context2));
   buffer.write('\n    ');
-  buffer.write(_renderExtensionType_partial_static_methods_10(context2));
+  buffer.write(_renderExtensionType_partial_static_methods_11(context2));
   buffer.write('\n    ');
-  buffer.write(_renderExtensionType_partial_static_constants_11(context2));
+  buffer.write(_renderExtensionType_partial_static_constants_12(context2));
   buffer.writeln();
   buffer.write('''
 
@@ -903,7 +906,7 @@ String renderExtensionType<T extends ExtensionType>(
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderExtensionType_partial_search_sidebar_12(context0));
+  buffer.write(_renderExtensionType_partial_search_sidebar_13(context0));
   buffer.writeln();
   buffer.write('''
     <h5>''');
@@ -917,7 +920,7 @@ String renderExtensionType<T extends ExtensionType>(
 </div><!--/.sidebar-offcanvas-->
 
 ''');
-  buffer.write(_renderExtensionType_partial_footer_13(context0));
+  buffer.write(_renderExtensionType_partial_footer_14(context0));
   buffer.writeln();
   buffer.writeln();
 
@@ -2864,33 +2867,36 @@ String _renderExtensionType_partial_container_annotations_5(
         ExtensionType context1) =>
     _deduplicated_lib_templates_html__container_annotations_html(context1);
 
-String _renderExtensionType_partial_property_6(Field context2) =>
+String _renderExtensionType_partial_constructors_6(ExtensionType context1) =>
+    _deduplicated_lib_templates_html__constructors_html(context1);
+
+String _renderExtensionType_partial_property_7(Field context2) =>
     _deduplicated_lib_templates_html__property_html(context2);
 
-String _renderExtensionType_partial_instance_methods_7(
+String _renderExtensionType_partial_instance_methods_8(
         ExtensionType context1) =>
     _deduplicated_lib_templates_html__instance_methods_html(context1);
 
-String _renderExtensionType_partial_instance_operators_8(
+String _renderExtensionType_partial_instance_operators_9(
         ExtensionType context1) =>
     _deduplicated_lib_templates_html__instance_operators_html(context1);
 
-String _renderExtensionType_partial_static_properties_9(
+String _renderExtensionType_partial_static_properties_10(
         ExtensionType context1) =>
     _deduplicated_lib_templates_html__static_properties_html(context1);
 
-String _renderExtensionType_partial_static_methods_10(ExtensionType context1) =>
+String _renderExtensionType_partial_static_methods_11(ExtensionType context1) =>
     _deduplicated_lib_templates_html__static_methods_html(context1);
 
-String _renderExtensionType_partial_static_constants_11(
+String _renderExtensionType_partial_static_constants_12(
         ExtensionType context1) =>
     _deduplicated_lib_templates_html__static_constants_html(context1);
 
-String _renderExtensionType_partial_search_sidebar_12<T extends ExtensionType>(
+String _renderExtensionType_partial_search_sidebar_13<T extends ExtensionType>(
         ExtensionTypeTemplateData<T> context0) =>
     _deduplicated_lib_templates_html__search_sidebar_html(context0);
 
-String _renderExtensionType_partial_footer_13<T extends ExtensionType>(
+String _renderExtensionType_partial_footer_14<T extends ExtensionType>(
         ExtensionTypeTemplateData<T> context0) =>
     _deduplicated_lib_templates_html__footer_html(context0);
 

--- a/lib/src/generator/templates.aot_renderers_for_md.dart
+++ b/lib/src/generator/templates.aot_renderers_for_md.dart
@@ -491,7 +491,7 @@ String renderExtensionType<T extends ExtensionType>(
   buffer.writeln();
   buffer.write('''
 on ''');
-  var context2 = context1.extendedType;
+  var context2 = context1.representationType;
   buffer.write(context2.linkedName);
   buffer.write('\n\n');
   buffer.write(_renderExtensionType_partial_source_link_1(context1));
@@ -505,6 +505,8 @@ on ''');
   buffer.write(_renderExtensionType_partial_documentation_4(context3));
   buffer.write('\n\n');
   buffer.write(_renderExtensionType_partial_annotations_5(context3));
+  buffer.write('\n\n');
+  buffer.write(_renderExtensionType_partial_constructors_6(context3));
   buffer.writeln();
   if (context3.hasPublicInstanceFields == true) {
     buffer.writeln();
@@ -514,25 +516,25 @@ on ''');
     var context4 = context3.publicInstanceFieldsSorted;
     for (var context5 in context4) {
       buffer.writeln();
-      buffer.write(_renderExtensionType_partial_property_6(context5));
+      buffer.write(_renderExtensionType_partial_property_7(context5));
       buffer.writeln();
     }
   }
   buffer.write('\n\n');
-  buffer.write(_renderExtensionType_partial_instance_methods_7(context3));
+  buffer.write(_renderExtensionType_partial_instance_methods_8(context3));
   buffer.write('\n\n');
-  buffer.write(_renderExtensionType_partial_instance_operators_8(context3));
+  buffer.write(_renderExtensionType_partial_instance_operators_9(context3));
   buffer.write('\n\n');
-  buffer.write(_renderExtensionType_partial_static_properties_9(context3));
+  buffer.write(_renderExtensionType_partial_static_properties_10(context3));
   buffer.write('\n\n');
-  buffer.write(_renderExtensionType_partial_static_methods_10(context3));
+  buffer.write(_renderExtensionType_partial_static_methods_11(context3));
   buffer.write('\n\n');
-  buffer.write(_renderExtensionType_partial_static_constants_11(context3));
+  buffer.write(_renderExtensionType_partial_static_constants_12(context3));
   buffer.writeln();
   buffer.write('''
 {{ /extension }}''');
   buffer.write('\n\n');
-  buffer.write(_renderExtensionType_partial_footer_12(context0));
+  buffer.write(_renderExtensionType_partial_footer_13(context0));
   buffer.writeln();
   buffer.writeln();
 
@@ -1434,29 +1436,32 @@ String _renderExtensionType_partial_documentation_4(ExtensionType context1) =>
 String _renderExtensionType_partial_annotations_5(ExtensionType context1) =>
     _deduplicated_lib_templates_md__annotations_md(context1);
 
-String _renderExtensionType_partial_property_6(Field context2) =>
+String _renderExtensionType_partial_constructors_6(ExtensionType context1) =>
+    _deduplicated_lib_templates_md__constructors_md(context1);
+
+String _renderExtensionType_partial_property_7(Field context2) =>
     _deduplicated_lib_templates_md__property_md(context2);
 
-String _renderExtensionType_partial_instance_methods_7(
+String _renderExtensionType_partial_instance_methods_8(
         ExtensionType context1) =>
     _deduplicated_lib_templates_md__instance_methods_md(context1);
 
-String _renderExtensionType_partial_instance_operators_8(
+String _renderExtensionType_partial_instance_operators_9(
         ExtensionType context1) =>
     _deduplicated_lib_templates_md__instance_operators_md(context1);
 
-String _renderExtensionType_partial_static_properties_9(
+String _renderExtensionType_partial_static_properties_10(
         ExtensionType context1) =>
     _deduplicated_lib_templates_md__static_properties_md(context1);
 
-String _renderExtensionType_partial_static_methods_10(ExtensionType context1) =>
+String _renderExtensionType_partial_static_methods_11(ExtensionType context1) =>
     _deduplicated_lib_templates_md__static_methods_md(context1);
 
-String _renderExtensionType_partial_static_constants_11(
+String _renderExtensionType_partial_static_constants_12(
         ExtensionType context1) =>
     _deduplicated_lib_templates_md__static_constants_md(context1);
 
-String _renderExtensionType_partial_footer_12<T extends ExtensionType>(
+String _renderExtensionType_partial_footer_13<T extends ExtensionType>(
         ExtensionTypeTemplateData<T> context0) =>
     _deduplicated_lib_templates_md__footer_md(context0);
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -5498,28 +5498,6 @@ class _Renderer_ExtensionType extends RendererBase<ExtensionType> {
                         parent: r);
                   },
                 ),
-                'extendedType': Property(
-                  getValue: (CT_ c) => c.extendedType,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ElementType.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as ElementType,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_ElementType(c.extendedType, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'filePath': Property(
                   getValue: (CT_ c) => c.filePath,
                   renderVariable:
@@ -5658,6 +5636,29 @@ class _Renderer_ExtensionType extends RendererBase<ExtensionType> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.relationshipsClass, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
+                'representationType': Property(
+                  getValue: (CT_ c) => c.representationType,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_ElementType.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as ElementType,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_ElementType(
+                        c.representationType, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -12,7 +12,7 @@ class ExtensionType extends InheritingContainer with Constructable {
   @override
   final ExtensionTypeElement element;
 
-  late final ElementType extendedType =
+  late final ElementType representationType =
       modelBuilder.typeFrom(element.typeErasure, library);
 
   ExtensionType(this.element, super.library, super.packageGraph);
@@ -56,7 +56,7 @@ class ExtensionType extends InheritingContainer with Constructable {
   @override
   late final List<ModelElement> allModelElements = [
     ...super.allModelElements,
-    ...typeParameters,
+    ...constructors,
   ];
 
   @override
@@ -86,8 +86,8 @@ class ExtensionType extends InheritingContainer with Constructable {
   @override
   Map<String, CommentReferable> get referenceChildren {
     return _referenceChildren ??= {
-      ...extendedType.referenceChildren,
-      // Override `extendedType` entries with local items.
+      ...representationType.referenceChildren,
+      // Override `representationType` entries with local items.
       ...super.referenceChildren,
     };
   }

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -459,13 +459,15 @@ abstract class ModelElement extends Canonicalization
   // The canonical ModelElement for this ModelElement,
   // or null if there isn't one.
   late final ModelElement? canonicalModelElement = () {
-    Container? preferredClass;
-    // TODO(srawlins): Add mixin.
-    if (enclosingElement is Class ||
-        enclosingElement is Enum ||
-        enclosingElement is Extension) {
-      preferredClass = enclosingElement as Container?;
-    }
+    final enclosingElement = this.enclosingElement;
+    var preferredClass = switch (enclosingElement) {
+      // TODO(srawlins): Add mixin.
+      Class() => enclosingElement,
+      Enum() => enclosingElement,
+      Extension() => enclosingElement,
+      ExtensionType() => enclosingElement,
+      _ => null,
+    };
     return packageGraph.findCanonicalModelElementFor(element,
         preferredClass: preferredClass);
   }();

--- a/lib/templates/html/extension_type.html
+++ b/lib/templates/html/extension_type.html
@@ -16,14 +16,16 @@
         <dt>on</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">
-            {{ #extendedType }}
+            {{ #representationType }}
               <li>{{{ linkedName }}}</li>
-            {{ /extendedType }}
+          {{ /representationType }}
           </ul>
         </dd>
       </dl>
       {{ >container_annotations }}
     </section>
+
+    {{ >constructors }}
 
     {{ #hasPublicInstanceFields }}
     <section class="summary offset-anchor" id="instance-properties">

--- a/lib/templates/md/extension_type.md
+++ b/lib/templates/md/extension_type.md
@@ -2,7 +2,7 @@
 
 {{ #self }}
 # {{{ nameWithGenerics }}} {{ kind }}
-on {{ #extendedType }}{{{ linkedName }}}{{ /extendedType }}
+on {{ #representationType }}{{{ linkedName }}}{{ /representationType }}
 
 {{ >source_link }}
 
@@ -14,6 +14,8 @@ on {{ #extendedType }}{{{ linkedName }}}{{ /extendedType }}
 {{ >documentation }}
 
 {{ >annotations }}
+
+{{ >constructors }}
 
 {{ #hasPublicInstanceFields }}
 ## Properties

--- a/test/extension_types_test.dart
+++ b/test/extension_types_test.dart
@@ -85,6 +85,24 @@ class C {}
     );
   }
 
+  @FailingTest(reason: 'Not implemented yet')
+  void test_referenceToExtensionTypeConstructor() async {
+    var library = await bootPackageWithLibrary('''
+extension type ET(int it) {
+  ET.named(int it);
+}
+
+/// Doc referring to [ET.new] and [Et.named].
+class C {}
+''');
+
+    expect(
+      library.classes.named('C').documentationAsHtml,
+      '<p>Doc referring to '
+      '<a href="${placeholder}extension_types/ET/named.html">ET.named</a>.</p>',
+    );
+  }
+
   void test_referenceToExtensionTypeMember() async {
     var library = await bootPackageWithLibrary('''
 extension type ET(int it) {

--- a/test/templates/extension_type_test.dart
+++ b/test/templates/extension_type_test.dart
@@ -71,7 +71,10 @@ analyzer:
 ''',
         libFiles: [
           d.file('lib.dart', '''
-extension type MyIterable<E>(Iterable<E> e) {
+extension type FooET<E>(Foo<E> e) {
+  /// A named constructor.
+  MyIterable.named(Foo<E> e);
+
   /// An instance method.
   void m1() {}
 
@@ -94,14 +97,7 @@ extension type MyIterable<E>(Iterable<E> e) {
   static void set gs1(int value) {}
 }
 
-extension type MyListQueue<E>(ListQueue<E> e) implements Iterable<E>, Queue<E> {
-  void m2() {}
-}
-
-extension type MyListOfInt(List<int> e)
-    implements MyIterable<int>, Iterable<int> {
-  void m3() {}
-}
+class Foo<E> {}
 '''),
         ],
         dartdocOptions: '''
@@ -115,13 +111,13 @@ dartdoc:
       await writeDartdocResources(resourceProvider);
       await (await buildDartdoc()).generateDocs();
       eLines = resourceProvider
-          .getFile(path.join(
-              packagePath, 'doc', 'lib', 'MyIterable-extension-type.html'))
+          .getFile(
+              path.join(packagePath, 'doc', 'lib', 'FooET-extension-type.html'))
           .readAsStringSync()
           .split('\n');
       eRightSidebarLines = resourceProvider
-          .getFile(path.join(packagePath, 'doc', 'lib',
-              'MyIterable-extension-type-sidebar.html'))
+          .getFile(path.join(
+              packagePath, 'doc', 'lib', 'FooET-extension-type-sidebar.html'))
           .readAsStringSync()
           .split('\n');
     });
@@ -129,30 +125,35 @@ dartdoc:
     test('page contains extension name with generics', () async {
       eLines.expectMainContentContainsAllInOrder([
         matches(
-          '<span class="kind-class">MyIterable&lt;<wbr>'
+          '<span class="kind-class">FooET&lt;<wbr>'
           '<span class="type-parameter">E</span>&gt;</span>',
         )
       ]);
     });
 
-    test('page contains extended type',
-        // TODO(srawlins): Implement.
-        skip: true, () async {
-      expect(
-        eLines,
-        containsAllInOrder([
-          matches('<dt>on</dt>'),
-          matches('<a href="../lib/Iterable-class.html">Iterable</a>'
-              '<span class="signature">&lt;<wbr>'
-              '<span class="type-parameter">E</span>&gt;</span>'),
-        ]),
-      );
+    test('page contains extended type', () async {
+      eLines.expectMainContentContainsAllInOrder([
+        matches('<dt>on</dt>'),
+        matches('<a href="../lib/Foo-class.html">Foo</a>'
+            '<span class="signature">&lt;<wbr>'
+            '<span class="type-parameter">E</span>&gt;</span>'),
+      ]);
+    });
+
+    test('page contains constructors', () async {
+      eLines.expectMainContentContainsAllInOrder([
+        matches('<h2>Constructors</h2>'),
+        matches('<a href="../lib/FooET/FooET.html">FooET</a>'),
+        matches('<a href="../lib/FooET/FooET.named.html">'
+            'FooET.named</a>'),
+        matches('A named constructor.'),
+      ]);
     });
 
     test('page contains static methods', () async {
       eLines.expectMainContentContainsAllInOrder([
         matches('<h2>Static Methods</h2>'),
-        matches('<a href="../lib/MyIterable/s1.html">s1</a>'),
+        matches('<a href="../lib/FooET/s1.html">s1</a>'),
         matches('A static method.'),
       ]);
     });
@@ -160,7 +161,7 @@ dartdoc:
     test('page contains static fields', () async {
       eLines.expectMainContentContainsAllInOrder([
         matches('<h2>Static Properties</h2>'),
-        matches('<a href="../lib/MyIterable/sf1.html">sf1</a>'),
+        matches('<a href="../lib/FooET/sf1.html">sf1</a>'),
         matches('A static field.'),
       ]);
     });
@@ -168,7 +169,7 @@ dartdoc:
     test('page contains static getter/setter pairs', () async {
       eLines.expectMainContentContainsAllInOrder([
         matches('<h2>Static Properties</h2>'),
-        matches('<a href="../lib/MyIterable/gs1.html">gs1</a>'),
+        matches('<a href="../lib/FooET/gs1.html">gs1</a>'),
         matches('A static getter.'),
       ]);
     });
@@ -180,7 +181,7 @@ dartdoc:
       () async {
         eLines.expectMainContentContainsAllInOrder([
           matches('<h2>Constants</h2>'),
-          matches('<a href="../lib/MyIterable/c1-constant.html">c1</a>'),
+          matches('<a href="../lib/FooET/c1-constant.html">c1</a>'),
           matches('A constant.'),
         ]);
       },
@@ -189,8 +190,7 @@ dartdoc:
     test('page contains instance operators', () async {
       eLines.expectMainContentContainsAllInOrder([
         matches('<h2>Operators</h2>'),
-        matches(
-            '<a href="../lib/MyIterable/operator_greater.html">operator ></a>'),
+        matches('<a href="../lib/FooET/operator_greater.html">operator ></a>'),
         matches('An operator.'),
       ]);
     });
@@ -200,10 +200,10 @@ dartdoc:
         eRightSidebarLines,
         containsAllInOrder([
           matches(
-            '<a href="../lib/MyIterable-extension-type.html#instance-methods">'
+            '<a href="../lib/FooET-extension-type.html#instance-methods">'
             'Methods</a>',
           ),
-          matches('<a href="../lib/MyIterable/m1.html">m1</a>'),
+          matches('<a href="../lib/FooET/m1.html">m1</a>'),
         ]),
       );
     });
@@ -213,11 +213,11 @@ dartdoc:
         eRightSidebarLines,
         containsAllInOrder([
           matches(
-            '<a href="../lib/MyIterable-extension-type.html#operators">'
+            '<a href="../lib/FooET-extension-type.html#operators">'
             'Operators</a>',
           ),
           matches(
-            '<a href="../lib/MyIterable/operator_greater.html">operator ></a>',
+            '<a href="../lib/FooET/operator_greater.html">operator ></a>',
           ),
         ]),
       );
@@ -228,9 +228,9 @@ dartdoc:
         eRightSidebarLines,
         containsAllInOrder([
           matches(
-              '<a href="../lib/MyIterable-extension-type.html#static-properties">Static properties</a>'),
-          matches('<a href="../lib/MyIterable/gs1.html">gs1</a>'),
-          matches('<a href="../lib/MyIterable/sf1.html">sf1</a>'),
+              '<a href="../lib/FooET-extension-type.html#static-properties">Static properties</a>'),
+          matches('<a href="../lib/FooET/gs1.html">gs1</a>'),
+          matches('<a href="../lib/FooET/sf1.html">sf1</a>'),
         ]),
       );
     });
@@ -240,8 +240,8 @@ dartdoc:
         eRightSidebarLines,
         containsAllInOrder([
           matches(
-              '<a href="../lib/MyIterable-extension-type.html#static-methods">Static methods</a>'),
-          matches('<a href="../lib/MyIterable/s1.html">s1</a>'),
+              '<a href="../lib/FooET-extension-type.html#static-methods">Static methods</a>'),
+          matches('<a href="../lib/FooET/s1.html">s1</a>'),
         ]),
       );
     });


### PR DESCRIPTION
Display them on an extension type's page. Change name of 'extended thing' to 'representationType'.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
