### PR TITLE
Fix canonicalization scoring when library shares package name

### DIFF
--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -58,7 +58,7 @@ abstract mixin class Canonicalization
     }
 
     // Give a big boost if the library has the package name embedded in it.
-    if (library.package.namePieces.intersection(library.namePieces).isEmpty) {
+    if (library.package.namePieces.intersection(library.namePieces).isNotEmpty) {
       scoredCandidate._alterScore(1.0, _Reason.packageName);
     }
 


### PR DESCRIPTION
The code and the comment for the code are opposite.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
